### PR TITLE
explorer: show miner fees in coinbase transaction

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1113,6 +1113,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	tx.Type = txhelpers.DetermineTxTypeString(msgTx)
 	tx.BlockHeight = txraw.BlockHeight
 	tx.BlockIndex = txraw.BlockIndex
+	tx.BlockHash = txraw.BlockHash
 	tx.Confirmations = txraw.Confirmations
 	tx.Time = txraw.Time
 	t := time.Unix(tx.Time, 0)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1025,7 +1025,10 @@ func (db *wiredDB) GetExplorerBlock(hash string) *explorer.BlockInfo {
 		switch stake.DetermineTxType(msgTx) {
 		case stake.TxTypeSSGen:
 			stx := makeExplorerTxBasic(tx, msgTx, db.params)
-			stx.Fee, stx.FeeRate = 0.0, 0.0
+			// Fees for votes should be zero, but if the transaction was created
+			// with unmatched inputs/outputs then the remainder becomes a fee.
+			// Account for this possibility by calculating the fee for votes as
+			// well.
 			votes = append(votes, stx)
 		case stake.TxTypeSStx:
 			stx := makeExplorerTxBasic(tx, msgTx, db.params)
@@ -1085,7 +1088,7 @@ func (db *wiredDB) GetExplorerBlock(hash string) *explorer.BlockInfo {
 	block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Revs) +
 		getTotalSent(block.Tickets) + getTotalSent(block.Votes)).ToCoin()
 	block.MiningFee = getTotalFee(block.Tx) + getTotalFee(block.Revs) +
-		getTotalFee(block.Tickets)
+		getTotalFee(block.Tickets) + getTotalFee(block.Votes)
 
 	return block
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -179,6 +179,20 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !exp.liteMode {
+		// For any coinbase transactions look up the total block fees to include as part of the inputs
+		if tx.Type == "Coinbase" {
+			blkHash, err := exp.blockData.GetBlockHash(tx.BlockHeight)
+			if err != nil {
+				log.Errorf("Unable to get block %v", tx.BlockHeight)
+				return
+			}
+			data := exp.blockData.GetExplorerBlock(blkHash)
+			if data == nil {
+				log.Errorf("Unable to get block %s", blkHash)
+				return
+			}
+			tx.BlockMiningFee = int64(data.MiningFee)
+		}
 		// For each output of this transaction, look up any spending transactions,
 		// and the index of the spending transaction input.
 		spendingTxHashes, spendingTxVinInds, voutInds, err := exp.explorerSource.SpendingTransactions(hash)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -181,14 +181,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 	if !exp.liteMode {
 		// For any coinbase transactions look up the total block fees to include as part of the inputs
 		if tx.Type == "Coinbase" {
-			blkHash, err := exp.blockData.GetBlockHash(tx.BlockHeight)
-			if err != nil {
-				log.Errorf("Unable to get block %v", tx.BlockHeight)
-				return
-			}
-			data := exp.blockData.GetExplorerBlock(blkHash)
+			data := exp.blockData.GetExplorerBlock(tx.BlockHash)
 			if data == nil {
-				log.Errorf("Unable to get block %s", blkHash)
+				log.Errorf("Unable to get block %s", tx.BlockHash)
 				return
 			}
 			tx.BlockMiningFee = int64(data.MiningFee)

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -77,6 +77,7 @@ type TxInfo struct {
 	Vout             []Vout
 	BlockHeight      int64
 	BlockIndex       uint32
+	BlockHash        string
 	BlockMiningFee   int64
 	Confirmations    int64
 	Time             int64

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -77,6 +77,7 @@ type TxInfo struct {
 	Vout             []Vout
 	BlockHeight      int64
 	BlockIndex       uint32
+	BlockMiningFee   int64
 	Confirmations    int64
 	Time             int64
 	FormattedTime    string

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -280,6 +280,14 @@
                         <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{template "decimalParts" (float64AsDecimalParts .AmountIn false)}} {{end}}</td>
                     </tr>
                     {{end}}
+                    {{if and (eq .Type "Coinbase") (gt .BlockMiningFee 0)}}
+                        <tr>
+                            <td class="mono fs13">(Transaction Fees Collected)</td>
+                            <td></td>
+                            <td></td>
+                            <td class="mono fs13 text-right">{{template "decimalParts" (amountAsDecimalParts .BlockMiningFee false)}}</td>
+                        </tr>        
+                    {{end}}
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
Block reward transactions are slightly confusing at present because the total value of inputs does not match the total value of outputs.  An example is as follows:

![image](https://user-images.githubusercontent.com/11194546/39549851-2b2f9438-4e14-11e8-857c-50e5541af19c.png)

**18.43873754 != 2.63410536 + 62.79779869**

To make these transactions less confusing the block fees are displayed in coinbase transactions as follows:

![image](https://user-images.githubusercontent.com/11194546/39549869-334c0e76-4e14-11e8-9990-8039a109a395.png)

I will continue to look for alternatives to the two step function call GetBlockHash(tx.BlockHeight) -> GetExplorerBlock(blkHash) to get block fees.  Recommendations welcome.  