### PR TITLE
Add websocket tx send buffer

### DIFF
--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -170,8 +170,9 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// ping and send user count
 					webData.Message = strconv.Itoa(exp.wsHub.NumClients())
 				case sigNewTx:
+					exp.wsHub.clients[&updateSig].Lock()
 					enc.Encode(exp.wsHub.clients[&updateSig].newTxs)
-					exp.wsHub.clients[&updateSig].RUnlock()
+					exp.wsHub.clients[&updateSig].Unlock()
 					webData.Message = buff.String()
 				}
 

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -170,8 +170,8 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// ping and send user count
 					webData.Message = strconv.Itoa(exp.wsHub.NumClients())
 				case sigNewTx:
-					tx := <-exp.wsHub.clients[&updateSig]
-					enc.Encode(tx)
+					enc.Encode(exp.wsHub.clients[&updateSig].newTxs)
+					exp.wsHub.clients[&updateSig].RUnlock()
 					webData.Message = buff.String()
 				}
 

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -154,8 +154,9 @@
         });
 
         ws.registerEvtHandler("newtx", function(evt) {
-            console.log("New Transaction: ", evt);
-            var tx = JSON.parse(evt)
+            console.log("New Transactions: ", evt);
+            var txs = JSON.parse(evt)
+            txs.forEach(function(tx, idx) {
             addTxRow = function(str) {
                 var rows = $('#' + str +' tbody tr')
                 var totalTxt = "" 
@@ -220,6 +221,7 @@
                 rows.last().remove()
                 $(newRowHtml).insertBefore(rows.first())
             }
+        })
             setTimeElements()
         });
 


### PR DESCRIPTION
Follow up to #343:
This add a buffer `WebsocketHub.newTxBuffer` of size `newTxBufferSize`
for the websocket new tx sends. The websocket clients are now of type
`client` (`[]*MempoolTx` and `sync.RwMutex`) to accommodate the bulk sends.
A ticker function, `WebsocketHub.periodicBufferSend()`, is sent on a
goroutine at the start of `WebsocketHub.run()` that sends the buffer every
`bufferTickerInterval` seconds. The buffer is cleared on every send.