### PR TITLE
[WIP] Address history update - add tx_time to existing address table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ MANIFEST-*
 ffldb_stake*/
 *.pprof
 testnet/
+dcrdata.exe*

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -116,6 +116,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8,
 				BlockHeight: txin.BlockHeight,
 				BlockIndex:  txin.BlockIndex,
 				ScriptHex:   txin.SignatureScript,
+				TxTime:      uint64(blockTime),
 			})
 		}
 
@@ -132,6 +133,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8,
 				Value:        uint64(txout.Value),
 				Version:      txout.Version,
 				ScriptPubKey: txout.PkScript,
+				TxTime:       uint64(blockTime),
 			}
 			scriptClass, scriptAddrs, reqSigs, err := txscript.ExtractPkScriptAddrs(
 				vout.Version, vout.ScriptPubKey, chainParams)

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -243,6 +243,7 @@ type Vout struct {
 	Version          uint16           `json:"version"`
 	ScriptPubKey     []byte           `json:"pkScriptHex"`
 	ScriptPubKeyData ScriptPubKeyData `json:"pkScript"`
+	TxTime           uint64           `json:"tx_time"`
 }
 
 // AddressRow represents a row in the addresses table
@@ -258,6 +259,19 @@ type AddressRow struct {
 	SpendingTxHash     string
 	SpendingTxVinIndex uint32
 	VinDbID            uint64
+	TxTime             uint64
+}
+
+type AddressRow_new struct {
+	// id int64
+	Address    string
+	TxHash     string
+	InOutRowID uint32
+	Value      uint64
+	TxTime     uint64
+	IsFunding  bool
+	//SpendingTxVinIndex uint32
+	//FundingTxVoutIndex uint32
 }
 
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)
@@ -281,6 +295,7 @@ type VinTxProperty struct {
 	BlockHeight uint32 `json:"blockheight"`
 	BlockIndex  uint32 `json:"blockindex"`
 	ScriptHex   []byte `json:"scripthex"`
+	TxTime      uint64 `json:"tx_time`
 }
 
 // Vin models a transaction input.

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -155,15 +155,7 @@ func (pgb *ChainDB) GetAddressInfo(address string, N, offset int64) *apitypes.In
 
 	var transactionIdList []string
 	for _, row := range rows {
-		fundingTxId := row.FundingTxHash
-		if fundingTxId != "" {
-			transactionIdList = append(transactionIdList, fundingTxId)
-		}
-
-		spendingTxId := row.SpendingTxHash
-		if spendingTxId != "" {
-			transactionIdList = append(transactionIdList, spendingTxId)
-		}
+		transactionIdList = append(transactionIdList, row.TxHash)
 	}
 
 	return &apitypes.InsightAddressInfo{

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -2,8 +2,8 @@ package internal
 
 const (
 	insertAddressRow0 = `INSERT INTO addresses (address, funding_tx_row_id,
-		funding_tx_hash, funding_tx_vout_index, vout_row_id, value)
-		VALUES ($1, $2, $3, $4, $5, $6) `
+		funding_tx_hash, funding_tx_vout_index, vout_row_id, value, funding_tx_time)
+		VALUES ($1, $2, $3, $4, $5, $6, $7) `
 	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
 	// InsertAddressRowChecked = insertAddressRow0 +
 	// 	`ON CONFLICT (vout_row_id, address) DO NOTHING RETURNING id;`
@@ -42,8 +42,13 @@ const (
 		spending_tx_row_id INT8,
 		spending_tx_hash TEXT,
 		spending_tx_vin_index INT4,
-		vin_row_id INT8
+		vin_row_id INT8,
+		funding_tx_time INT8,
+		spending_tx_time INT8
 	);`
+
+	//to bring addresses table to version 2.1.0 perform following sql manually (this assumes all other tables are up to date and filled with data)
+	//UPDATE addresses as a1 SET spending_tx_time=transactions.time FROM addresses as a2 LEFT JOIN transactions ON transactions.tx_hash=a2.spending_tx_hash WHERE a2.spending_tx_hash IS NOT NULL;
 
 	SelectAddressAllByAddress = `SELECT * FROM addresses WHERE address=$1 order by id desc;`
 	SelectAddressRecvCount    = `SELECT COUNT(*) FROM addresses WHERE address=$1;`
@@ -70,10 +75,38 @@ const (
 	SelectAddressLimitNByAddressSubQry = `WITH these as (SELECT * FROM addresses WHERE address=$1)
 		SELECT * FROM these order by id desc limit $2 offset $3;`
 
-	// SelectAddressDebitsLimitNByAddress = `SELECT *
-	// 	FROM addresses
-	// 	WHERE address=$1 AND spending_tx_row_id IS NOT NULL
-	// 	ORDER BY id DESC LIMIT $2 OFFSET $3;`
+	SelectAddressFundingTxByAddressLO = `SELECT 
+										address, 
+										funding_tx_hash,
+										funding_tx_vout_index,  
+										value, 
+										funding_tx_time 
+									FROM addresses 
+									WHERE address=$1 
+									ORDER BY funding_tx_time DESC 
+									LIMIT $2 OFFSET $3;`
+
+	SelectAddressSpendingTxByAddressT = `SELECT 
+										address,
+										spending_tx_hash,
+										max(spending_tx_row_id) as spending_tx_row_id, 
+										sum(value) as value,
+										max(spending_tx_time) as spending_tx_time
+									FROM addresses
+									WHERE address=$1 AND spending_tx_time>=$2 
+									GROUP BY spending_tx_hash, address
+									ORDER BY spending_tx_time DESC;`
+	SelectAddressSpendingTxByAddressLO = `SELECT 
+										address,
+										spending_tx_hash, 
+										max(spending_tx_row_id) as spending_tx_row_id, 
+										sum(value) as value,
+										max(spending_tx_time) as spending_tx_time
+									FROM addresses
+									WHERE address=$1 AND spending_tx_time>=$2 
+									GROUP BY spending_tx_hash, address
+									ORDER BY spending_tx_time DESC 
+									LIMIT $2 OFFSET $3;`
 	SelectAddressDebitsLimitNByAddress = `WITH these as (SELECT * FROM addresses WHERE address=$1)
 		SELECT * FROM these WHERE spending_tx_row_id IS NOT NULL
 		ORDER BY id DESC LIMIT $2 OFFSET $3;`
@@ -92,7 +125,7 @@ const (
 		spending_tx_hash = $3, spending_tx_vin_index = $4, vin_row_id = $5 
 		WHERE id=$1;`
 	SetAddressSpendingForOutpoint = `UPDATE addresses SET spending_tx_row_id = $3, 
-		spending_tx_hash = $4, spending_tx_vin_index = $5, vin_row_id = $6 
+		spending_tx_hash = $4, spending_tx_vin_index = $5, vin_row_id = $6, spending_tx_time = $7 
 		WHERE funding_tx_hash=$1 and funding_tx_vout_index=$2;`
 
 	IndexAddressTableOnAddress = `CREATE INDEX uix_addresses_address

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -18,11 +18,12 @@ const (
 		tx_tree INT2,
 		prev_tx_hash TEXT,
 		prev_tx_index INT8,
-		prev_tx_tree INT2
+		prev_tx_tree INT2,
+		tx_time INT8
 	);`
 
-	InsertVinRow0 = `INSERT INTO vins (tx_hash, tx_index, tx_tree, prev_tx_hash, prev_tx_index, prev_tx_tree)
-		VALUES ($1, $2, $3, $4, $5, $6) `
+	InsertVinRow0 = `INSERT INTO vins (tx_hash, tx_index, tx_tree, prev_tx_hash, prev_tx_index, prev_tx_tree, tx_time)
+		VALUES ($1, $2, $3, $4, $5, $6, $7) `
 	InsertVinRow = InsertVinRow0 + `RETURNING id;`
 	// InsertVinRowChecked = InsertVinRow0 +
 	// 	`ON CONFLICT (tx_hash, tx_index, tx_tree) DO NOTHING RETURNING id;`

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -41,10 +41,10 @@ const tableMajor = 2
 var requiredVersions = map[string]TableVersion{
 	"blocks":       NewTableVersion(tableMajor, 0, 0),
 	"transactions": NewTableVersion(tableMajor, 0, 0),
-	"vins":         NewTableVersion(tableMajor, 0, 0),
+	"vins":         NewTableVersion(tableMajor, 1, 0), //add times to vins table that will be used for bulk import
 	"vouts":        NewTableVersion(tableMajor, 0, 0),
 	"block_chain":  NewTableVersion(tableMajor, 0, 0),
-	"addresses":    NewTableVersion(tableMajor, 0, 0),
+	"addresses":    NewTableVersion(tableMajor, 1, 0), //add times to address table
 	"tickets":      NewTableVersion(tableMajor, 0, 0),
 	"votes":        NewTableVersion(tableMajor, 0, 0),
 	"misses":       NewTableVersion(tableMajor, 0, 0),

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -57,7 +57,7 @@ type explorerDataSource interface {
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
 	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
-	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *AddressBalance, error)
+	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow_new, *AddressBalance, error)
 	FillAddressTransactions(addrInfo *AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -390,18 +390,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			addrData.NumTransactions = addrData.Limit
 		}
 
-		// Transactions to fetch with FillAddressTransactions. This should be a
-		// noop if ReduceAddressHistory is working right.
-		switch txnType {
-		case dbtypes.AddrTxnAll:
-		case dbtypes.AddrTxnCredit:
-			addrData.Transactions = addrData.TxnsFunding
-		case dbtypes.AddrTxnDebit:
-			addrData.Transactions = addrData.TxnsSpending
-		default:
-			log.Warnf("Unknown address transaction type: %v", txnType)
-		}
-
 		// Query database for transaction details
 		err = exp.explorerSource.FillAddressTransactions(addrData)
 		if err != nil {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -296,7 +296,7 @@ type ChainParams struct {
 // completely. Transactions is partially set, with each transaction having only
 // the TxID and ReceivedTotal set. The rest of the data should be filled in by
 // other means, such as RPC calls or database queries.
-func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
+func ReduceAddressHistory(addrHist []*dbtypes.AddressRow_new) *AddressInfo {
 	if len(addrHist) == 0 {
 		return nil
 	}
@@ -305,31 +305,25 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 	var transactions, creditTxns, debitTxns []*AddressTx
 	for _, addrOut := range addrHist {
 		coin := dcrutil.Amount(addrOut.Value).ToCoin()
-
-		// Funding transaction
-		received += int64(addrOut.Value)
-		fundingTx := AddressTx{
-			TxID:          addrOut.FundingTxHash,
-			InOutID:       addrOut.FundingTxVoutIndex,
-			ReceivedTotal: coin,
+		if addrOut.IsFunding {
+			// Funding transaction
+			received += int64(addrOut.Value)
+			fundingTx := AddressTx{
+				TxID:          addrOut.TxHash,
+				InOutID:       addrOut.InOutRowID,
+				ReceivedTotal: coin,
+			}
+			transactions = append(transactions, &fundingTx)
+		} else {
+			// Spending transaction
+			sent += int64(addrOut.Value)
+			spendingTx := AddressTx{
+				TxID:      addrOut.TxHash,
+				InOutID:   addrOut.InOutRowID,
+				SentTotal: coin,
+			}
+			transactions = append(transactions, &spendingTx)
 		}
-		transactions = append(transactions, &fundingTx)
-		creditTxns = append(creditTxns, &fundingTx)
-
-		// Is the outpoint spent?
-		if addrOut.SpendingTxHash == "" {
-			continue
-		}
-
-		// Spending transaction
-		sent += int64(addrOut.Value)
-		spendingTx := AddressTx{
-			TxID:      addrOut.SpendingTxHash,
-			InOutID:   addrOut.SpendingTxVinIndex,
-			SentTotal: coin,
-		}
-		transactions = append(transactions, &spendingTx)
-		debitTxns = append(debitTxns, &spendingTx)
 	}
 
 	return &AddressInfo{


### PR DESCRIPTION
This PR demonstrates one possible solution for #327 

Database changes are:
1.  TxTime added to vins
2.  SpendingTxTime added to addresses
3.  FundingTxTime added to addresses

Relationship to PR #427: 
This PR gives an alternative strategy to the full rebuild of the addresses table.  However, the rendering side makes use of the same struct for address rows (AddressRow_new) that I imagine will be used with that methodology as well and thus at least this part is reusable.

What is not complete:
1.  API has not been updated
2.  rebuilddb has not bee updated
3.  Only works with pg db.  no testing has been done with litedb

A rebuild of the database is required to add in the TxTimes but it takes about a full day on my computer.  Easiest way to accomplish that is to just update the name of the db in your dcrdata.conf to a new db and let the system re-initialize.

It *may* also be possible to use the following query to manually update addresses table so the performance can be evaluated.  To try a manual update make the necessary modifications to the table structure and then run the following queries:  (This query timed out every time I tried to run):

`UPDATE addresses as a1 SET spending_tx_time=transactions.time FROM addresses as a2 LEFT JOIN transactions ON transactions.tx_hash=a2.spending_tx_hash WHERE a2.spending_tx_hash IS NOT NULL;`

`UPDATE addresses as a1 SET funding_tx_time=transactions.time FROM addresses as a2 LEFT JOIN transactions ON transactions.id=a2.funding_tx_row_id`

ToDo- Metrics:
I plan to do some metrics to compare performance between this version and the existing addresses implementation.  For the following test cases I would like to rig up page load times.  If anyone would like to see other metrics then please send them my way.

| URL |      Proposed(ms)|  Current(ms) |
|----------|-------------:|------:|
|address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx | | |
| address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx?n=20&start=200000&txntype=all | | |
| address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx?txntype=credit&n=1000&start=0 | | |
|address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx?txntype=debit&n=1000&start=0| | |
