### PR TITLE
restyle progress bars

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -640,7 +640,19 @@ body.darkBG #menu {
   padding: 1px 5px;
 }
 
+.progress-bar {
+  background: #41BF53;
+  color: #fff;
+  height: 20px;
+  line-height: 20px;
+  text-shadow: 1px 1px 0px #00000012;
+}
+
 /*bootstrap overrides*/
+.progress {
+  background-color: #c5c4c4;
+  border-radius: 2px;
+}
 .btn-primary {
   background-color: #2970ff;
   border-color: #2970ff;

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -41,12 +41,12 @@
                                                 class="progress-bar"
                                                 id="pos-window-progess-bar"
                                                 role="progressbar"
-                                                style="width: {{ticketWindowProgress .IdxBlockInWindow}}%; background: #2ed8a3;"
+                                                style="width: {{ticketWindowProgress .IdxBlockInWindow}}%;"
                                                 aria-valuenow="{{.IdxBlockInWindow}}"
                                                 aria-valuemin="0"
                                                 aria-valuemax="{{.Params.WindowSize}}"
                                             >
-                                            <span style="color:#383b41" class="nowrap pl-1">block <span id="window_block_index" >{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}} ({{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}})</span>
+                                            <span class="nowrap pl-1">block <span id="window_block_index" >{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}} ({{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}})</span>
                                             </div>
                                         </div>
                                     </div>
@@ -83,12 +83,12 @@
                                                 class="progress-bar"
                                                 id="pow-window-progess-bar"
                                                 role="progressbar"
-                                                style="width: {{rewardAdjustmentProgress .IdxInRewardWindow}}%; background: #2ed8a3;"
+                                                style="width: {{rewardAdjustmentProgress .IdxInRewardWindow}}%;"
                                                 aria-valuenow="{{.IdxInRewardWindow}}"
                                                 aria-valuemin="0"
                                                 aria-valuemax="{{.Params.RewardWindowSize}}"
                                             >
-                                            <span id="powreward" style="color:#383b41" class="nowrap pl-1">block <span id="reward_block_index" >{{.IdxInRewardWindow}}</span> of {{.Params.RewardWindowSize}} ({{remaining .IdxInRewardWindow .Params.RewardWindowSize .Params.BlockTime}})</span>
+                                            <span id="powreward" class="nowrap pl-1">block <span id="reward_block_index" >{{.IdxInRewardWindow}}</span> of {{.Params.RewardWindowSize}} ({{remaining .IdxInRewardWindow .Params.RewardWindowSize .Params.BlockTime}})</span>
                                             </div>
                                         </div>
                                     </div>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -73,12 +73,12 @@
                                     <div
                                         class="progress-bar"
                                         role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%; background: #2ed8a3;"
+                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%;"
                                         aria-valuenow="{{.Confirmations}}"
                                         aria-valuemin="0"
                                         aria-valuemax="256"
                                     >
-                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">
+                                        <span class="nowrap pl-1 pr-1">
                                             Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} days remaining){{end}}
                                         </span>
                                     </div>
@@ -110,12 +110,12 @@
                                     <div
                                         class="progress-bar"
                                         role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketExpiry}}%; background: #2ed8a3;"
+                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketExpiry}}%;"
                                         aria-valuenow="{{.Confirmations}}"
                                         aria-valuemin="0"
                                         aria-valuemax="256"
                                     >
-                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">
+                                        <span class="nowrap pl-1 pr-1">
                                             block {{.Confirmations}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)
                                         </span>
                                     </div>


### PR DESCRIPTION
Updates progress bar appearance so to be more like the design comps. The gray background is a bit darker than the comp and a slight drop shadow has been added to the white text to improve readability when it overflows the green bar.

design comp:
<img width="432" alt="screen shot 2018-04-04 at 1 08 23 am" src="https://user-images.githubusercontent.com/25571523/38295996-cc812a76-37a4-11e8-9dad-7b99d1fd0acf.png">

PR:
<img width="476" alt="screen shot 2018-04-04 at 12 53 16 am" src="https://user-images.githubusercontent.com/25571523/38295982-c6e99efe-37a4-11e8-82d7-6ea89d69cb35.png">

<img width="271" alt="screen shot 2018-04-04 at 1 15 46 am" src="https://user-images.githubusercontent.com/25571523/38296273-c13dded8-37a5-11e8-8944-28b4a1d4613f.png">

