### PR TITLE
Unconfirmed transaction helpers, reworked CountUnconfirmedTransactions

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -1294,25 +1295,51 @@ func ValidateNetworkAddress(address dcrutil.Address, p *chaincfg.Params) bool {
 	return address.IsForNet(p)
 }
 
-// CountUnconfirmedTransactions returns the number of unconfirmed transactions involving the specified address,
-// given a maximum possible unconfirmed
-func (db *wiredDB) CountUnconfirmedTransactions(address string, maxUnconfirmedPossible int64) (numUnconfirmed int64, err error) {
-	addr, err := dcrutil.DecodeAddress(address)
+// CountUnconfirmedTransactions returns the number of unconfirmed transactions
+// involving the specified address, given a maximum possible unconfirmed.
+func (db *wiredDB) CountUnconfirmedTransactions(address string) (int64, error) {
+	_, numUnconfirmed, err := db.UnconfirmedTxnsForAddress(address)
+	return numUnconfirmed, err
+}
+
+// UnconfirmedTxnsForAddress returns the chainhash.Hash of all transactions in
+// mempool that (1) pay to the given address, or (2) spend a previous outpoint
+// that payed to the address.
+func (db *wiredDB) UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error) {
+	// Mempool transactions
+	var numUnconfirmed int64
+	mempoolTxns, err := db.client.GetRawMempool(dcrjson.GRMAll)
 	if err != nil {
-		log.Infof("Invalid address %s: %v", address, err)
-		return
+		log.Warnf("GetRawMempool failed for address %s: %v", address, err)
+		return nil, numUnconfirmed, err
 	}
-	txs, err := db.client.SearchRawTransactionsVerbose(addr, 0, int(maxUnconfirmedPossible), false, true, nil)
-	if err != nil {
-		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
-		return
-	}
-	for _, tx := range txs {
-		if tx.Confirmations == 0 {
-			numUnconfirmed++
+
+	// Check each transaction for involvement with provided address.
+	addressOutpoints := txhelpers.NewAddressOutpoints(address)
+	for _, tx := range mempoolTxns {
+		// Transaction details from dcrd
+		Tx, err1 := db.client.GetRawTransaction(tx)
+		if err1 != nil {
+			log.Warnf("Unable to GetRawTransactions(%s): %v", tx, err1)
+			err = err1
+			continue
 		}
+		// Scan transaction for inputs/outputs involving the address of interest
+		outpoints, prevouts, prevTxns := txhelpers.TxInvolvesAddress(Tx.MsgTx(),
+			address, db.client, db.params)
+		if len(outpoints) == 0 && len(prevouts) == 0 {
+			continue
+		}
+		// Add present transaction to previous outpoint txn slice
+		numUnconfirmed++
+		thisTxUnconfirmed := &txhelpers.TxWithBlockData{
+			Tx: Tx.MsgTx(),
+		}
+		prevTxns = append(prevTxns, thisTxUnconfirmed)
+		// Merge the I/Os and the transactions into results
+		addressOutpoints.Update(prevTxns, outpoints, prevouts)
 	}
-	return
+	return addressOutpoints, numUnconfirmed, err
 }
 
 // GetMepool gets all transactions from the mempool for explorer and adds the

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/blockdata"
 	"github.com/decred/dcrdata/db/dbtypes"
+	"github.com/decred/dcrdata/txhelpers"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -26,11 +27,10 @@ import (
 )
 
 const (
-	maxExplorerRows              = 2000
-	minExplorerRows              = 20
-	defaultAddressRows     int64 = 20
-	MaxAddressRows         int64 = 1000
-	MaxUnconfirmedPossible int64 = 1000
+	maxExplorerRows          = 2000
+	minExplorerRows          = 20
+	defaultAddressRows int64 = 20
+	MaxAddressRows     int64 = 1000
 )
 
 // explorerDataSourceLite implements an interface for collecting data for the
@@ -46,7 +46,7 @@ type explorerDataSourceLite interface {
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int
 	GetChainParams() *chaincfg.Params
-	CountUnconfirmedTransactions(address string, maxUnconfirmedPossible int64) (int64, error)
+	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 	GetMempool() []MempoolTx
 	TxHeight(txid string) (height int64)
 }

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -168,6 +168,14 @@ type BlockInfo struct {
 	StakeValidationHeight int64
 }
 
+// AddressTransactions collects the transactions for an address as AddressTx
+// slices.
+type AddressTransactions struct {
+	Transactions []*AddressTx
+	TxnsFunding  []*AddressTx
+	TxnsSpending []*AddressTx
+}
+
 // AddressInfo models data for display on the address page
 type AddressInfo struct {
 	// Address is the decred address on the current page
@@ -182,6 +190,7 @@ type AddressInfo struct {
 
 	// NumUnconfirmed is the number of unconfirmed txns for the address
 	NumUnconfirmed int64
+	UnconfirmedTxns *AddressTransactions
 
 	// Transactions on the current page
 	Transactions    []*AddressTx

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -189,7 +189,7 @@ type AddressInfo struct {
 	TxnType       string // ?txntype=TxnType
 
 	// NumUnconfirmed is the number of unconfirmed txns for the address
-	NumUnconfirmed int64
+	NumUnconfirmed  int64
 	UnconfirmedTxns *AddressTransactions
 
 	// Transactions on the current page


### PR DESCRIPTION
This is extracted from the swelling address-filter PR.

Add func UnconfirmedTxnsForAddress.
Updated AddressInfo type.
Modify explorer.AddressPage to get unconfirmed txns and store them.  They are not displayed at all.  Treat this as an example.