### PR TITLE
main: check network is the expected one

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,12 @@ func mainCore() error {
 	log.Infof("Connected to dcrd (JSON-RPC API v%s) on %v",
 		nodeVer.String(), curnet.String())
 
+	if curnet != activeNet.Net {
+		log.Criticalf("Network of connected node, %s, does not match expected "+
+			"network, %s.", activeNet.Net, curnet)
+		return fmt.Errorf("expected network %s, got %s", activeNet.Net, curnet)
+	}
+
 	// Sqlite output
 	dbPath := filepath.Join(cfg.DataDir, cfg.DBFileName)
 	dbInfo := dcrsqlite.DBInfo{FileName: dbPath}


### PR DESCRIPTION
This prevents dcrdata from using a network node for a network (mainnet, testnet, simnet) that does not match the network specified with dcrdata's flags (e.g. --mainnet).

Previously, one could use `--testnet`, while the config file specifed `dcrdserv=host:19109` (i.e. likely a testnet node) and dcrdata would do it's best, eventually throwing hard to diagnose errors.

Now, dcrdata refuses to operate:

```
[CRT] DATD: Network of connected node, TestNet2, does not match expected network, MainNet.
[INF] DATD: Closing connection to dcrd.
[INF] DATD: Bye!
[ERR] DATD: expected network TestNet2, got MainNet
```

This resolves issue #387 .