### PR TITLE
Adds pagination to /address API

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -149,6 +149,11 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 				ri.Use(m.NPathCtx)
 				ri.Get("/", app.getAddressTransactions)
 				ri.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
+				ri.Route("/skip/{M}", func(rj chi.Router) {
+					rj.Use(m.MPathCtx)
+					rj.Get("/", app.getAddressTransactions)
+					rj.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
+				})
 			})
 		})
 	})

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -67,6 +67,8 @@ type APIDataSource interface {
 	GetMempoolSSTxDetails(N int) *apitypes.MempoolTicketDetails
 	GetAddressTransactions(addr string, count int) *apitypes.Address
 	GetAddressTransactionsRaw(addr string, count int) []*apitypes.AddressTxRaw
+	GetAddressTransactionsWithSkip(addr string, count int, skip int) *apitypes.Address
+	GetAddressTransactionsRawWithSkip(addr string, count int, skip int) []*apitypes.AddressTxRaw
 	SendRawTransaction(txhex string) (string, error)
 	GetExplorerAddress(address string, count, offset int64) *explorer.AddressInfo
 }
@@ -949,6 +951,7 @@ func (c *appContext) getStakeDiffRange(w http.ResponseWriter, r *http.Request) {
 func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Request) {
 	address := m.GetAddressCtx(r)
 	count := m.GetNCtx(r)
+	skip := m.GetMCtx(r)
 	if address == "" {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -958,7 +961,10 @@ func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Reque
 	} else if count > 2000 {
 		count = 2000
 	}
-	txs := c.BlockData.GetAddressTransactions(address, count)
+	if skip <= 0 {
+		skip = 0
+	}
+	txs := c.BlockData.GetAddressTransactionsWithSkip(address, count, skip)
 	if txs == nil {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -969,6 +975,7 @@ func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Reque
 func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Request) {
 	address := m.GetAddressCtx(r)
 	count := m.GetNCtx(r)
+	skip := m.GetMCtx(r)
 	if address == "" {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -978,7 +985,10 @@ func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Re
 	} else if count > 2000 {
 		count = 2000
 	}
-	txs := c.BlockData.GetAddressTransactionsRaw(address, count)
+	if skip <= 0 {
+		skip = 0
+	}
+	txs := c.BlockData.GetAddressTransactionsRawWithSkip(address, count, skip)
 	if txs == nil {
 		http.Error(w, http.StatusText(422), 422)
 		return

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -802,11 +802,14 @@ func (db *wiredDB) GetAddressTransactions(addr string, count int) *apitypes.Addr
 	return db.GetAddressTransactionsWithSkip(addr, count, 0)
 }
 
-// GetAddressTransactions returns an array of apitypes.AddressTxRaw objects
+// GetAddressTransactionsRaw returns an array of apitypes.AddressTxRaw objects
 // representing the raw result of SearchRawTransactionsverbose
 func (db *wiredDB) GetAddressTransactionsRaw(addr string, count int) []*apitypes.AddressTxRaw {
 	return db.GetAddressTransactionsRawWithSkip(addr, count, 0)
 }
+
+// GetAddressTransactionsRawWithSkip returns an array of apitypes.AddressTxRaw objects
+// representing the raw result of SearchRawTransactionsverbose
 func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, skip int) []*apitypes.AddressTxRaw {
 	address, err := dcrutil.DecodeAddress(addr)
 	if err != nil {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -799,42 +799,21 @@ func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) 
 // GetAddressTransactions returns an apitypes.Address Object with at most the
 // last count transactions the address was in
 func (db *wiredDB) GetAddressTransactions(addr string, count int) *apitypes.Address {
-	address, err := dcrutil.DecodeAddress(addr)
-	if err != nil {
-		log.Infof("Invalid address %s: %v", addr, err)
-		return nil
-	}
-	txs, err := db.client.SearchRawTransactionsVerbose(address, 0, count, false, true, nil)
-	if err != nil {
-		log.Warnf("GetAddressTransactions failed for address %s: %v", addr, err)
-		return nil
-	}
-	tx := make([]*apitypes.AddressTxShort, 0, len(txs))
-	for i := range txs {
-		tx = append(tx, &apitypes.AddressTxShort{
-			TxID:          txs[i].Txid,
-			Time:          txs[i].Time,
-			Value:         txhelpers.TotalVout(txs[i].Vout).ToCoin(),
-			Confirmations: int64(txs[i].Confirmations),
-			Size:          int32(len(txs[i].Hex) / 2),
-		})
-	}
-	return &apitypes.Address{
-		Address:      addr,
-		Transactions: tx,
-	}
-
+	return db.GetAddressTransactionsWithSkip(addr, count, 0)
 }
 
 // GetAddressTransactions returns an array of apitypes.AddressTxRaw objects
 // representing the raw result of SearchRawTransactionsverbose
 func (db *wiredDB) GetAddressTransactionsRaw(addr string, count int) []*apitypes.AddressTxRaw {
+	return db.GetAddressTransactionsRawWithSkip(addr, count, 0)
+}
+func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, skip int) []*apitypes.AddressTxRaw {
 	address, err := dcrutil.DecodeAddress(addr)
 	if err != nil {
 		log.Infof("Invalid address %s: %v", addr, err)
 		return nil
 	}
-	txs, err := db.client.SearchRawTransactionsVerbose(address, 0, count, true, true, nil)
+	txs, err := db.client.SearchRawTransactionsVerbose(address, skip, count, true, true, nil)
 	if err != nil {
 		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
 		return nil

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -96,6 +96,8 @@ func GetNCtx(r *http.Request) int {
 	return N
 }
 
+// GetMCtx retrieves the ctxM data from the request context. If not set, the
+// return value is -1.
 func GetMCtx(r *http.Request) int {
 	M, ok := r.Context().Value(ctxM).(int)
 	if !ok {
@@ -316,17 +318,17 @@ func NPathCtx(next http.Handler) http.Handler {
 // MPathCtx returns a http.HandlerFunc that embeds the value at the url
 // part {M} into the request context
 func MPathCtx(next http.Handler) http.Handler {
-        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                pathMStr := chi.URLParam(r, "M")
-                M, err := strconv.Atoi(pathMStr)
-                if err != nil {
-                        apiLog.Infof("No/invalid numeric value (uint64): %v", err)
-                        http.NotFound(w, r)
-                        return
-                }
-                ctx := context.WithValue(r.Context(), ctxM, M)
-                next.ServeHTTP(w, r.WithContext(ctx))
-        })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pathMStr := chi.URLParam(r, "M")
+		M, err := strconv.Atoi(pathMStr)
+		if err != nil {
+			apiLog.Infof("No/invalid numeric value (uint64): %v", err)
+			http.NotFound(w, r)
+			return
+		}
+		ctx := context.WithValue(r.Context(), ctxM, M)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 // BlockHashPathCtx returns a http.HandlerFunc that embeds the value at the url


### PR DESCRIPTION
Alexandre de Sousa created a spreadsheet to keep track of voted tickets (collecting stats, etc), using the dcrdata API. Some users were complaining that they have too many tickets and that the spreadsheet was unable to load them all. I proposed changing dcrdata do accommodate for "pagination". This involved using the "skip" parameter in "GetAddressTransactionsRawWithSkip" calls, so i had to change the whole call stack to add this new parameter.

Also, i removed duplicated code from GetAddressTransactionsWithSkip and GetAddressTransactions.