### PR TITLE
name the go-humanize import

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/stakedb"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 )
 
 // wiredDB is intended to satisfy APIDataSource interface. The block header is

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrdata/txhelpers"
-
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 )
 
 func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {


### PR DESCRIPTION
Some linters are confused by the go-humanize import when it is missing
an explicit name of the package, humanize. Fix this by naming it
humanize in the source where it's not already done like that.