### PR TITLE
add missing night mode styling for flex table header bg & row borders

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -92,9 +92,12 @@ body.darkBG a:hover {
 body.darkBG .table thead th {
   vertical-align: bottom;
 }
+body.darkBG .flex-table .header,
 body.darkBG .table thead tr {
   background: #2d2d2d !important;
 }
+body.darkBG .flex-table .flex-table-row,
+body.darkBG .flex-table .header,
 body.darkBG .table tr {
   border-bottom: 1px solid #2d2d2d;
 }
@@ -478,7 +481,7 @@ body.darkBG .progress {
 /*flexboxtable*/
 .flex-table .header {
   padding: 0.36rem .5rem;
-  background: #fff !important;
+  background: #fff;
   border-bottom: 1px solid #e2e2e2;
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
before
<img width="501" alt="screen shot 2018-05-04 at 12 29 05 pm" src="https://user-images.githubusercontent.com/25571523/39648359-ca5c8196-4f96-11e8-958a-72ee49edb6ba.png">

<img width="505" alt="screen shot 2018-05-04 at 12 29 16 pm" src="https://user-images.githubusercontent.com/25571523/39648367-d3977b12-4f96-11e8-85f8-5bb25146f2f2.png">
after
