### PR TITLE
Insight API broadcast_tx [17]

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -5,9 +5,20 @@
 package insight
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 
+	apitypes "github.com/decred/dcrdata/api/types"
 	m "github.com/decred/dcrdata/middleware"
+)
+
+type contextKey int
+
+const (
+	ctxRawHexTx contextKey = iota
 )
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
@@ -39,4 +50,44 @@ func (c *insightApiContext) getBlockHashCtx(r *http.Request) string {
 		}
 	}
 	return hash
+}
+
+// GetRawHexTx retrieves the ctxRawHexTx data from the request context. If not
+// set, the return value is an empty string.
+func (c *insightApiContext) GetRawHexTx(r *http.Request) (string, bool) {
+	rawHexTx, ok := r.Context().Value(ctxRawHexTx).(string)
+	if !ok {
+		apiLog.Trace("Rawtx hex transaction not set")
+		return "", false
+	}
+	return rawHexTx, true
+}
+
+// Process params given in post body for an broadcast tx endpoint.
+func (c *insightApiContext) PostBroadcastTxCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apitypes.InsightRawTx
+		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil {
+			apiLog.Errorf("error reading JSON message: %v", err)
+			writeInsightError(w, fmt.Sprintf("error reading JSON message: %v", err))
+			return
+		}
+		err = json.Unmarshal(body, &req)
+		if err != nil {
+			apiLog.Errorf("Failed to parse request: %v", err)
+			writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
+			return
+		}
+		// Successful extraction of Body JSON as long as the rawtx is not empty
+		// string we should return it
+		if req.Rawtx == "" {
+			writeInsightError(w, fmt.Sprintf("rawtx cannot be an empty string."))
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), ctxRawHexTx, req.Rawtx)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -9,6 +9,8 @@ package insight
 
 import (
 	m "github.com/decred/dcrdata/middleware"
+	"github.com/didip/tollbooth"
+	"github.com/didip/tollbooth_chi"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 )
@@ -24,8 +26,13 @@ const APIVersion = 0
 // NewInsightApiRouter returns a new HTTP path router, ApiMux, for the Insight
 // API.
 func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
+	// Create a limiter struct.
+	limiter := tollbooth.NewLimiter(1, nil)
+
 	// chi router
 	mux := chi.NewRouter()
+
+	mux.Use(tollbooth_chi.LimitHandler(limiter))
 
 	if userRealIP {
 		mux.Use(middleware.RealIP)

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -41,7 +41,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	mux.With(m.BlockIndexOrHashPathCtx).Get("/rawblock/{idx}", app.getRawBlock)
 
 	// Transaction endpoints
-	mux.With(m.RawTransactionCtx).Post("/tx/send", app.broadcastTransactionRaw)
+	mux.With(app.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
 	mux.With(m.TransactionHashCtx).Get("/tx/{txid}", app.getTransaction)
 	mux.With(m.TransactionHashCtx).Get("/rawtx/{txid}", app.getTransactionHex)
 	mux.With(m.TransactionsCtx).Get("/txs", app.getTransactions)

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -188,21 +188,21 @@ func (c *insightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) 
 }
 
 func (c *insightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *http.Request) {
-	//
-	rawHexTx, ok := c.GetRawHexTx(r) // Check for rawtx
-
+	// Check for rawtx
+	rawHexTx, ok := c.GetRawHexTx(r)
 	if !ok {
 		// JSON extraction failed or rawtx blank.  Error message already returned.
 		return
 	}
 
-	// Check for maximum size
+	// Check maximum transaction size
 	if len(rawHexTx)/2 > c.params.MaxTxSize {
-		apiLog.Errorf("Rawtx length exceeds maximum allowable characters (%v bytes received)", len(rawHexTx)/2)
-		writeInsightError(w, fmt.Sprintf("Rawtx length exceeds maximum allowable characters (%v bytes received)", len(rawHexTx)/2))
+		apiLog.Errorf("Rawtx length exceeds maximum allowable characters (%d bytes received)", len(rawHexTx)/2)
+		writeInsightError(w, fmt.Sprintf("Rawtx length exceeds maximum allowable characters (%d bytes received)", len(rawHexTx)/2))
 		return
 	}
 
+	// Broadcast
 	txid, err := c.BlockData.SendRawTransaction(rawHexTx)
 	if err != nil {
 		apiLog.Errorf("Unable to send transaction %s", rawHexTx)
@@ -210,6 +210,7 @@ func (c *insightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *ht
 		return
 	}
 
+	// Respond with hash of broadcasted transaction
 	txidJSON := struct {
 		TxidHash string `json:"rawtx"`
 	}{

--- a/main.go
+++ b/main.go
@@ -513,7 +513,7 @@ func mainCore() error {
 
 	if usePG {
 		chainDBRPC, _ := dcrpg.NewChainDBRPC(auxDB, dcrdClient)
-		insightApp := insight.NewInsightContext(dcrdClient, chainDBRPC, cfg.IndentJSON)
+		insightApp := insight.NewInsightContext(dcrdClient, chainDBRPC, activeChain, cfg.IndentJSON)
 		insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP)
 		webMux.Mount("/insight/api", insightMux.Mux)
 

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -458,17 +458,6 @@ func PaginationCtx(next http.Handler) http.Handler {
 	})
 }
 
-// RawTransactionCtx returns a http.HandlerFunc that embeds the value at the url
-// part {rawtx} into the request context.
-func RawTransactionCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rawHexTx := r.PostFormValue("rawtx")
-		// txid := chi.URLParam(r, "rawtx")
-		ctx := context.WithValue(r.Context(), ctxRawHexTx, rawHexTx)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
 // AddressPostCtx returns a http.HandlerFunc that embeds the {addrs} value in
 // the post request into the request context.
 func AddressPostCtx(next http.Handler) http.Handler {


### PR DESCRIPTION
This PR is ready for testing on the broadcast Tx endpoint
[17] send_tx

Also a new standard API failure packet was included as described in PR #479. 

**Valid Successful Response**

```
{
    "rawtx": "18a4eeed058c2266512863d03f79651cd38d94d6d682ae3f1e4aad0178c6998f"
}
```

**Failure Response**

```
{
    "status": 404,
    "url": "/insight-api/tx/send",
    "error": "SendRawTransaction failed: -1: Rejected transaction 18a4eeed058c2266512863d03f79651cd38d94d6d682ae3f1e4aad0178c6998f: orphan transaction 18a4eeed058c2266512863d03f79651cd38d94d6d682ae3f1e4aad0178c6998f references outputs of unknown or fully-spent transaction 1d3fe2879c60c040fc5b3426aa305b29565aa27035726eaccbb4970b6971de84"
}
```

**Creating a raw transaction for testing**

Below is a powershell script for creating a new raw transaction using dcrctl.  YMMV.
```
$unspentobj = ./dcrctl.exe --testnet /wallet listunspent | ConvertFrom-Json

$unspent = $unspentobj | Select-Object -Property * -ExcludeProperty ("txtype","address","account","scriptPubKey","amount","confirmations","spendable") | ConvertTo-Json -Compress

$unspent = "[" + $unspent.replace('"','\"') + "]"

$sendto = '{\"TsWjioPrP8E1TuTMmTrVMM2BA4iPrjQXBpR\":0.1,\"Tsmsr99vrJTxMMtnhmLT3okH6UJji8g5KVU\":7.4}'

$rawtransaction = ./dcrctl.exe --testnet /wallet createrawtransaction $unspent $sendto

$rawsignedtx = ./dcrctl.exe --testnet /wallet signrawtransaction $rawtransaction| ConvertFrom-Json

$rawsignedtx."hex"

```