### PR TITLE
APR Calculation on home page

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -6,6 +6,7 @@ package explorer
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -51,6 +52,7 @@ type explorerDataSourceLite interface {
 	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 	GetMempool() []MempoolTx
 	TxHeight(txid string) (height int64)
+	GetBlockSubsidy(height int64, voters uint16) *dcrjson.GetBlockSubsidyResult
 }
 
 // explorerDataSource implements extra data retrieval functions that require a
@@ -230,6 +232,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		return (a / b) * 100
 	}
 
+	stakePerc := blockData.PoolInfo.Value / dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()
+
 	// Update all ExtraInfo with latest data
 	exp.ExtraInfo.CoinSupply = blockData.ExtraInfo.CoinSupply
 	exp.ExtraInfo.StakeDiff = blockData.CurrentStakeDiff.CurrentStakeDifficulty
@@ -243,7 +247,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	exp.ExtraInfo.PoolInfo.Size = blockData.PoolInfo.Size
 	exp.ExtraInfo.PoolInfo.Value = blockData.PoolInfo.Value
 	exp.ExtraInfo.PoolInfo.ValAvg = blockData.PoolInfo.ValAvg
-	exp.ExtraInfo.PoolInfo.Percentage = percentage(blockData.PoolInfo.Value, dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin())
+	exp.ExtraInfo.PoolInfo.Percentage = stakePerc * 100
 
 	exp.ExtraInfo.PoolInfo.PercentTarget = func() float64 {
 		target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
@@ -281,6 +285,13 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 				exp.ChainParams.CoinbaseMaturity)
 		return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
 	}()
+
+	apr, _ := exp.simulateAPR(1000, false, stakePerc,
+		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(),
+		float64(exp.NewBlockData.Height),
+		blockData.CurrentStakeDiff.CurrentStakeDifficulty)
+
+	exp.ExtraInfo.APR = apr
 
 	exp.NewBlockDataMtx.Unlock()
 
@@ -341,4 +352,116 @@ func (exp *explorerUI) addRoutes() {
 	exp.Mux.Get("/address/{x}", redirect("address"))
 
 	exp.Mux.Get("/decodetx", redirect("decodetx"))
+}
+
+// Simulate ticket purchase and re-investment over a full year for a given
+// starting amount of DCR and calculation parameters.  Generate a TEXT table of
+// the simulation results that can optionally be used for future expansion of
+// dcrdata functionality.
+func (exp *explorerUI) simulateAPR(
+	StartingDCRBalance float64,
+	IntegerTicketQty bool,
+	CurrentStakePercent float64,
+	ActualCoinbase float64,
+	CurrentBlockNum float64,
+	ActualTicketPrice float64) (APR float64, ReturnTable string) {
+
+	var AvgTicketBlocks = float64(exp.ChainParams.TicketExpiry) / float64(exp.ChainParams.TicketsPerBlock)
+	var BlocksPerDay float64 = 86400 / exp.ChainParams.TargetTimePerBlock.Seconds()
+	var BlocksPerYear float64 = 365 * BlocksPerDay
+	var TicketsPurchased float64
+
+	StakeRewardAtBlock := func(blocknum float64) float64 {
+		// Option 1:  RPC Call
+		Subsidy := exp.blockData.GetBlockSubsidy(int64(blocknum), 1)
+		return dcrutil.Amount(Subsidy.PoS).ToCoin()
+
+		// Option 2:  Calculation
+		// epoch := math.Floor(blocknum / float64(exp.ChainParams.SubsidyReductionInterval))
+		// RewardProportionPerVote := float64(exp.ChainParams.StakeRewardProportion) / (10 * float64(exp.ChainParams.TicketsPerBlock))
+		// return float64(RewardProportionPerVote) * dcrutil.Amount(exp.ChainParams.BaseSubsidy).ToCoin() *
+		// 	math.Pow(float64(exp.ChainParams.MulSubsidy)/float64(exp.ChainParams.DivSubsidy), epoch)
+	}
+
+	MaxCoinSupplyAtBlock := func(blocknum float64) float64 {
+		// 4th order poly best fit curve to Decred mainnet emissions plot.
+		// Curve fit was done with 0 Y intercept and Pre-Mine added after.
+
+		return (-9E-19*math.Pow(blocknum, 4) +
+			7E-12*math.Pow(blocknum, 3) -
+			2E-05*math.Pow(blocknum, 2) +
+			29.757*blocknum + 76963 +
+			1680000) // Premine 1.68M
+
+	}
+
+	var CoinAdjustmentFactor = ActualCoinbase / MaxCoinSupplyAtBlock(CurrentBlockNum)
+
+	TheoreticalTicketPrice := func(blocknum float64) float64 {
+		ProjectedCoinsCirculating := MaxCoinSupplyAtBlock(blocknum) * CoinAdjustmentFactor * CurrentStakePercent
+		TicketPoolSize := (AvgTicketBlocks + float64(exp.ChainParams.TicketMaturity) +
+			float64(exp.ChainParams.CoinbaseMaturity)) * float64(exp.ChainParams.TicketsPerBlock)
+		return ProjectedCoinsCirculating / TicketPoolSize
+
+	}
+	var TicketAdjustmentFactor = ActualTicketPrice / TheoreticalTicketPrice(CurrentBlockNum)
+
+	// Prepare for simulation
+	simblock := CurrentBlockNum
+	TicketPrice := ActualTicketPrice
+	DCRBalance := StartingDCRBalance
+
+	ReturnTable += fmt.Sprintf("\n\nBLOCKNUM        DCR  TICKETS TKT_PRICE TKT_REWRD  ACTION\n")
+	ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    INIT\n",
+		int64(simblock), DCRBalance, TicketsPurchased,
+		TicketPrice, StakeRewardAtBlock(simblock))
+
+	for simblock < (BlocksPerYear + CurrentBlockNum) {
+
+		// Simulate a Purchase on simblock
+		TicketPrice = TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor
+
+		if IntegerTicketQty {
+			// Use this to simulate integer qtys of tickets up to max funds
+			TicketsPurchased = math.Floor(DCRBalance / TicketPrice)
+		} else {
+			// Use this to simulate ALL funds used to buy tickets - even fractional tickets
+			// which is actually not possible
+			TicketsPurchased = (DCRBalance / TicketPrice)
+		}
+
+		DCRBalance -= (TicketPrice * TicketsPurchased)
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f     BUY\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			TicketPrice, StakeRewardAtBlock(simblock))
+
+		// Move forward to average vote
+		simblock += (float64(exp.ChainParams.TicketMaturity) + AvgTicketBlocks)
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    VOTE\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+
+		// Simulate return of funds
+		DCRBalance += (TicketPrice * TicketsPurchased)
+
+		// Simulate reward
+		DCRBalance += (StakeRewardAtBlock(simblock) * TicketsPurchased)
+		TicketsPurchased = 0
+
+		// Move forward to coinbase maturity
+		simblock += float64(exp.ChainParams.CoinbaseMaturity)
+
+		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f  REWARD\n",
+			int64(simblock), DCRBalance, TicketsPurchased,
+			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+
+		// Need to receive funds before we can use them again so add 1 block
+		simblock++
+	}
+
+	// Scale down to exactly 365 days
+	SimulationROI := ((DCRBalance - StartingDCRBalance) / StartingDCRBalance) * 100
+	APR = (BlocksPerYear / (simblock - CurrentBlockNum)) * SimulationROI
+	ReturnTable += fmt.Sprintf("APR over 365 Days is %.2f.\n", APR)
+	return
 }

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -258,6 +258,7 @@ type HomeInfo struct {
 	DevAddress        string         `json:"dev_address"`
 	TicketROI         float64        `json:"roi"`
 	ROIPeriod         string         `json:"roi_period"`
+	APR               float64        `json:"APR"`
 	NBlockSubsidy     BlockSubsidy   `json:"subsidy"`
 	Params            ChainParams    `json:"params"`
 	PoolInfo          TicketPoolInfo `json:"pool_info"`

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -59,7 +59,7 @@
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1 vam">TICKET ROI</td>
-                            <td class="mono vam fs24 fs14-decimal">+<span id="ticket_roi">{{printf "%.2f" .TicketROI}}</span>% <span class="mono lh1rem fs18">per ~{{.ROIPeriod}}</span></td>
+                            <td class="mono vam fs24 fs14-decimal">+<span id="ticket_roi">{{printf "%.2f" .TicketROI}}</span>% <span class="mono lh1rem fs18">per ~{{.ROIPeriod}}</span>  <span class="mono lh1rem fs18">({{printf "%.2f" .APR}}% APR)</span></td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1">TICKET POOL SIZE</td>


### PR DESCRIPTION
This PR supersedes #455 . 

This Proposed PR addresses APR calculations as referenced in #381
![image](https://user-images.githubusercontent.com/11194546/39547822-8eb42ea8-4e0d-11e8-95b2-52a4dd45ef3d.png)

**Guidance is requested on the following items:**

1.  A new function, simulateAPR,  was added to explorer.go.  Architecturally I'm not sure if this is the best place for this.  Viable alternatives may be:  explorermiddleware.go or txhelpers.go
2.  StakeRewardAtBlock was originally created using a calculation and then replaced with an RPC call.  Either works fine so its just a matter of preference.  Seems like an RPC call would be less efficient, but likely is a better architecture to use a function if it exists.
3.  MaxCoinSupplyAtBlock is a calculation.  I was hoping to find an RPC call to provide a theoretical coinbase projection for an arbitrary future block, but it does not seem to exist.  I created a 4th order poly to fit to the expected emissions.  The calculation is here:  https://docs.google.com/spreadsheets/d/1uzIBF9q__JYx4EWeAJAdviB4B-Y8IVNEUGmSww3HRX8/edit?usp=sharing
4.  Should the apr simulation be executed on a separate thread much like we have done with `go exp.updateDevFundBalance()` to help improve rendering time?  

**Brief Explanation of Solution:**
1.  We have a function to forecast reward at an arbitrary block number
2.  We have a function to forecast max coin supply at an arbitrary block number
3.  We have a function to forecast theoretical ticket price at an arbitrary block number.  Assuming stake pool percent of total coin supply stays constant, we can project forward what the ticket price will be as the coin supply increases.
4.  We normalize our ticket prices and coin supply to match existing actuals to further refine our projections.
5.  We then start a loop where we simulate a purchase at the current block, a reward after the "average" reward time in blocks, and coinbase maturity to get the funds back in our wallet.  We repeat this cycle enough times to get through a full year.
6.  Once we are through at least 365 days we then reduce the ROI down to exactly 365 days to get a APR for a year rather than for the simulated number of days.

**Simulation Options:**
1.  You can select to use integer ticket numbers or float ticket numbers.  This was done to make the ROI independent of actual tickets purchased, and assuming 100% of funds are in use.  It is our vision that in the future a separate "detailed APR" calculation page can be implemented where the user can enter their actual DCR and simulate actual possible ticket purchases.
2.  The simulation outputs a simple text table that can be leveraged into a future implementation where the details of the simulation are presented to the user.  Rather than remove it from the prototyping I did, I left it so its easier to add back later.  You can see it in action here:  https://play.golang.org/p/y6exAOH9yQD

