### PR TITLE
api: add coin supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ parsing more efficient for the client.
 | Other | Path | Type |
 | --- | --- | --- |
 | Status | `/status` | `types.Status` |
+| Coin Supply | `/supply` | `types.CoinSupply` |
 | Endpoint list (always indented) | `/list` | `[]string` |
 | Directory | `/directory` | `string` |
 

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -33,7 +33,8 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 
 	mux.Get("/", app.root)
 
-	mux.HandleFunc("/status", app.status)
+	mux.Get("/status", app.status)
+	mux.Get("/supply", app.coinSupply)
 
 	mux.Route("/block", func(r chi.Router) {
 		r.Route("/best", func(rd chi.Router) {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -26,6 +26,7 @@ import (
 // DataSourceLite specifies an interface for collecting data from the built-in
 // databases (i.e. SQLite, storm, ffldb)
 type DataSourceLite interface {
+	CoinSupply() *apitypes.CoinSupply
 	GetHeight() int
 	GetBestBlockHash() (string, error)
 	GetBlockHash(idx int64) (string, error)
@@ -248,6 +249,17 @@ func (c *appContext) status(w http.ResponseWriter, r *http.Request) {
 	c.statusMtx.RLock()
 	defer c.statusMtx.RUnlock()
 	writeJSON(w, c.Status, c.getIndentQuery(r))
+}
+
+func (c *appContext) coinSupply(w http.ResponseWriter, r *http.Request) {
+	supply := c.BlockData.CoinSupply()
+	if supply == nil {
+		apiLog.Error("Unable to get coin supply.")
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSON(w, supply, c.getIndentQuery(r))
 }
 
 func (c *appContext) currentHeight(w http.ResponseWriter, r *http.Request) {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -247,6 +247,14 @@ type Status struct {
 	DcrdataVersion  string `json:"dcrdata_version"`
 }
 
+// CoinSupply models the coin supply at a certain best block.
+type CoinSupply struct {
+	Height   int64  `json:"block_height"`
+	Hash     string `json:"block_hash"`
+	Mined    int64  `json:"supply_mined"`
+	Ultimate int64  `json:"supply_ultimate"`
+}
+
 // TicketPoolInfo models data about ticket pool
 type TicketPoolInfo struct {
 	Height  uint32   `json:"height"`

--- a/txhelpers/subsidy.go
+++ b/txhelpers/subsidy.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2013-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txhelpers
+
+import (
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/chaincfg"
+)
+
+// UltimateSubsidy computes the total subsidy over the entire subsidy
+// distribution period of the network.
+func UltimateSubsidy(params *chaincfg.Params) int64 {
+	subsidyCache := blockchain.NewSubsidyCache(0, params)
+
+	totalSubsidy := params.BlockOneSubsidy()
+	for i := int64(0); ; i++ {
+		// Genesis block or first block.
+		if i <= 1 {
+			continue
+		}
+
+		if i%params.SubsidyReductionInterval == 0 {
+			numBlocks := params.SubsidyReductionInterval
+			// First reduction internal, which is reduction interval - 2 to skip
+			// the genesis block and block one.
+			if i == params.SubsidyReductionInterval {
+				numBlocks -= 2
+			}
+			height := i - numBlocks
+
+			work := blockchain.CalcBlockWorkSubsidy(subsidyCache, height,
+				params.TicketsPerBlock, params)
+			stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, height,
+				params) * int64(params.TicketsPerBlock)
+			tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, height,
+				params.TicketsPerBlock, params)
+			if (work + stake + tax) == 0 {
+				break // all done
+			}
+			totalSubsidy += ((work + stake + tax) * numBlocks)
+
+			// First reduction internal -- subtract the stake subsidy for blocks
+			// before the staking system is enabled.
+			if i == params.SubsidyReductionInterval {
+				totalSubsidy -= stake * (params.StakeValidationHeight - 2)
+			}
+		}
+	}
+	return totalSubsidy
+}

--- a/txhelpers/subsidy_test.go
+++ b/txhelpers/subsidy_test.go
@@ -1,0 +1,15 @@
+package txhelpers
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+func TestBlockSubsidy(t *testing.T) {
+	totalSubsidy := UltimateSubsidy(&chaincfg.MainNetParams)
+
+	if totalSubsidy != 2099999999800912 {
+		t.Errorf("Bad total subsidy; want 2099999999800912, got %v", totalSubsidy)
+	}
+}


### PR DESCRIPTION
This adds the `/supply` API endpoint and `apitypes.CoinSupply`.

txhelpers/subsidy.go is added with the function `UltimateSubsidy`.