### PR TITLE
Insight API - Misc cleanup [1], [2], [5], [5.1], [8], [8.1], [8.2], [9.1], [9.2], [9.3], [9.4]

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -29,6 +29,8 @@ const (
 	ctxNoSpent
 	ctxBlockHash
 	ctxBlockIndex
+	ctxNoTxList
+	ctxLimit
 )
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
@@ -306,4 +308,43 @@ func (c *insightApiContext) GetInsightBlockHashCtx(r *http.Request) (string, boo
 		return "", false
 	}
 	return hash, true
+}
+
+// NoTxListCtx returns a http.Handlerfunc that embeds the {noTxList} value in
+// the request into the request context.
+func (c *insightApiContext) NoTxListCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notxlist := r.FormValue("noTxList")
+		notxlistint, err := strconv.Atoi(notxlist)
+		if err != nil {
+			notxlistint = 0
+		}
+		ctx := context.WithValue(r.Context(), ctxNoTxList, notxlistint)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetLimitCtx retrieves the ctxLimit data from the request context. If not set,
+// the return value is 0 which is interpreted as no limit.
+func (c *insightApiContext) GetLimitCtx(r *http.Request) int {
+	limit, ok := r.Context().Value(ctxLimit).(string)
+	fmt.Println("limit ", limit)
+	if !ok {
+		return 0
+	}
+	intValue, err := strconv.Atoi(limit)
+	if err != nil {
+		return 0
+	}
+	return intValue
+}
+
+// GetNoTxListCtx retrieves the ctxNoTxList data ("noTxList") from the request context.
+// If not set, the return value is false.
+func (c *insightApiContext) GetNoTxListCtx(r *http.Request) int {
+	notxlist, ok := r.Context().Value(ctxNoTxList).(int)
+	if !ok {
+		return 0
+	}
+	return notxlist
 }

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -76,7 +76,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	// Address endpoints
 	mux.Route("/addr/{address}", func(rd chi.Router) {
 		rd.Use(m.AddressPathCtx)
-		rd.With(m.PaginationCtx).Get("/", app.getAddressInfo)
+		rd.With(m.PaginationCtx, app.NoTxListCtx).Get("/", app.getAddressInfo)
 		rd.Get("/utxo", app.getAddressesTxnOutput)
 		rd.Get("/balance", app.getAddressBalance)
 		rd.Get("/totalReceived", app.getAddressTotalReceived)

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -44,9 +44,9 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	mux.Use(middleware.DefaultCompress)
 
 	// Block endpoints
-	mux.With(m.BlockDateQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
-	mux.With(app.BlockHashPathAndIndexCtx).Get("/block/{blockhash}", app.getBlockSummary)
-	mux.With(m.BlockIndexPathCtx).Get("/block-index/{idx}", app.getBlockHash)
+	mux.With(app.BlockDateLimitQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
+	mux.With(app.BlockIndexOrHashPathCtx).Get("/block/{idxorhash}", app.getBlockSummary)
+	mux.With(app.BlockIndexOrHashPathCtx).Get("/block-index/{idxorhash}", app.getBlockHash)
 	mux.With(app.BlockIndexOrHashPathCtx).Get("/rawblock/{idxorhash}", app.getRawBlock)
 
 	// Transaction endpoints
@@ -76,13 +76,11 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	// Address endpoints
 	mux.Route("/addr/{address}", func(rd chi.Router) {
 		rd.Use(m.AddressPathCtx)
-		rd.With(m.PaginationCtx, app.NoTxListCtx).Get("/", app.getAddressInfo)
+		rd.With(app.FromToPaginationCtx, app.NoTxListCtx).Get("/", app.getAddressInfo)
 		rd.Get("/utxo", app.getAddressesTxnOutput)
-		rd.Get("/balance", app.getAddressBalance)
-		rd.Get("/totalReceived", app.getAddressTotalReceived)
-		// TODO Missing unconfirmed balance implementation
-		rd.Get("/unconfirmedBalance", app.getAddressUnconfirmedBalance)
-		rd.Get("/totalSent", app.getAddressTotalSent)
+		rd.Route("/{command}", func(ra chi.Router) {
+			ra.With(app.AddressCommandCtx).Get("/", app.getAddressInfo)
+		})
 	})
 
 	return ApiMux{mux}

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -807,7 +807,6 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 			unconfirmedTxs = append(unconfirmedTxs, f.TxSpending.String()) // Spending tx
 			recentTxs = append(recentTxs, f.TxSpending.String())
 		}
-
 	}
 
 	if isCmd {

--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -60,7 +60,6 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 				}
 			}
 
-			// Lookup addresses OPTION 2
 			// Note, this only gathers information from the database which does not include mempool transactions
 			_, addresses, value, err := c.BlockData.ChainDB.RetrieveAddressIDsByOutpoint(vin.Txid, vin.Vout)
 			if err == nil {
@@ -90,6 +89,7 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 				ScriptPubKey: apitypes.InsightScriptPubKey{
 					Addresses: v.ScriptPubKey.Addresses,
 					Type:      v.ScriptPubKey.Type,
+					Hex:       v.ScriptPubKey.Hex,
 				},
 			}
 			if !noAsm {

--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -5,8 +5,7 @@
 package insight
 
 import (
-	"math"
-
+	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/dcrutil"
@@ -151,47 +150,36 @@ func (c *insightApiContext) TxConverterWithParams(txs []*dcrjson.TxRawResult, no
 	return newTxs, nil
 }
 
-// BlockConverter converts dcrd-block to insight block
+// BlockConverter converts dcrd-block to Insight block
 func (c *insightApiContext) BlockConverter(inBlocks []*dcrjson.GetBlockVerboseResult) ([]*apitypes.InsightBlockResult, error) {
 	params := &chaincfg.MainNetParams
 
 	RewardAtBlock := func(blocknum int64, voters uint16) float64 {
-		// Use DCRD package
-		// subsidyCache := blockchain.NewSubsidyCache(0, params)
-		// work := blockchain.CalcBlockWorkSubsidy(subsidyCache, blocknum,
-		// 	voters, params)
-		// stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, blocknum,
-		// 	params) * voters
-		// tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, blocknum,
-		// 	voters, params)
-		// return work + stake + tax
-
-		// Use Calculation
-		epoch := math.Floor(float64(blocknum) / float64(params.SubsidyReductionInterval))
-		StakeRewardProportion := (float64(voters) / float64(params.TicketsPerBlock)) * float64(params.StakeRewardProportion)
-		TotalRewardProportion := ((float64(params.WorkRewardProportion) +
-			float64(params.BlockTaxProportion) + StakeRewardProportion) / 10)
-		TotalReward := TotalRewardProportion * dcrutil.Amount(params.BaseSubsidy).ToCoin() *
-			math.Pow(float64(params.MulSubsidy)/float64(params.DivSubsidy), epoch)
-		return math.Round(TotalReward/0.00000001) * 0.00000001
+		subsidyCache := blockchain.NewSubsidyCache(0, params)
+		work := blockchain.CalcBlockWorkSubsidy(subsidyCache, blocknum, voters, params)
+		stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, blocknum, params) * int64(voters)
+		tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, blocknum, voters, params)
+		return dcrutil.Amount(work + stake + tax).ToCoin()
 	}
 
 	outBlocks := make([]*apitypes.InsightBlockResult, 0)
 	for _, inBlock := range inBlocks {
-		var outBlock apitypes.InsightBlockResult
-		outBlock.Hash = inBlock.Hash
-		outBlock.Confirmations = inBlock.Confirmations
-		outBlock.Size = inBlock.Size
-		outBlock.Height = inBlock.Height
-		outBlock.Version = inBlock.Version
-		outBlock.MerkleRoot = inBlock.MerkleRoot
-		outBlock.Tx = append(inBlock.Tx, inBlock.STx...)
-		outBlock.Time = inBlock.Time
-		outBlock.Nonce = inBlock.Nonce
-		outBlock.Bits = inBlock.Bits
-		outBlock.Difficulty = inBlock.Difficulty
-		outBlock.PreviousHash = inBlock.PreviousHash
-		outBlock.Reward = RewardAtBlock(inBlock.Height, inBlock.Voters)
+		outBlock := apitypes.InsightBlockResult{
+			Hash:          inBlock.Hash,
+			Confirmations: inBlock.Confirmations,
+			Size:          inBlock.Size,
+			Height:        inBlock.Height,
+			Version:       inBlock.Version,
+			MerkleRoot:    inBlock.MerkleRoot,
+			Tx:            append(inBlock.Tx, inBlock.STx...),
+			Time:          inBlock.Time,
+			Nonce:         inBlock.Nonce,
+			Bits:          inBlock.Bits,
+			Difficulty:    inBlock.Difficulty,
+			PreviousHash:  inBlock.PreviousHash,
+			NextHash:      inBlock.NextHash,
+			Reward:        RewardAtBlock(inBlock.Height, inBlock.Voters),
+		}
 		if inBlock.Height > 0 {
 			outBlock.IsMainChain = true
 		} else {

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -33,13 +33,6 @@ type InsightAddressInfo struct {
 	UnconfirmedTxAppearances int64    `json:"unconfirmedTxApperances"`
 	TxAppearances            int64    `json:"txApperances"`
 	TransactionsID           []string `json:"transactions,omitempty"`
-	// NumFundingTxns           int64          `json:"numFundingTxns,omitempty"`// Not Required per Insight API
-	// NumSpendingTxns          int64          `json:"numSpendingTxns,omitempty"`// Not Required per Insight API
-	// KnownFundingTxns         int64          `json:"knownFundingTxns,omitempty"`// Not Required per Insight API
-	// NumUnconfirmed           int64          `json:"numUnconfirmed,omitempty"`// Not Required per Insight API
-	// Path string `json:"path,omitempty"`// Not Required per Insight API
-	// Limit  int64 `json:"limit,omitemtpy"`  // Not Required per Insight API
-	// Offset int64 `json:"offset,omitempty"` // Not Required per Insight API
 }
 
 // InsightRawTx contains the raw transaction string

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -6,7 +6,7 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 // InsightAddress models an address transactions
@@ -21,18 +21,25 @@ type InsightAddress struct {
 // InsightAddressInfo models basic information
 // about an address
 type InsightAddressInfo struct {
-	Address          string         `json:"addrStr,omitempty"`
-	Limit            int64          `json:"limit,omitemtpy"`
-	Offset           int64          `json:"offset,omitempty"`
-	TransactionsID   []string       `json:"transactions,omitempty"`
-	NumFundingTxns   int64          `json:"numFundingTxns,omitempty"`
-	NumSpendingTxns  int64          `json:"numSpendingTxns,omitempty"`
-	KnownFundingTxns int64          `json:"knownFundingTxns,omitempty"`
-	NumUnconfirmed   int64          `json:"numUnconfirmed,omitempty"`
-	TotalReceived    dcrutil.Amount `json:"totalReceived"`
-	TotalSent        dcrutil.Amount `json:"totalSent"`
-	Unspent          dcrutil.Amount `json:"balance"`
-	Path             string         `json:"path,omitempty"`
+	Address                  string   `json:"addrStr,omitempty"`
+	Balance                  float64  `json:"balance"`
+	BalanceSat               int64    `json:"balanceSat"`
+	TotalReceived            float64  `json:"totalReceived"`
+	TotalReceivedSat         int64    `json:"totalReceivedSat"`
+	TotalSent                float64  `json:"totalSent"`
+	TotalSentSat             int64    `json:"totalSentSat"`
+	UnconfirmedBalance       float64  `json:"unconfirmedBalance"`
+	UnconfirmedBalanceSat    int64    `json:"unconfirmedBalanceSat"`
+	UnconfirmedTxAppearances int64    `json:"unconfirmedTxApperances"`
+	TxAppearances            int64    `json:"txApperances"`
+	TransactionsID           []string `json:"transactions,omitempty"`
+	// NumFundingTxns           int64          `json:"numFundingTxns,omitempty"`// Not Required per Insight API
+	// NumSpendingTxns          int64          `json:"numSpendingTxns,omitempty"`// Not Required per Insight API
+	// KnownFundingTxns         int64          `json:"knownFundingTxns,omitempty"`// Not Required per Insight API
+	// NumUnconfirmed           int64          `json:"numUnconfirmed,omitempty"`// Not Required per Insight API
+	// Path string `json:"path,omitempty"`// Not Required per Insight API
+	// Limit  int64 `json:"limit,omitemtpy"`  // Not Required per Insight API
+	// Offset int64 `json:"offset,omitempty"` // Not Required per Insight API
 }
 
 // InsightRawTx contains the raw transaction string
@@ -144,4 +151,40 @@ type InsightScriptPubKey struct {
 	Asm       string   `json:"asm,omitempty"`
 	Addresses []string `json:"addresses,omitempty"`
 	Type      string   `json:"type,omitempty"`
+}
+
+// InsightBlockResult models the data required by a block json return for
+// Insight API
+type InsightBlockResult struct {
+	Hash          string   `json:"hash"`
+	Confirmations int64    `json:"confirmations"`
+	Size          int32    `json:"size"`
+	Height        int64    `json:"height"`
+	Version       int32    `json:"version"`
+	MerkleRoot    string   `json:"merkleroot"`
+	Tx            []string `json:"tx,omitempty"`
+	Time          int64    `json:"time"`
+	Nonce         uint32   `json:"nonce"`
+	Bits          string   `json:"bits"`
+	Difficulty    float64  `json:"difficulty"`
+	PreviousHash  string   `json:"previousblockhash"`
+	NextHash      string   `json:"nextblockhash,omitempty"`
+	Reward        float64  `json:"reward"`
+	IsMainChain   bool     `json:"isMainChain"`
+}
+
+// InsightBlocksSummaryResult models data required by blocks json return for
+// Insight API
+type InsightBlocksSummaryResult struct {
+	Blocks     []dbtypes.BlockDataBasic `json:"blocks"`
+	Length     int                      `json:"length"`
+	Pagination struct {
+		Next      string `json:"next"`
+		Prev      string `json:"prev"`
+		CurrentTs int64  `json:"currentTs"`
+		Current   string `json:"current"`
+		IsToday   bool   `json:"isToday"`
+		More      bool   `json:"more"`
+		MoreTs    int64  `json:"moreTs,omitempty"`
+	} `json:"pagination"`
 }

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -155,37 +155,43 @@ func (pgb *ChainDB) GetAddressBalance(address string, N, offset int64) *explorer
 // GetAddressInfo returns the basic information for the specified address
 // (*apitypes.InsightAddressInfo), given a transaction count limit, and
 // transaction number offset.
-func (pgb *ChainDB) GetAddressInfo(address string, N, offset int64) *apitypes.InsightAddressInfo {
+func (pgb *ChainDB) GetAddressInfo(address string, N, offset int64, notxlist int64) *apitypes.InsightAddressInfo {
 	rows, balance, err := pgb.AddressHistoryAll(address, N, offset)
 	if err != nil {
 		return nil
 	}
+	var addressInfo apitypes.InsightAddressInfo
+	addressInfo.Address = address
+	addressInfo.TotalReceivedSat = balance.TotalSpent + balance.TotalUnspent
+	addressInfo.TotalSentSat = balance.TotalSpent
+	addressInfo.BalanceSat = balance.TotalUnspent
+	addressInfo.TotalReceived = dcrutil.Amount(addressInfo.TotalReceivedSat).ToCoin()
+	addressInfo.TotalSent = dcrutil.Amount(addressInfo.TotalSentSat).ToCoin()
+	addressInfo.Balance = dcrutil.Amount(addressInfo.BalanceSat).ToCoin()
 
-	var totalReceived, totalSent, unSpent dcrutil.Amount
-	totalReceived, _ = dcrutil.NewAmount(float64(balance.TotalSpent + balance.TotalUnspent))
-	totalSent, _ = dcrutil.NewAmount(float64(balance.TotalSpent))
-	unSpent, _ = dcrutil.NewAmount(float64(balance.TotalUnspent))
+	// Due to the way transactions are stored in Addresses table, each row can
+	// be just a funding Tx or both a funding Tx and a Spending Tx.  It is not
+	// possible to correctly count/offset into this list at present.  Once the
+	// new addresses PR goes through (#427 currently) we need to fix this to
+	// index properly.
+	if notxlist == 0 {
+		var transactionIdList []string
+		for _, row := range rows {
+			fundingTxId := row.FundingTxHash
+			if fundingTxId != "" {
+				transactionIdList = append(transactionIdList, fundingTxId)
+			}
 
-	var transactionIdList []string
-	for _, row := range rows {
-		fundingTxId := row.FundingTxHash
-		if fundingTxId != "" {
-			transactionIdList = append(transactionIdList, fundingTxId)
+			spendingTxId := row.SpendingTxHash
+			if spendingTxId != "" {
+				transactionIdList = append(transactionIdList, spendingTxId)
+			}
 		}
-
-		spendingTxId := row.SpendingTxHash
-		if spendingTxId != "" {
-			transactionIdList = append(transactionIdList, spendingTxId)
-		}
+		addressInfo.TransactionsID = transactionIdList
 	}
+	addressInfo.TxAppearances = (2 * balance.NumSpent) + balance.NumUnspent
 
-	return &apitypes.InsightAddressInfo{
-		Address:        address,
-		TotalReceived:  totalReceived,
-		TransactionsID: transactionIdList,
-		TotalSent:      totalSent,
-		Unspent:        unSpent,
-	}
+	return &addressInfo
 }
 
 // GetBlockSummaryTimeRange returns the blocks created within a specified time

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -63,6 +63,12 @@ func (pgb *ChainDB) InsightPgGetAddressTransactions(addr []string,
 	return RetrieveAddressTxnsOrdered(pgb.db, addr, recentBlockHeight)
 }
 
+// RetrieveAddressSpentUnspent retreivese balance information for a specific
+// address.
+func (pgb *ChainDB) RetrieveAddressSpentUnspent(address string) (int64, int64, int64, int64, error) {
+	return RetrieveAddressSpentUnspent(pgb.db, address)
+}
+
 // Update Vin due to DCRD AMOUNTIN - START
 func (pgb *ChainDB) RetrieveAddressIDsByOutpoint(txHash string,
 	voutIndex uint32) ([]uint64, []string, int64, error) {

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -37,7 +37,8 @@ const (
 
 	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
 
-	SelectBlockByTimeRangeSQL = `select hash, height, size, time, numtx from blocks where time between $1 and $2 ORDER BY time LIMIT $3;`
+	SelectBlockByTimeRangeSQL        = `select hash, height, size, time, numtx from blocks where time between $1 and $2 ORDER BY time DESC LIMIT $3;`
+	SelectBlockByTimeRangeSQLNoLimit = `select hash, height, size, time, numtx from blocks where time between $1 and $2 ORDER BY time DESC;`
 
 	CreateBlockTable = `CREATE TABLE IF NOT EXISTS blocks (  
 		id SERIAL PRIMARY KEY,

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1196,13 +1196,23 @@ func RetrieveAddressTxnsByFundingTx(db *sql.DB, fundTxHash string,
 
 func RetrieveBlockSummaryByTimeRange(db *sql.DB, minTime, maxTime int64, limit int) ([]dbtypes.BlockDataBasic, error) {
 	var blocks []dbtypes.BlockDataBasic
+	var stmt *sql.Stmt
+	var rows *sql.Rows
+	var err error
 
-	stmt, err := db.Prepare(internal.SelectBlockByTimeRangeSQL)
-	if err != nil {
-		return nil, err
+	if limit == 0 {
+		stmt, err = db.Prepare(internal.SelectBlockByTimeRangeSQLNoLimit)
+		if err != nil {
+			return nil, err
+		}
+		rows, err = stmt.Query(minTime, maxTime)
+	} else {
+		stmt, err = db.Prepare(internal.SelectBlockByTimeRangeSQL)
+		if err != nil {
+			return nil, err
+		}
+		rows, err = stmt.Query(minTime, maxTime, limit)
 	}
-	fmt.Println(minTime, " * ", maxTime, " * ", limit)
-	rows, err := stmt.Query(minTime, maxTime, limit)
 
 	if err != nil {
 		log.Error(err)

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -184,23 +184,6 @@ func GetStatusInfoCtx(r *http.Request) string {
 	return statusInfo
 }
 
-// GetLimitCtx retrieves the ctxLimit data from the request context. If not set,
-// the return value is 1.
-func GetLimitCtx(r *http.Request) int {
-	limit, ok := r.Context().Value(ctxLimit).(string)
-	fmt.Println("limit ", limit)
-	if !ok {
-		fmt.Println(ok)
-		apiLog.Trace("limit not set")
-		return 1
-	}
-	intValue, err := strconv.Atoi(limit)
-	if err != nil {
-		return 1
-	}
-	return intValue
-}
-
 // GetBlockDateCtx retrieves the ctxBlockDate data from the request context. If
 // not set, the return value is an empty string.
 func GetBlockDateCtx(r *http.Request) string {

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -36,8 +36,8 @@ const (
 	ctxN
 	ctxCount
 	ctxOffset
-	ctxBlockDate
-	ctxLimit
+	CtxBlockDate
+	CtxLimit
 	ctxGetStatus
 	ctxStakeVersionLatest
 	ctxRawHexTx
@@ -187,7 +187,7 @@ func GetStatusInfoCtx(r *http.Request) string {
 // GetBlockDateCtx retrieves the ctxBlockDate data from the request context. If
 // not set, the return value is an empty string.
 func GetBlockDateCtx(r *http.Request) string {
-	blockDate, _ := r.Context().Value(ctxBlockDate).(string)
+	blockDate, _ := r.Context().Value(CtxBlockDate).(string)
 	return blockDate
 }
 
@@ -462,8 +462,8 @@ func BlockDateQueryCtx(next http.Handler) http.Handler {
 			return
 		}
 		fmt.Println("limit in block query ", limit)
-		ctx := context.WithValue(r.Context(), ctxBlockDate, blockDate)
-		ctx = context.WithValue(ctx, ctxLimit, limit)
+		ctx := context.WithValue(r.Context(), CtxBlockDate, blockDate)
+		ctx = context.WithValue(ctx, CtxLimit, limit)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
These endpoints are ready for test and merge:

Full comparison list is here:  https://docs.google.com/spreadsheets/d/1WGHezqRG5VY-t4O6cGpZGwsq69IKJ3deEnERaVvQOb4

**[1] Block**

*Comparison*
![image](https://user-images.githubusercontent.com/11194546/41206443-e9285b38-6cb8-11e8-8a9e-d9d351cd8d90.png)

*Example Output*
```
[
    {
        "hash": "000000000000000663a4ea037091a5ce844051f0c6d5fd0d0389103b993fc977",
        "confirmations": 11083,
        "size": 4154,
        "height": 235615,
        "version": 5,
        "merkleroot": "6c360aa257d7485326c1b5e9cad32d9d0f0a28dfa1654cbec3bff04a37bf033a",
        "tx": [
            "d1414ca25a008dfd6502b64ec77fa625b1f95f73828c975453920993ba4bf044",
            "24e3367c225234bda3b4fbe2279e446c39febbf5311bbfbef68a581bf168c6f0",
            "d2c249b66b73ed7942f476fb5d5977aadb0ff7c0da59ffc4529f6887a7845b3d",
            "1bef2b097b3d81dba57fee9e852df13f7f0fc729fcb772cfabc67c6ce3777413",
            "15be0712c0344db0e838f3f098125c0c11d67b6f6ca604995998a48f9dd6a67f",
            "a7524910d4abdae398f07d2ccfee102ac58f4a5647fc762c2e682c18829d4cc2",
            "354c967c3ee9f7aed979bc7eff1c05b56285057e4cc0be988fe4ab4f3630d39a",
            "66c9059b91f649c84b4a23a924e3e69aa69a6d1f5e4c4cf93750692a52274428",
            "ead3f793c8261b1498d0e3db53f5bb8961d4e4162dc2e2b9a88ad3bd166567a5",
            "95c0f5500f0fd853bddffe4e2d36d1c0df4f472936b0542b65f73c73f269c35f",
            "7199976fdf8871cb1a04e588bc25a2373740a6d8d004e725e85845e716b5618e"
        ],
        "time": 1525406423,
        "nonce": 881740634,
        "bits": "190ce566",
        "difficulty": 333039126.108207,
        "previousblockhash": "00000000000000013888138b5ba974ece595f20a8873a53bc533fb00bf056840",
        "nextblockhash": "000000000000000bb6708673b63bd6c3f4d0ad631b9b0a91cef33bc7c9051442",
        "reward": 21.37392543,
        "isMainChain": true
    }
]
```

**[2] Block Index**

```
{
    "blockHash": "0000000000000000817be0e4473f99be251518e3762957f731d077d5b274b847"
}
```

**[5] [5.1] Blocks (queryparams version shown for brevity)**
*Comparison*
![image](https://user-images.githubusercontent.com/11194546/41206492-9a616c28-6cb9-11e8-96ff-312cc515e5c9.png)

*Example Output*

```
{
    "blocks": [
        {
            "height": 126949,
            "size": 2801,
            "hash": "00000000000000b9b2724a8af60fda67a3b72910f2a0d6ee290ff31e534c4175",
            "diff": 0,
            "sdiff": 0,
            "time": 1492905537,
            "txlength": 7
        },
        {
            "height": 126948,
            "size": 6650,
            "hash": "0000000000000234d31499770066344da85deaec3c057cd4d0849c91da237a1c",
            "diff": 0,
            "sdiff": 0,
            "time": 1492905288,
            "txlength": 17
        },
        {
            "height": 126947,
            "size": 5197,
            "hash": "00000000000001867a3aed194f59e383d9b1a161fa507f678dc473c7d30154f2",
            "diff": 0,
            "sdiff": 0,
            "time": 1492904835,
            "txlength": 18
        }
    ],
    "length": 3,
    "pagination": {
        "next": "2017-04-23",
        "prev": "2017-04-21",
        "currentTs": 1492905599,
        "current": "2017-04-22",
        "isToday": false,
        "more": true,
        "moreTs": 1492904835
    }
}
```

**[8] [8.1] Addr**

also implemented are from/to and noTxList query params (note appearances is misspelled on bitpay.insight..  gotta be compatible)

*Comparison*

![image](https://user-images.githubusercontent.com/11194546/41206518-12b32068-6cba-11e8-8ef0-2df9410c27b0.png)


*Example Output*

```
{
    "addrStr": "DshRLMBrqyDmMpp9gcz3bLgCnjMa75mrHsS",
    "balance": 0,
    "balanceSat": 0,
    "totalReceived": 93.00360718,
    "totalReceivedSat": 9300360718,
    "totalSent": 93.00360718,
    "totalSentSat": 9300360718,
    "unconfirmedBalance": 0,
    "unconfirmedBalanceSat": 0,
    "unconfirmedTxApperances": 0,
    "txApperances": 2,
    "transactions": [
        "08f0944772cd2fb292ed9907471a3acc33a659ec567baa6f621ab485e5fd82c9",
        "5d95f88528a1303c016ba10e26495d0e83cd6a3b8ff5239676b7cec03486d7cc"
    ]
}
```

**[9.1] [9.2] [9.3] [9.4] Addr values**

balance, totalReceived, totalSent, unconfirmedBalance

*Example Output*

```
208770778628
```
