### PR TITLE
explorer/websocket: avoid repeatedly unregistering a websocket client

### DIFF
--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -47,8 +47,9 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				msg := &WebSocketMessage{}
 				ws.SetReadDeadline(time.Now().Add(wsReadTimeout))
 				if err := websocket.JSON.Receive(ws, &msg); err != nil {
-					log.Warnf("websocket client receive error: %v", err)
-					exp.wsHub.UnregisterClient(&updateSig)
+					if err.Error() != "EOF" {
+						log.Warnf("websocket client receive error: %v", err)
+					}
 					return
 				}
 
@@ -134,8 +135,6 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				// response to (http.CloseNotifier).CloseNotify() and only then if
 				// the hub has somehow lost track of the client.
 				if !ok {
-					//ws.WriteClose(1)
-					exp.wsHub.UnregisterClient(&updateSig)
 					break loop
 				}
 


### PR DESCRIPTION
The send and receive loops in `RootWebsocket` were both running
`(*WebsocketHub).UnregisterClient`.  In addition, `RootWebsocket` had a
`defer` running `UnregisterClient`. Only the deferred call is needed. 
Remove the other two.

In the receive loop, a warning was always issued when `JSON.Receive`
returned a non-nil error.  However, when a client is lost, `"EOF"` is
expected, so do not log in this case.