### PR TITLE
notification: make each reorg handler indicate when it is finished

### DIFF
--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -17,6 +18,7 @@ type ReorgData struct {
 	OldChainHeight int32
 	NewChainHead   chainhash.Hash
 	NewChainHeight int32
+	WG             *sync.WaitGroup
 }
 
 // for getblock, ticketfeeinfo, estimatestakediff, etc.
@@ -232,6 +234,8 @@ out:
 				newHash, newHeight)
 			log.Infof("Reorganize started in blockdata. OLD head block %v at height %d.",
 				oldHash, oldHeight)
+
+			reorgData.WG.Done()
 
 		case _, ok := <-p.quit:
 			if !ok {

--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -17,6 +18,7 @@ type ReorgData struct {
 	OldChainHeight int32
 	NewChainHead   chainhash.Hash
 	NewChainHeight int32
+	WG             *sync.WaitGroup
 }
 
 // ChainMonitor handles change notifications from the node client
@@ -246,6 +248,8 @@ out:
 				newHash, newHeight)
 			log.Infof("Reorganize started. OLD head block %v at height %d.",
 				oldHash, oldHeight)
+
+			reorgData.WG.Done()
 
 		case _, ok := <-p.quit:
 			if !ok {

--- a/notification/ntfnchans.go
+++ b/notification/ntfnchans.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -26,14 +27,12 @@ const (
 	// expNewTxChanBuffer is the size of the new transaction buffer for explorer
 	expNewTxChanBuffer = 70
 
-	reorgBuffer = 2
-
 	// relevantMempoolTxChanBuffer is the size of the new transaction channel
 	// buffer, for relevant transactions that are added into mempool.
 	//relevantMempoolTxChanBuffer = 2048
 )
 
-// Channels are package-level variables for simplicity
+// NtfnChans collects the chain server notification channels
 var NtfnChans struct {
 	ConnectChan                       chan *chainhash.Hash
 	ReorgChanBlockData                chan *blockdata.ReorgData
@@ -65,9 +64,9 @@ func MakeNtfnChans(monitorMempool bool) {
 	NtfnChans.ConnectChanStakeDB = make(chan *chainhash.Hash)
 
 	// Reorg data channels
-	NtfnChans.ReorgChanBlockData = make(chan *blockdata.ReorgData, reorgBuffer)
-	NtfnChans.ReorgChanWiredDB = make(chan *dcrsqlite.ReorgData, reorgBuffer)
-	NtfnChans.ReorgChanStakeDB = make(chan *stakedb.ReorgData, reorgBuffer)
+	NtfnChans.ReorgChanBlockData = make(chan *blockdata.ReorgData)
+	NtfnChans.ReorgChanWiredDB = make(chan *dcrsqlite.ReorgData)
+	NtfnChans.ReorgChanStakeDB = make(chan *stakedb.ReorgData)
 
 	// To update app status
 	NtfnChans.UpdateStatusNodeHeight = make(chan uint32, blockConnChanBuffer)

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -17,6 +18,7 @@ type ReorgData struct {
 	OldChainHeight int32
 	NewChainHead   chainhash.Hash
 	NewChainHeight int32
+	WG             *sync.WaitGroup
 }
 
 // ChainMonitor connects blocks to the stake DB as they come in.
@@ -240,6 +242,8 @@ out:
 				newHash, newHeight)
 			log.Infof("Reorganize started. OLD head block %v at height %d.",
 				oldHash, oldHeight)
+
+			reorgData.WG.Done()
 
 		case _, ok := <-p.quit:
 			if !ok {


### PR DESCRIPTION
Do not leave OnReorganization before each handler sets the reorg flag.

Make reorg channels unbuffered.

This is intended to address a possible panic if `OnReorganization` before each handler that connected to `OnBlockConnected` has gone into reorg mode.