### PR TITLE
APR Calculation on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ parsing more efficient for the client.
 | Other | Path | Type |
 | --- | --- | --- |
 | Status | `/status` | `types.Status` |
+| Coin Supply | `/supply` | `types.CoinSupply` |
 | Endpoint list (always indented) | `/list` | `[]string` |
 | Directory | `/directory` | `string` |
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ necessary.
 
 ## Getting Started
 
+### Configure PostgreSQL (IMPORTANT)
+
+If you intend to run dcrdata in "full" mode (i.e. with the `--pg` switch), which
+uses a PostgreSQL database backend, it is crucial that you configure your
+PostgreSQL server for your hardware and the dcrdata workload.
+
+Read [postgresql-tuning.conf](./db/dcrpg/postgresql-tuning.conf) carefully for
+details on how to make the necessary changes to your system.
+
 ### Create configuration file
 
 Begin with the sample configuration file:

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -33,7 +33,8 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 
 	mux.Get("/", app.root)
 
-	mux.HandleFunc("/status", app.status)
+	mux.Get("/status", app.status)
+	mux.Get("/supply", app.coinSupply)
 
 	mux.Route("/block", func(r chi.Router) {
 		r.Route("/best", func(rd chi.Router) {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -26,6 +26,7 @@ import (
 // DataSourceLite specifies an interface for collecting data from the built-in
 // databases (i.e. SQLite, storm, ffldb)
 type DataSourceLite interface {
+	CoinSupply() *apitypes.CoinSupply
 	GetHeight() int
 	GetBestBlockHash() (string, error)
 	GetBlockHash(idx int64) (string, error)
@@ -248,6 +249,17 @@ func (c *appContext) status(w http.ResponseWriter, r *http.Request) {
 	c.statusMtx.RLock()
 	defer c.statusMtx.RUnlock()
 	writeJSON(w, c.Status, c.getIndentQuery(r))
+}
+
+func (c *appContext) coinSupply(w http.ResponseWriter, r *http.Request) {
+	supply := c.BlockData.CoinSupply()
+	if supply == nil {
+		apiLog.Error("Unable to get coin supply.")
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSON(w, supply, c.getIndentQuery(r))
 }
 
 func (c *appContext) currentHeight(w http.ResponseWriter, r *http.Request) {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -247,6 +247,14 @@ type Status struct {
 	DcrdataVersion  string `json:"dcrdata_version"`
 }
 
+// CoinSupply models the coin supply at a certain best block.
+type CoinSupply struct {
+	Height   int64  `json:"block_height"`
+	Hash     string `json:"block_hash"`
+	Mined    int64  `json:"supply_mined"`
+	Ultimate int64  `json:"supply_ultimate"`
+}
+
 // TicketPoolInfo models data about ticket pool
 type TicketPoolInfo struct {
 	Height  uint32   `json:"height"`

--- a/db/dcrpg/postgresql-tuning.conf
+++ b/db/dcrpg/postgresql-tuning.conf
@@ -1,22 +1,39 @@
-# General PostgreSQL tuning (adjust for your machine)
+# PostgreSQL tuning suggestions (adjust for your machine).
 # See PgTune: http://pgtune.leopard.in.ua/
-# Decent values for a 8GB system:
-max_connections = 8
-shared_buffers = 2048MB
-effective_cache_size = 6GB
-work_mem = 256MB
-maintenance_work_mem = 512MB
-max_worker_processes = 6
-wal_buffers = 16MB
-max_wal_size = 4GB
-min_wal_size = 2GB
-checkpoint_completion_target = 0.8
-default_statistics_target = 200
+# 
+# To apply these changes, edit the existing postgresql.conf that is in use on
+# your system.
+# - Arch: /var/lib/postgres/data/postgresql.conf
+# - Ubuntu: /etc/postgresql/{{.pg_version}}/main/postgresql.conf
+# - Mac: /usr/local/var/postgres/postgres.conf
+# Be sure to restart PostgreSQL after saving the config.
 
+# This is the most important setting for fast initial database population.
 # OK for general use on a stable system. Insert with alacrity.
 synchronous_commit = off
 
-# Large import/insert only
+# Decent values for a 6-8GB system with 2 cores:
+max_connections = 22
+shared_buffers = 2GB
+effective_cache_size = 6GB
+maintenance_work_mem = 512MB
+max_worker_processes = 2
+work_mem = 47662kB # scale this down with increasing #cores and #connections!
+max_parallel_workers_per_gather = 1
+# max_parallel_workers = 2 # v10+ only
+wal_buffers = 16MB
+max_wal_size = 2GB
+min_wal_size = 1GB
+checkpoint_completion_target = 0.9
+default_statistics_target = 100
+
+# Drive type-specific settings
+random_page_cost = 1.1 # for SSD/SAN
+effective_io_concurrency = 200 # for SSD/SAN
+# random_page_cost = 4 # for HDD
+# effective_io_concurrency = 2 # for HDD
+
+# Large import/insert only. Reverse for normal use.
 autovacuum = off
 fsync = off # but synchronous_commit is probably enough
 full_page_writes = off

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -364,14 +364,14 @@ func (exp *explorerUI) simulateAPR(
 	ActualTicketPrice float64) (APR float64, ReturnTable string) {
 
 	var AvgTicketBlocks = float64(exp.ChainParams.TicketExpiry) / float64(exp.ChainParams.TicketsPerBlock)
-	var BlocksPerDay float64 = 86400 / float64(exp.ChainParams.TargetTimePerBlock.Seconds())
+	var BlocksPerDay float64 = 86400 / exp.ChainParams.TargetTimePerBlock.Seconds()
 	var BlocksPerYear float64 = 365 * BlocksPerDay
 	var TicketsPurchased float64
 
 	StakeRewardAtBlock := func(blocknum float64) float64 {
 		// Option 1:  RPC Call
 		Subsidy := exp.blockData.GetBlockSubsidy(int64(blocknum), 1)
-		return float64(dcrutil.Amount(Subsidy.PoS).ToCoin())
+		return dcrutil.Amount(Subsidy.PoS).ToCoin()
 
 		// Option 2:  Calculation
 		// epoch := math.Floor(blocknum / float64(exp.ChainParams.SubsidyReductionInterval))

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -172,8 +172,18 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		log.Warnf("explorer.New: %v", err)
 	}
 	log.Debugf("Organization address: %s", devSubsidyAddress)
+
+	// Set default static values for ExtraInfo
 	exp.ExtraInfo = &HomeInfo{
 		DevAddress: devSubsidyAddress,
+		Params: ChainParams{
+			WindowSize:       exp.ChainParams.StakeDiffWindowSize,
+			RewardWindowSize: exp.ChainParams.SubsidyReductionInterval,
+			BlockTime:        exp.ChainParams.TargetTimePerBlock.Nanoseconds(),
+		},
+		PoolInfo: TicketPoolInfo{
+			Target: exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock,
+		},
 	}
 
 	noTemplateError := func(err error) *explorerUI {
@@ -220,73 +230,63 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		return (a / b) * 100
 	}
 
-	exp.ExtraInfo = &HomeInfo{
-		CoinSupply:        blockData.ExtraInfo.CoinSupply,
-		StakeDiff:         blockData.CurrentStakeDiff.CurrentStakeDifficulty,
-		IdxBlockInWindow:  blockData.IdxBlockInWindow,
-		IdxInRewardWindow: int(newBlockData.Height % exp.ChainParams.SubsidyReductionInterval),
-		DevAddress:        exp.ExtraInfo.DevAddress,
-		Difficulty:        blockData.Header.Difficulty,
-		NBlockSubsidy: BlockSubsidy{
-			Dev:   blockData.ExtraInfo.NextBlockSubsidy.Developer,
-			PoS:   blockData.ExtraInfo.NextBlockSubsidy.PoS,
-			PoW:   blockData.ExtraInfo.NextBlockSubsidy.PoW,
-			Total: blockData.ExtraInfo.NextBlockSubsidy.Total,
-		},
-		Params: ChainParams{
-			WindowSize:       exp.ChainParams.StakeDiffWindowSize,
-			RewardWindowSize: exp.ChainParams.SubsidyReductionInterval,
-			BlockTime:        exp.ChainParams.TargetTimePerBlock.Nanoseconds(),
-		},
-		PoolInfo: TicketPoolInfo{
-			Size:       blockData.PoolInfo.Size,
-			Value:      blockData.PoolInfo.Value,
-			ValAvg:     blockData.PoolInfo.ValAvg,
-			Percentage: percentage(blockData.PoolInfo.Value, dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()),
-			Target:     exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock,
-			PercentTarget: func() float64 {
-				target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
-				return float64(blockData.PoolInfo.Size) / target * 100
-			}(),
-		},
-		TicketROI: func() float64 {
-			PosSubPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() / float64(exp.ChainParams.TicketsPerBlock)
-			return percentage(PosSubPerVote, blockData.CurrentStakeDiff.CurrentStakeDifficulty)
-		}(),
+	// Update all ExtraInfo with latest data
+	exp.ExtraInfo.CoinSupply = blockData.ExtraInfo.CoinSupply
+	exp.ExtraInfo.StakeDiff = blockData.CurrentStakeDiff.CurrentStakeDifficulty
+	exp.ExtraInfo.IdxBlockInWindow = blockData.IdxBlockInWindow
+	exp.ExtraInfo.IdxInRewardWindow = int(newBlockData.Height % exp.ChainParams.SubsidyReductionInterval)
+	exp.ExtraInfo.Difficulty = blockData.Header.Difficulty
+	exp.ExtraInfo.NBlockSubsidy.Dev = blockData.ExtraInfo.NextBlockSubsidy.Developer
+	exp.ExtraInfo.NBlockSubsidy.PoS = blockData.ExtraInfo.NextBlockSubsidy.PoS
+	exp.ExtraInfo.NBlockSubsidy.PoW = blockData.ExtraInfo.NextBlockSubsidy.PoW
+	exp.ExtraInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
+	exp.ExtraInfo.PoolInfo.Size = blockData.PoolInfo.Size
+	exp.ExtraInfo.PoolInfo.Value = blockData.PoolInfo.Value
+	exp.ExtraInfo.PoolInfo.ValAvg = blockData.PoolInfo.ValAvg
+	exp.ExtraInfo.PoolInfo.Percentage = percentage(blockData.PoolInfo.Value, dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin())
 
-		// If there are ticketpoolsize*TicketsPerBlock total tickets and
-		// TicketsPerBlock are drawn every block, and assuming random selection
-		// of tickets, then any one ticket will, on average, be selected to vote
-		// once every ticketpoolsize blocks
+	exp.ExtraInfo.PoolInfo.PercentTarget = func() float64 {
+		target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
+		return float64(blockData.PoolInfo.Size) / target * 100
+	}()
 
-		// Small deviations in reality are due to:
-		// 1.  Not all blocks have 5 votes.  On average each block in Decred
-		// currently has about 4.8 votes per block
-		// 2.  Total tickets in the pool varies slightly above and below
-		// ticketpoolsize*TicketsPerBlock depending on supply and demand
+	exp.ExtraInfo.TicketROI = func() float64 {
+		PosSubPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() / float64(exp.ChainParams.TicketsPerBlock)
+		return percentage(PosSubPerVote, blockData.CurrentStakeDiff.CurrentStakeDifficulty)
+	}()
 
-		// Both minor deviations are not accounted for in the general ROI
-		// calculation below because the variance they cause would be would be
-		// extremely small.
+	// If there are ticketpoolsize*TicketsPerBlock total tickets and
+	// TicketsPerBlock are drawn every block, and assuming random selection
+	// of tickets, then any one ticket will, on average, be selected to vote
+	// once every ticketpoolsize blocks
 
-		// The actual ROI of a ticket needs to also take into consideration the
-		// ticket maturity (time from ticket purchase until its eligible to vote)
-		// and coinbase maturity (time after vote until funds distributed to
-		// ticket holder are avaliable to use)
-		ROIPeriod: func() string {
-			PosAvgTotalBlocks := float64(
-				exp.ChainParams.TicketPoolSize +
-					exp.ChainParams.TicketMaturity +
-					exp.ChainParams.CoinbaseMaturity)
-			return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
-		}(),
-	}
+	// Small deviations in reality are due to:
+	// 1.  Not all blocks have 5 votes.  On average each block in Decred
+	// currently has about 4.8 votes per block
+	// 2.  Total tickets in the pool varies slightly above and below
+	// ticketpoolsize*TicketsPerBlock depending on supply and demand
+
+	// Both minor deviations are not accounted for in the general ROI
+	// calculation below because the variance they cause would be would be
+	// extremely small.
+
+	// The actual ROI of a ticket needs to also take into consideration the
+	// ticket maturity (time from ticket purchase until its eligible to vote)
+	// and coinbase maturity (time after vote until funds distributed to
+	// ticket holder are avaliable to use)
+	exp.ExtraInfo.ROIPeriod = func() string {
+		PosAvgTotalBlocks := float64(
+			exp.ChainParams.TicketPoolSize +
+				exp.ChainParams.TicketMaturity +
+				exp.ChainParams.CoinbaseMaturity)
+		return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
+	}()
+
+	exp.NewBlockDataMtx.Unlock()
 
 	if !exp.liteMode {
 		go exp.updateDevFundBalance()
 	}
-
-	exp.NewBlockDataMtx.Unlock()
 
 	// Signal to the websocket hub that a new block was received, but do not
 	// block Store(), and do not hang forever in a goroutine waiting to send.

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -232,6 +232,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		return (a / b) * 100
 	}
 
+	stakePerc := blockData.PoolInfo.Value / dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()
+
 	// Update all ExtraInfo with latest data
 	exp.ExtraInfo.CoinSupply = blockData.ExtraInfo.CoinSupply
 	exp.ExtraInfo.StakeDiff = blockData.CurrentStakeDiff.CurrentStakeDifficulty
@@ -245,7 +247,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	exp.ExtraInfo.PoolInfo.Size = blockData.PoolInfo.Size
 	exp.ExtraInfo.PoolInfo.Value = blockData.PoolInfo.Value
 	exp.ExtraInfo.PoolInfo.ValAvg = blockData.PoolInfo.ValAvg
-	exp.ExtraInfo.PoolInfo.Percentage = blockData.PoolInfo.Value / dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()
+	exp.ExtraInfo.PoolInfo.Percentage = stakePerc * 100
 
 	exp.ExtraInfo.PoolInfo.PercentTarget = func() float64 {
 		target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
@@ -283,9 +285,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 				exp.ChainParams.CoinbaseMaturity)
 		return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
 	}()
-	apr, _ := exp.simulateAPR(1000, false, exp.ExtraInfo.PoolInfo.Percentage, 
-		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(), 
-		float64(exp.NewBlockData.Height), 
+	apr, _ := exp.simulateAPR(1000, false, stakePerc,
+		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(),
+		float64(exp.NewBlockData.Height),
 		blockData.CurrentStakeDiff.CurrentStakeDifficulty)
 
 	exp.ExtraInfo.APR = apr

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -6,6 +6,7 @@ package explorer
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -51,6 +52,7 @@ type explorerDataSourceLite interface {
 	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 	GetMempool() []MempoolTx
 	TxHeight(txid string) (height int64)
+	GetBlockSubsidy(height int64, voters uint16) *dcrjson.GetBlockSubsidyResult
 }
 
 // explorerDataSource implements extra data retrieval functions that require a
@@ -243,7 +245,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	exp.ExtraInfo.PoolInfo.Size = blockData.PoolInfo.Size
 	exp.ExtraInfo.PoolInfo.Value = blockData.PoolInfo.Value
 	exp.ExtraInfo.PoolInfo.ValAvg = blockData.PoolInfo.ValAvg
-	exp.ExtraInfo.PoolInfo.Percentage = percentage(blockData.PoolInfo.Value, dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin())
+	exp.ExtraInfo.PoolInfo.Percentage = blockData.PoolInfo.Value / dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()
 
 	exp.ExtraInfo.PoolInfo.PercentTarget = func() float64 {
 		target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
@@ -281,6 +283,12 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 				exp.ChainParams.CoinbaseMaturity)
 		return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
 	}()
+	apr, _ := exp.simulateAPR(1000, false, exp.ExtraInfo.PoolInfo.Percentage, 
+		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(), 
+		float64(exp.NewBlockData.Height), 
+		blockData.CurrentStakeDiff.CurrentStakeDifficulty)
+
+	exp.ExtraInfo.APR = apr
 
 	exp.NewBlockDataMtx.Unlock()
 
@@ -341,4 +349,116 @@ func (exp *explorerUI) addRoutes() {
 	exp.Mux.Get("/address/{x}", redirect("address"))
 
 	exp.Mux.Get("/decodetx", redirect("decodetx"))
+}
+
+// Simulate ticket purchase and re-investment over a full year for a given
+// starting amount of DCR and calculation parameters.  Generate a TEXT table of
+// the simulation results that can optionally be used for future expansion of
+// dcrdata functionality.
+func (exp *explorerUI) simulateAPR(
+	StartingDCRBalance float64,
+	IntegerTicketQty bool,
+	CurrentStakePercent float64,
+	ActualCoinbase float64,
+	CurrentBlockNum float64,
+	ActualTicketPrice float64) (APR float64, ReturnTable string) {
+
+	var AvgTicketBlocks = float64(exp.ChainParams.TicketExpiry) / float64(exp.ChainParams.TicketsPerBlock)
+	var BlocksPerDay float64 = 86400 / float64(exp.ChainParams.TargetTimePerBlock.Seconds())
+	var BlocksPerYear float64 = 365 * BlocksPerDay
+	var TicketsPurchased float64
+
+	StakeRewardAtBlock := func(blocknum float64) float64 {
+		// Option 1:  RPC Call
+		Subsidy := exp.blockData.GetBlockSubsidy(int64(blocknum), 1)
+		return float64(dcrutil.Amount(Subsidy.PoS).ToCoin())
+
+		// Option 2:  Calculation
+		// epoch := math.Floor(blocknum / float64(exp.ChainParams.SubsidyReductionInterval))
+		// RewardProportionPerVote := float64(exp.ChainParams.StakeRewardProportion) / (10 * float64(exp.ChainParams.TicketsPerBlock))
+		// return float64(RewardProportionPerVote) * dcrutil.Amount(exp.ChainParams.BaseSubsidy).ToCoin() *
+		// 	math.Pow(float64(exp.ChainParams.MulSubsidy)/float64(exp.ChainParams.DivSubsidy), epoch)
+	}
+
+	MaxCoinSupplyAtBlock := func(blocknum float64) float64 {
+		// 4th order poly best fit curve to Decred mainnet emissions plot.
+		// Curve fit was done with 0 Y intercept and Pre-Mine added after.
+
+		return (-9E-19*math.Pow(blocknum, 4) +
+			7E-12*math.Pow(blocknum, 3) -
+			2E-05*math.Pow(blocknum, 2) +
+			29.757*blocknum + 76963 +
+			1680000) // Premine 1.68M
+
+	}
+
+	var CoinAdjustmentFactor = ActualCoinbase / MaxCoinSupplyAtBlock(CurrentBlockNum)
+
+	TheoreticalTicketPrice := func(blocknum float64) float64 {
+		ProjectedCoinsCirculating := MaxCoinSupplyAtBlock(blocknum) * CoinAdjustmentFactor * CurrentStakePercent
+		TicketPoolSize := (AvgTicketBlocks + float64(exp.ChainParams.TicketMaturity) +
+			float64(exp.ChainParams.CoinbaseMaturity)) * float64(exp.ChainParams.TicketsPerBlock)
+		return ProjectedCoinsCirculating / TicketPoolSize
+
+	}
+	var TicketAdjustmentFactor = ActualTicketPrice / TheoreticalTicketPrice(CurrentBlockNum)
+
+	// Prepare for simulation
+	simblock := CurrentBlockNum
+	TicketPrice := ActualTicketPrice
+	DCRBalance := StartingDCRBalance
+
+	ReturnTable += fmt.Sprintf("\n\nBLOCKNUM        DCR  TICKETS TKT_PRICE TKT_REWRD  ACTION\n")
+	ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    INIT\n",
+		int64(simblock), DCRBalance, TicketsPurchased,
+		TicketPrice, StakeRewardAtBlock(simblock))
+
+	for simblock < (BlocksPerYear + CurrentBlockNum) {
+
+		// Simulate a Purchase on simblock
+		TicketPrice = TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor
+
+		if IntegerTicketQty {
+			// Use this to simulate integer qtys of tickets up to max funds
+			TicketsPurchased = math.Floor(DCRBalance / TicketPrice)
+		} else {
+			// Use this to simulate ALL funds used to buy tickets - even fractional tickets
+			// which is actually not possible
+			TicketsPurchased = (DCRBalance / TicketPrice)
+		}
+
+		DCRBalance -= (TicketPrice * TicketsPurchased)
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f     BUY\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			TicketPrice, StakeRewardAtBlock(simblock))
+
+		// Move forward to average vote
+		simblock += (float64(exp.ChainParams.TicketMaturity) + AvgTicketBlocks)
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    VOTE\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+
+		// Simulate return of funds
+		DCRBalance += (TicketPrice * TicketsPurchased)
+
+		// Simulate reward
+		DCRBalance += (StakeRewardAtBlock(simblock) * TicketsPurchased)
+		TicketsPurchased = 0
+
+		// Move forward to coinbase maturity
+		simblock += float64(exp.ChainParams.CoinbaseMaturity)
+
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f  REWARD\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+
+		// Need to receive funds before we can use them again so add 1 block
+		simblock++
+	}
+
+	// Scale down to exactly 365 days
+	SimulationROI := ((DCRBalance - StartingDCRBalance) / StartingDCRBalance) * 100
+	APR = (BlocksPerYear / (simblock - CurrentBlockNum)) * SimulationROI
+	ReturnTable += fmt.Sprintf("APR over 365 Days is %.2f.\n", APR)
+	return
 }

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -258,6 +258,7 @@ type HomeInfo struct {
 	DevAddress        string         `json:"dev_address"`
 	TicketROI         float64        `json:"roi"`
 	ROIPeriod         string         `json:"roi_period"`
+	APR               float64        `json:"APR"`
 	NBlockSubsidy     BlockSubsidy   `json:"subsidy"`
 	Params            ChainParams    `json:"params"`
 	PoolInfo          TicketPoolInfo `json:"pool_info"`

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -92,9 +92,12 @@ body.darkBG a:hover {
 body.darkBG .table thead th {
   vertical-align: bottom;
 }
+body.darkBG .flex-table .header,
 body.darkBG .table thead tr {
   background: #2d2d2d !important;
 }
+body.darkBG .flex-table .flex-table-row,
+body.darkBG .flex-table .header,
 body.darkBG .table tr {
   border-bottom: 1px solid #2d2d2d;
 }
@@ -478,7 +481,7 @@ body.darkBG .progress {
 /*flexboxtable*/
 .flex-table .header {
   padding: 0.36rem .5rem;
-  background: #fff !important;
+  background: #fff;
   border-bottom: 1px solid #e2e2e2;
   font-size: 13px;
   font-weight: 500;

--- a/txhelpers/subsidy.go
+++ b/txhelpers/subsidy.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2013-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txhelpers
+
+import (
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/chaincfg"
+)
+
+// UltimateSubsidy computes the total subsidy over the entire subsidy
+// distribution period of the network.
+func UltimateSubsidy(params *chaincfg.Params) int64 {
+	subsidyCache := blockchain.NewSubsidyCache(0, params)
+
+	totalSubsidy := params.BlockOneSubsidy()
+	for i := int64(0); ; i++ {
+		// Genesis block or first block.
+		if i <= 1 {
+			continue
+		}
+
+		if i%params.SubsidyReductionInterval == 0 {
+			numBlocks := params.SubsidyReductionInterval
+			// First reduction internal, which is reduction interval - 2 to skip
+			// the genesis block and block one.
+			if i == params.SubsidyReductionInterval {
+				numBlocks -= 2
+			}
+			height := i - numBlocks
+
+			work := blockchain.CalcBlockWorkSubsidy(subsidyCache, height,
+				params.TicketsPerBlock, params)
+			stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, height,
+				params) * int64(params.TicketsPerBlock)
+			tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, height,
+				params.TicketsPerBlock, params)
+			if (work + stake + tax) == 0 {
+				break // all done
+			}
+			totalSubsidy += ((work + stake + tax) * numBlocks)
+
+			// First reduction internal -- subtract the stake subsidy for blocks
+			// before the staking system is enabled.
+			if i == params.SubsidyReductionInterval {
+				totalSubsidy -= stake * (params.StakeValidationHeight - 2)
+			}
+		}
+	}
+	return totalSubsidy
+}

--- a/txhelpers/subsidy_test.go
+++ b/txhelpers/subsidy_test.go
@@ -1,0 +1,15 @@
+package txhelpers
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+func TestBlockSubsidy(t *testing.T) {
+	totalSubsidy := UltimateSubsidy(&chaincfg.MainNetParams)
+
+	if totalSubsidy != 2099999999800912 {
+		t.Errorf("Bad total subsidy; want 2099999999800912, got %v", totalSubsidy)
+	}
+}

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -59,7 +59,7 @@
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1 vam">TICKET ROI</td>
-                            <td class="mono vam fs24 fs14-decimal">+<span id="ticket_roi">{{printf "%.2f" .TicketROI}}</span>% <span class="mono lh1rem fs18">per ~{{.ROIPeriod}}</span></td>
+                            <td class="mono vam fs24 fs14-decimal">+<span id="ticket_roi">{{printf "%.2f" .TicketROI}}</span>% <span class="mono lh1rem fs18">per ~{{.ROIPeriod}}</span>  <span class="mono lh1rem fs18">({{printf "%.2f" .APR}}% APR)</span></td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1">TICKET POOL SIZE</td>


### PR DESCRIPTION
This Proposed PR addresses APR calculations as referenced in #381
![image](https://user-images.githubusercontent.com/11194546/39547822-8eb42ea8-4e0d-11e8-95b2-52a4dd45ef3d.png)

**Guidance is requested on the following items:**

1.  A new function, simulateAPR,  was added to explorer.go.  Architecturally I'm not sure if this is the best place for this.  Viable alternatives may be:  explorermiddleware.go or txhelpers.go
2.  StakeRewardAtBlock was originally created using a calculation and then replaced with an RPC call.  Either works fine so its just a matter of preference.  Seems like an RPC call would be less efficient, but likely is a better architecture to use a function if it exists.
3.  MaxCoinSupplyAtBlock is a calculation.  I was hoping to find an RPC call to provide a theoretical coinbase projection for an arbitrary future block, but it does not seem to exist.  I created a 4th order poly to fit to the expected emissions.  The calculation is here:  https://docs.google.com/spreadsheets/d/1uzIBF9q__JYx4EWeAJAdviB4B-Y8IVNEUGmSww3HRX8/edit?usp=sharing
4.  Should the apr simulation be executed on a separate thread much like we have done with `go exp.updateDevFundBalance()` to help improve rendering time?  

**Brief Explanation of Solution:**
1.  We have a function to forecast reward at an arbitrary block number
2.  We have a function to forecast max coin supply at an arbitrary block number
3.  We have a function to forecast theoretical ticket price at an arbitrary block number.  Assuming stake pool percent of total coin supply stays constant, we can project forward what the ticket price will be as the coin supply increases.
4.  We normalize our ticket prices and coin supply to match existing actuals to further refine our projections.
5.  We then start a loop where we simulate a purchase at the current block, a reward after the "average" reward time in blocks, and coinbase maturity to get the funds back in our wallet.  We repeat this cycle enough times to get through a full year.
6.  Once we are through at least 365 days we then reduce the ROI down to exactly 365 days to get a APR for a year rather than for the simulated number of days.

**Simulation Options:**
1.  You can select to use integer ticket numbers or float ticket numbers.  This was done to make the ROI independent of actual tickets purchased, and assuming 100% of funds are in use.  It is our vision that in the future a separate "detailed APR" calculation page can be implemented where the user can enter their actual DCR and simulate actual possible ticket purchases.
2.  The simulation outputs a simple text table that can be leveraged into a future implementation where the details of the simulation are presented to the user.  Rather than remove it from the prototyping I did, I left it so its easier to add back later.  You can see it in action here:  https://play.golang.org/p/y6exAOH9yQD
