### PR TITLE
main: add optional gops agent and instrumentation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -166,10 +166,26 @@
   version = "v1.0.2"
 
 [[projects]]
+  name = "github.com/google/gops"
+  packages = [
+    "agent",
+    "internal",
+    "signal"
+  ]
+  revision = "0e2aa5d22efec1603f7ded7097c500e9a36a13b3"
+  version = "v0.3.3"
+
+[[projects]]
   branch = "master"
   name = "github.com/jrick/logrotate"
   packages = ["rotator"]
   revision = "a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/kardianos/osext"
+  packages = ["."]
+  revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
   branch = "master"
@@ -260,6 +276,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2bfe6c04715a8ce07c4c67aeaa959e5781c1fd325c9add797b1a3cf9cb5036ed"
+  inputs-digest = "fe5b947435570c0e28a50da66350ad16286a4680e2344bca270bb81cc707e5dd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config.go
+++ b/config.go
@@ -77,6 +77,7 @@ type config struct {
 	HTTPProfile  bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
 	HTTPProfPath string `long:"httpprofprefix" description:"URL path prefix for the HTTP profiler."`
 	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling."`
+	UseGops      bool   `short:"g" long:"gops" description:"Run with gops diagnostics agent listening. See github.com/google/gops for more information."`
 
 	// API
 	APIProto           string `long:"apiproto" description:"Protocol for API (http or https)"`

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/version"
 	"github.com/go-chi/chi"
+	"github.com/google/gops/agent"
 )
 
 // mainCore does all the work. Deferred functions do not run after os.Exit(),
@@ -62,6 +63,14 @@ func mainCore() error {
 		}
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if cfg.UseGops {
+		// Start gops diagnostic agent, without shutdown cleanup
+		if err = agent.Listen(agent.Options{}); err != nil {
+			return err
+		}
+		defer agent.Close()
 	}
 
 	// Start with version info

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -436,7 +436,7 @@ func (db *StakeDatabase) connectBlock(block *dcrutil.Block, spent []chainhash.Ha
 
 	// Get ticket pool info at current best (just connected in stakedb) block,
 	// and store it in the StakeDatabase's PoolInfoCache.
-	liveTickets := db.BestNode.LiveTickets()
+	liveTickets := db.BestNode.LiveTickets() // TODO: use NewTickets() instead and merge with liveTicketCache
 	winningTickets := db.BestNode.Winners()
 	height := db.BestNode.Height()
 	pib := db.calcPoolInfo(liveTickets, winningTickets, height)


### PR DESCRIPTION
This PR adds the ability to start the gops agent running (see https://github.com/google/gops).  The gops agent is used in conjunction with the `gops` command line tool to report information including: the current stack trace, Go version, memory stats, etc.  Profiling and traces can also be collected for 30 and 5 second intervals, respectively.