### PR TITLE
accelerate StakeDatabase.ConnectBlock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -125,7 +125,7 @@
     "txscript",
     "wire"
   ]
-  revision = "7a457fc9c32a415604aba12a6aedd96dfc3f470e"
+  revision = "5386a6375874cbbc001ee915c887a8240933751b"
 
 [[projects]]
   branch = "master"

--- a/stakedb/ticketpool_test.go
+++ b/stakedb/ticketpool_test.go
@@ -28,8 +28,8 @@ var (
 	dbFile             = "pooldiffs.db"
 	dbFileRef          = "pooldiffs0.db"
 	dbFileFull         = "stakedb_ticket_pool.db"
-	fullHeight   int64 = 204578
-	fullPoolSize       = 41061
+	fullHeight   int64 = 245754
+	fullPoolSize       = 40931
 	poolSpots          = []int64{32215, 43268, 85508, 66322, 178346, 11013, 98265, 1081,
 		40170, 105957, 187824, 148370, 14478, 153239, 109536, 169157, 92064,
 		200277, 27558, 116203, 2338, 28323, 51459, 145753, 137377, 108501,

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -110,6 +110,23 @@ func IncludesTx(txHash *chainhash.Hash, block *dcrutil.Block) (int, int8) {
 	return -1, -1
 }
 
+// FilterHashSlice removes elements from the specified if the doRemove function
+// evaluates to true for a given element. For example, given a slice of hashes
+// called blackList that should be removed from the slice hashList:
+//
+// hashList = FilterHashSlice(hashList, func(h chainhash.Hash) bool {
+//  return HashInSlice(h, blackList)
+// })
+func FilterHashSlice(s []chainhash.Hash, doRemove func(h chainhash.Hash) bool) []chainhash.Hash {
+	_s := s[:0]
+	for _, h := range s {
+		if !doRemove(h) {
+			_s = append(_s, h)
+		}
+	}
+	return _s
+}
+
 // PrevOut contains a transaction input's previous outpoint, the Hash of the
 // spending (following) transaction, and input index in the transaction.
 type PrevOut struct {

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -178,3 +178,38 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool) (*rpcclient.
 
 	return dcrdClient, nodeVer, nil
 }
+
+func TestFilterHashSlice(t *testing.T) {
+	var hashList, blackList []chainhash.Hash
+	var h *chainhash.Hash
+
+	h, _ = chainhash.NewHashFromStr("8e5b17d75d1845f90940d07ac8338d0919f1cbd8e12e943c972322c628b47416")
+	hashList = append(hashList, *h)
+	h, _ = chainhash.NewHashFromStr("3365991083571c527bd3c81bd7374b6f06c17e67b50671067e78371e0511d1d5") // ***
+	hashList = append(hashList, *h)
+	h, _ = chainhash.NewHashFromStr("fd1a252947ee2ba7be5d0b197952640bdd74066a2a36f3c00beca34dbd3ac8ad")
+	hashList = append(hashList, *h)
+
+	h, _ = chainhash.NewHashFromStr("7ea06b193187dc028b6266ce49f4c942b3d57b4572991b527b5abd9ade4974b8")
+	blackList = append(blackList, *h)
+	h, _ = chainhash.NewHashFromStr("0839e25863e4d04b099d945d57180283e8be217ce6d7bc589c289bc8a1300804")
+	blackList = append(blackList, *h)
+	h, _ = chainhash.NewHashFromStr("3365991083571c527bd3c81bd7374b6f06c17e67b50671067e78371e0511d1d5") // *** [2]
+	blackList = append(blackList, *h)
+	h, _ = chainhash.NewHashFromStr("3edbc5318c36049d5fa70e6b04ef69b02d68e98c4739390c50220509a9803e26")
+	blackList = append(blackList, *h)
+	h, _ = chainhash.NewHashFromStr("37e032ece5ef4bda7b86c8b410476f3399d1ab48863d7d6279a66bea1e3876ab")
+	blackList = append(blackList, *h)
+
+	t.Logf("original: %v", hashList)
+
+	hashList = FilterHashSlice(hashList, func(h chainhash.Hash) bool {
+		return HashInSlice(h, blackList)
+	})
+
+	t.Logf("filtered: %v", hashList)
+
+	if HashInSlice(blackList[2], hashList) {
+		t.Errorf("filtered slice still has hash %v", blackList[2])
+	}
+}


### PR DESCRIPTION
This changes how StakeDatabase gets the live ticket pool and the diffs (in/out) for each block in ConnectBlock.

The `liveTicketCache` in `StakeDatabase` is now a faithful representation of the live ticket pool at the current best block.  So when the live ticket list is needed, it is no longer necessary to use the `stake.Node` (`BestNode.LiveTickets()`).

Add `poolValue int64` to `StakeDatabase`, updating it on connect/disconnect via += / -+ for the pool in/out tickets.

A major optimization in `ConnectBlock` is using the new `ExpiredByBlock` function in dcrd/stake instead of the much more costly `ExistsExpiredTicket` and `ExistsRevokedTicket`.  This requires dcrd PR https://github.com/decred/dcrd/pull/1221.

 Improve the process of "Pre-populating live ticket cache..." by prefetching the tickets from the stake `BestNode` (dcrdata's best node) rather than asking dcrd for it's idea of the live ticket pool.  This ensures `liveTicketCache` will always contain an accurate ticket pool.