### PR TITLE
config: add appdata/datadir options

### DIFF
--- a/cmd/rebuilddb/rebuilddb.go
+++ b/cmd/rebuilddb/rebuilddb.go
@@ -78,7 +78,8 @@ func mainCore() int {
 	// Sqlite output
 	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
 	//sqliteDB, err := dcrsqlite.InitDB(&dbInfo)
-	sqliteDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo, nil, client, activeChain)
+	sqliteDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo, nil, client,
+		activeChain, "rebuild_data")
 	defer cleanupDB()
 	if err != nil {
 		log.Errorf("Unable to initialize SQLite database: %v", err)

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -110,7 +110,7 @@ func mainCore() error {
 		}
 	}
 
-	stakeDB, err := stakedb.NewStakeDatabase(client, activeChain, "pg_rebuild_stakedb")
+	stakeDB, err := stakedb.NewStakeDatabase(client, activeChain, "rebuild_data")
 	if err != nil {
 		return fmt.Errorf("Unable to create stake DB: %v", err)
 	}

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -215,6 +215,9 @@ func (exp *explorerUI) reloadTemplatesSig(sig os.Signal) {
 
 // StopWebsocketHub stops the websocket hub
 func (exp *explorerUI) StopWebsocketHub() {
+	if exp == nil {
+		return
+	}
 	log.Info("Stopping websocket hub.")
 	exp.wsHub.Stop()
 }
@@ -399,6 +402,11 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		},
 	}
 
+	noTemplateError := func(err error) *explorerUI {
+		log.Errorf("Unable to create new html template: %v", err)
+		return nil
+	}
+
 	exp.templates = make([]*template.Template, 0, 4)
 
 	homeTemplate, err := template.New("home").Funcs(exp.templateHelpers).ParseFiles(
@@ -406,7 +414,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, homeTemplate)
 
@@ -415,7 +423,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, explorerTemplate)
 
@@ -424,7 +432,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, blockTemplate)
 
@@ -433,7 +441,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, txTemplate)
 
@@ -442,7 +450,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, addrTemplate)
 
@@ -451,7 +459,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, decodeTxTemplate)
 
@@ -460,7 +468,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		exp.templateFiles["extras"],
 	)
 	if err != nil {
-		log.Errorf("Unable to create new html template: %v", err)
+		return noTemplateError(err)
 	}
 	exp.templates = append(exp.templates, errorTemplate)
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/pprof"
 	"strings"
 	"sync"
@@ -105,9 +106,10 @@ func mainCore() error {
 		nodeVer.String(), curnet.String())
 
 	// Sqlite output
-	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
+	dbPath := filepath.Join(cfg.DataDir, cfg.DBFileName)
+	dbInfo := dcrsqlite.DBInfo{FileName: dbPath}
 	baseDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo,
-		ntfnChans.updateStatusDBHeight, dcrdClient, activeChain)
+		ntfnChans.updateStatusDBHeight, dcrdClient, activeChain, cfg.DataDir)
 	defer cleanupDB()
 	if err != nil {
 		return fmt.Errorf("Unable to initialize SQLite database: %v", err)

--- a/main.go
+++ b/main.go
@@ -61,9 +61,6 @@ func mainCore() error {
 	// Start with version info
 	log.Infof(appName+" version %s", ver.String())
 
-	//log.Debugf("Output folder: %v", cfg.OutFolder)
-	log.Debugf("Log folder: %v", cfg.LogDir)
-
 	// PostgreSQL
 	usePG := cfg.FullMode
 	if usePG {
@@ -275,6 +272,9 @@ func mainCore() error {
 
 	// Create the explorer system
 	explore := explorer.New(&baseDB, auxDB, cfg.UseRealIP, ver.String())
+	if explore == nil {
+		return fmt.Errorf("failed to create new explorer (templates missing?)")
+	}
 	explore.UseSIGToReloadTemplates()
 	defer explore.StopWebsocketHub()
 	blockDataSavers = append(blockDataSavers, explore)

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -106,17 +107,18 @@ const (
 	// dbType is the database backend type to use
 	dbType = "ffldb"
 	// DefaultStakeDbName is the default name of the stakedb database folder
-	DefaultStakeDbName = "ffldb_stake"
+	DefaultStakeDbName = "stakenodes"
 	// DefaultTicketPoolDbName is the default name of the ticket pool database
-	DefaultTicketPoolDbName = "stakedb_ticket_pool.db"
+	DefaultTicketPoolDbName = "ticket_pool.db"
 )
 
 // NewStakeDatabase creates a StakeDatabase instance, opening or creating a new
 // ffldb-backed stake database, and loads all live tickets into a cache.
 func NewStakeDatabase(client *rpcclient.Client, params *chaincfg.Params,
-	dbNameOpt ...string) (*StakeDatabase, error) {
+	dbFolder string) (*StakeDatabase, error) {
 	log.Infof("Loading ticket pool DB. This may take a minute...")
-	poolDB, err := NewTicketPool(DefaultTicketPoolDbName)
+	ticketPoolDBPath := filepath.Join(dbFolder, DefaultTicketPoolDbName)
+	poolDB, err := NewTicketPool(ticketPoolDBPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open ticket pool DB: %v", err)
 	}
@@ -134,12 +136,8 @@ func NewStakeDatabase(client *rpcclient.Client, params *chaincfg.Params,
 	// genesis. Hence it will never be connected, how TPI is usually cached.
 	sDB.poolInfo.Set(*params.GenesisHash, &apitypes.TicketPoolInfo{})
 
-	dbName := DefaultStakeDbName
-	if len(dbNameOpt) > 0 {
-		dbName = dbNameOpt[0]
-	}
-
-	if err = sDB.Open(dbName); err != nil {
+	stakeDBPath := filepath.Join(dbFolder, DefaultStakeDbName)
+	if err = sDB.Open(stakeDBPath); err != nil {
 		return nil, err
 	}
 

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -116,6 +116,11 @@ const (
 // ffldb-backed stake database, and loads all live tickets into a cache.
 func NewStakeDatabase(client *rpcclient.Client, params *chaincfg.Params,
 	dbFolder string) (*StakeDatabase, error) {
+	// Create DB folder
+	err := os.MkdirAll(dbFolder, 0700)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create DB folder: %v", err)
+	}
 	log.Infof("Loading ticket pool DB. This may take a minute...")
 	ticketPoolDBPath := filepath.Join(dbFolder, DefaultTicketPoolDbName)
 	poolDB, err := NewTicketPool(ticketPoolDBPath)


### PR DESCRIPTION
Add `appdata` and `datadir` options to config, and reorganize database folders.  The config file may be:
1. missing
2. default location (in appdata)
3. specified on command line with `-C`

Templates folder (views folder with tmpl files) must be in same folder as the executable.

Addresses issue #363.

appdata layout looks like this now:

```
.
├── data
│   └── mainnet
│       ├── dcrdata.sqlt.db
│       ├── stakenodes
│       │   └── metadata
│       │       ├── 000006.log
│       │       ├── 000008.ldb
│       │       ├── 000009.ldb
│       │       ├── 000010.ldb
│       │       ├── 000011.ldb
│       │       ├── CURRENT
│       │       ├── LOCK
│       │       ├── LOG
│       │       └── MANIFEST-000007
│       ├── ticket_pool.db
│       └── ticket_pool.db.lock
├── dcrdata.conf
└── logs
    └── mainnet
        └── dcrdata.log```