### PR TITLE
Docker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - docker
 
 env:
+  - GOVERSION=1.9
   - GOVERSION=1.10
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: go
 go:
-  - 1.9.x
-  - 1.10.x
-sudo: false
-install:
-  - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure -v
-  - go get -v github.com/alecthomas/gometalinter
-  - gometalinter --install
+  - "1.x"
+
+sudo: required
+services:
+  - docker
+
+env:
+  - GOVERSION=1.10
+
+install: true
+
+cache:
+  directories:
+    - ~/.cache
+
 script:
-  - export PATH=$PATH:$GOPATH/bin
-  - ./run_tests.sh
+  - ./run_tests.sh $GOVERSION

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -335,6 +335,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ff9de567f336b0e635f43022eb24981052129452c9569381930a3e5b23d4488"
+  inputs-digest = "b0d2e972ec426db76162229ab52c5ac0688d06aea98fedbd2c23603dee1e82ca"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -23,6 +23,9 @@ testrepo () {
   # Check lockfile
   dep ensure -no-vendor -dry-run
 
+  # All good, so run for real
+  dep ensure
+
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m \
     --enable=gofmt \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -21,11 +21,7 @@ testrepo () {
   TMPFILE=$(mktemp)
 
   # Check lockfile
-  cp Gopkg.lock $TMPFILE && dep ensure && diff Gopkg.lock $TMPFILE >/dev/null
-  if [ $? != 0 ]; then
-    echo 'lockfile must be updated with dep ensure'
-    exit 1
-  fi
+  dep ensure -no-vendor -dry-run
 
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -74,7 +74,8 @@ if [ $? != 0 ]; then
 fi
 
 docker run --rm -it -v $(pwd):/src decred/$DOCKER_IMAGE_TAG /bin/bash -c "\
-  rsync -ra --filter=':- .gitignore'  \
+  rsync -ra --filter=':- .gitignore' \
+  --files-from=<(git --git-dir=/src/.git ls-files) \
   /src/ /go/src/github.com/decred/$REPO/ && \
   cd github.com/decred/$REPO/ && \
   bash run_tests.sh local"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -74,8 +74,8 @@ if [ $? != 0 ]; then
 fi
 
 docker run --rm -it -v $(pwd):/src decred/$DOCKER_IMAGE_TAG /bin/bash -c "\
-  rsync -ra --filter=':- .gitignore' \
-  --files-from=<(git --git-dir=/src/.git ls-files) \
+  rsync -ra --include-from=<(git --git-dir=/src/.git ls-files) \
+  --filter=':- .gitignore' \
   /src/ /go/src/github.com/decred/$REPO/ && \
   cd github.com/decred/$REPO/ && \
   bash run_tests.sh local"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,6 +13,10 @@ set -ex
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each each
 # static checker.
 
+GOVERSION=${1:-1.10}
+REPO=dcrdata
+DOCKER_IMAGE_TAG=decred-golang-builder-$GOVERSION
+
 testrepo () {
   TMPFILE=$(mktemp)
 
@@ -58,5 +62,23 @@ testrepo () {
   echo "Tests completed successfully!"
 }
 
-GOVERSION=$(go version | awk '{print $3}' | tr -d 'go' | cut -f1,2 -d.)
-testrepo
+if [ $GOVERSION == "local" ]; then
+    testrepo
+    exit
+fi
+
+docker pull decred/$DOCKER_IMAGE_TAG
+if [ $? != 0 ]; then
+        echo 'docker pull failed'
+        exit 1
+fi
+
+docker run --rm -it -v $(pwd):/src decred/$DOCKER_IMAGE_TAG /bin/bash -c "\
+  rsync -ra --filter=':- .gitignore'  \
+  /src/ /go/src/github.com/decred/$REPO/ && \
+  cd github.com/decred/$REPO/ && \
+  bash run_tests.sh local"
+if [ $? != 0 ]; then
+        echo 'docker run failed'
+        exit 1
+fi


### PR DESCRIPTION
This change modifies the tests to use the same Docker image as other Go projects use.

I did modify the process slightly by adding an 'include' for rsync, so that it includes any files that are tracked by git but would normally be ignored by the .gitignore.

As per other projects, should be able to use ./run_tests.sh to run tests locally inside docker image, giving a more consistent environment for tests.