### PR TITLE
do not drop URL query params

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -412,8 +412,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	}
 
 	// N is a limit on NumFundingTxns, so this checks if we have them all.
-	if addrInfo.NumFundingTxns < N && offset == 0 &&
-		(txnType == dbtypes.AddrTxnAll || txnType == dbtypes.AddrTxnDebit) {
+	if addrInfo.NumFundingTxns < N && offset == 0 && txnType == dbtypes.AddrTxnAll {
 		balanceInfo = explorer.AddressBalance{
 			Address:      address,
 			NumSpent:     addrInfo.NumSpendingTxns,

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -135,7 +135,7 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html")
-	w.Header().Set("Turbolinks-Location", "/block/"+hash)
+	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, str)
 }
@@ -261,7 +261,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html")
-	w.Header().Set("Turbolinks-Location", "/tx/"+hash)
+	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, str)
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -386,12 +386,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.KnownSpendingTxns = balance.NumSpent
 
-		// Transactions on current page
-		addrData.NumTransactions = int64(len(addrData.Transactions))
-		if addrData.NumTransactions > addrData.Limit {
-			addrData.NumTransactions = addrData.Limit
-		}
-
 		// Transactions to fetch with FillAddressTransactions. This should be a
 		// noop if ReduceAddressHistory is working right.
 		switch txnType {
@@ -402,6 +396,12 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			addrData.Transactions = addrData.TxnsSpending
 		default:
 			log.Warnf("Unknown address transaction type: %v", txnType)
+		}
+
+		// Transactions on current page
+		addrData.NumTransactions = int64(len(addrData.Transactions))
+		if addrData.NumTransactions > limitN {
+			addrData.NumTransactions = limitN
 		}
 
 		// Query database for transaction details

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -336,7 +336,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				exp.ErrorPage(w, "Something went wrong...", "could not find that address", true)
 				return
 			}
-			addrData.Fullmode = true
+
+			// Set page parameters
+			addrData.Path = r.URL.Path
+			addrData.Limit, addrData.Offset = limitN, offsetAddrOuts
+			addrData.TxnType = txnType.String()
 
 			confirmHeights := make([]int64, len(addrData.Transactions))
 			for i, v := range addrData.Transactions {
@@ -374,11 +378,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			addrData = new(AddressInfo)
 			addrData.Address = address
 		}
-
-		// Set page parameters
-		addrData.Path = r.URL.Path
-		addrData.Limit, addrData.Offset = limitN, offsetAddrOuts
-		addrData.TxnType = txnType.String()
 		addrData.Fullmode = true
 
 		// Balances and txn counts (partial unless in full mode)
@@ -468,6 +467,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			uctxn.TxnsSpending = append(uctxn.TxnsSpending, addrTx)
 		}
 	}
+
+	// Set page parameters
+	addrData.Path = r.URL.Path
+	addrData.Limit, addrData.Offset = limitN, offsetAddrOuts
+	addrData.TxnType = txnType.String()
 
 	confirmHeights := make([]int64, len(addrData.Transactions))
 	for i, v := range addrData.Transactions {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -95,7 +95,7 @@
             <div class="col">
                 <div class="d-flex flex-wrap align-items-center justify-content-end mb-1">
                     <h5 class="mr-auto mb-0">History</h5>
-                    {{if lt .NumTransactions .KnownTransactions}}
+                    {{if lt .NumTransactions $TxnCount}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
                         <span class="fs12 nowrap text-right">
                             {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of {{intComma $TxnCount}} transactions

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -38,7 +38,7 @@
                             {{if ge .KnownTransactions .MaxTxLimit}}
                             <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
                             {{else}}
-                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
+                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.AmountUnspent.ToCoin}}</td>
                             {{end}}
                         {{end}}
                     </tr>
@@ -57,7 +57,7 @@
                             {{if ge .KnownTransactions .MaxTxLimit}}
                             <td class="mono nowrap text-right">unavailable</td>
                             {{else}}
-                            <td class="mono nowrap text-right">{{.TotalReceived}}</td>
+                            <td class="mono nowrap text-right">{{.AmountReceived.ToCoin}}</td>
                             {{end}}
                         {{end}}
                     </tr>
@@ -75,7 +75,7 @@
                             {{if ge .KnownTransactions .MaxTxLimit}}
                             <td class="mono nowrap text-right">unavailable</td>
                             {{else}}
-                            <td class="mono nowrap text-right">{{.TotalSent}}</td>
+                            <td class="mono nowrap text-right">{{.AmountSent.ToCoin}}</td>
                             {{end}}
                         {{end}}
                     </tr>


### PR DESCRIPTION
Use `r.URL.RequestURI` to set the `Turbolinks-Location` html header correctly on the Block and Transaction page.  This was already addressed on the Address page.