### PR TITLE
Insight API UTXO+ [10] [11] [12] [3] [4]

### DIFF
--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -47,7 +47,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	mux.With(m.BlockDateQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
 	mux.With(app.BlockHashPathAndIndexCtx).Get("/block/{blockhash}", app.getBlockSummary)
 	mux.With(m.BlockIndexPathCtx).Get("/block-index/{idx}", app.getBlockHash)
-	mux.With(m.BlockIndexOrHashPathCtx).Get("/rawblock/{idx}", app.getRawBlock)
+	mux.With(app.BlockIndexOrHashPathCtx).Get("/rawblock/{idxorhash}", app.getRawBlock)
 
 	// Transaction endpoints
 	mux.With(middleware.AllowContentType("application/json"),
@@ -69,14 +69,15 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 		// POST methods
 		rd.With(middleware.AllowContentType("application/json"),
 			app.ValidatePostCtx, app.PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
-		rd.With(m.AddressPostCtx).Post("/utxo", app.getAddressesTxnOutput)
+		rd.With(middleware.AllowContentType("application/json"),
+			app.ValidatePostCtx, app.PostAddrsUtxoCtx).Post("/utxo", app.getAddressesTxnOutput)
 	})
 
 	// Address endpoints
 	mux.Route("/addr/{address}", func(rd chi.Router) {
 		rd.Use(m.AddressPathCtx)
 		rd.With(m.PaginationCtx).Get("/", app.getAddressInfo)
-		rd.Get("/utxo", app.getAddressTxnOutput)
+		rd.Get("/utxo", app.getAddressesTxnOutput)
 		rd.Get("/balance", app.getAddressBalance)
 		rd.Get("/totalReceived", app.getAddressTotalReceived)
 		// TODO Missing unconfirmed balance implementation

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -188,17 +189,40 @@ func (c *insightApiContext) getBlockChainHashCtx(r *http.Request) *chainhash.Has
 }
 
 func (c *insightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) {
-	hash := c.getBlockChainHashCtx(r)
-	blockMsg, err := c.nodeClient.GetBlock(hash)
+
+	hash, ok := c.GetInsightBlockHashCtx(r)
+	if !ok {
+		idx, ok := c.GetInsightBlockIndexCtx(r)
+		if !ok {
+			apiLog.Error("Unable to get block hash from index")
+			writeInsightError(w, "Must provide an index or block hash")
+			return
+		}
+		var err error
+		hash, err = c.BlockData.ChainDB.GetBlockHash(int64(idx))
+		if err != nil {
+			apiLog.Error("Unable to get block hash from index")
+			writeInsightError(w, "Unable to get block hash from index")
+			return
+		}
+	}
+	chainHash, err := chainhash.NewHashFromStr(hash)
 	if err != nil {
-		apiLog.Errorf("Failed to retrieve block %s: %v", hash.String(), err)
-		http.Error(w, http.StatusText(422), 422)
+		apiLog.Errorf("Failed to parse block hash: %v", err)
+		writeInsightError(w, fmt.Sprintf("Failed to parse block hash: %v", err))
+		return
+	}
+
+	blockMsg, err := c.nodeClient.GetBlock(chainHash)
+	if err != nil {
+		apiLog.Errorf("Failed to retrieve block %s: %v", chainHash.String(), err)
+		writeInsightNotFound(w, fmt.Sprintf("Failed to retrieve block %s: %v", chainHash.String(), err))
 		return
 	}
 	var blockHex bytes.Buffer
 	if err = blockMsg.Serialize(&blockHex); err != nil {
 		apiLog.Errorf("Failed to serialize block: %v", err)
-		http.Error(w, http.StatusText(422), 422)
+		writeInsightError(w, fmt.Sprintf("Failed to serialize block"))
 		return
 	}
 
@@ -220,7 +244,6 @@ func (c *insightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *ht
 
 	// Check maximum transaction size
 	if len(rawHexTx)/2 > c.params.MaxTxSize {
-		apiLog.Errorf("Rawtx length exceeds maximum allowable characters (%d bytes received)", len(rawHexTx)/2)
 		writeInsightError(w, fmt.Sprintf("Rawtx length exceeds maximum allowable characters (%d bytes received)", len(rawHexTx)/2))
 		return
 	}
@@ -242,29 +265,95 @@ func (c *insightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *ht
 	writeJSON(w, txidJSON, c.getIndentQuery(r))
 }
 
-func (c *insightApiContext) getAddressTxnOutput(w http.ResponseWriter, r *http.Request) {
-	address := m.GetAddressCtx(r)
+func (c *insightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http.Request) {
+	address := m.GetAddressCtx(r) // Required
 	if address == "" {
-		http.Error(w, http.StatusText(422), 422)
+		writeInsightError(w, "Address cannot be empty")
 		return
 	}
-	txnOutputs := c.BlockData.ChainDB.GetAddressUTXO(address)
-	writeJSON(w, txnOutputs, c.getIndentQuery(r))
-}
 
-func (c *insightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http.Request) {
-	addresses := strings.Split(m.GetAddressCtx(r), ",")
+	// Allow Addresses to be single or multiple separated by a comma.
+	addresses := strings.Split(address, ",")
 
-	var txnOutputs []apitypes.AddressTxnOutput
+	// Initialize Output Structure
+	txnOutputs := make([]apitypes.AddressTxnOutput, 0)
 
 	for _, address := range addresses {
-		if address == "" {
-			http.Error(w, http.StatusText(422), 422)
-			return
+
+		confirmedTxnOutputs := c.BlockData.ChainDB.GetAddressUTXO(address)
+
+		addressOuts, _, err := c.MemPool.UnconfirmedTxnsForAddress(address)
+		if err != nil {
+			apiLog.Errorf("Error in getting unconfirmed transactions")
 		}
-		utxo := c.BlockData.ChainDB.GetAddressUTXO(address)
-		txnOutputs = append(txnOutputs, utxo...)
+
+		if addressOuts != nil {
+			// If there is any mempool add to the utxo set
+		FUNDING_TX_DUPLICATE_CHECK:
+			for _, f := range addressOuts.Outpoints {
+				fundingTx, ok := addressOuts.TxnsStore[f.Hash]
+				if !ok {
+					apiLog.Errorf("An outpoint's transaction is not available in TxnStore.")
+					continue
+				}
+				if fundingTx.Confirmed() {
+					apiLog.Errorf("An outpoint's transaction is unexpectedly confirmed.")
+					continue
+				}
+				// TODO: Confirmed() not always return true for txs that have
+				// already been confirmed in a block.  The mempool cache update
+				// process should correctly update these.  Until we sort out why we
+				// need to do one more search on utxo and do not add if this is
+				// already in the list as a confirmed tx.
+				for _, utxo := range confirmedTxnOutputs {
+					if utxo.Vout == f.Index && utxo.TxnID == f.Hash.String() {
+						continue FUNDING_TX_DUPLICATE_CHECK
+					}
+				}
+
+				txnOutput := apitypes.AddressTxnOutput{
+					Address:       address,
+					TxnID:         fundingTx.Hash().String(),
+					Vout:          f.Index,
+					ScriptPubKey:  hex.EncodeToString(fundingTx.Tx.TxOut[f.Index].PkScript),
+					Amount:        dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
+					Satoshis:      fundingTx.Tx.TxOut[f.Index].Value,
+					Confirmations: 0,
+					BlockTime:     fundingTx.MemPoolTime,
+				}
+				txnOutputs = append(txnOutputs, txnOutput)
+			}
+		}
+		txnOutputs = append(txnOutputs, confirmedTxnOutputs...)
+
+		// Search for items in mempool that spend utxo (matching hash and index)
+		// and remove those from the set
+		for _, f := range addressOuts.PrevOuts {
+			spendingTx, ok := addressOuts.TxnsStore[f.TxSpending]
+			if !ok {
+				apiLog.Errorf("An outpoint's transaction is not available in TxnStore.")
+				continue
+			}
+			if spendingTx.Confirmed() {
+				apiLog.Errorf("A transaction spending the outpoint of an unconfirmed transaction is unexpectedly confirmed.")
+				continue
+			}
+			for g, utxo := range txnOutputs {
+				if utxo.Vout == f.PreviousOutpoint.Index && utxo.TxnID == f.PreviousOutpoint.Hash.String() {
+					// Found a utxo that is unconfirmed spent.  Remove from slice
+					txnOutputs = append(txnOutputs[:g], txnOutputs[g+1:]...)
+				}
+			}
+		}
 	}
+	// Final sort by timestamp desc if unconfirmed and by confirmations
+	// ascending if confirmed
+	sort.Slice(txnOutputs, func(i, j int) bool {
+		if txnOutputs[i].Confirmations == 0 && txnOutputs[j].Confirmations == 0 {
+			return txnOutputs[i].BlockTime > txnOutputs[j].BlockTime
+		}
+		return txnOutputs[i].Confirmations < txnOutputs[j].Confirmations
+	})
 
 	writeJSON(w, txnOutputs, c.getIndentQuery(r))
 }

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -194,28 +194,24 @@ func (c *insightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		idx, ok := c.GetInsightBlockIndexCtx(r)
 		if !ok {
-			apiLog.Error("Unable to get block hash from index")
 			writeInsightError(w, "Must provide an index or block hash")
 			return
 		}
 		var err error
 		hash, err = c.BlockData.ChainDB.GetBlockHash(int64(idx))
 		if err != nil {
-			apiLog.Error("Unable to get block hash from index")
 			writeInsightError(w, "Unable to get block hash from index")
 			return
 		}
 	}
 	chainHash, err := chainhash.NewHashFromStr(hash)
 	if err != nil {
-		apiLog.Errorf("Failed to parse block hash: %v", err)
 		writeInsightError(w, fmt.Sprintf("Failed to parse block hash: %v", err))
 		return
 	}
 
 	blockMsg, err := c.nodeClient.GetBlock(chainHash)
 	if err != nil {
-		apiLog.Errorf("Failed to retrieve block %s: %v", chainHash.String(), err)
 		writeInsightNotFound(w, fmt.Sprintf("Failed to retrieve block %s: %v", chainHash.String(), err))
 		return
 	}

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -58,6 +58,11 @@ type InsightMultiAddrsTxOutput struct {
 	Items      []InsightTx `json:"items"`
 }
 
+// InsightAddr models the multi address post data structure
+type InsightAddr struct {
+	Addrs string `json:"addrs"`
+}
+
 // InsightPagination models basic pagination output
 // for a result
 type InsightPagination struct {
@@ -70,12 +75,14 @@ type InsightPagination struct {
 type AddressTxnOutput struct {
 	Address       string  `json:"address"`
 	TxnID         string  `json:"txid"`
-	Vout          uint32  `json:"vout,omitempty"`
-	ScriptPubKey  string  `json:"scriptPubKey,omitempty"`
+	Vout          uint32  `json:"vout"`
+	BlockTime     int64   `json:"ts,omitempty"`
+	ScriptPubKey  string  `json:"scriptPubKey"`
 	Height        int64   `json:"height,omitempty"`
 	BlockHash     string  `json:"block_hash,omitempty"`
-	Amount        float64 `json:"amount"`
-	Atoms         float64 `json:"atoms"`
+	Amount        float64 `json:"amount,omitempty"`
+	Atoms         int64   `json:"atoms,omitempty"` // Not Required per Insight spec
+	Satoshis      int64   `json:"satoshis,omitempty"`
 	Confirmations int64   `json:"confirmations"`
 }
 

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -198,26 +198,6 @@ func (pgb *ChainDB) GetBlockSummaryTimeRange(min, max int64, limit int) []dbtype
 	return blockSummary
 }
 
-func makeAddressTxOutput(data *dcrjson.SearchRawTransactionsResult, address string) *apitypes.AddressTxnOutput {
-	tx := new(apitypes.AddressTxnOutput)
-	tx.Address = address
-	tx.TxnID = data.Txid
-	tx.Height = 0
-
-	for i := range data.Vout {
-		if len(data.Vout[i].ScriptPubKey.Addresses) != 0 {
-			if data.Vout[i].ScriptPubKey.Addresses[0] == address {
-				tx.ScriptPubKey = data.Vout[i].ScriptPubKey.Hex
-				tx.Vout = data.Vout[i].N
-				tx.Atoms += data.Vout[i].Value
-			}
-		}
-	}
-
-	tx.Amount = tx.Atoms * 100000000
-	return tx
-}
-
 // GetAddressUTXO returns the unspent transaction outputs (UTXOs) paying to the
 // specified address in a []apitypes.AddressTxnOutput.
 func (pgb *ChainDB) GetAddressUTXO(address string) []apitypes.AddressTxnOutput {

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -68,14 +68,17 @@ const (
 									addresses.funding_tx_hash,
 									addresses.value,
 									transactions.block_height,
-									transactions.block_hash
+									block_time,
+									funding_tx_vout_index,
+									pkscript
 									FROM addresses 
 									JOIN transactions ON 
 									addresses.funding_tx_hash = transactions.tx_hash 
+									JOIN vouts on addresses.funding_tx_hash = vouts.tx_hash and addresses.funding_tx_vout_index=vouts.tx_index 
 									WHERE 
 									addresses.address=$1 
 									AND 
-									addresses.spending_tx_row_id IS NULL`
+									addresses.spending_tx_row_id IS NULL order by block_height desc`
 
 	SelectAddressLimitNByAddress = `SELECT * FROM addresses WHERE address=$1 order by id desc limit $2 offset $3;`
 

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -119,11 +119,12 @@ type PrevOut struct {
 }
 
 // TxWithBlockData contains a MsgTx and the block hash and height in which it
-// was mined.
+// was mined and Time it entered MemPool.
 type TxWithBlockData struct {
 	Tx          *wire.MsgTx
 	BlockHeight int64
 	BlockHash   string
+	MemPoolTime int64
 }
 
 // Hash returns the chainhash.Hash of the transaction.


### PR DESCRIPTION
This PR is ready for testing on the UTXO endpoints:
[10] addr_utxo
[11] multi_addr_utxo
[12] POST_multi_addr_utxo; 

In addition the following changes were implemented:
1.  New standard API failure packet.  Return values for failure modes is highly inconsistent across mainnet and bitpay api.  We used the return error format from bitpay for a blank hash on a block call as our model.  Specifically:
```
{
    "status": 404,
    "url": "/api/block/",
    "error": "Not found"
}
```
I hope to align all Insight API failure responses to use this method.

2.  rawblock endpoint was fixed.  so [3] and [4] are also ready for test.

**Valid UTXO Response**
The target UTXO schema is shown below:
![image](https://user-images.githubusercontent.com/11194546/40348504-c0083616-5d58-11e8-8b21-ab6feee9482e.png)
(latest version can always be found here:  https://docs.google.com/spreadsheets/d/1WGHezqRG5VY-t4O6cGpZGwsq69IKJ3deEnERaVvQOb4/edit?usp=sharing)

**Example Output of unconfirmed**
```
[
    {
        "address": "Dsbb8DHHwWMkxSSgfAj9czC44VVKXZPWAmg",
        "txid": "fe4b0315638d81070917f84312f8e288121922080662ed43016af37edcb5ff25",
        "vout": 0,
        "ts": 1526970773,
        "scriptPubKey": "76a914748ada15e1200593e21e9d3eb15e1e259cabdbeb88ac",
        "amount": 0.0489327,
        "satoshis": 4893270,
        "confirmations": 0
    },
    {
        "address": "Dsbb8DHHwWMkxSSgfAj9czC44VVKXZPWAmg",
        "txid": "4f44f80db15c0da95e89458371561e9a22db4469b271d17a68d218a8421dec05",
        "vout": 1,
        "scriptPubKey": "76a914748ada15e1200593e21e9d3eb15e1e259cabdbeb88ac",
        "height": 240352,
        "amount": 0.01700671,
        "satoshis": 1700671,
        "confirmations": 561
    }
]
```
**Example response for multi addr**
```
[
    {
        "address": "37p9pUugydmoLpQyFLLqGAgjWmUFERa1Pq",
        "txid": "80106ac7ef410be2b99fab552da9fba0e19cf5d0d79fa9eb64d946ece8a5ff0c",
        "vout": 0,
        "scriptPubKey": "a914432a41db83cc1f7e5cc9c48a0808b00ff2992a3a87",
        "amount": 0.01200328,
        "satoshis": 1200328,
        "height": 523812,
        "confirmations": 6
    },
    {
        "address": "37p9pUugydmoLpQyFLLqGAgjWmUFERa1Pq",
        "txid": "c88a6c5aa4c84fb3d4674ffca1f0ed25399ff674af3b4d21bfddfd039708f9ac",
        "vout": 0,
        "scriptPubKey": "a914432a41db83cc1f7e5cc9c48a0808b00ff2992a3a87",
        "amount": 0.00598253,
        "satoshis": 598253,
        "height": 523809,
        "confirmations": 9
    },
    {
        "address": "1C49cQ6hxQhsr6dpBEWPEjmTAR6jQqQtFz",
        "txid": "f6876026feaa4dae041d09edce89752741a3e3508729f6a481480b54b77c30c1",
        "vout": 0,
        "scriptPubKey": "76a9147941d1ac5141791e2bd6400982b256a78f8cfe1a88ac",
        "amount": 0.13410335,
        "satoshis": 13410335,
        "height": 523806,
        "confirmations": 12
    },
    {
        "address": "37p9pUugydmoLpQyFLLqGAgjWmUFERa1Pq",
        "txid": "648cf7d824f8714dfe2f94a8b3042752e7538b81c8158826622f1facd1270883",
        "vout": 0,
        "scriptPubKey": "a914432a41db83cc1f7e5cc9c48a0808b00ff2992a3a87",
        "amount": 0.01200631,
        "satoshis": 1200631,
        "height": 523784,
        "confirmations": 34
    },
//remainder deleted for brevity
```

**Implementation Question 1**
The post params are part of the body, not form parameters.  I borrowed the methodology from dcrd in this section:
```
if len(addresses) == 0 {
+		// No query post.  Check for a Body JSON
+		// Read and close the JSON-RPC request body from the caller.
+		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil {
```
1.  Should we try to move this to a middleware function?  
2.  dcrd implements a hijack prevention strategy.  Do we need this?

https://github.com/decred/dcrd/blob/2e293f28bfdd81e08b012bd83b7ccdb12e19a94a/rpcserver.go#L6121

**Implementation Question 2**
1.  The mempool implementation in dcrdata is very limited.  It extracts a small set of the mempool data.  I added time to the data, but we may want to consider expanding the cached details for mempool so more aspects of the mempool transactions are available locally.
2.  As noted in the code.  Mempool transactions are not cleared out immediately from the mempool cache.  At least the way I was trying to use it which meant I needed to check things manually.  We might want to sort this out.
