### PR TITLE
Update configuration file description

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Begin with the sample configuration file:
 cp sample-dcrdata.conf dcrdata.conf
 ```
 
-Then edit dcrdata.conf with your dcrd RPC settings. See the output of
+Then edit dcrdata.conf with your dcrd RPC settings. After you are finished, move dcrdata.conf to ./dcrdata.
+
+See the output of
 `dcrdata --help` for a list of all options and their default values.
 
 ### Indexing the Blockchain


### PR DESCRIPTION
After you are finished with changing the default, you have to move dcrdata.conf to the ./dcrdata folder to start otherwise it gives you an error when you start dcrdata because ./dcrdata is missing the dcrdata.conf. Maybe change this?