### PR TITLE
explorer/mempool: Ignore mempool votes not for the tip block

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1306,9 +1306,10 @@ func (db *wiredDB) GetMempool() []explorer.MempoolTx {
 						Height:   validation.Height,
 						Validity: validation.Validity,
 					},
-					Version: version,
-					Bits:    bits,
-					Choices: choices,
+					Version:     version,
+					Bits:        bits,
+					Choices:     choices,
+					TicketSpent: msgTx.TxIn[1].PreviousOutPoint.Hash.String(),
 				}
 			}
 		}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -80,10 +80,12 @@ type TxInID struct {
 
 // VoteInfo models data about a SSGen transaction (vote)
 type VoteInfo struct {
-	Validation BlockValidation         `json:"block_validation"`
-	Version    uint32                  `json:"vote_version"`
-	Bits       uint16                  `json:"vote_bits"`
-	Choices    []*txhelpers.VoteChoice `json:"vote_choices"`
+	Validation         BlockValidation         `json:"block_validation"`
+	Version            uint32                  `json:"vote_version"`
+	Bits               uint16                  `json:"vote_bits"`
+	Choices            []*txhelpers.VoteChoice `json:"vote_choices"`
+	TicketSpent        string                  `json:"ticket_spent"`
+	MempoolTicketIndex int                     `json:"mempool_ticket_index"`
 }
 
 // BlockValidation models data about a vote's decision on a block
@@ -207,17 +209,18 @@ type MempoolInfo struct {
 
 // MempoolShort represents the mempool data sent as the mempool update
 type MempoolShort struct {
-	LastBlockHeight    int64       `json:"block_height"`
-	LastBlockTime      int64       `json:"block_time"`
-	TotalOut           float64     `json:"total"`
-	TotalSize          int32       `json:"size"`
-	NumTickets         int         `json:"num_tickets"`
-	NumVotes           int         `json:"num_votes"`
-	NumRegular         int         `json:"num_regular"`
-	NumRevokes         int         `json:"num_revokes"`
-	NumAll             int         `json:"num_all"`
-	LatestTransactions []MempoolTx `json:"latest"`
-	FormattedTotalSize string      `json:"formatted_size"`
+	LastBlockHeight    int64          `json:"block_height"`
+	LastBlockTime      int64          `json:"block_time"`
+	TotalOut           float64        `json:"total"`
+	TotalSize          int32          `json:"size"`
+	NumTickets         int            `json:"num_tickets"`
+	NumVotes           int            `json:"num_votes"`
+	NumRegular         int            `json:"num_regular"`
+	NumRevokes         int            `json:"num_revokes"`
+	NumAll             int            `json:"num_all"`
+	LatestTransactions []MempoolTx    `json:"latest"`
+	FormattedTotalSize string         `json:"formatted_size"`
+	TicketIndexes      map[string]int `json:"ticket_indexes"`
 }
 
 // ChainParams models simple data about the chain server's parameters used for some

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -182,8 +182,8 @@
                     humanize.decimalParts(tx.total, false, 8).forEach(function (str) {
                         totalTxt += str.textContent
                     })
-                    var newRow = '<tr><td class="break-word"><span><a class="hash" href="/tx/' +
-                        tx.hash + '">' + tx.hash + '</a></span></td>' +
+                    var newRow = '<tr><td class="break-word"><span><a class="hash" title="('+tx.vote_info.mempool_ticket_index+
+                        ') ' + tx.vote_info.ticket_spent + '" href="/tx/' + tx.hash + '">' + tx.hash + '</a></span></td>' +
                         '<td class="mono fs15">' + tx.vote_info.vote_version + '</td>' +
                         '<td class="mono fs15">' + tx.vote_info.block_validation.validity + '</td>' +
                         '<td class="mono fs15">' + tx.vote_info.vote_choices[0].id + '</td>' +
@@ -253,8 +253,8 @@
                     humanize.decimalParts(tx.total, false, 8).forEach(function (str) {
                         totalTxt += str.textContent
                     })
-                    newTable += '<tr><td class="break-word"><span><a class="hash" href="/tx/' +
-                        tx.hash + '">' + tx.hash + '</a></span></td>' +
+                    newTable += '<tr><td class="break-word"><span><a class="hash" title="('+tx.vote_info.mempool_ticket_index+
+                        ') ' + tx.vote_info.ticket_spent + '" href="/tx/' + tx.hash + '">' + tx.hash + '</a></span></td>' +
                         '<td class="mono fs15">' + tx.vote_info.vote_version + '</td>' +
                         '<td class="mono fs15">' + tx.vote_info.block_validation.validity + '</td>' +
                         '<td class="mono fs15">' + tx.vote_info.vote_choices[0].id + '</td>' +

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -74,7 +74,7 @@
                             <tr>
                                 <td class="break-word">
                                     <span>
-                                        <a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a>
+                                        <a class="hash lh1rem" title="({{.VoteInfo.MempoolTicketIndex}}) {{.VoteInfo.TicketSpent}}" href="/tx/{{.Hash}}">{{.Hash}}</a>
                                     </span>
                                 </td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>


### PR DESCRIPTION
Another follow up to #343. Still [WIP] because I have no idea how identify votes spending the same ticket so I can combine them. Currently reduces vote count to around 5-7.