### PR TITLE
Add db_block_time to API JSON status response

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -17,9 +17,6 @@ type apiMux struct {
 	*chi.Mux
 }
 
-// APIVersion is an integer value, incremented for breaking changes
-const APIVersion = 0
-
 func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 	// chi router
 	mux := chi.NewRouter()

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrdata/explorer"
 	m "github.com/decred/dcrdata/middleware"
 	notify "github.com/decred/dcrdata/notification"
+	appver "github.com/decred/dcrdata/version"
 )
 
 // DataSourceLite specifies an interface for collecting data from the built-in
@@ -117,7 +118,7 @@ func NewContext(client *rpcclient.Client, dataSource DataSourceLite, auxDataSour
 			Height:          uint32(nodeHeight),
 			NodeConnections: conns,
 			APIVersion:      APIVersion,
-			DcrdataVersion:  ver.String(),
+			DcrdataVersion:  appver.Ver.String(),
 		},
 		JSONIndent: JSONIndent,
 	}

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -171,6 +171,7 @@ out:
 
 			c.statusMtx.Lock()
 			c.Status.DBHeight = height
+			c.Status.DBLastBlockTime = summary.Time
 
 			bdHeight := c.BlockData.GetHeight()
 			if bdHeight >= 0 && summary.Height == uint32(bdHeight) &&

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -240,6 +240,7 @@ type VinPrevOut struct {
 type Status struct {
 	Ready           bool   `json:"ready"`
 	DBHeight        uint32 `json:"db_height"`
+	DBLastBlockTime int64  `json:"db_block_time"`
 	Height          uint32 `json:"node_height"`
 	NodeConnections int64  `json:"node_connections"`
 	APIVersion      int    `json:"api_version"`

--- a/api/version.go
+++ b/api/version.go
@@ -5,6 +5,9 @@ package api
 
 import "fmt"
 
+// APIVersion is an integer value, incremented for breaking changes
+const APIVersion = 1
+
 type version struct {
 	Major, Minor, Patch int
 	Label               string

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrdata/version"
 	"github.com/decred/dcrwallet/netparams"
 )
 
@@ -290,7 +291,7 @@ func loadConfig() (*config, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	if preCfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s)\n", appName,
-			ver.String(), runtime.Version())
+			version.Ver.String(), runtime.Version())
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/semver"
 	"github.com/decred/dcrdata/txhelpers"
+	"github.com/decred/dcrdata/version"
 	"github.com/go-chi/chi"
 )
 
@@ -64,7 +65,8 @@ func mainCore() error {
 	}
 
 	// Start with version info
-	log.Infof(appName+" version %s", ver.String())
+	ver := &version.Ver
+	log.Infof(version.AppName+" version %s", ver)
 
 	// PostgreSQL
 	usePG := cfg.FullMode

--- a/version/version.go
+++ b/version/version.go
@@ -1,14 +1,14 @@
-package main
+package version
 
 import "fmt"
 
-type version struct {
+type Version struct {
 	Major, Minor, Patch int
 	Label               string
 	Nick                string
 }
 
-var ver = version{
+var Ver = Version{
 	Major: 2,
 	Minor: 0,
 	Patch: 0,
@@ -18,9 +18,9 @@ var ver = version{
 // go build -ldflags "-X main.CommitHash=`git rev-parse --short HEAD`"
 var CommitHash string
 
-const appName string = "dcrdata"
+const AppName string = "dcrdata"
 
-func (v *version) String() string {
+func (v *Version) String() string {
 	var hashStr string
 	if CommitHash != "" {
 		hashStr = "+" + CommitHash


### PR DESCRIPTION
This is a step toward addressing PR #399 .  It adds the `db_block_time` key to the `/api/status` response:

```json
{
  "ready": true,
  "db_height": 231821,
  "db_block_time": 1524286912,
  "node_height": 231821,
  "node_connections": 1,
  "api_version": 1,
  "dcrdata_version": "2.0.0"
}
```

This is UNIX epoch time, so it is easy to compute the age of the block.  In addition, the user may check:
1.  `db_height` and `node_height`
2. `ready`, which should now be fixed, such that it only reports true when `db_height == node_height`

This PR also creates a `version` package for dcrdata, uses the proper app version in the status response, and bumps `APIVersion` to 1.