### PR TITLE
README.md: syntax and appdata changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,27 +110,32 @@ Then edit dcrdata.conf with your dcrd RPC settings. See the output of `dcrdata
 
 If dcrdata has not previously been run with the PostgreSQL database backend, it
 is necessary to perform a bulk import of blockchain data and generate table
-indexes. This will be done automatically by dcrdata, but the PostgreSQL tables
-may also be generated with the `rebuilddb2` command line tool:
+indexes. *This will be done automatically by `dcrdata`* on a fresh startup.
 
-- Create the dcrdata user and database in PostgreSQL (tables will be created automatically).
-- Set your PostgreSQL credentials and host in both `./cmd/rebuilddb2/rebuilddb2.conf` and `./dcrdata.conf`.
-- Run `rebuilddb2 -u` to bulk import and index.
-- In case of errors, or schema changes, the tables may be dropped with `rebuilddb2 -D`.
+Alternatively, the PostgreSQL tables may also be generated with the `rebuilddb2`
+command line tool:
+
+* Create the dcrdata user and database in PostgreSQL (tables will be created automatically).
+* Set your PostgreSQL credentials and host in both `./cmd/rebuilddb2/rebuilddb2.conf`,
+  and `dcrdata.conf` in the location specified by the `appdata` flag.
+* Run `./rebuilddb2` to bulk import data and index the tables.
+* In case of irrecoverable errors, such as detected schema changes without an
+  upgrade path, the tables and their indexes may be dropped with `rebuilddb2 -D`.
 
 ### Starting dcrdata
 
 Launch the dcrdata daemon and allow the databases to process new blocks. Both
 SQLite and PostgreSQL synchronization require about an hour the first time
-dcrdata is run, but they will be done concurrently. On subsequent launches, only
-blocks new to dcrdata are scanned.
+dcrdata is run, but they are done concurrently. On subsequent launches, only
+blocks new to dcrdata are processed.
 
 ```bash
-./dcrdata    # don't forget to configure dcrdata.conf in this folder
+./dcrdata    # don't forget to configure dcrdata.conf in the appdata folder!
 ```
 
-The "public" and "views" folders *must* be in the same folder as the `dcrdata`
-executable.
+Unlike dcrdata.conf, which must be placed in the `appdata` folder or explicitly
+set with `-C`, the "public" and "views" folders *must* be in the same folder as
+the `dcrdata` executable.
 
 ## dcrdata daemon
 
@@ -180,7 +185,6 @@ API endpoints are currently prefixed with `/api`** (e.g.
 | Transactions | `/block/best/tx` |
 | Transactions Count | `/block/best/tx/count` |
 | Verbose block result | `/block/best/verbose` |
-
 
 | Block X (block index) | |
 | --- | --- |
@@ -385,6 +389,14 @@ Yes, please! See the CONTRIBUTING.md file for details, but here's the gist of it
 1. Code something great.
 1. Commit and push to your repo.
 1. Create a [pull request](https://github.com/decred/dcrdata/compare).
+
+Before committing any changes to the Gopkg.lock file, you must update `dep` to
+the latest version via:
+
+    go get -u github.com/golang/dep/cmd/dep
+
+**To update `dep` from the network, it is important to use the `-u` flag as
+shown above.**
 
 Note that all dcrdata.org community and team members are expected to adhere to
 the code of conduct, described in the CODE_OF_CONDUCT file.

--- a/cmd/rebuilddb2/README.md
+++ b/cmd/rebuilddb2/README.md
@@ -1,8 +1,11 @@
 # Command line app `rebuilddb2`
 
-The `rebuilddb2` app is used for maintenance of dcrdata's `dcrpg` database (a.k.a. DB v2) that uses PostgreSQL to store a nearly complete record of the Decred blockchain data.
+The `rebuilddb2` app is used for maintenance of dcrdata's `dcrpg` database that
+uses PostgreSQL to store a nearly complete record of the Decred blockchain data.
 
-**IMPORTANT**: When performing a bulk data import (e.g. full chain scan from genesis block), be sure to configure PostgreSQL appropriately.  Please see [postgresql-tuning.conf](../../db/dcrpg/postgresql-tuning.conf) for tips.
+**IMPORTANT**: When performing a bulk data import (e.g. full chain scan from
+genesis block), be sure to configure PostgreSQL appropriately.  Please see
+[postgresql-tuning.conf](../../db/dcrpg/postgresql-tuning.conf) for tips.
 
 ## Installation
 
@@ -31,32 +34,32 @@ Be able to build dcrdata (see [../../README.md](../../README.md#build-from-sourc
 
 ## Usage
 
-First edit rebuilddb2.conf, using sample-rebuilddb2.conf to start.  You will need to follow a typical PostgreSQL setup process, creating a new database/scheme and a new role that has permissions/owns that database.
+First edit rebuilddb2.conf, using sample-rebuilddb2.conf to start.  You will
+need to follow a typical PostgreSQL setup process, creating a new
+database/scheme and a new role that has permissions/owns that database.
 
 A fresh rebuild of the database is accomplished via:
 
 ```
 ./rebuilddb2 -D  # drop any existing tables
-./rebuilddb2 -u  # rebuild tables, and update (-u) address table from scratch
+./rebuilddb2     # rebuild tables from scratch
 ```
 
-Running without `-u` is only appropriate when the tables are behind the network's current best block by **at most** a few thousand blocks.  Otherwise, run with `-u` to recreate the address table in a more efficient batch process.
-
-Remember to update your PostgreSQL config (postgresql.conf) before *and after* bulk data imports. Namely, before normal dcrdata operation, ensure that `fsync=true` and other setting are adjusted for efficient queries.
-
-Use the `--help` flag for more information.
+Remember to update your PostgreSQL config (postgresql.conf) before *and after*
+bulk data imports. Namely, before normal dcrdata operation, ensure that
+`fsync=true` and other setting are adjusted for efficient queries.
 
 ## Details
 
 Rebuilding the dcrdata tables from scratch involves the following steps:
 
 * Connect to the PostgreSQL database using the settings in rebuilddb2.conf
-* Create tables: "blocks", "transactions", "vins", "vouts", and "addresses".
+* Create the tables (i.e. "blocks", "transactions", "vins", etc).
 * Starting from genesis block, process each block and store in tables.
-* If `-u` is not specified, a relatively expensive process is used to keep the spending transaction information up-to-date in the "addresses" table.
-* If `-u` is specified, updating this part of the "addresses" table is deferred until after all other tables are populated and indexes for faster queries.
+* Create indexes for each table.
+
+See `rebuilddb2 --help` for more information on how to tweak the operating mode.
 
 ## License
 
 See [LICENSE](../../LICENSE) at the base of the dcrdata repository.
-


### PR DESCRIPTION
There is no longer a `-u` flag for rebuilddb2.

- dcrdata.conf lives in `appdata` now.

- Remind developers to update the dep binary prior to committing changes
to Gopkg.lock

- Cleanup and wrapping