### PR TITLE
html templates: Do not automatically request to enable desktop ntfns

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -394,47 +394,48 @@
             Turbolinks.visit("/search?search="+this.value);
             return false;
         }
-}
-    function desktopNotifyNewBlock (block) {
-            function onShowNotification () {
-                console.log('block ntfn shown');
-            }
-            function onCloseNotification () {
-                console.log('block ntfn closed');
-            }
-            function onClickNotification () {
-                console.log('block ntfn clicked');
-            }
-            function onErrorNotification () {
-                console.error('Error showing notification. You may need to request permission.');
-            }
-            function onPermissionGranted () {
-                console.log('Permission has been granted by the user');
-                doNotification();
-            }
-            function onPermissionDenied () {
-                console.warn('Permission has been denied by the user');
-            }
-            function doNotification () {
-                var newBlockNtfn = new Notify('New Decred Block Mined', {
-                    body: 'Decred block mined at height ' + block.height,
-                    tag: 'blockheight',
-                    image: '/images/dcrdata144x128.png',
-                    icon: '/images/dcrdata144x128.png',
-                    notifyShow: onShowNotification,
-                    notifyClose: onCloseNotification,
-                    notifyClick: onClickNotification,
-                    notifyError: onErrorNotification,
-                    timeout: 10
-                });
-                newBlockNtfn.show();
-            }
-            if (!Notify.needsPermission) {
-                doNotification();
-            } else if (Notify.isSupported()) {
-                Notify.requestPermission(onPermissionGranted, onPermissionDenied);
-            }
+    }
+
+    // desktop notifications
+    function onShowNotification() {
+        console.log('block ntfn shown');
+    }
+    function onCloseNotification() {
+        console.log('block ntfn closed');
+    }
+    function onClickNotification() {
+        console.log('block ntfn clicked');
+    }
+    function onErrorNotification() {
+        console.error('Error showing notification. You may need to request permission.');
+    }
+    function onPermissionGranted() {
+        console.log('Permission has been granted by the user');
+    }
+    function onPermissionDenied() {
+        console.warn('Permission has been denied by the user');
+    }
+
+    function doNotification(block) {
+        var newBlockNtfn = new Notify('New Decred Block Mined', {
+            body: 'Block mined at height ' + block.height,
+            tag: 'blockheight',
+            image: '/images/dcrdata144x128.png',
+            icon: '/images/dcrdata144x128.png',
+            notifyShow: onShowNotification,
+            notifyClose: onCloseNotification,
+            notifyClick: onClickNotification,
+            notifyError: onErrorNotification,
+            timeout: 10
+        });
+        newBlockNtfn.show();
+    }
+    
+    function desktopNotifyNewBlock(block) {
+        if (!Notify.needsPermission) {
+            doNotification(block);
         }
+    }
 </script>
 
 <script>
@@ -444,10 +445,6 @@
 </script>
 
 <script src="/js/notify.min.js"></script>
-<script>
-Notify.requestPermission(function(){console.log("Desktop notification permissions granted.")},
-    function(){console.log("Desktop notification permissions denied.")});
-</script>
 {{end}}
 
 {{define "footer"}}
@@ -463,7 +460,10 @@ Notify.requestPermission(function(){console.log("Desktop notification permission
             <a class="nav-item" href="https://github.com/decred/dcrdata/blob/master/LICENSE" target="_blank">© 2017-2018 The dcrdata developers (ISC)</a>
         </div>
         <div style="float: right;">
-            <span data-turbolinks-permanent class="nav-item hidden" id="connection" title="While connected, you will receive live page updates and desktop notifications.">Connecting to WebSocket...<div></div></span>
+            <span data-turbolinks-permanent class="nav-item hidden" id="connection"
+                title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
+                >Connecting to WebSocket...<div></div>
+            </span>
         </div>
     </div>
 </footer>
@@ -489,9 +489,14 @@ Notify.requestPermission(function(){console.log("Desktop notification permission
     setInterval(updateAges, 10000);
 </script>
 <script>
-    $('.scriptDataStar').on('click',function(){
+    $('.scriptDataStar').on('click', function(){
         $(this).next('.scriptData').slideToggle();
     });
+    $('#connection').on('click', function(){
+        if (Notify.needsPermission) {
+            Notify.requestPermission(onPermissionGranted, onPermissionDenied);
+        }
+    })
 </script>
 {{end}}
 


### PR DESCRIPTION
To enable desktop notifications, the user must click the connection
indicator at the bottom right.

This resolves issue #374 