### PR TITLE
Ticket Probability Fixes 

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1152,6 +1152,8 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 		} else {
 			tx.Mature = "True"
 		}
+		tx.Maturity = int64(db.params.CoinbaseMaturity)
+
 	}
 	if tx.Type == "Vote" || tx.Type == "Ticket" {
 		if db.GetBestBlockHeight() >= (int64(db.params.TicketMaturity) + tx.BlockHeight) {
@@ -1167,7 +1169,12 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 		} else {
 			tx.VoteFundsLocked = "False"
 		}
+		tx.Maturity = int64(db.params.CoinbaseMaturity) + 1 // Add one to reflect < instead of <=
 	}
+	CoinbaseMaturityInDay := (db.params.TargetTimePerBlock.Hours() * float64(db.params.CoinbaseMaturity)) / 24
+	tx.MaturityTimeTill = ((float64(db.params.CoinbaseMaturity) -
+		float64(tx.Confirmations)) / float64(db.params.CoinbaseMaturity)) * CoinbaseMaturityInDay
+
 	outputs := make([]explorer.Vout, 0, len(txraw.Vout))
 	for i, vout := range txraw.Vout {
 		txout, err := db.client.GetTxOut(txhash, uint32(i), true)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -247,16 +247,37 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 				return float64(blockData.PoolInfo.Size) / target * 100
 			}(),
 		},
-		TicketROI: percentage(dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin()/5, blockData.CurrentStakeDiff.CurrentStakeDifficulty),
-		//If there are ticketpoolsize*TicketsPerBlock total tickets and TicketsPerBlock are drawn every block, and assuming random selection of tickets, then any one ticket will, on average, be selected to vote once every ticketpoolsize blocks
+		TicketROI: func() float64 {
+			PosSubPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() / float64(exp.ChainParams.TicketsPerBlock)
+			return percentage(PosSubPerVote, blockData.CurrentStakeDiff.CurrentStakeDifficulty)
+		}(),
 
-		//small deviations in reality are due to:
-		//1.  Not all blocks have 5 votes.  On average each block in Decred currently has about 4.8 votes per block
-		//2.  Total tickets in the pool varies slightly above and below ticketpoolsize*TicketsPerBlock depending on supply and demand
-		//Both minor deviations are not accounted for in the general ROI calculation below because the variance they cause would be would be extremely small.
+		// If there are ticketpoolsize*TicketsPerBlock total tickets and
+		// TicketsPerBlock are drawn every block, and assuming random selection
+		// of tickets, then any one ticket will, on average, be selected to vote
+		// once every ticketpoolsize blocks
 
-		//The actual ROI of a ticket needs to also take into consideration the ticket maturity (time from ticket purchase until its eligible to vote) and coinbase maturity (time after vote until funds distributed to ticket holder are avaliable to use)
-		ROIPeriod: fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*float64(exp.ChainParams.TicketPoolSize+exp.ChainParams.TicketMaturity+exp.ChainParams.CoinbaseMaturity)/86400),
+		// Small deviations in reality are due to:
+		// 1.  Not all blocks have 5 votes.  On average each block in Decred
+		// currently has about 4.8 votes per block
+		// 2.  Total tickets in the pool varies slightly above and below
+		// ticketpoolsize*TicketsPerBlock depending on supply and demand
+
+		// Both minor deviations are not accounted for in the general ROI
+		// calculation below because the variance they cause would be would be
+		// extremely small.
+
+		// The actual ROI of a ticket needs to also take into consideration the
+		// ticket maturity (time from ticket purchase until its eligible to vote)
+		// and coinbase maturity (time after vote until funds distributed to
+		// ticket holder are avaliable to use)
+		ROIPeriod:  func() string {
+			PosAvgTotalBlocks := float64(
+				exp.ChainParams.TicketPoolSize+
+				exp.ChainParams.TicketMaturity+
+				exp.ChainParams.CoinbaseMaturity)
+			return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)	
+		}(),	
 	}
 
 	if !exp.liteMode {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -271,13 +271,13 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		// ticket maturity (time from ticket purchase until its eligible to vote)
 		// and coinbase maturity (time after vote until funds distributed to
 		// ticket holder are avaliable to use)
-		ROIPeriod:  func() string {
+		ROIPeriod: func() string {
 			PosAvgTotalBlocks := float64(
-				exp.ChainParams.TicketPoolSize+
-				exp.ChainParams.TicketMaturity+
-				exp.ChainParams.CoinbaseMaturity)
-			return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)	
-		}(),	
+				exp.ChainParams.TicketPoolSize +
+					exp.ChainParams.TicketMaturity +
+					exp.ChainParams.CoinbaseMaturity)
+			return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
+		}(),
 	}
 
 	if !exp.liteMode {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -6,6 +6,7 @@ package explorer
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -248,7 +249,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 			}(),
 		},
 		TicketROI: percentage(dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin()/5, blockData.CurrentStakeDiff.CurrentStakeDifficulty),
-		ROIPeriod: fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*float64(exp.ChainParams.TicketPoolSize)/86400),
+		ROIPeriod: fmt.Sprintf("%.2f days", ((math.Log(0.5)/math.Log(1-(float64(exp.ChainParams.TicketsPerBlock)/float64(blockData.PoolInfo.Size))))+float64(exp.ChainParams.TicketMaturity)+float64(exp.ChainParams.CoinbaseMaturity))/(86400/exp.ChainParams.TargetTimePerBlock.Seconds())),
 	}
 
 	if !exp.liteMode {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -220,23 +220,23 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 					float64(exp.ChainParams.TicketExpiry)) * expirationInDays
 				if tx.TicketInfo.SpendStatus == "Voted" {
 					// Blocks from eligible until voted (actual luck)
-					tx.TicketInfo.ShortConfirms = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) -
+					tx.TicketInfo.TicketLiveBlocks = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) -
 						tx.BlockHeight - int64(exp.ChainParams.TicketMaturity) - 1
 				} else if tx.Confirmations >= int64(exp.ChainParams.TicketExpiry+
 					uint32(exp.ChainParams.TicketMaturity)) { // Expired
 					// Blocks ticket was active before expiring (actual no luck)
-					tx.TicketInfo.ShortConfirms = int64(exp.ChainParams.TicketExpiry)
+					tx.TicketInfo.TicketLiveBlocks = int64(exp.ChainParams.TicketExpiry)
 				} else { // Active
 					// Blocks ticket has been active and eligible to vote
-					tx.TicketInfo.ShortConfirms = blocksLive
+					tx.TicketInfo.TicketLiveBlocks = blocksLive
 				}
 				tx.TicketInfo.BestLuck = tx.TicketInfo.TicketExpiry / int64(exp.ChainParams.TicketPoolSize)
 				tx.TicketInfo.AvgLuck = tx.TicketInfo.BestLuck - 1
-				if tx.TicketInfo.ShortConfirms == int64(exp.ChainParams.TicketExpiry) {
+				if tx.TicketInfo.TicketLiveBlocks == int64(exp.ChainParams.TicketExpiry) {
 					tx.TicketInfo.VoteLuck = 0
 				} else {
 					tx.TicketInfo.VoteLuck = float64(tx.TicketInfo.BestLuck) -
-						(float64(tx.TicketInfo.ShortConfirms) / float64(exp.ChainParams.TicketPoolSize))
+						(float64(tx.TicketInfo.TicketLiveBlocks) / float64(exp.ChainParams.TicketPoolSize))
 				}
 				if tx.TicketInfo.VoteLuck >= float64(tx.TicketInfo.BestLuck-(1/int64(exp.ChainParams.TicketPoolSize))) {
 					tx.TicketInfo.LuckStatus = "Perfection"

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -7,6 +7,7 @@ package explorer
 import (
 	"database/sql"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -240,6 +241,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				} else if tx.TicketInfo.VoteLuck == 0 {
 					tx.TicketInfo.LuckStatus = "No Luck"
 				}
+				tx.TicketInfo.Probability = (1 - math.Pow((1-(float64(exp.ChainParams.TicketsPerBlock)/float64(exp.ExtraInfo.PoolInfo.Size))), (float64(exp.ChainParams.TicketExpiry)-float64(tx.Confirmations)-float64(exp.ChainParams.TicketMaturity)))) * 100
 			}
 		}
 	}

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -208,27 +208,35 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 					tx.TicketInfo.PoolStatus = poolStatus.String()
 				}
 				tx.TicketInfo.SpendStatus = spendStatus.String()
+				blocksLive := tx.Confirmations - int64(exp.ChainParams.TicketMaturity)
 				tx.TicketInfo.TicketPoolSize = int64(exp.ChainParams.TicketPoolSize) * int64(exp.ChainParams.TicketsPerBlock)
 				tx.TicketInfo.TicketExpiry = int64(exp.ChainParams.TicketExpiry)
 				expirationInDays := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(exp.ChainParams.TicketExpiry)) / 24
 				maturityInDay := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(tx.TicketInfo.TicketMaturity)) / 24
-				tx.TicketInfo.TimeTillMaturity = ((float64(exp.ChainParams.TicketMaturity) - float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInDay
-				ticketExpiryBlocksLeft := int64(exp.ChainParams.TicketExpiry+uint32(exp.ChainParams.TicketMaturity)) - tx.Confirmations
-				tx.TicketInfo.TicketExpiryDaysLeft = (float64(ticketExpiryBlocksLeft) / float64(exp.ChainParams.TicketExpiry)) * expirationInDays
+				tx.TicketInfo.TimeTillMaturity = ((float64(exp.ChainParams.TicketMaturity) -
+					float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInDay
+				ticketExpiryBlocksLeft := int64(exp.ChainParams.TicketExpiry) - blocksLive
+				tx.TicketInfo.TicketExpiryDaysLeft = (float64(ticketExpiryBlocksLeft) /
+					float64(exp.ChainParams.TicketExpiry)) * expirationInDays
 				if tx.TicketInfo.SpendStatus == "Voted" {
-					tx.TicketInfo.ShortConfirms = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) - tx.BlockHeight - int64(exp.ChainParams.TicketMaturity) //blocks from eligible until voted (actual luck)
-				} else if tx.Confirmations >= int64(exp.ChainParams.TicketExpiry+uint32(exp.ChainParams.TicketMaturity)) { // expired
-					tx.TicketInfo.ShortConfirms = int64(exp.ChainParams.TicketExpiry) //blocks ticket was active before expiring (actual no luck)
-				} else { //active
-					tx.TicketInfo.ShortConfirms = tx.Confirmations - int64(exp.ChainParams.TicketMaturity) //blocks ticket has been active and eligible to vote
+					// Blocks from eligible until voted (actual luck)
+					tx.TicketInfo.ShortConfirms = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) -
+						tx.BlockHeight - int64(exp.ChainParams.TicketMaturity)
+				} else if tx.Confirmations >= int64(exp.ChainParams.TicketExpiry+
+					uint32(exp.ChainParams.TicketMaturity)) { // Expired
+					// Blocks ticket was active before expiring (actual no luck)
+					tx.TicketInfo.ShortConfirms = int64(exp.ChainParams.TicketExpiry)
+				} else { // Active
+					// Blocks ticket has been active and eligible to vote
+					tx.TicketInfo.ShortConfirms = blocksLive
 				}
 				tx.TicketInfo.BestLuck = tx.TicketInfo.TicketExpiry / int64(exp.ChainParams.TicketPoolSize)
 				tx.TicketInfo.AvgLuck = tx.TicketInfo.BestLuck - 1
-				log.Infof("%v %v", tx.TicketInfo.ShortConfirms, exp.ChainParams.TicketExpiry)
 				if tx.TicketInfo.ShortConfirms == int64(exp.ChainParams.TicketExpiry) {
 					tx.TicketInfo.VoteLuck = 0
 				} else {
-					tx.TicketInfo.VoteLuck = float64(tx.TicketInfo.BestLuck) - (float64(tx.TicketInfo.ShortConfirms-1) / float64(exp.ChainParams.TicketPoolSize))
+					tx.TicketInfo.VoteLuck = float64(tx.TicketInfo.BestLuck) -
+						(float64(tx.TicketInfo.ShortConfirms-1) / float64(exp.ChainParams.TicketPoolSize))
 				}
 				if tx.TicketInfo.VoteLuck >= float64(tx.TicketInfo.BestLuck-(1/int64(exp.ChainParams.TicketPoolSize))) {
 					tx.TicketInfo.LuckStatus = "Perfection"
@@ -248,12 +256,15 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 
 				// Chance for a ticket to NOT be voted in a given time frame:
 				// C = (1 - P)^N
-
-				// Where:
-				// P is the probability of a vote in one block. (votes per block / current ticket pool size)
-				// N is the number of blocks before ticket expiry. (ticket expiry in blocks - (number of blocks since ticket purchase - ticket maturity))
+				// Where: P is the probability of a vote in one block. (votes
+				// per block / current ticket pool size)
+				// N is the number of blocks before ticket expiry. (ticket
+				// expiry in blocks - (number of blocks since ticket purchase -
+				// ticket maturity))
 				// C is the probability (chance)
-				tx.TicketInfo.Probability = (math.Pow((1 - (float64(exp.ChainParams.TicketsPerBlock) / float64(exp.ExtraInfo.PoolInfo.Size))), (float64(exp.ChainParams.TicketExpiry) - (float64(tx.Confirmations) - float64(exp.ChainParams.TicketMaturity))))) * 100
+				pVote := float64(exp.ChainParams.TicketsPerBlock) / float64(exp.ExtraInfo.PoolInfo.Size)
+				tx.TicketInfo.Probability = 100 * (math.Pow(1-pVote,
+					float64(exp.ChainParams.TicketExpiry)-float64(blocksLive)))
 			}
 		}
 	}

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -221,7 +221,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				if tx.TicketInfo.SpendStatus == "Voted" {
 					// Blocks from eligible until voted (actual luck)
 					tx.TicketInfo.ShortConfirms = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) -
-						tx.BlockHeight - int64(exp.ChainParams.TicketMaturity)
+						tx.BlockHeight - int64(exp.ChainParams.TicketMaturity) - 1
 				} else if tx.Confirmations >= int64(exp.ChainParams.TicketExpiry+
 					uint32(exp.ChainParams.TicketMaturity)) { // Expired
 					// Blocks ticket was active before expiring (actual no luck)
@@ -236,7 +236,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 					tx.TicketInfo.VoteLuck = 0
 				} else {
 					tx.TicketInfo.VoteLuck = float64(tx.TicketInfo.BestLuck) -
-						(float64(tx.TicketInfo.ShortConfirms-1) / float64(exp.ChainParams.TicketPoolSize))
+						(float64(tx.TicketInfo.ShortConfirms) / float64(exp.ChainParams.TicketPoolSize))
 				}
 				if tx.TicketInfo.VoteLuck >= float64(tx.TicketInfo.BestLuck-(1/int64(exp.ChainParams.TicketPoolSize))) {
 					tx.TicketInfo.LuckStatus = "Perfection"

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -96,6 +96,7 @@ type TicketInfo struct {
 	AvgLuck              int64   // Average Luck for voting
 	VoteLuck             float64 // Actual Luck for voting on a ticket
 	LuckStatus           string  // Short discription based on the VoteLuck
+	Probability          float64 // Probability of success before ticket expires
 }
 
 // TxInID models the identity of a spending transaction input

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -68,17 +68,19 @@ func (a *AddressTx) IOID() string {
 // TxInfo models data needed for display on the tx page
 type TxInfo struct {
 	*TxBasic
-	SpendingTxns    []TxInID
-	Type            string
-	Vin             []Vin
-	Vout            []Vout
-	BlockHeight     int64
-	BlockIndex      uint32
-	Confirmations   int64
-	Time            int64
-	FormattedTime   string
-	Mature          string
-	VoteFundsLocked string
+	SpendingTxns     []TxInID
+	Type             string
+	Vin              []Vin
+	Vout             []Vout
+	BlockHeight      int64
+	BlockIndex       uint32
+	Confirmations    int64
+	Time             int64
+	FormattedTime    string
+	Mature           string
+	VoteFundsLocked  string
+	Maturity         int64   // Total number of blocks before mature
+	MaturityTimeTill float64 // Time in days until mature
 	TicketInfo
 }
 
@@ -91,7 +93,7 @@ type TicketInfo struct {
 	TicketPoolSize       int64   // Total number of ticket in the pool
 	TicketExpiry         int64   // Total number of blocks before a ticket expires
 	TicketExpiryDaysLeft float64 // Approximate days left before the given ticket expires
-	ShortConfirms        int64   // Total number of confirms up until the point the ticket votes or expires
+	TicketLiveBlocks     int64   // Total number of confirms after maturity and up until the point the ticket votes or expires
 	BestLuck             int64   // Best possible Luck for voting
 	AvgLuck              int64   // Average Luck for voting
 	VoteLuck             float64 // Actual Luck for voting on a ticket

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -94,7 +94,7 @@
                             <td class="text-right pr-2 h1rem p03rem0">LUCK</td>
                             <td>
                                 {{printf "%.4f" .TicketInfo.VoteLuck}}
-                                {{if (or (lt .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
+                                {{if (and (lt .TicketInfo.ShortConfirms .TicketInfo.TicketExpiry) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
                                 (Best: {{.TicketInfo.BestLuck}} Avg: {{.TicketInfo.AvgLuck}})
                             </td>
                         </tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -63,7 +63,7 @@
                 {{if eq .Mature "True"}}
                     <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td></tr>
                 {{end}}
-                {{if eq .Mature "False"}}
+                {{if and (eq .Mature "False") (eq .Type "Ticket")}}
                     <tr>
                         <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                         <td>
@@ -88,20 +88,45 @@
                         </td>
                     </tr>
                 {{end}}
+                {{if and (eq .Mature "False") (or (eq .Type "Vote") (eq .Type "Coinbase"))}}
+                    <tr>
+                        <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
+                        <td>
+                            <div class="row">
+                                <div class="col-11 col-lg-8 col-sm-12">
+                                    <div class="progress" style="max-width: 330px">
+                                        <div
+                                            class="progress-bar"
+                                            role="progressbar"
+                                            style="width: {{percentage  .Confirmations .Maturity}}%;"
+                                            aria-valuenow="{{.Confirmations}}"
+                                            aria-valuemin="0"
+                                            aria-valuemax="256"
+                                        >
+                                            <span class="nowrap pl-1 pr-1">
+                                                Immature, spendable in {{ if eq (add .Confirmations 1) .Maturity }}next block{{else}}{{subtract .Maturity .Confirmations}} blocks ({{printf "%.1f" .MaturityTimeTill}} days remaining){{end}}
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                {{end}}
                 {{if eq .Type "Ticket"}}
-                    {{if  (eq .Mature "True")}}
+                    {{if and (eq .Mature "True") (ne .TicketInfo.PoolStatus "missed")}}
                         <tr>
                             <td class="text-right pr-2 h1rem p03rem0">LUCK</td>
                             <td>
                                 {{printf "%.4f" .TicketInfo.VoteLuck}}
-                                {{if (and (lt .TicketInfo.ShortConfirms .TicketInfo.TicketExpiry) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
+                                {{if (and (lt .TicketInfo.TicketLiveBlocks .TicketInfo.TicketExpiry) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
                                 (Best: {{.TicketInfo.BestLuck}} Avg: {{.TicketInfo.AvgLuck}})
                             </td>
                         </tr>
                     {{end}}
                     
                     {{if and (and (eq .Mature "True")  (ne .TicketInfo.SpendStatus "Voted")) (eq .TicketInfo.PoolStatus "live")}}
-                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms}}
+                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.TicketLiveBlocks}}
                             <tr>
                                 <td class="text-right pr-2 h1rem p03rem0">PROBABILITY</td>
                                 <td>
@@ -126,7 +151,7 @@
                                 </td>
                             </tr>
                         {{end}}
-                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms}}
+                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.TicketLiveBlocks}}
                             <tr>
                                 <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
                                 <td>
@@ -136,13 +161,13 @@
                                                 <div
                                                     class="progress-bar"
                                                     role="progressbar"
-                                                    style="width: {{percentage (subtract .TicketInfo.ShortConfirms 1) .TicketInfo.TicketExpiry}}%;"
+                                                    style="width: {{percentage (subtract .TicketInfo.TicketLiveBlocks 1) .TicketInfo.TicketExpiry}}%;"
                                                     aria-valuenow="{{.Confirmations}}"
                                                     aria-valuemin="0"
                                                     aria-valuemax="256"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">
-                                                        block {{.TicketInfo.ShortConfirms}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)
+                                                        block {{.TicketInfo.TicketLiveBlocks}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)
                                                     </span>
                                                 </div>
                                             </div>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -117,7 +117,7 @@
                                                     aria-valuemax="1"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">
-                                                        {{printf "%.2f%%" .TicketInfo.Probability}} Chance of not voting
+                                                        {{printf "%.2f%%" .TicketInfo.Probability}} Chance of expiry
                                                     </span>
                                                 </div>
                                             </div>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -100,6 +100,33 @@
                 </tr>
                 {{end}}
                 {{if .TicketInfo.TicketExpiryDaysLeft}}
+                {{if eq .Mature "True"}}
+                {{if ge .TicketInfo.TicketExpiry .Confirmations}}
+                <tr>
+                    <td class="text-right pr-2 h1rem p03rem0">PROBABILITY</td>
+                    <td>
+                        <div class="row">
+                            <div class="col-11 col-lg-8 col-sm-12">
+                                <div class="progress" style="max-width: 330px">
+                                    <div
+                                        class="progress-bar"
+                                        role="progressbar"
+                                        style="width: {{.TicketInfo.Probability}}%;"
+                                        aria-valuenow="{{.TicketInfo.Probability}}"
+                                        aria-valuemin="0"
+                                        aria-valuemax="1"
+                                    >
+                                        <span class="nowrap pl-1 pr-1">
+                                            {{printf "%.2f%%" .TicketInfo.Probability}} Chance
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                {{end}}
+                {{end}}
                 {{if ge .TicketInfo.TicketExpiry .Confirmations}}
                 <tr>
                     <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -53,110 +53,110 @@
                     </td>
                 </tr>
                 {{if and (eq .Type "Ticket") (gt .Confirmations 0)}}
-                <tr>
-                    <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
-                    <td>
-                        {{if ne .TicketInfo.SpendStatus "Voted"}} {{.TicketInfo.PoolStatus}}  / {{end}} {{if (index .SpendingTxns 0).Hash}}<a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{.TicketInfo.SpendStatus}}</a>{{else}}{{.TicketInfo.SpendStatus}}{{end}}
-                    </td>
-                </tr>
+                    <tr>
+                        <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
+                        <td>
+                            {{if ne .TicketInfo.SpendStatus "Voted"}} {{.TicketInfo.PoolStatus}}  / {{end}} {{if (index .SpendingTxns 0).Hash}}<a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{.TicketInfo.SpendStatus}}</a>{{else}}{{.TicketInfo.SpendStatus}}{{end}}
+                        </td>
+                    </tr>
                 {{end}}
                 {{if eq .Mature "True"}}
-                    <td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td>
+                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td></tr>
                 {{end}}
                 {{if eq .Mature "False"}}
-                <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
-                    <td>
-                        <div class="row">
-                            <div class="col-11 col-lg-8 col-sm-12">
-                                <div class="progress" style="max-width: 330px">
-                                    <div
-                                        class="progress-bar"
-                                        role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%;"
-                                        aria-valuenow="{{.Confirmations}}"
-                                        aria-valuemin="0"
-                                        aria-valuemax="256"
-                                    >
-                                        <span class="nowrap pl-1 pr-1">
-                                            Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} days remaining){{end}}
-                                        </span>
+                    <tr>
+                        <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
+                        <td>
+                            <div class="row">
+                                <div class="col-11 col-lg-8 col-sm-12">
+                                    <div class="progress" style="max-width: 330px">
+                                        <div
+                                            class="progress-bar"
+                                            role="progressbar"
+                                            style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%;"
+                                            aria-valuenow="{{.Confirmations}}"
+                                            aria-valuemin="0"
+                                            aria-valuemax="256"
+                                        >
+                                            <span class="nowrap pl-1 pr-1">
+                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} days remaining){{end}}
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </td>
-                </tr>
+                        </td>
+                    </tr>
                 {{end}}
                 {{if eq .Type "Ticket"}}
-                {{if (and (.TicketInfo.VoteLuck) (eq .Mature "True"))}}
-                <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">LUCK</td>
-                    <td>
-                        {{printf "%.4f" .TicketInfo.VoteLuck}}
-                        {{if (or (le .TicketInfo.TicketExpiry .Confirmations) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
-                        (Best: {{.TicketInfo.BestLuck}} Avg: {{.TicketInfo.AvgLuck}})
-                    </td>
-                </tr>
-                {{end}}
-                {{if .TicketInfo.TicketExpiryDaysLeft}}
-                {{if eq .Mature "True"}}
-                {{if ge .TicketInfo.TicketExpiry .Confirmations}}
-                <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">PROBABILITY</td>
-                    <td>
-                        <div class="row">
-                            <div class="col-11 col-lg-8 col-sm-12">
-                                <div class="progress" style="max-width: 330px">
-                                    <div
-                                        class="progress-bar"
-                                        role="progressbar"
-                                        style="width: {{.TicketInfo.Probability}}%;"
-                                        aria-valuenow="{{.TicketInfo.Probability}}"
-                                        aria-valuemin="0"
-                                        aria-valuemax="1"
-                                    >
-                                        <span class="nowrap pl-1 pr-1">
-                                            {{printf "%.2f%%" .TicketInfo.Probability}} Chance
-                                        </span>
+                    {{if  (eq .Mature "True")}}
+                        <tr>
+                            <td class="text-right pr-2 h1rem p03rem0">LUCK</td>
+                            <td>
+                                {{printf "%.4f" .TicketInfo.VoteLuck}}
+                                {{if (or (lt .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms) (ne .TicketInfo.SpendStatus "Voted"))}} possible, {{.TicketInfo.LuckStatus}} {{else}} final, {{.TicketInfo.LuckStatus}} {{end}}
+                                (Best: {{.TicketInfo.BestLuck}} Avg: {{.TicketInfo.AvgLuck}})
+                            </td>
+                        </tr>
+                    {{end}}
+                    
+                    {{if and (and (eq .Mature "True")  (ne .TicketInfo.SpendStatus "Voted")) (eq .TicketInfo.PoolStatus "live")}}
+                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms}}
+                            <tr>
+                                <td class="text-right pr-2 h1rem p03rem0">PROBABILITY</td>
+                                <td>
+                                    <div class="row">
+                                        <div class="col-11 col-lg-8 col-sm-12">
+                                            <div class="progress" style="max-width: 330px">
+                                                <div
+                                                    class="progress-bar"
+                                                    role="progressbar"
+                                                    style="width: {{.TicketInfo.Probability}}%;"
+                                                    aria-valuenow="{{.TicketInfo.Probability}}"
+                                                    aria-valuemin="0"
+                                                    aria-valuemax="1"
+                                                >
+                                                    <span class="nowrap pl-1 pr-1">
+                                                        {{printf "%.2f%%" .TicketInfo.Probability}} Chance of not voting
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-                {{end}}
-                {{end}}
-                {{if ge .TicketInfo.TicketExpiry .Confirmations}}
-                <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
-                    <td>
-                        <div class="row">
-                            <div class="col-11 col-lg-8 col-sm-12">
-                                <div class="progress" style="max-width: 330px">
-                                    <div
-                                        class="progress-bar"
-                                        role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketExpiry}}%;"
-                                        aria-valuenow="{{.Confirmations}}"
-                                        aria-valuemin="0"
-                                        aria-valuemax="256"
-                                    >
-                                        <span class="nowrap pl-1 pr-1">
-                                            block {{.Confirmations}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)
-                                        </span>
+                                </td>
+                            </tr>
+                        {{end}}
+                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.ShortConfirms}}
+                            <tr>
+                                <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
+                                <td>
+                                    <div class="row">
+                                        <div class="col-11 col-lg-8 col-sm-12">
+                                            <div class="progress" style="max-width: 330px">
+                                                <div
+                                                    class="progress-bar"
+                                                    role="progressbar"
+                                                    style="width: {{percentage (subtract .TicketInfo.ShortConfirms 1) .TicketInfo.TicketExpiry}}%;"
+                                                    aria-valuenow="{{.Confirmations}}"
+                                                    aria-valuemin="0"
+                                                    aria-valuemax="256"
+                                                >
+                                                    <span class="nowrap pl-1 pr-1">
+                                                        block {{.TicketInfo.ShortConfirms}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-                {{else}}
-                <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
-                    <td>Expired</td>
-                {{end}}
-                {{end}}
+                                </td>
+                            </tr>
+                        {{else}}
+                        <tr>
+                            <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
+                            <td>Expired</td>
+                        {{end}}
+                    {{end}}
+
                 {{end}}
                 {{if .VoteFundsLocked}}
                 <tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -117,7 +117,7 @@
                                                     aria-valuemax="1"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">
-                                                        {{printf "%.2f%%" .TicketInfo.Probability}} Chance of expiry
+                                                        {{printf "%.2f%%" .TicketInfo.Probability}} chance of expiry
                                                     </span>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Proposed fixes for #281 

the ROI calculation for the main page was adjusted to take into consideration 50% likelihood days based on the following Poisson calculation of probabilities:

> Chance for a ticket to be voted in a given time frame:
> 1 - (1 - P)^N
> 
> Where:
> P is the probability of a vote in one block.
> N is the number of blocks before ticket expiry.

**Main Page**
ROI_DAYS= [[ ln(50%) / ln(1-(5/ACTUAL_TICKET_POOL)) ] + TICKET_MATURITY +COINBASE_MATURITY ] / BLOCKS_PER_DAY

**Transaction Page**
Added probability bar chart for this ticket based on time to expiry.  I'm not sure if this is what @raedah was referring to in https://github.com/decred/dcrdata/issues/281#issuecomment-374038922 or not but I felt it would be useful on this page.

Please let me know if you have any thoughts on the luck section.

**Additional Issues Noted**
The expiry time is incorrect.  Expiry starts at the end of the ticket maturity and therefore actual expiry is 40960+256 blocks after ticket purchase.  I would like to adjust that chart so its only visible for mature tickets and starts at block 0 right when the ticket matures, and 100% is at 40960.

**Screenshots**
![image](https://user-images.githubusercontent.com/11194546/39030952-3bb61cc2-441a-11e8-950c-fdf3902328c9.png)

![image](https://user-images.githubusercontent.com/11194546/39030967-5339126e-441a-11e8-8156-c9d4210f877f.png)

![image](https://user-images.githubusercontent.com/11194546/39030977-6205b43c-441a-11e8-95bc-5cc316f22956.png)

**Todo**

1. Fix Expiry on transactions page
2. Confirm boundary cases display the proper info for probability and expiry bar charts: immaturity -> maturity -> expiry.  Voted, revoked, expired, missed.
3. Check for divide by zero problems or at least see how Go handles them


