### PR TITLE
ChainDB/rebuilddb2: add to ChainDB the ability to set a StakeDatabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dcrdata.sqlt.db*
 rebuilddb.conf
 rebuilddb2.conf
 cmd/rebuilddb/rebuilddb
+cmd/rebuilddb2/rebuilddb2
+rebuild_data/
 cmd/scanblocks/scanblocks
 fullscan.json
 *.swp

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, The dcrdata developers
+// See LICENSE for details.
+
 package main
 
 import (
@@ -5,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	flags "github.com/btcsuite/go-flags"
@@ -134,12 +139,13 @@ func loadConfig() (*config, error) {
 	}
 
 	// Show the version and exit if the version flag was specified.
-	// appName := filepath.Base(os.Args[0])
-	// appName = strings.TrimSuffix(appName, filepath.Ext(appName))
-	// if preCfg.ShowVersion {
-	// 	fmt.Println(appName, "version", ver.String())
-	// 	os.Exit(0)
-	// }
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	if preCfg.ShowVersion {
+		fmt.Printf("%s version %s (Go version %s, %s-%s)\n", appName,
+			ver.String(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		os.Exit(0)
+	}
 
 	// Load additional config from file.
 	var configFileError error

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, The dcrdata developers
+// See LICENSE for details.
+
 package main
 
 import (

--- a/cmd/rebuilddb2/version.go
+++ b/cmd/rebuilddb2/version.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, The dcrdata developers
+// See LICENSE for details.
+
+package main
+
+import "fmt"
+
+type version struct {
+	Major, Minor, Patch int
+	Label               string
+	Nick                string
+}
+
+var ver = version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+	Label: ""}
+
+// CommitHash may be set on the build command line:
+// go build -ldflags "-X main.CommitHash=`git rev-parse --short HEAD`"
+var CommitHash string
+
+const appName string = "rebuilddb2"
+
+func (v *version) String() string {
+	var hashStr string
+	if CommitHash != "" {
+		hashStr = "+" + CommitHash
+	}
+	if v.Label != "" {
+		return fmt.Sprintf("%d.%d.%d-%s%s",
+			v.Major, v.Minor, v.Patch, v.Label, hashStr)
+	}
+	return fmt.Sprintf("%d.%d.%d%s",
+		v.Major, v.Minor, v.Patch, hashStr)
+}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -177,6 +177,13 @@ func (pgb *ChainDB) Close() error {
 	return pgb.db.Close()
 }
 
+// UseStakeDB is used to assign a stakedb.StakeDatabase for ticket tracking.
+// This may be useful when it is necessary to construct a ChainDB prior to
+// creating or loading a StakeDatabase, such as when dropping tables.
+func (pgb *ChainDB) UseStakeDB(stakeDB *stakedb.StakeDatabase) {
+	pgb.stakeDB = stakeDB
+}
+
 // EnableDuplicateCheckOnInsert specifies whether SQL insertions should check
 // for row conflicts (duplicates), and avoid adding or updating.
 func (pgb *ChainDB) EnableDuplicateCheckOnInsert(dupCheck bool) {


### PR DESCRIPTION
Modify rebuilddb2 to load the `StakeDatabase` (and ticket pool db) *after*
creating the `ChainDB` so that it is not necessary to load the ticket pool
db when only using `ChainDB` to drop tables.

Add "rebuild_data/" to .gitignore.