### PR TITLE
address page: credit/debit txn filter

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/decred/dcrdata/db/dbtypes/internal"
 )
@@ -33,6 +34,49 @@ func (p TicketSpendType) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// AddrTxnType enumerates the different transaction types as displayed by the
+// address page.
+type AddrTxnType int
+
+const (
+	AddrTxnAll AddrTxnType = iota
+	AddrTxnCredit
+	AddrTxnDebit
+	AddrTxnUnknown
+)
+
+func (a AddrTxnType) String() string {
+	return AddrTxnTypes[a]
+}
+
+// AddrTxnTypeFromStr
+func AddrTxnTypeFromStr(txnType string) AddrTxnType {
+	txnType = strings.ToLower(txnType)
+	switch txnType {
+	case "all":
+		return AddrTxnAll
+	case "credit":
+		fallthrough
+	case "credits":
+		return AddrTxnCredit
+	case "debit":
+		fallthrough
+	case "debits":
+		return AddrTxnDebit
+	default:
+		return AddrTxnUnknown
+	}
+
+}
+
+// AddrTxnTypes is the canonical mapping from AddrTxnType to string.
+var AddrTxnTypes = map[AddrTxnType]string{
+	AddrTxnAll:     "all",
+	AddrTxnCredit:  "credit",
+	AddrTxnDebit:   "debit",
+	AddrTxnUnknown: "unknown",
 }
 
 type TicketPoolStatus int16

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -47,11 +47,19 @@ const (
 	AddrTxnUnknown
 )
 
+// AddrTxnTypes is the canonical mapping from AddrTxnType to string.
+var AddrTxnTypes = map[AddrTxnType]string{
+	AddrTxnAll:     "all",
+	AddrTxnCredit:  "credit",
+	AddrTxnDebit:   "debit",
+	AddrTxnUnknown: "unknown",
+}
+
 func (a AddrTxnType) String() string {
 	return AddrTxnTypes[a]
 }
 
-// AddrTxnTypeFromStr
+// AddrTxnTypeFromStr attempts to decode a string into an AddrTxnType.
 func AddrTxnTypeFromStr(txnType string) AddrTxnType {
 	txnType = strings.ToLower(txnType)
 	switch txnType {
@@ -69,14 +77,6 @@ func AddrTxnTypeFromStr(txnType string) AddrTxnType {
 		return AddrTxnUnknown
 	}
 
-}
-
-// AddrTxnTypes is the canonical mapping from AddrTxnType to string.
-var AddrTxnTypes = map[AddrTxnType]string{
-	AddrTxnAll:     "all",
-	AddrTxnCredit:  "credit",
-	AddrTxnDebit:   "debit",
-	AddrTxnUnknown: "unknown",
 }
 
 type TicketPoolStatus int16

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -132,7 +132,7 @@ func (pgb *ChainDB) GetBlockHash(idx int64) (string, error) {
 // GetAddressBalance returns a *explorer.AddressBalance for the specified
 // address, transaction count limit, and transaction number offset.
 func (pgb *ChainDB) GetAddressBalance(address string, N, offset int64) *explorer.AddressBalance {
-	_, balance, err := pgb.AddressHistory(address, N, offset)
+	_, balance, err := pgb.AddressHistoryAll(address, N, offset)
 	if err != nil {
 		return nil
 	}
@@ -143,7 +143,7 @@ func (pgb *ChainDB) GetAddressBalance(address string, N, offset int64) *explorer
 // (*apitypes.InsightAddressInfo), given a transaction count limit, and
 // transaction number offset.
 func (pgb *ChainDB) GetAddressInfo(address string, N, offset int64) *apitypes.InsightAddressInfo {
-	rows, balance, err := pgb.AddressHistory(address, N, offset)
+	rows, balance, err := pgb.AddressHistoryAll(address, N, offset)
 	if err != nil {
 		return nil
 	}

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -70,9 +70,12 @@ const (
 	SelectAddressLimitNByAddressSubQry = `WITH these as (SELECT * FROM addresses WHERE address=$1)
 		SELECT * FROM these order by id desc limit $2 offset $3;`
 
-	SelectAddressDebitsLimitNByAddress = `SELECT *
-		FROM addresses
-		WHERE address=$1 AND spending_tx_row_id IS NOT NULL
+	// SelectAddressDebitsLimitNByAddress = `SELECT *
+	// 	FROM addresses
+	// 	WHERE address=$1 AND spending_tx_row_id IS NOT NULL
+	// 	ORDER BY id DESC LIMIT $2 OFFSET $3;`
+	SelectAddressDebitsLimitNByAddress = `WITH these as (SELECT * FROM addresses WHERE address=$1)
+		SELECT * FROM these WHERE spending_tx_row_id IS NOT NULL
 		ORDER BY id DESC LIMIT $2 OFFSET $3;`
 	SelectAddressCreditsLimitNByAddress = `SELECT id, funding_tx_row_id, funding_tx_hash, funding_tx_vout_index, vout_row_id, value
 		FROM addresses

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -79,7 +79,7 @@ const (
 		ORDER BY id DESC LIMIT $2 OFFSET $3;`
 	SelectAddressCreditsLimitNByAddress = `SELECT id, funding_tx_row_id, funding_tx_hash, funding_tx_vout_index, vout_row_id, value
 		FROM addresses
-		WHERE address=$1 AND spending_tx_row_id IS NULL
+		WHERE address=$1
 		ORDER BY id DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -70,6 +70,15 @@ const (
 	SelectAddressLimitNByAddressSubQry = `WITH these as (SELECT * FROM addresses WHERE address=$1)
 		SELECT * FROM these order by id desc limit $2 offset $3;`
 
+	SelectAddressDebitsLimitNByAddress = `SELECT *
+		FROM addresses
+		WHERE address=$1 AND spending_tx_row_id IS NOT NULL
+		ORDER BY id DESC LIMIT $2 OFFSET $3;`
+	SelectAddressCreditsLimitNByAddress = `SELECT id, funding_tx_row_id, funding_tx_hash, funding_tx_vout_index, vout_row_id, value
+		FROM addresses
+		WHERE address=$1 AND spending_tx_row_id IS NULL
+		ORDER BY id DESC LIMIT $2 OFFSET $3;`
+
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses
 		WHERE funding_tx_hash=$1 and funding_tx_vout_index=$2;`
 	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -30,14 +30,6 @@ var (
 	zeroHashStringBytes = []byte(chainhash.Hash{}.String())
 )
 
-type AddrTxnType int
-
-const (
-	AddrTxnAll AddrTxnType = iota
-	AddrTxnCredit
-	AddrTxnDebit
-)
-
 // ChainDB provides an interface for storing and manipulating extracted
 // blockchain data in a PostgreSQL database.
 type ChainDB struct {
@@ -338,11 +330,15 @@ func (pgb *ChainDB) TransactionBlock(txID string) (string, uint32, int8, error) 
 	return blockHash, blockInd, tree, err
 }
 
+// AddressTransactions retrieves a slice of *dbtypes.AddressRow for a given
+// address and transaction type (i.e. all, credit, or debit) from the DB. Only
+// the first N transactions starting from the offset element in the set of
+// transactions of in the transaction class.
 func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
-	txnType AddrTxnType) (addressRows []*dbtypes.AddressRow, err error) {
+	txnType dbtypes.AddrTxnType) (addressRows []*dbtypes.AddressRow, err error) {
 	var addrFunc func(*sql.DB, string, int64, int64) ([]uint64, []*dbtypes.AddressRow, error)
 	switch txnType {
-	case AddrTxnAll:
+	case dbtypes.AddrTxnAll:
 		// The organization address occurs very frequently, so use the regular
 		// (non sub-query) select as it is much more efficient.
 		if address == pgb.devAddress {
@@ -350,9 +346,9 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 		} else {
 			addrFunc = RetrieveAddressTxns
 		}
-	case AddrTxnCredit:
+	case dbtypes.AddrTxnCredit:
 		addrFunc = RetrieveAddressCreditTxns
-	case AddrTxnDebit:
+	case dbtypes.AddrTxnDebit:
 		addrFunc = RetrieveAddressDebitTxns
 	default:
 		return nil, fmt.Errorf("Unknown AddrTxnType %v", txnType)
@@ -362,9 +358,17 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 	return
 }
 
-// AddressHistory queries the database for all rows of the addresses table for
-// the given address.
-func (pgb *ChainDB) AddressHistory(address string, N, offset int64) ([]*dbtypes.AddressRow, *explorer.AddressBalance, error) {
+// AddressHistoryAll queries the database for all rows of the addresses table
+// for the given address.
+func (pgb *ChainDB) AddressHistoryAll(address string, N, offset int64) ([]*dbtypes.AddressRow, *explorer.AddressBalance, error) {
+	return pgb.AddressHistory(address, N, offset, dbtypes.AddrTxnAll)
+}
+
+// AddressHistory queries the database for rows of the addresses table
+// containing values for a certain type of transaction (all, credits, or debits)
+// for the given address.
+func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
+	txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *explorer.AddressBalance, error) {
 
 	bb, err := pgb.HeightDB()
 	if err != nil {
@@ -372,70 +376,75 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64) ([]*dbtypes.
 	}
 	bestBlock := int64(bb)
 
-	pgb.addressCounts.Lock()
-	defer pgb.addressCounts.Unlock()
+	totals := pgb.addressCounts
+	totals.Lock()
+	defer totals.Unlock()
 
 	// See if address count cache includes a fresh count for this address.
 	var balanceInfo explorer.AddressBalance
 	var fresh bool
-	if pgb.addressCounts.validHeight == bestBlock {
-		balanceInfo, fresh = pgb.addressCounts.balance[address]
+	if totals.validHeight == bestBlock {
+		balanceInfo, fresh = totals.balance[address]
 	} else {
 		// StoreBlock should do this, but the idea is to clear the old cached
 		// results when a new block is encountered.
 		log.Warnf("Address receive counter stale, at block %d when best is %d.",
-			pgb.addressCounts.validHeight, bestBlock)
-		pgb.addressCounts.balance = make(map[string]explorer.AddressBalance)
-		pgb.addressCounts.validHeight = bestBlock
+			totals.validHeight, bestBlock)
+		totals.balance = make(map[string]explorer.AddressBalance)
+		totals.validHeight = bestBlock
 	}
 
-	addressRows, err := pgb.AddressTransactions(address, N, offset, AddrTxnAll)
-
-	// If the address receive count was not cached, store it in the cache if it
-	// is worth storing (when the length of the short list returned above is no
-	// less than the query limit).
-	if !fresh {
-		addrInfo := explorer.ReduceAddressHistory(addressRows)
-		if addrInfo == nil {
-			return addressRows, nil, fmt.Errorf("ReduceAddressHistory failed")
-		}
-
-		if addrInfo.NumFundingTxns < N {
-			balanceInfo = explorer.AddressBalance{
-				Address:      address,
-				NumSpent:     addrInfo.NumSpendingTxns,
-				NumUnspent:   addrInfo.NumFundingTxns - addrInfo.NumSpendingTxns,
-				TotalSpent:   int64(addrInfo.TotalSent),
-				TotalUnspent: int64(addrInfo.Unspent),
-			}
-		} else {
-			var numSpent, numUnspent, totalSpent, totalUnspent int64
-
-			numSpent, numUnspent, totalSpent, totalUnspent, err =
-				RetrieveAddressSpentUnspent(pgb.db, address)
-
-			if err != nil {
-				return nil, nil, err
-			}
-			balanceInfo = explorer.AddressBalance{
-				Address:      address,
-				NumSpent:     numSpent,
-				NumUnspent:   numUnspent,
-				TotalSpent:   totalSpent,
-				TotalUnspent: totalUnspent,
-			}
-		}
-
-		log.Infof("%s: %d spent totalling %f DCR, %d unspent totalling %f DCR",
-			address, balanceInfo.NumSpent, dcrutil.Amount(balanceInfo.TotalSpent).ToCoin(),
-			balanceInfo.NumUnspent, dcrutil.Amount(balanceInfo.TotalUnspent).ToCoin())
-		log.Infof("Caching address receive count for address %s: "+
-			"count = %d at block %d.", address,
-			balanceInfo.NumSpent+balanceInfo.NumUnspent, bestBlock)
-		pgb.addressCounts.balance[address] = balanceInfo
+	// Retrieve relevant transactions
+	addressRows, err := pgb.AddressTransactions(address, N, offset, txnType)
+	if err != nil {
+		return nil, nil, err
+	}
+	if fresh {
+		return addressRows, &balanceInfo, nil
 	}
 
-	return addressRows, &balanceInfo, err
+	// If the address receive count was not cached, compute it and store it in
+	// the cache.
+	addrInfo := explorer.ReduceAddressHistory(addressRows)
+	if addrInfo == nil {
+		return addressRows, nil, fmt.Errorf("ReduceAddressHistory failed")
+	}
+
+	// N is a limit on NumFundingTxns, so this checks if we have them all.
+	if addrInfo.NumFundingTxns < N && offset == 0 &&
+		(txnType == dbtypes.AddrTxnAll || txnType == dbtypes.AddrTxnDebit) {
+		balanceInfo = explorer.AddressBalance{
+			Address:      address,
+			NumSpent:     addrInfo.NumSpendingTxns,
+			NumUnspent:   addrInfo.NumFundingTxns - addrInfo.NumSpendingTxns,
+			TotalSpent:   int64(addrInfo.TotalSent),
+			TotalUnspent: int64(addrInfo.Unspent),
+		}
+	} else {
+		var numSpent, numUnspent, totalSpent, totalUnspent int64
+		numSpent, numUnspent, totalSpent, totalUnspent, err =
+			RetrieveAddressSpentUnspent(pgb.db, address)
+		if err != nil {
+			return nil, nil, err
+		}
+		balanceInfo = explorer.AddressBalance{
+			Address:      address,
+			NumSpent:     numSpent,
+			NumUnspent:   numUnspent,
+			TotalSpent:   totalSpent,
+			TotalUnspent: totalUnspent,
+		}
+	}
+
+	log.Infof("%s: %d spent totalling %f DCR, %d unspent totalling %f DCR",
+		address, balanceInfo.NumSpent, dcrutil.Amount(balanceInfo.TotalSpent).ToCoin(),
+		balanceInfo.NumUnspent, dcrutil.Amount(balanceInfo.TotalUnspent).ToCoin())
+	log.Infof("Caching address receive count for address %s: "+
+		"count = %d at block %d.", address,
+		balanceInfo.NumSpent+balanceInfo.NumUnspent, bestBlock)
+	totals.balance[address] = balanceInfo
+
+	return addressRows, &balanceInfo, nil
 }
 
 // FillAddressTransactions is used to fill out the transaction details in an

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -391,6 +391,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 			totals.validHeight, bestBlock)
 		totals.balance = make(map[string]explorer.AddressBalance)
 		totals.validHeight = bestBlock
+		balanceInfo.Address = address
 	}
 	totals.Unlock()
 
@@ -463,7 +464,6 @@ func (pgb *ChainDB) FillAddressTransactions(addrInfo *explorer.AddressInfo) erro
 		if err != nil {
 			return err
 		}
-		txn.TxID = dbTx.TxID
 		txn.FormattedSize = humanize.Bytes(uint64(dbTx.Size))
 		txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()
 		txn.Time = dbTx.BlockTime

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -769,6 +769,11 @@ func RetrieveAddressTxnsAlt(db *sql.DB, address string, N, offset int64) ([]uint
 		internal.SelectAddressLimitNByAddress)
 }
 
+func RetrieveAddressDebitTxns(db *sql.DB, address string, N, offset int64) ([]uint64, []*dbtypes.AddressRow, error) {
+	return retrieveAddressTxns(db, address, N, offset,
+		internal.SelectAddressDebitsLimitNByAddress)
+}
+
 func retrieveAddressTxns(db *sql.DB, address string, N, offset int64,
 	statement string) ([]uint64, []*dbtypes.AddressRow, error) {
 	rows, err := db.Query(statement, address, N, offset)
@@ -810,6 +815,33 @@ func scanAddressQueryRows(rows *sql.Rows) (ids []uint64, addressRows []*dbtypes.
 			addr.VinDbID = uint64(vinDbID.Int64)
 		}
 
+		ids = append(ids, id)
+		addressRows = append(addressRows, &addr)
+	}
+	return
+}
+
+func RetrieveAddressCreditTxns(db *sql.DB, address string, N, offset int64) (ids []uint64, addressRows []*dbtypes.AddressRow, err error) {
+	var rows *sql.Rows
+	rows, err = db.Query(internal.SelectAddressCreditsLimitNByAddress, address, N, offset)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := rows.Close(); e != nil {
+			log.Errorf("Close of Query failed: %v", e)
+		}
+	}()
+
+	for rows.Next() {
+		var id uint64
+		var addr dbtypes.AddressRow
+		err = rows.Scan(&id, &addr.FundingTxDbID, &addr.FundingTxHash,
+			&addr.FundingTxVoutIndex, &addr.VoutDbID, &addr.Value)
+		if err != nil {
+			return
+		}
+		addr.Address = address
 		ids = append(ids, id)
 		addressRows = append(addressRows, &addr)
 	}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -937,7 +937,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	for i := range data.Vout {
 		if len(data.Vout[i].ScriptPubKey.Addresses) != 0 {
 			if data.Vout[i].ScriptPubKey.Addresses[0] == address {
-				tx.RecievedTotal += data.Vout[i].Value
+				tx.ReceivedTotal += data.Vout[i].Value
 			}
 		}
 	}
@@ -1258,9 +1258,9 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 			}
 		}
 	}
-	numberMaxOfTx := int64(len(txs))
-	var numTxns = count
-	if numberMaxOfTx < count {
+
+	numTxns, numberMaxOfTx := count, int64(len(txs))
+	if numTxns > numberMaxOfTx {
 		numTxns = numberMaxOfTx
 	}
 	balance := &explorer.AddressBalance{
@@ -1272,19 +1272,21 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 	}
 	return &explorer.AddressInfo{
 		Address:           address,
-		Limit:             count,
 		MaxTxLimit:        maxcount,
+		Limit:             count,
 		Offset:            offset,
+		NumUnconfirmed:    numUnconfirmed,
 		Transactions:      addressTxs,
 		NumTransactions:   numTxns,
+		NumFundingTxns:    numReceiving,
+		NumSpendingTxns:   numSpending,
+		AmountReceived:    totalreceived,
+		AmountSent:        totalsent,
+		AmountUnspent:     totalreceived - totalsent,
+		Balance:           balance,
 		KnownTransactions: numberMaxOfTx,
 		KnownFundingTxns:  numReceiving,
-		NumSpendingTxns:   numSpending,
-		NumUnconfirmed:    numUnconfirmed,
-		TotalReceived:     totalreceived,
-		TotalSent:         totalsent,
-		Unspent:           totalreceived - totalsent,
-		Balance:           balance,
+		KnownSpendingTxns: numSpending,
 	}
 }
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -57,7 +57,7 @@ type explorerDataSource interface {
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
 	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
-	AddressHistory(address string, N, offset int64) ([]*dbtypes.AddressRow, *AddressBalance, error)
+	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *AddressBalance, error)
 	FillAddressTransactions(addrInfo *AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)
 }
@@ -270,7 +270,8 @@ func (exp *explorerUI) updateDevFundBalance() {
 	exp.NewBlockDataMtx.Lock()
 	defer exp.NewBlockDataMtx.Unlock()
 
-	_, devBalance, err := exp.explorerSource.AddressHistory(exp.ExtraInfo.DevAddress, 1, 0)
+	_, devBalance, err := exp.explorerSource.AddressHistory(
+		exp.ExtraInfo.DevAddress, 1, 0, dbtypes.AddrTxnAll)
 	if err == nil && devBalance != nil {
 		exp.ExtraInfo.DevFund = devBalance.TotalUnspent
 	} else {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
@@ -367,8 +368,9 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				exp.ErrorPage(w, "Something went wrong...", "that address has no history", true)
 				return
 			}
-			// No transactions
+			// No mined transactions
 			addrData = new(AddressInfo)
+			addrData.Address = address
 		}
 
 		// Set page parameters
@@ -410,7 +412,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		}
 		addrData.NumUnconfirmed, err = exp.blockData.CountUnconfirmedTransactions(address, MaxUnconfirmedPossible)
 		if err != nil {
-			log.Warnf("SearchRawTransactionsForUnconfirmedTransactions failed for address %s: %v", address, err)
+			log.Warnf("CountUnconfirmedTransactions failed for address %s: %v", address, err)
 		}
 	}
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -290,6 +290,13 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		offsetAddrOuts = 0
 	}
 
+	// Transaction types to show.
+	txntype := r.URL.Query().Get("txntype")
+	if txntype == "" {
+		txntype = "all"
+	}
+	log.Debugf("Showing transaction types: %s", txntype)
+
 	var addrData *AddressInfo
 	if exp.liteMode {
 		addrData = exp.blockData.GetExplorerAddress(address, limitN, offsetAddrOuts)
@@ -302,6 +309,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		// Get addresses table rows for the address
 		addrHist, balance, errH := exp.explorerSource.AddressHistory(
 			address, limitN, offsetAddrOuts)
+		// Fallback to RPC if DB query fails
 		if errH != nil {
 			log.Errorf("Unable to get address %s history: %v", address, errH)
 			addrData = exp.blockData.GetExplorerAddress(address, limitN, offsetAddrOuts)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -324,6 +324,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				exp.ErrorPage(w, "Something went wrong...", "could not find that address", true)
 				return
 			}
+			addrData.TxnType = txnType.String()
 			confirmHeights := make([]int64, len(addrData.Transactions))
 			addrData.Fullmode = true
 			pageData := struct {
@@ -357,6 +358,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			}
 			addrData = new(AddressInfo)
 		}
+		addrData.TxnType = txnType.String()
 		addrData.Limit, addrData.Offset = limitN, offsetAddrOuts
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.Balance = balance
@@ -413,7 +415,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html")
-	w.Header().Set("Turbolinks-Location", "/address/"+address)
+	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, str)
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -333,7 +333,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				exp.ErrorPage(w, "Something went wrong...", "could not find that address", true)
 				return
 			}
-			addrData.TxnType = txnType.String()
 			addrData.Fullmode = true
 
 			confirmHeights := make([]int64, len(addrData.Transactions))

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -361,11 +361,13 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		// Generate AddressInfo skeleton from the address table rows
 		addrData = ReduceAddressHistory(addrHist)
 		if addrData == nil {
+			// Empty history is not expected for credit txnType with any txns.
 			if txnType != dbtypes.AddrTxnDebit && (balance.NumSpent+balance.NumUnspent) > 0 {
 				log.Debugf("empty address history (%s): n=%d&start=%d", address, limitN, offsetAddrOuts)
 				exp.ErrorPage(w, "Something went wrong...", "that address has no history", true)
 				return
 			}
+			// No transactions
 			addrData = new(AddressInfo)
 		}
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -51,11 +51,16 @@ type AddressTx struct {
 	SentTotal     float64
 }
 
+// IOID formats an identification string for the transaction input (or output)
+// represented by the AddressTx.
 func (a *AddressTx) IOID() string {
+	// When AddressTx is used properly, at least one of ReceivedTotal or
+	// SentTotal should be zero.
 	if a.ReceivedTotal > a.SentTotal {
 		// an outpoint receiving funds
 		return fmt.Sprintf("%s:out[%d]", a.TxID, a.InOutID)
 	}
+	// a transaction input referencing an outpoint being spent
 	return fmt.Sprintf("%s:in[%d]", a.TxID, a.InOutID)
 }
 
@@ -76,6 +81,7 @@ type TxInfo struct {
 	TicketInfo
 }
 
+// TicketInfo is used to represent data shown for a sstx transaction.
 type TicketInfo struct {
 	TicketMaturity       int64
 	TimeTillMaturity     float64 // Time before a particular ticket reaches maturity
@@ -341,6 +347,7 @@ type WebsocketBlock struct {
 	Extra *HomeInfo   `json:"extra"`
 }
 
+// TicketPoolInfo describes the live ticket pool
 type TicketPoolInfo struct {
 	Size          uint32  `json:"size"`
 	Value         float64 `json:"value"`

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -175,6 +175,14 @@ type AddressInfo struct {
 	Fullmode          bool
 }
 
+// TxnCount returns the number of transaction "rows" available.
+func (a *AddressInfo) TxnCount() int64 {
+	if a.Fullmode {
+		return a.KnownFundingTxns
+	}
+	return a.KnownTransactions
+}
+
 // AddressBalance represents the number and value of spent and unspent outputs
 // for an address.
 type AddressBalance struct {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -206,6 +206,9 @@ type AddressInfo struct {
 
 // TxnCount returns the number of transaction "rows" available.
 func (a *AddressInfo) TxnCount() int64 {
+	if !a.Fullmode {
+		return a.KnownTransactions
+	}
 	switch dbtypes.AddrTxnTypeFromStr(a.TxnType) {
 	case dbtypes.AddrTxnAll:
 		return a.KnownTransactions

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -157,6 +157,7 @@ type AddressInfo struct {
 	Limit             int64
 	MaxTxLimit        int64
 	Offset            int64
+	TxnType           string
 	Transactions      []*AddressTx
 	NumFundingTxns    int64 // The number of transactions paying to the address
 	NumSpendingTxns   int64 // The number of transactions spending from the address

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017, The Dcrdata developers
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
 package explorer

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -124,7 +124,7 @@
                         </nav>
                     </div>
                     {{else}}
-                    <span class="fs12 nowrap text-right">{{intComma $TxnCount}} transaction{{if gt .KnownTransactions 1}}s{{end}}</span>
+                    <span class="fs12 nowrap text-right">{{intComma $TxnCount}} transaction{{if gt $TxnCount 1}}s{{end}}</span>
                     {{end}}
                 </div>
                 {{if .Transactions}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {{with .Data}}
+{{$NumTxns := .TxnCount}}
 {{template "html-head" printf "Decred Address %s" .Address}}
 <body>
     {{$heights := $.ConfirmHeight}}
@@ -110,14 +111,14 @@
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}"
+                                        href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}&txntype={{.TxnType}}"
                                         id="prev"
                                     >Previous</a>
                                 </li>
                                 <li class="page-item {{if lt (subtract .KnownTransactions .Offset) (add .Limit 1)}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}"
+                                        href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}&txntype={{.TxnType}}"
                                         id="next">
                                         Next
                                     </a>
@@ -212,15 +213,11 @@
                         <option {{if eq .TxnType "debit"}}selected{{end}} value="debit">Debits</option>
                     </select>
                 </div>
-                {{if ge .KnownTransactions .MaxTxLimit}}
-                {{if not .Fullmode}}
+                {{if and (not .Fullmode) (ge .KnownTransactions .MaxTxLimit)}}
                 <div>
-                    *Limit of 1000 transactions shown in lite mode.
+                    *Limit of {{.MaxTxLimit}} transactions shown in lite mode.
                 </div>
                 {{end}}
-                {{end}}
-                {{if .Fullmode}}
-                {{if gt .KnownFundingTxns 20}}
                 <div
                     id="pagesize-wrapper"
                     class="hidden d-flex align-items-center justify-content-end"
@@ -229,52 +226,23 @@
                     <select
                         name="pagesize"
                         id="pagesize"
-                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $NumTxns 20}}disabled{{end}}"
+                        {{if lt $NumTxns 20}}disabled="disabled"{{end}}>
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
-                        {{if ge .KnownFundingTxns 100}}
+                        {{if ge $NumTxns 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit .KnownFundingTxns}}selected{{end}} value="{{.KnownFundingTxns}}">All ({{.KnownFundingTxns}})</option>
+                        <option {{if eq .Limit $NumTxns}}selected{{end}} value="{{$NumTxns}}">All ({{$NumTxns}})</option>
                         {{end}}
-                        {{if gt .KnownFundingTxns 100}}
-                        {{if ge .KnownFundingTxns 1000}}
+                        {{if gt $NumTxns 100}}
+                        {{if ge $NumTxns 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit .KnownFundingTxns}}selected{{end}} value="{{.KnownFundingTxns}}">All ({{.KnownFundingTxns}})</option>
+                        <option {{if eq .Limit $NumTxns}}selected{{end}} value="{{$NumTxns}}">All ({{$NumTxns}})</option>
                         {{end}}
                         {{end}}
                     </select>
                 </div>
-                {{end}}
-                {{else}}
-                {{if gt .KnownTransactions 20}}
-                <div
-                    id="pagesize-wrapper"
-                    class="hidden d-flex align-items-center justify-content-end"
-                >
-                    <label class="mb-0 mr-1" for="pagesize">Page size</label>
-                    <select
-                        name="pagesize"
-                        id="pagesize"
-                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
-                        <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
-                        {{if ge .KnownTransactions 100}}
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
-                        {{else}}
-                        <option {{if eq .Limit .KnownTransactions}}selected{{end}} value="{{.KnownTransactions}}">All ({{.KnownTransactions}})</option>
-                        {{end}}
-                        {{if gt .KnownTransactions 100}}
-                        {{if ge .KnownTransactions 1000}}
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
-                        {{else}}
-                        <option {{if eq .Limit .KnownTransactions}}selected{{end}} value="{{.KnownTransactions}}">All ({{.KnownTransactions}})</option>
-                        {{end}}
-                        {{end}}
-                    </select>
-                </div>
-                {{end}}
-                {{end}}
-
             </div>
         </div>
     </div>
@@ -285,7 +253,8 @@
         $("#pagesize").change(function(ev) {
             Turbolinks.visit(
                 window.location.pathname
-                + "?n="+ parseInt($(ev.currentTarget).val())
+                + "?txntype="+ $("#txntype").val()
+                + "&n="+ parseInt($(ev.currentTarget).val())
                 + "&start=" + {{.Offset}}
             )
         })

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -200,7 +200,9 @@
                     <select
                         name="txntype"
                         id="txntype"
-                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if not .Fullmode}}disabled{{end}}"
+                        {{if not .Fullmode}}disabled="disabled"{{end}}
+                    >
                         <option {{if eq .TxnType "all"}}selected{{end}} value="all">All</option>
                         <option {{if eq .TxnType "credit"}}selected{{end}} value="credit">Credits</option>
                         <option {{if eq .TxnType "debit"}}selected{{end}} value="debit">Debits</option>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -198,6 +198,20 @@
                 </table>
                 {{end}}
 
+                <div
+                    id="txntype-wrapper"
+                    class="d-flex align-items-center justify-content-end"
+                >
+                    <label class="mb-0 mr-1" for="txntype">Type</label>
+                    <select
+                        name="txntype"
+                        id="txntype"
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                        <option {{if eq .TxnType "all"}}selected{{end}} value="all">All</option>
+                        <option {{if eq .TxnType "credit"}}selected{{end}} value="credit">Credits</option>
+                        <option {{if eq .TxnType "debit"}}selected{{end}} value="debit">Debits</option>
+                    </select>
+                </div>
                 {{if ge .KnownTransactions .MaxTxLimit}}
                 {{if not .Fullmode}}
                 <div>
@@ -276,6 +290,15 @@
             )
         })
         {{end}}
+
+        $("#txntype").change(function(ev) {
+            Turbolinks.visit(
+                window.location.pathname
+                + "?txntype="+ $(ev.currentTarget).val()
+                + "?n="+ parseInt($("#pagesize").val())
+                + "&start=" + {{.Offset}}
+            )
+        })
 
         function showAddressQRCode() {
             var $qrcode = $("#address-qrcode")

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -295,7 +295,7 @@
             Turbolinks.visit(
                 window.location.pathname
                 + "?txntype="+ $(ev.currentTarget).val()
-                + "?n="+ parseInt($("#pagesize").val())
+                + "&n="+ parseInt($("#pagesize").val())
                 + "&start=" + {{.Offset}}
             )
         })

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {{with .Data}}
-{{$NumTxns := .TxnCount}}
+{{$TxnCount := .TxnCount}}
 {{template "html-head" printf "Decred Address %s" .Address}}
 <body>
     {{$heights := $.ConfirmHeight}}
@@ -94,17 +94,14 @@
         <div class="row">
             <div class="col">
                 <div class="d-flex flex-wrap align-items-center justify-content-end mb-1">
-                    <h5 class="mr-auto mb-0">Transactions</h5>
+                    <h5 class="mr-auto mb-0">History</h5>
                     {{if lt .NumTransactions .KnownTransactions}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
-                        {{if .Fullmode}}
-                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} of {{intComma .KnownFundingTxns}} funding transactions
-                        {{else}}
-                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of {{intComma .KnownTransactions}} transactions
-                            {{if ge .KnownTransactions .MaxTxLimit}}
+                        <span class="fs12 nowrap text-right">
+                            {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of {{intComma $TxnCount}} transactions
+                            {{if and (not .Fullmode) (ge .KnownTransactions .MaxTxLimit)}}
                             <sup>*</sup>
                             {{end}}
-                        {{end}}
                         </span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
@@ -127,17 +124,13 @@
                         </nav>
                     </div>
                     {{else}}
-                    {{if .Fullmode}}
-                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} funding transaction{{if gt .KnownFundingTxns 1}}s{{end}}</span>
-                    {{else}}
-                    <span class="fs12 nowrap text-right">{{intComma .KnownTransactions}} transaction{{if gt .KnownTransactions 1}}s{{end}}</span>
-                    {{end}}
+                    <span class="fs12 nowrap text-right">{{intComma $TxnCount}} transaction{{if gt .KnownTransactions 1}}s{{end}}</span>
                     {{end}}
                 </div>
                 {{if .Transactions}}
                 <table class="table table-mono-cells table-sm striped">
                     <thead>
-                        <th>Transactions ID</th>
+                        <th>Input/Output ID</th>
                         <th class="text-right">Credit DCR</th>
                         <th>Debit DCR</th>
                         <th>Time</th>
@@ -149,9 +142,9 @@
                         {{range $i, $v := .Transactions}}
                         <tr>
                             {{with $v}}
-                            <td><a href="/tx/{{.TxID}}" class="hash">{{.TxID}}</a></td>
-                            {{if ne .RecievedTotal 0.0}}
-                                <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .RecievedTotal false)}}</td>
+                            <td><a href="/tx/{{.TxID}}" class="hash">{{.IOID}}</a></td>
+                            {{if ne .ReceivedTotal 0.0}}
+                                <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal false)}}</td>
                             {{else}}
                                 {{if eq .SentTotal 0.0}}
                                 <td class="text-right">sstxcommitment</td>
@@ -226,19 +219,20 @@
                     <select
                         name="pagesize"
                         id="pagesize"
-                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $NumTxns 20}}disabled{{end}}"
-                        {{if lt $NumTxns 20}}disabled="disabled"{{end}}>
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}}"
+                        {{if lt $TxnCount 20}}disabled="disabled"{{end}}
+                    >
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
-                        {{if ge $NumTxns 100}}
+                        {{if ge $TxnCount 100}}
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         {{else}}
-                        <option {{if eq .Limit $NumTxns}}selected{{end}} value="{{$NumTxns}}">All ({{$NumTxns}})</option>
+                        <option {{if eq .Limit $TxnCount}}selected{{end}} value="{{$TxnCount}}">All ({{$TxnCount}})</option>
                         {{end}}
-                        {{if gt $NumTxns 100}}
-                        {{if ge $NumTxns 1000}}
+                        {{if gt $TxnCount 100}}
+                        {{if ge $TxnCount 1000}}
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         {{else}}
-                        <option {{if eq .Limit $NumTxns}}selected{{end}} value="{{$NumTxns}}">All ({{$NumTxns}})</option>
+                        <option {{if eq .Limit $TxnCount}}selected{{end}} value="{{$TxnCount}}">All ({{$TxnCount}})</option>
                         {{end}}
                         {{end}}
                     </select>


### PR DESCRIPTION
This provides a major overhaul to the full-mode address page.   The main introduced change is, a new drop-down listbox on the address page with the following options: "All", "Credit", and "Debit".

Other related changes:

The page size logic in the address html template is also simplified.
The problem of URL query params disappearing was related to the solution we used for handling redirects from the search page.  Instead of:

```go
w.Header().Set("Turbolinks-Location", "/address/"+address)
```

we should use:

```go
w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
```

This will include the path, as before, but also include the URL queries (e.g. `?txntype=credit&n=20&start=0`).

Resolves issue #377 .