### PR TITLE
Address page: Only show the applicable page sizes

### DIFF
--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -204,6 +204,8 @@
                     *Limit of 1000 transactions shown in lite mode.
                 </div>
                 {{end}}
+                {{if .Fullmode}}
+                {{if gt .KnownFundingTxns 20}}
                 <div
                     id="pagesize-wrapper"
                     class="hidden d-flex align-items-center justify-content-end"
@@ -214,10 +216,53 @@
                         id="pagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
+                        {{if gt .KnownFundingTxns 20}}
+                        {{if ge .KnownFundingTxns 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
+                        {{else}}
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">{{.KnownFundingTxns}}</option>
+                        {{end}}
+                        {{end}}
+                        {{if gt .KnownFundingTxns 100}}
+                        {{if ge .KnownFundingTxns 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
+                        {{else}}
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">{{.KnownFundingTxns}}</option>
+                        {{end}}
+                        {{end}}
                     </select>
                 </div>
+                {{end}}
+                {{else}}
+                {{if gt .KnownTransactions 20}}
+                <div
+                    id="pagesize-wrapper"
+                    class="hidden d-flex align-items-center justify-content-end"
+                >
+                    <label class="mb-0 mr-1" for="pagesize">Page size</label>
+                    <select
+                        name="pagesize"
+                        id="pagesize"
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                        <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
+                        {{if gt .KnownTransactions 20}}
+                        {{if ge .KnownTransactions 100}}
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
+                        {{else}}
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">{{.KnownTransactions}}</option>
+                        {{end}}
+                        {{end}}
+                        {{if gt .KnownTransactions 100}}
+                        {{if ge .KnownTransactions 1000}}
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
+                        {{else}}
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">{{.KnownTransactions}}</option>
+                        {{end}}
+                        {{end}}
+                    </select>
+                </div>
+                {{end}}
+                {{end}}
                 {{end}}
 
             </div>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -204,6 +204,7 @@
                     *Limit of 1000 transactions shown in lite mode.
                 </div>
                 {{end}}
+                {{end}}
                 {{if .Fullmode}}
                 {{if gt .KnownFundingTxns 20}}
                 <div
@@ -216,18 +217,16 @@
                         id="pagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
-                        {{if gt .KnownFundingTxns 20}}
                         {{if ge .KnownFundingTxns 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">{{.KnownFundingTxns}}</option>
-                        {{end}}
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">All ({{.KnownFundingTxns}})</option>
                         {{end}}
                         {{if gt .KnownFundingTxns 100}}
                         {{if ge .KnownFundingTxns 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">{{.KnownFundingTxns}}</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">All ({{.KnownFundingTxns}})</option>
                         {{end}}
                         {{end}}
                     </select>
@@ -245,23 +244,20 @@
                         id="pagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
-                        {{if gt .KnownTransactions 20}}
                         {{if ge .KnownTransactions 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">{{.KnownTransactions}}</option>
-                        {{end}}
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">All ({{.KnownTransactions}})</option>
                         {{end}}
                         {{if gt .KnownTransactions 100}}
                         {{if ge .KnownTransactions 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">{{.KnownTransactions}}</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">All ({{.KnownTransactions}})</option>
                         {{end}}
                         {{end}}
                     </select>
                 </div>
-                {{end}}
                 {{end}}
                 {{end}}
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -220,13 +220,13 @@
                         {{if ge .KnownFundingTxns 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">All ({{.KnownFundingTxns}})</option>
+                        <option {{if eq .Limit 100}}selected{{end}} value="{{.KnownFundingTxns}}">All ({{.KnownFundingTxns}})</option>
                         {{end}}
                         {{if gt .KnownFundingTxns 100}}
                         {{if ge .KnownFundingTxns 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">All ({{.KnownFundingTxns}})</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="{{.KnownFundingTxns}}">All ({{.KnownFundingTxns}})</option>
                         {{end}}
                         {{end}}
                     </select>
@@ -247,13 +247,13 @@
                         {{if ge .KnownTransactions 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">All ({{.KnownTransactions}})</option>
+                        <option {{if eq .Limit 100}}selected{{end}} value="{{.KnownTransactions}}">All ({{.KnownTransactions}})</option>
                         {{end}}
                         {{if gt .KnownTransactions 100}}
                         {{if ge .KnownTransactions 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">All ({{.KnownTransactions}})</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="{{.KnownTransactions}}">All ({{.KnownTransactions}})</option>
                         {{end}}
                         {{end}}
                     </select>


### PR DESCRIPTION
Showing only the applicable page sizes on the address page
If 20rows are being returned, then the page size selector should not be shown.
If 95 rows were being returned, page size options should be 20, 95.
If 522 rows were being returned, page size options should be 20, 100, 522.
resolving https://github.com/decred/dcrdata/issues/360