### PR TITLE
explorer: avoid concurrent map access

### DIFF
--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -20,7 +20,7 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 		// Create channel to signal updated data availability
 		updateSig := make(hubSpoke, 3)
 		// register websocket client with our signal channel
-		exp.wsHub.RegisterClient(&updateSig)
+		clientData := exp.wsHub.RegisterClient(&updateSig)
 		// unregister (and close signal channel) before return
 		defer exp.wsHub.UnregisterClient(&updateSig)
 
@@ -158,9 +158,9 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// ping and send user count
 					webData.Message = strconv.Itoa(exp.wsHub.NumClients())
 				case sigNewTx:
-					exp.wsHub.clients[&updateSig].Lock()
-					enc.Encode(exp.wsHub.clients[&updateSig].newTxs)
-					exp.wsHub.clients[&updateSig].Unlock()
+					clientData.RLock()
+					enc.Encode(clientData.newTxs)
+					clientData.RUnlock()
 					webData.Message = buff.String()
 				}
 


### PR DESCRIPTION
Each connection's `(exp *explorerUI).RootWebsocket` now stores a pointer
to it's own client data.  Previously each connection had to look up
this object in the `WebSockethub` client map, which was not thread-safe.

Add type `clientHubSpoke`, which wraps the `*client` and the corresponding `*hubSpoke`.
Change `WebsocketHub.Register` from `chan *hubSpoke` to `chan *clientHubSpoke`
Update `(wsh *WebsocketHub).RegisterClient` to return the `*client` created for the input `*hubSpoke`, and
send a `*clientHubSpoke` to the event loop, where `registerClient` will
actually insert the client into the `WebSockethub`'s client map.