### PR TITLE
Insight API [6], [6.1], [15], [15.1], [16], [16.1], [16.2], [16.3], [16.4]

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -10,15 +10,23 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	apitypes "github.com/decred/dcrdata/api/types"
 	m "github.com/decred/dcrdata/middleware"
+	"github.com/go-chi/chi"
 )
 
 type contextKey int
 
 const (
 	ctxRawHexTx contextKey = iota
+	ctxFrom
+	ctxTo
+	ctxNoAsm
+	ctxNoScriptSig
+	ctxNoSpent
+	ctxAddress
 )
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
@@ -50,6 +58,16 @@ func (c *insightApiContext) getBlockHashCtx(r *http.Request) string {
 		}
 	}
 	return hash
+}
+
+// AddressPathCtx returns a http.HandlerFunc that embeds the value at the url
+// part {address} into the request context.
+func (c *insightApiContext) AddressPathCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		address := chi.URLParam(r, "address")
+		ctx := context.WithValue(r.Context(), ctxAddress, address)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 // GetRawHexTx retrieves the ctxRawHexTx data from the request context. If not
@@ -88,6 +106,164 @@ func (c *insightApiContext) PostBroadcastTxCtx(next http.Handler) http.Handler {
 		}
 
 		ctx := context.WithValue(r.Context(), ctxRawHexTx, req.Rawtx)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetAddressCtx retrieves the ctxAddress data from the request context. If not
+// set, the return value is an empty string.
+func (c *insightApiContext) GetAddressCtx(r *http.Request) string {
+	address, ok := r.Context().Value(ctxAddress).(string)
+	if !ok {
+		apiLog.Trace("address not set")
+		return ""
+	}
+	return address
+}
+
+// GetToCtx retrieves the ctxTo data ("to") from the request context. If not
+// set, the return value ok is false.
+func (c *insightApiContext) GetToCtx(r *http.Request) (int64, bool) {
+	to, ok := r.Context().Value(ctxTo).(int)
+	if !ok {
+		apiLog.Errorf("to param not set")
+		return int64(0), false
+	}
+	return int64(to), true
+}
+
+// GetFromCtx retrieves the ctxFrom data ("from") from the request context.
+// If not set, the return value ok is false.
+func (c *insightApiContext) GetFromCtx(r *http.Request) (int64, bool) {
+	from, ok := r.Context().Value(ctxFrom).(int)
+	if !ok {
+		apiLog.Errorf("from param not set")
+		return int64(0), false
+	}
+	return int64(from), true
+}
+
+// GetNoAsmCtx retrieves the ctxNoAsm data ("noAsm") from the request context.
+// If not set, the return value is false.
+func (c *insightApiContext) GetNoAsmCtx(r *http.Request) bool {
+	noAsm, ok := r.Context().Value(ctxNoAsm).(bool)
+	if !ok {
+		return false
+	}
+	return noAsm
+}
+
+// GetNoScriptSigCtx retrieves the ctxNoScriptSig data ("noScriptSig") from the
+// request context. If not set, the return value is false.
+func (c *insightApiContext) GetNoScriptSigCtx(r *http.Request) bool {
+	noScriptSig, ok := r.Context().Value(ctxNoScriptSig).(bool)
+	if !ok {
+		return false
+	}
+	return noScriptSig
+}
+
+// GetNoSpentCtx retrieves the ctxNoSpent data ("noSpent") from the
+// request context. If not set, the return value is false.
+func (c *insightApiContext) GetNoSpentCtx(r *http.Request) bool {
+	noNoSpent, ok := r.Context().Value(ctxNoSpent).(bool)
+	if !ok {
+		return false
+	}
+	return noNoSpent
+}
+
+// PaginationCtx will parse the query parameters for from/to values.
+func (c *insightApiContext) PaginationCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		to, from := r.FormValue("to"), r.FormValue("from")
+		fromint, err := strconv.Atoi(from)
+		if err == nil {
+			ctx = context.WithValue(r.Context(), ctxFrom, fromint)
+		}
+		toint, err := strconv.Atoi(to)
+		if err == nil {
+			ctx = context.WithValue(ctx, ctxTo, toint)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// Process params given in post body for an addrs endpoint
+func (c *insightApiContext) PostAddrsTxsCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apitypes.InsightMultiAddrsTx
+		var from, to, noAsm, noScriptSig, noSpent int64
+		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil {
+			apiLog.Errorf("error reading JSON message: %v", err)
+			writeInsightError(w, fmt.Sprintf("error reading JSON message: %v", err))
+			return
+		}
+		err = json.Unmarshal(body, &req)
+		if err != nil {
+			apiLog.Errorf("Failed to parse request: %v", err)
+			writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
+			return
+		}
+		// Successful extraction of Body JSON
+		ctx := context.WithValue(r.Context(), ctxAddress, req.Addresses)
+
+		if req.From != "" {
+			from, err = req.From.Int64()
+			if err != nil {
+				apiLog.Errorf("Error converting 'from' to Int.  Expecting Integer.")
+			} else {
+				ctx = context.WithValue(ctx, ctxFrom, int(from))
+			}
+		}
+		if req.To != "" {
+			to, err = req.To.Int64()
+			if err != nil {
+				apiLog.Errorf("Error converting 'to' to Int.  Expecting Integer.")
+			} else {
+				ctx = context.WithValue(ctx, ctxTo, int(to))
+			}
+		}
+		if req.NoAsm != "" {
+			noAsm, err = req.NoAsm.Int64()
+			if err != nil {
+				apiLog.Errorf("Error converting 'noAsm' to Int.  Expecting 0 or 1.")
+			} else {
+				if noAsm == 0 {
+					ctx = context.WithValue(ctx, ctxNoAsm, false)
+				} else {
+					ctx = context.WithValue(ctx, ctxNoAsm, true)
+				}
+			}
+		}
+		if req.NoScriptSig != "" {
+			noScriptSig, err = req.To.Int64()
+			if err != nil {
+				apiLog.Errorf("Error converting 'noScriptSig' to Int.  Expecting 0 or 1.")
+			} else {
+				if noScriptSig == 0 {
+					ctx = context.WithValue(ctx, ctxNoScriptSig, false)
+				} else {
+					ctx = context.WithValue(ctx, ctxNoScriptSig, true)
+				}
+			}
+		}
+
+		if req.NoSpent != "" {
+			noSpent, err = req.NoSpent.Int64()
+			if err != nil {
+				apiLog.Errorf("Error converting 'noSpent' to Int.  Expecting 0 or 1.")
+			} else {
+				if noSpent == 0 {
+					ctx = context.WithValue(ctx, ctxNoSpent, false)
+				} else {
+					ctx = context.WithValue(ctx, ctxNoSpent, true)
+				}
+			}
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -14,7 +14,6 @@ import (
 
 	apitypes "github.com/decred/dcrdata/api/types"
 	m "github.com/decred/dcrdata/middleware"
-	"github.com/go-chi/chi"
 )
 
 type contextKey int
@@ -26,7 +25,6 @@ const (
 	ctxNoAsm
 	ctxNoScriptSig
 	ctxNoSpent
-	ctxAddress
 )
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
@@ -58,16 +56,6 @@ func (c *insightApiContext) getBlockHashCtx(r *http.Request) string {
 		}
 	}
 	return hash
-}
-
-// AddressPathCtx returns a http.HandlerFunc that embeds the value at the url
-// part {address} into the request context.
-func (c *insightApiContext) AddressPathCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		address := chi.URLParam(r, "address")
-		ctx := context.WithValue(r.Context(), ctxAddress, address)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
 }
 
 // GetRawHexTx retrieves the ctxRawHexTx data from the request context. If not
@@ -110,37 +98,24 @@ func (c *insightApiContext) PostBroadcastTxCtx(next http.Handler) http.Handler {
 	})
 }
 
-// GetAddressCtx retrieves the ctxAddress data from the request context. If not
-// set, the return value is an empty string.
-func (c *insightApiContext) GetAddressCtx(r *http.Request) string {
-	address, ok := r.Context().Value(ctxAddress).(string)
-	if !ok {
-		apiLog.Trace("address not set")
-		return ""
-	}
-	return address
-}
-
 // GetToCtx retrieves the ctxTo data ("to") from the request context. If not
 // set, the return value ok is false.
 func (c *insightApiContext) GetToCtx(r *http.Request) (int64, bool) {
 	to, ok := r.Context().Value(ctxTo).(int)
 	if !ok {
-		apiLog.Errorf("to param not set")
 		return int64(0), false
 	}
 	return int64(to), true
 }
 
 // GetFromCtx retrieves the ctxFrom data ("from") from the request context.
-// If not set, the return value ok is false.
-func (c *insightApiContext) GetFromCtx(r *http.Request) (int64, bool) {
+// If not set, the return value is 0
+func (c *insightApiContext) GetFromCtx(r *http.Request) int64 {
 	from, ok := r.Context().Value(ctxFrom).(int)
 	if !ok {
-		apiLog.Errorf("from param not set")
-		return int64(0), false
+		return int64(0)
 	}
-	return int64(from), true
+	return int64(from)
 }
 
 // GetNoAsmCtx retrieves the ctxNoAsm data ("noAsm") from the request context.
@@ -166,15 +141,15 @@ func (c *insightApiContext) GetNoScriptSigCtx(r *http.Request) bool {
 // GetNoSpentCtx retrieves the ctxNoSpent data ("noSpent") from the
 // request context. If not set, the return value is false.
 func (c *insightApiContext) GetNoSpentCtx(r *http.Request) bool {
-	noNoSpent, ok := r.Context().Value(ctxNoSpent).(bool)
+	noSpent, ok := r.Context().Value(ctxNoSpent).(bool)
 	if !ok {
 		return false
 	}
-	return noNoSpent
+	return noSpent
 }
 
-// PaginationCtx will parse the query parameters for from/to values.
-func (c *insightApiContext) PaginationCtx(next http.Handler) http.Handler {
+// FromToPaginationCtx will parse the query parameters for from/to values.
+func (c *insightApiContext) FromToPaginationCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		to, from := r.FormValue("to"), r.FormValue("from")
@@ -190,78 +165,76 @@ func (c *insightApiContext) PaginationCtx(next http.Handler) http.Handler {
 	})
 }
 
+// ValidatePostCtx will confirm Post content length is valid.
+func (c *insightApiContext) ValidatePostCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentLengthString := r.Header.Get("Content-Length")
+		contentLength, err := strconv.Atoi(contentLengthString)
+		if err != nil {
+			writeInsightError(w, "Content-Length Header must be set")
+			return
+		}
+		// Broadcast Tx has the largest possible body.  Cap max content length
+		// to c.params.MaxTxSize * 2 plus some arbitrary extra for JSON
+		// encapsulation.
+		maxPayload := (c.params.MaxTxSize * 2) + 50
+		if contentLength > maxPayload {
+			writeInsightError(w, fmt.Sprintf("Maximum Content-Length is %d", maxPayload))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // Process params given in post body for an addrs endpoint
 func (c *insightApiContext) PostAddrsTxsCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req apitypes.InsightMultiAddrsTx
 		var from, to, noAsm, noScriptSig, noSpent int64
+
 		body, err := ioutil.ReadAll(r.Body)
 		r.Body.Close()
 		if err != nil {
-			apiLog.Errorf("error reading JSON message: %v", err)
 			writeInsightError(w, fmt.Sprintf("error reading JSON message: %v", err))
 			return
 		}
 		err = json.Unmarshal(body, &req)
 		if err != nil {
-			apiLog.Errorf("Failed to parse request: %v", err)
 			writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
 			return
 		}
 		// Successful extraction of Body JSON
-		ctx := context.WithValue(r.Context(), ctxAddress, req.Addresses)
+		ctx := context.WithValue(r.Context(), m.CtxAddress, req.Addresses)
 
 		if req.From != "" {
 			from, err = req.From.Int64()
-			if err != nil {
-				apiLog.Errorf("Error converting 'from' to Int.  Expecting Integer.")
-			} else {
+			if err == nil {
 				ctx = context.WithValue(ctx, ctxFrom, int(from))
 			}
 		}
 		if req.To != "" {
 			to, err = req.To.Int64()
-			if err != nil {
-				apiLog.Errorf("Error converting 'to' to Int.  Expecting Integer.")
-			} else {
+			if err == nil {
 				ctx = context.WithValue(ctx, ctxTo, int(to))
 			}
 		}
 		if req.NoAsm != "" {
 			noAsm, err = req.NoAsm.Int64()
-			if err != nil {
-				apiLog.Errorf("Error converting 'noAsm' to Int.  Expecting 0 or 1.")
-			} else {
-				if noAsm == 0 {
-					ctx = context.WithValue(ctx, ctxNoAsm, false)
-				} else {
-					ctx = context.WithValue(ctx, ctxNoAsm, true)
-				}
+			if err == nil && noAsm != 0 {
+				ctx = context.WithValue(ctx, ctxNoAsm, true)
 			}
 		}
 		if req.NoScriptSig != "" {
 			noScriptSig, err = req.To.Int64()
-			if err != nil {
-				apiLog.Errorf("Error converting 'noScriptSig' to Int.  Expecting 0 or 1.")
-			} else {
-				if noScriptSig == 0 {
-					ctx = context.WithValue(ctx, ctxNoScriptSig, false)
-				} else {
-					ctx = context.WithValue(ctx, ctxNoScriptSig, true)
-				}
+			if err == nil && noScriptSig != 0 {
+				ctx = context.WithValue(ctx, ctxNoScriptSig, true)
 			}
 		}
 
 		if req.NoSpent != "" {
 			noSpent, err = req.NoSpent.Int64()
-			if err != nil {
-				apiLog.Errorf("Error converting 'noSpent' to Int.  Expecting 0 or 1.")
-			} else {
-				if noSpent == 0 {
-					ctx = context.WithValue(ctx, ctxNoSpent, false)
-				} else {
-					ctx = context.WithValue(ctx, ctxNoSpent, true)
-				}
+			if err == nil && noSpent != 0 {
+				ctx = context.WithValue(ctx, ctxNoSpent, true)
 			}
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -40,6 +40,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
+	mux.Use(middleware.StripSlashes)
 
 	// Block endpoints
 	mux.With(m.BlockDateQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
@@ -58,13 +59,13 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 
 	// Addresses endpoints
 	mux.Route("/addrs", func(rd chi.Router) {
-		mux.Route("/{address}", func(ra chi.Router) {
-			ra.Use(m.AddressPathCtx, m.PaginationCtx)
+		rd.Route("/{address}", func(ra chi.Router) {
+			ra.Use(app.AddressPathCtx, app.PaginationCtx)
 			ra.Get("/txs", app.getAddressesTxn)
 			ra.Get("/utxo", app.getAddressesTxnOutput)
 		})
 		// POST methods
-		rd.With(m.PaginationCtx, m.AddressPostCtx).Post("/txs", app.getAddressesTxn)
+		rd.With(app.PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
 		rd.With(m.AddressPostCtx).Post("/utxo", app.getAddressesTxnOutput)
 	})
 

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -41,6 +41,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.StripSlashes)
+	mux.Use(middleware.DefaultCompress)
 
 	// Block endpoints
 	mux.With(m.BlockDateQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
@@ -49,7 +50,8 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	mux.With(m.BlockIndexOrHashPathCtx).Get("/rawblock/{idx}", app.getRawBlock)
 
 	// Transaction endpoints
-	mux.With(app.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
+	mux.With(middleware.AllowContentType("application/json"),
+		app.ValidatePostCtx, app.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
 	mux.With(m.TransactionHashCtx).Get("/tx/{txid}", app.getTransaction)
 	mux.With(m.TransactionHashCtx).Get("/rawtx/{txid}", app.getTransactionHex)
 	mux.With(m.TransactionsCtx).Get("/txs", app.getTransactions)
@@ -60,12 +62,13 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 	// Addresses endpoints
 	mux.Route("/addrs", func(rd chi.Router) {
 		rd.Route("/{address}", func(ra chi.Router) {
-			ra.Use(app.AddressPathCtx, app.PaginationCtx)
+			ra.Use(m.AddressPathCtx, app.FromToPaginationCtx)
 			ra.Get("/txs", app.getAddressesTxn)
 			ra.Get("/utxo", app.getAddressesTxnOutput)
 		})
 		// POST methods
-		rd.With(app.PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
+		rd.With(middleware.AllowContentType("application/json"),
+			app.ValidatePostCtx, app.PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
 		rd.With(m.AddressPostCtx).Post("/utxo", app.getAddressesTxnOutput)
 	})
 

--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, The dcrdata developers
+// See LICENSE for details.
+
+package insight
+
+import (
+	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrd/dcrutil"
+	apitypes "github.com/decred/dcrdata/api/types"
+)
+
+// TxConverter converts dcrd-tx to insight tx
+func (c *insightApiContext) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.InsightTx, error) {
+	return c.TxConverterWithParams(txs, false, false, false)
+}
+
+// TxConverterWithParams takes struct with filter params
+func (c *insightApiContext) TxConverterWithParams(txs []*dcrjson.TxRawResult, noAsm bool, noScriptSig bool, noSpent bool) ([]apitypes.InsightTx, error) {
+	newTxs := []apitypes.InsightTx{}
+	for _, tx := range txs {
+
+		vInSum := float64(0)
+		vOutSum := float64(0)
+
+		// Build new model. Based on the old api responses of
+		txNew := apitypes.InsightTx{}
+		txNew.Txid = tx.Txid
+		txNew.Version = tx.Version
+		txNew.Locktime = tx.LockTime
+
+		// Vins fill
+		for vinID, vin := range tx.Vin {
+			vinEmpty := &apitypes.InsightVin{}
+			emptySS := &apitypes.InsightScriptSig{}
+			txNew.Vins = append(txNew.Vins, vinEmpty)
+			txNew.Vins[vinID].Txid = vin.Txid
+			txNew.Vins[vinID].Vout = vin.Vout
+			txNew.Vins[vinID].Sequence = vin.Sequence
+
+			txNew.Vins[vinID].CoinBase = vin.Coinbase
+
+			// init ScriptPubKey
+			if !noScriptSig {
+				txNew.Vins[vinID].ScriptSig = emptySS
+				if vin.ScriptSig != nil {
+					if !noAsm {
+						txNew.Vins[vinID].ScriptSig.Asm = vin.ScriptSig.Asm
+					}
+					txNew.Vins[vinID].ScriptSig.Hex = vin.ScriptSig.Hex
+				}
+			}
+
+			txNew.Vins[vinID].N = vinID
+
+			txNew.Vins[vinID].Value = vin.AmountIn
+
+			// Lookup addresses OPTION 2
+			// Note, this only gathers information from the database which does not include mempool transactions
+			_, addresses, value, err := c.BlockData.ChainDB.RetrieveAddressIDsByOutpoint(vin.Txid, vin.Vout)
+			if err == nil {
+				if len(addresses) > 0 {
+					// Update Vin due to DCRD AMOUNTIN - START
+					// NOTE THIS IS ONLY USEFUL FOR INPUT AMOUNTS THAT ARE NOT ALSO FROM MEMPOOL
+					if tx.Confirmations == 0 {
+						txNew.Vins[vinID].Value = dcrutil.Amount(value).ToCoin()
+					}
+					// Update Vin due to DCRD AMOUNTIN - END
+					txNew.Vins[vinID].Addr = addresses[0]
+				}
+			}
+			dcramt, _ := dcrutil.NewAmount(txNew.Vins[vinID].Value)
+			txNew.Vins[vinID].ValueSat = int64(dcramt)
+			vInSum += txNew.Vins[vinID].Value
+
+		}
+
+		// Vout fill
+		for _, v := range tx.Vout {
+			voutEmpty := &apitypes.InsightVout{}
+			emptyPubKey := apitypes.InsightScriptPubKey{}
+			txNew.Vouts = append(txNew.Vouts, voutEmpty)
+			txNew.Vouts[v.N].Value = v.Value
+			vOutSum += v.Value
+			txNew.Vouts[v.N].N = v.N
+			// pk block
+			txNew.Vouts[v.N].ScriptPubKey = emptyPubKey
+			if !noAsm {
+				txNew.Vouts[v.N].ScriptPubKey.Asm = v.ScriptPubKey.Asm
+			}
+			txNew.Vouts[v.N].ScriptPubKey.Hex = v.ScriptPubKey.Hex
+			txNew.Vouts[v.N].ScriptPubKey.Type = v.ScriptPubKey.Type
+			txNew.Vouts[v.N].ScriptPubKey.Addresses = v.ScriptPubKey.Addresses
+		}
+
+		txNew.Blockhash = tx.BlockHash
+		txNew.Blockheight = tx.BlockHeight
+		txNew.Confirmations = tx.Confirmations
+		txNew.Time = tx.Time
+		txNew.Blocktime = tx.Blocktime
+		txNew.Size = uint32(len(tx.Hex) / 2)
+
+		dcramt, _ := dcrutil.NewAmount(vOutSum)
+		txNew.ValueOut = dcramt.ToCoin()
+
+		dcramt, _ = dcrutil.NewAmount(vInSum)
+		txNew.ValueIn = dcramt.ToCoin()
+
+		dcramt, _ = dcrutil.NewAmount(txNew.ValueIn - txNew.ValueOut)
+		txNew.Fees = dcramt.ToCoin()
+
+		// Return true if coinbase value is not empty, return 0 at some fields
+		if txNew.Vins != nil && len(txNew.Vins[0].CoinBase) > 0 {
+			txNew.IsCoinBase = true
+			txNew.ValueIn = 0
+			txNew.Fees = 0
+			for _, v := range txNew.Vins {
+				v.Value = 0
+				v.ValueSat = 0
+			}
+		}
+
+		if !noSpent {
+
+			// set of unique addresses for db query
+			uniqAddrs := make(map[string]string)
+
+			for _, vout := range txNew.Vouts {
+				for _, addr := range vout.ScriptPubKey.Addresses {
+					uniqAddrs[addr] = txNew.Txid
+				}
+			}
+
+			addresses := []string{}
+			for addr := range uniqAddrs {
+				addresses = append(addresses, addr)
+			}
+			// Note, this only gathers information from the database which does not include mempool transactions
+			addrFull := c.BlockData.ChainDB.GetAddressSpendByFunHash(addresses, txNew.Txid)
+			for _, dbaddr := range addrFull {
+				txNew.Vouts[dbaddr.FundingTxVoutIndex].SpentIndex = dbaddr.SpendingTxVinIndex
+				txNew.Vouts[dbaddr.FundingTxVoutIndex].SpentTxID = dbaddr.SpendingTxHash
+				txNew.Vouts[dbaddr.FundingTxVoutIndex].SpentHeight = dbaddr.BlockHeight
+			}
+		}
+		newTxs = append(newTxs, txNew)
+	}
+	return newTxs, nil
+}

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -95,14 +95,6 @@ type Vout struct {
 	ScriptPubKeyDecoded ScriptPubKey `json:"scriptPubKey"`
 }
 
-// VoutHexScript models the hex script for a transaction output
-type VoutHexScript struct {
-	Value           float64 `json:"value"`
-	N               uint32  `json:"n"`
-	Version         uint16  `json:"version"`
-	ScriptPubKeyHex string  `json:"scriptPubKey"`
-}
-
 // ScriptPubKey is the result of decodescript(ScriptPubKeyHex)
 type ScriptPubKey struct {
 	Asm       string   `json:"asm"`
@@ -207,8 +199,8 @@ type TxRawWithTxType struct {
 // ScriptSig models the signature script used to redeem the origin transaction
 // as a JSON object (non-coinbase txns only)
 type ScriptSig struct {
-	Asm string `json:"asm"`
-	Hex string `json:"hex"`
+	Asm string `json:"asm,omitempty"`
+	Hex string `json:"hex,omitempty"`
 }
 
 // PrevOut represents previous output for an input Vin.

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -4,17 +4,18 @@
 package types
 
 import (
-	"github.com/decred/dcrd/dcrjson"
+	"encoding/json"
+
 	"github.com/decred/dcrd/dcrutil"
 )
 
 // InsightAddress models an address transactions
 //
 type InsightAddress struct {
-	Address      string                                 `json:"address,omitempty"`
-	From         int                                    `json:"from,omitempty"`
-	To           int                                    `json:"to,omitempty"`
-	Transactions []*dcrjson.SearchRawTransactionsResult `json:"items,omitempty"`
+	Address      string      `json:"address,omitempty"`
+	From         int         `json:"from"`
+	To           int         `json:"to"`
+	Transactions []InsightTx `json:"items,omitempty"`
 }
 
 // InsightAddressInfo models basic information
@@ -40,6 +41,23 @@ type InsightRawTx struct {
 	Rawtx string `json:"rawtx"`
 }
 
+// InsightMultiAddrsTx models multi address post data structure
+type InsightMultiAddrsTx struct {
+	Addresses   string      `json:"addrs"`
+	From        json.Number `json:"from,Number,omitempty"`
+	To          json.Number `json:"to,Number,omitempty"`
+	NoAsm       json.Number `json:"noAsm"`
+	NoScriptSig json.Number `json:"noScriptSig"`
+	NoSpent     json.Number `json:"noSpent"`
+}
+
+type InsightMultiAddrsTxOutput struct {
+	TotalItems int64       `json:"totalItems"`
+	From       int         `json:"from"`
+	To         int         `json:"to"`
+	Items      []InsightTx `json:"items"`
+}
+
 // InsightPagination models basic pagination output
 // for a result
 type InsightPagination struct {
@@ -59,4 +77,64 @@ type AddressTxnOutput struct {
 	Amount        float64 `json:"amount"`
 	Atoms         float64 `json:"atoms"`
 	Confirmations int64   `json:"confirmations"`
+}
+
+// AddressSpendByFunHash models a return from
+// GetAddressSpendByFunHash
+type AddressSpendByFunHash struct {
+	FundingTxVoutIndex uint32
+	SpendingTxVinIndex interface{}
+	SpendingTxHash     interface{}
+	BlockHeight        interface{}
+}
+
+type InsightTx struct {
+	Txid          string         `json:"txid,omitempty"`
+	Version       int32          `json:"version,omitempty"`
+	Locktime      uint32         `json:"locktime"`
+	IsCoinBase    bool           `json:"isCoinBase,omitempty"`
+	Vins          []*InsightVin  `json:"vin,omitempty"`
+	Vouts         []*InsightVout `json:"vout,omitempty"`
+	Blockhash     string         `json:"blockhash,omitempty"`
+	Blockheight   int64          `json:"blockheight"`
+	Confirmations int64          `json:"confirmations"`
+	Time          int64          `json:"time,omitempty"`
+	Blocktime     int64          `json:"blocktime,omitempty"`
+	ValueOut      float64        `json:"valueOut,omitempty"`
+	Size          uint32         `json:"size,omitempty"`
+	ValueIn       float64        `json:"valueIn,omitempty"`
+	Fees          float64        `json:"fees,omitempty"`
+}
+
+type InsightVin struct {
+	Txid      string            `json:"txid,omitempty"`
+	Vout      uint32            `json:"vout,omitempty"`
+	Sequence  uint32            `json:"sequence,omitempty"`
+	N         int               `json:"n"`
+	ScriptSig *InsightScriptSig `json:"scriptSig,omitempty"`
+	Addr      string            `json:"addr,omitempty"`
+	ValueSat  int64             `json:"valueSat,omitempty"`
+	Value     float64           `json:"value,omitempty"`
+	CoinBase  string            `json:"coinbase,omitempty"`
+}
+
+type InsightScriptSig struct {
+	Hex string `json:"hex,omitempty"`
+	Asm string `json:"asm,omitempty"`
+}
+
+type InsightVout struct {
+	Value        float64             `json:"value"`
+	N            uint32              `json:"n"`
+	ScriptPubKey InsightScriptPubKey `json:"scriptPubKey,omitempty"`
+	SpentTxID    interface{}         `json:"spentTxId"`   // Insight requires null if unspent and spending TxID if spent
+	SpentIndex   interface{}         `json:"spentIndex"`  // Insight requires null if unspent and Index if spent
+	SpentHeight  interface{}         `json:"spentHeight"` // Insight requires null if unspent and SpentHeight if spent
+}
+
+type InsightScriptPubKey struct {
+	Hex       string   `json:"hex,omitempty"`
+	Asm       string   `json:"asm,omitempty"`
+	Addresses []string `json:"addresses,omitempty"`
+	Type      string   `json:"type,omitempty"`
 }

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -56,6 +56,19 @@ func (db *ChainDBRPC) SendRawTransaction(txhex string) (string, error) {
 	return hash.String(), err
 }
 
+// InsightPgGetAddressTransactions performs a db query to pull all txids for the
+// specified addresses ordered desc by time.
+func (pgb *ChainDB) InsightPgGetAddressTransactions(addr []string,
+	recentBlockHeight int64) ([]string, []string) {
+	return RetrieveAddressTxnsOrdered(pgb.db, addr, recentBlockHeight)
+}
+
+// Update Vin due to DCRD AMOUNTIN - START
+func (pgb *ChainDB) RetrieveAddressIDsByOutpoint(txHash string,
+	voutIndex uint32) ([]uint64, []string, int64, error) {
+	return RetrieveAddressIDsByOutpoint(pgb.db, txHash, voutIndex)
+} // Update Vin due to DCRD AMOUNTIN - END
+
 // InsightGetAddressTransactions performs a searchrawtransactions for the
 // specfied address, max number of transactions, and offset into the transaction
 // list. The search results are in reverse temporal order.
@@ -219,4 +232,15 @@ func (pgb *ChainDB) GetAddressUTXO(address string) []apitypes.AddressTxnOutput {
 		return nil
 	}
 	return txnOutput
+}
+
+// GetAddressSpendByFunHash will return the address that fundex a tx
+func (pgb *ChainDB) GetAddressSpendByFunHash(addresses []string, fundHash string) []*apitypes.AddressSpendByFunHash {
+
+	AddrRow, err := RetrieveAddressTxnsByFundingTx(pgb.db, fundHash, addresses)
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+	return AddrRow
 }

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -848,13 +848,16 @@ func RetrieveAddressCreditTxns(db *sql.DB, address string, N, offset int64) (ids
 	return
 }
 
+// Retreive All AddressIDs for a given Hash and Index
+// Update Vin due to DCRD AMOUNTIN - START - DO NOT MERGE CHANGES IF DCRD FIXED
 func RetrieveAddressIDsByOutpoint(db *sql.DB, txHash string,
-	voutIndex uint32) ([]uint64, []string, error) {
+	voutIndex uint32) ([]uint64, []string, int64, error) {
 	var ids []uint64
 	var addresses []string
+	var value int64
 	rows, err := db.Query(internal.SelectAddressIDsByFundingOutpoint, txHash, voutIndex)
 	if err != nil {
-		return ids, addresses, err
+		return ids, addresses, 0, err
 	}
 	defer func() {
 		if e := rows.Close(); e != nil {
@@ -865,7 +868,7 @@ func RetrieveAddressIDsByOutpoint(db *sql.DB, txHash string,
 	for rows.Next() {
 		var id uint64
 		var addr string
-		err = rows.Scan(&id, &addr)
+		err = rows.Scan(&id, &addr, &value)
 		if err != nil {
 			break
 		}
@@ -873,9 +876,8 @@ func RetrieveAddressIDsByOutpoint(db *sql.DB, txHash string,
 		ids = append(ids, id)
 		addresses = append(addresses, addr)
 	}
-
-	return ids, addresses, err
-}
+	return ids, addresses, value, err
+} // Update Vin due to DCRD AMOUNTIN - END
 
 func RetrieveAllVinDbIDs(db *sql.DB) (vinDbIDs []uint64, err error) {
 	rows, err := db.Query(internal.SelectVinIDsALL)
@@ -1121,6 +1123,69 @@ func RetrieveAddressTxnOutputWithTransaction(db *sql.DB, address string, current
 	}
 
 	return outputs, nil
+}
+
+// RetrieveAddressTxnsOrdered will get all transactions for addresses provided
+// and return them sorted by time in descending order. It will also return a
+// short list of recently (defined as greater than recentBlockHeight) confirmed
+// transactions that can be used to validate mempool status.
+func RetrieveAddressTxnsOrdered(db *sql.DB, addresses []string, recentBlockHeight int64) (txs []string, recenttxs []string) {
+	var tx_hash string
+	var height int64
+	stmt, err := db.Prepare(internal.SelectAddressesAllTxn)
+	if err != nil {
+		log.Error(err)
+		return nil, nil
+	}
+
+	rows, err := stmt.Query(pq.Array(addresses))
+	if err != nil {
+		log.Error(err)
+		return nil, nil
+	}
+
+	for rows.Next() {
+		err = rows.Scan(&tx_hash, &height)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		txs = append(txs, tx_hash)
+		if height > recentBlockHeight {
+			recenttxs = append(recenttxs, tx_hash)
+		}
+	}
+	return
+}
+
+// Retrieve all Transactions related to a set of addresses and funded by a
+// specific transaction
+func RetrieveAddressTxnsByFundingTx(db *sql.DB, fundTxHash string,
+	addresses []string) (aSpendByFunHash []*apitypes.AddressSpendByFunHash, err error) {
+
+	stmt, err := db.Prepare(internal.SelectAddressesTxnByFundingTx)
+	if err != nil {
+		log.Error(err)
+		return nil, nil
+	}
+
+	rows, err := stmt.Query(pq.Array(addresses), fundTxHash)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	for rows.Next() {
+		var addr apitypes.AddressSpendByFunHash
+		err = rows.Scan(&addr.FundingTxVoutIndex,
+			&addr.SpendingTxHash, &addr.SpendingTxVinIndex, &addr.BlockHeight)
+		if err != nil {
+			return
+		}
+
+		aSpendByFunHash = append(aSpendByFunHash, &addr)
+	}
+	return
 }
 
 func RetrieveBlockSummaryByTimeRange(db *sql.DB, minTime, maxTime int64, limit int) ([]dbtypes.BlockDataBasic, error) {

--- a/main.go
+++ b/main.go
@@ -513,7 +513,7 @@ func mainCore() error {
 
 	if usePG {
 		chainDBRPC, _ := dcrpg.NewChainDBRPC(auxDB, dcrdClient)
-		insightApp := insight.NewInsightContext(dcrdClient, chainDBRPC, activeChain, cfg.IndentJSON)
+		insightApp := insight.NewInsightContext(dcrdClient, chainDBRPC, activeChain, &baseDB, cfg.IndentJSON)
 		insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP)
 		webMux.Mount("/insight/api", insightMux.Mux)
 

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -25,7 +25,7 @@ type contextKey int
 const (
 	ctxAPIDocs contextKey = iota
 	ctxAPIStatus
-	ctxAddress
+	CtxAddress
 	ctxBlockIndex0
 	ctxBlockIndex
 	ctxBlockStep
@@ -142,7 +142,7 @@ func GetBlockHashCtx(r *http.Request) string {
 // GetAddressCtx retrieves the ctxAddress data from the request context. If not
 // set, the return value is an empty string.
 func GetAddressCtx(r *http.Request) string {
-	address, ok := r.Context().Value(ctxAddress).(string)
+	address, ok := r.Context().Value(CtxAddress).(string)
 	if !ok {
 		apiLog.Trace("address not set")
 		return ""
@@ -372,7 +372,7 @@ func TransactionIOIndexCtx(next http.Handler) http.Handler {
 func AddressPathCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		address := chi.URLParam(r, "address")
-		ctx := context.WithValue(r.Context(), ctxAddress, address)
+		ctx := context.WithValue(r.Context(), CtxAddress, address)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -416,7 +416,7 @@ func TransactionsCtx(next http.Handler) http.Handler {
 
 		address := r.FormValue("address")
 		if address != "" {
-			ctx := context.WithValue(r.Context(), ctxAddress, address)
+			ctx := context.WithValue(r.Context(), CtxAddress, address)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}
 
@@ -463,7 +463,7 @@ func PaginationCtx(next http.Handler) http.Handler {
 func AddressPostCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		address := r.PostFormValue("addrs")
-		ctx := context.WithValue(r.Context(), ctxAddress, address)
+		ctx := context.WithValue(r.Context(), CtxAddress, address)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
This PR replaces PR #450 and was developed by both @rmukhamet and I.  This PR addresses issues #260 and #400 but does not yet close them. 

The following Insight API endpoints are completed with exceptions as noted below.
[6]  tx/{txid}
[6.1] tx/{unknown txid}
[15] addrs/{addr1},{addr2}/txs
[15.1] addrs/{addr1},{addr2}/txs?from=X&to=Y
[16]  addrs/txs (POST)
[16.1] addrs/txs (POST with from/to)
[16.2] addrs/txs (POST with noAsm)
[16.3] addrs/txs (POST with noScriptSig)
[16.4] addrs/txs (POST with noSpent)

All endpoint comparisons are visible here:  https://docs.google.com/spreadsheets/d/1WGHezqRG5VY-t4O6cGpZGwsq69IKJ3deEnERaVvQOb4/edit?usp=sharing

**JSON output comparison for [6]**
![image](https://user-images.githubusercontent.com/11194546/41000166-fa285640-68c1-11e8-8143-66c8688ac1a5.png)

**JSON output comparison for [15],[16]**
![image](https://user-images.githubusercontent.com/11194546/41000146-e6cad082-68c1-11e8-8a83-a4f713cc869b.png)

Notable issues
1.  Vin addresses for transactions that are spending other mempool outputs are not accurate
2.  Vout spend fields for transactions that are spent in mempool are not accurate

These issues affect only transactions in mempool.  I'm recommending we fix these with a broader update of mempool caching sorting/filtering in dcrdata and merge and likely open an issue for these small issues so we can get exodus testing started.

To start Exodus testing all we need is this PR and #479 to get merged.