### PR TITLE
use flexbox & truncate tx hash to compact mempool table on home page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -464,6 +464,20 @@ body.darkBG #menu {
   table-layout: fixed;
 }
 
+/*flexboxtable*/
+.flex-table .header {
+  padding: 0.36rem .5rem;
+  background: #fff !important;
+  border-bottom: 1px solid #e2e2e2;
+  font-size: 13px;
+  font-weight: 500;
+}
+.flex-table-row {
+  padding: .4rem;
+  font-size: 13px;
+  border-bottom: 1px solid #e4e4e4;
+}
+
 .addressAndScriptData {
   overflow: hidden;
 }
@@ -524,6 +538,12 @@ body.darkBG #menu {
   display: inline-block;
   word-wrap: break-word;
   transition: .133s transform;
+}
+.truncate-hash {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /*resemble voting.decred.org*/

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -154,6 +154,20 @@
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    function txRowHTMLFlexBox(tx) {
+        var totalTxt = ""
+        humanize.decimalParts(tx.total, false, 8).forEach(function (str) {
+            totalTxt += str.textContent
+        })
+        return `<div class="d-flex flex-table-row">
+            <a class="hash truncate-hash" style="flex: 1 1 auto" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
+            <span style="flex: 0 0 60px" class="mono text-right ml-1">${tx.Type}</span>
+            <span style="flex: 0 0 105px" class="mono text-right ml-1">${totalTxt}</span>
+            <span style="flex: 0 0 50px" class="mono text-right ml-1">${tx.size} B</span>
+            <span style="flex: 0 0 65px" class="mono text-right ml-1" data-age="${tx.time}">${humanize.timeSince(tx.time)}</span>
+        </div>`
+    }
+
     var ws; // websocket global
     async function createWebSocket(loc) {
         // wait a bit to prevent websocket churn from drive by page loads
@@ -232,18 +246,8 @@
             }
             
             if (window.location.pathname == "/"){
-                var rows = $('#mini-transactions tbody tr')
-                var totalTxt = "" 
-                humanize.decimalParts(tx.total, false, 8).forEach(function (str) {
-                    totalTxt += str.textContent
-                })
-                var newRow = '<tr><td class="break-word"><span><a class="hash" href="/tx/' +
-                    tx.hash + '">' + tx.hash + '</a></span></td>' +
-                    '<td class="mono fs15">' + tx.Type + '</td>' +
-                    '<td class="mono fs15">' + totalTxt +'</td>' +
-                    '<td class="mono fs15">' + tx.size + ' B</td>' +
-                    '<td class="mono fs15" data-age="' + tx.time +'">' + humanize.timeSince(tx.time) +'</td></tr>'
-                var newRowHtml = $.parseHTML(newRow)
+                var rows = $('#mini-transactions .flex-table-row')
+                var newRowHtml = $.parseHTML(txRowHTMLFlexBox(tx))
                 rows.last().remove()
                 $(newRowHtml).insertBefore(rows.first())
             }
@@ -404,7 +408,7 @@
                     '<td class="mono fs15">' + tx.Type + '</td>'+
                     '<td class="mono fs15">' + totalTxt +'</td>' +
                     '<td class="mono fs15">' + tx.size + ' B</td>' +
-                    '<td class="mono fs15" data-age="' + tx.time +'">' + humanize.timeSince(tx.time) +'</td></tr>' 
+                    '<td class="mono fs15" data-age="' + tx.time +'">' + humanize.timeSince(tx.time) +'</td></tr>'
                 })
                 $('#mini-transactions tbody').html(newTable)
             }

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -145,34 +145,35 @@
 
             <div class="col-md-6">
 
-                <h4 class="mb-3">Latest Transactions</h4>
-                <table class="table table-sm striped" id="mini-transactions">
-                    <thead>
-                        <th>Hash</th>
-                        <th>Type</th>
-                        <th>Total Sent</th>
-                        <th>Size</th>
-                        <th>Age</th>
-                    </thead>
-                    <tbody>
-                        {{range .Mempool.LatestTransactions}}
-                            <tr>
-                                <td class="break-word">
-                                    <span>
-                                        <a class="hash" href="/tx/{{.Hash}}">{{.Hash}}</a>
-                                    </span>
-                                </td>
-                                <td class="mono fs15">{{.Type}}</td>
-                                <td class="mono fs15">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
-                                <td class="mono fs15">{{.Size}} B</td>
-                                <td class="mono fs15" data-age="{{.Time}}"></td>
-                            </tr>
-                        {{end}}
-                    </tbody>
-                </table>
-                <div class="mb-3"><a href="/mempool"><small>More mempool...</small></a></div>
+                <div class="d-flex align-items-center">
+                    <h4>Latest Transactions</h4> <a href="/mempool" class="pl-2"><small>see more ...</small></a>
+                </div>
 
-                <h4 class="mb-3">Latest Blocks</h4>
+                <div class="mb-3 flex-table">
+                    <div class="d-flex justify-content-end header">
+                        <span class="lh1rem mr-auto">Hash</span>
+                        <span style="flex: 0 0 65px" class="lh1rem text-right ml-1">Type</span>
+                        <span style="flex: 0 0 105px" class="lh1rem text-right ml-1">Total Sent</span>
+                        <span style="flex: 0 0 50px" class="lh1rem text-right ml-1">Size</span>
+                        <span style="flex: 0 0 62px" class="lh1rem text-right ml-1">Age</span>
+                    </div>
+                    <div id="mini-transactions" class="transactions md-height-rows rows">
+                    {{range .Mempool.LatestTransactions}}
+                        <div class="d-flex flex-table-row">
+                            <a class="hash truncate-hash" style="flex: 1 1 auto" href="/tx/{{.Hash}}" title="{{.Hash}}">{{.Hash}}</a>
+                            <span style="flex: 0 0 65px" class="mono text-right ml-1">{{.Type}}</span>
+                            <span style="flex: 0 0 105px" class="mono text-right ml-1">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</span>
+                            <span style="flex: 0 0 50px" class="mono text-right ml-1">{{.Size}} B</span>
+                            <span style="flex: 0 0 62px" class="mono text-right ml-1" data-age="{{.Time}}"></span>
+                        </div>
+                    {{end}}
+                    </div>
+                </div>
+
+                <div class="d-flex align-items-center">
+                    <h4>Latest Blocks</h4> <a href="/blocks" class="pl-2"><small>see more ...</small></a>
+                </div>
+
                 <table class="table striped table-responsive full-width" id="explorertable">
                     <thead>
                         <tr>
@@ -207,7 +208,6 @@
                         {{end}}
                     </tbody>
                 </table>
-                <div class="mb-3"><a href="/blocks"><small>More blocks...</small></a></div>
 
             </div>
 


### PR DESCRIPTION
This change makes it so the mempool table on home page takes up a bit less space.
The transaction column now takes up as much space as is available, while the rest of the columns have fixed widths set to accommodate their widest possible values. 

Couple notes:
- Added title attribute so full hash is shown in hover state
- The full value of the tx hash is always there in the html, so users can still copy/paste a full tx hash into their browser Find function <img width="660" alt="screen shot 2018-04-26 at 12 14 35 am" src="https://user-images.githubusercontent.com/25571523/39291180-fd4b6394-48e6-11e8-86be-2982e683773a.png">
- moved "more mempool" & "more blocks" links up to their respective headings and re-worded to "see more", to further conserve space

Old:
<img width="1202" alt="screen shot 2018-04-26 at 12 24 10 am" src="https://user-images.githubusercontent.com/25571523/39291532-3410a4b0-48e8-11e8-98dd-819730408e1f.png">
New: 
<img width="1202" alt="screen shot 2018-04-26 at 12 24 16 am" src="https://user-images.githubusercontent.com/25571523/39291538-3996ec1e-48e8-11e8-887f-c63658d52335.png">

