### PR TITLE
Fresh coinbase miner fee tx fix

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -215,9 +215,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			data := exp.blockData.GetExplorerBlock(tx.BlockHash)
 			if data == nil {
 				log.Errorf("Unable to get block %s", tx.BlockHash)
-				return
+			} else {
+				tx.BlockMiningFee = int64(data.MiningFee)
 			}
-			tx.BlockMiningFee = int64(data.MiningFee)
 		}
 		// For each output of this transaction, look up any spending transactions,
 		// and the index of the spending transaction input.


### PR DESCRIPTION
This is a fix for PR #456.

Blockhash is not set in a ` GetRawTransactionVerbose` until after the first confirmation.  Therefore the existing code will fail for transactions with only one confirmation.  A call to `GetBlockHash` however does work on 1 confirmation.

There are three solutions:
1.  Get DCRD to return a blockhash in any `GetRawTransactionVerbose` if the transaction has been mined (1 confirmation)
2.  Switch back to a two step process to get the hash with `GetBlockHash` and then the block for that hash as was implemented in the first version of PR #456.
3.  Error check the blockhash and display the Tx without the fees if the blockhash was not valid instead of the white screen of death.

This PR implements the third option since its likely the right solution to have DCRD report a block hash on a transactions that has been mined.

**GetBlockHash DCRD for a freshly mined block (1 confirmation)**
```
{
    "jsonrpc": "1.0",
    "result": "0000000000000000ef7c9e92b6968418e99a308300950a11546dd78c0f2684dc",
    "error": null,
    "id": 1
}
```

**GetRawTransaction DCRD for a freshly mined tx (1 confirmation)**
```
{
    "jsonrpc": "1.0",
    "result": {
        "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff03c3237d0c00000000000017a914f5916158e3e2c4551c1796708db8367207ed13bb87000000000000000000000e6a0c3fc103004e57d6bbcb5ffc1ebe04024b0000000000001976a91410ef8ec21265c609d709854b931ab0cf5803de0088ac00000000000000000155fa6b570000000000000000ffffffff0800002f646372642f",
        "txid": "25f9c9a06dc5f14b4c344ead9342cff7055c0982981ce3acc9884bca968f4518",
        "version": 1,
        "locktime": 0,
        "expiry": 0,
        "vin": [
            {
                "amountin": 14.66694229,
                "blockheight": 0,
                "blockindex": 4294967295,
                "coinbase": "00002f646372642f",
                "sequence": 4294967295
            }
        ],
        "vout": [
            {
                "value": 2.09527747,
                "n": 0,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_HASH160 f5916158e3e2c4551c1796708db8367207ed13bb OP_EQUAL",
                    "hex": "a914f5916158e3e2c4551c1796708db8367207ed13bb87",
                    "reqSigs": 1,
                    "type": "scripthash",
                    "addresses": [
                        "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx"
                    ]
                }
            },
            {
                "value": 0,
                "n": 1,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_RETURN 3fc103004e57d6bbcb5ffc1e",
                    "hex": "6a0c3fc103004e57d6bbcb5ffc1e",
                    "type": "nulldata"
                }
            },
            {
                "value": 12.58423486,
                "n": 2,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_DUP OP_HASH160 10ef8ec21265c609d709854b931ab0cf5803de00 OP_EQUALVERIFY OP_CHECKSIG",
                    "hex": "76a91410ef8ec21265c609d709854b931ab0cf5803de0088ac",
                    "reqSigs": 1,
                    "type": "pubkeyhash",
                    "addresses": [
                        "DsSWTHFrsXV77SwAcMe451kJTwWjwPYjWTM"
                    ]
                }
            }
        ],
        "blockheight": 0
    },
    "error": null,
    "id": 1
}
```
**GetRawTransaction DCRD for a older tx (10 confirmations)**
```
{
    "jsonrpc": "1.0",
    "result": {
        "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff03c3237d0c00000000000017a914f5916158e3e2c4551c1796708db8367207ed13bb87000000000000000000000e6a0c3fc103004e57d6bbcb5ffc1ebe04024b0000000000001976a91410ef8ec21265c609d709854b931ab0cf5803de0088ac00000000000000000155fa6b570000000000000000ffffffff0800002f646372642f",
        "txid": "25f9c9a06dc5f14b4c344ead9342cff7055c0982981ce3acc9884bca968f4518",
        "version": 1,
        "locktime": 0,
        "expiry": 0,
        "vin": [
            {
                "amountin": 14.66694229,
                "blockheight": 0,
                "blockindex": 4294967295,
                "coinbase": "00002f646372642f",
                "sequence": 4294967295
            }
        ],
        "vout": [
            {
                "value": 2.09527747,
                "n": 0,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_HASH160 f5916158e3e2c4551c1796708db8367207ed13bb OP_EQUAL",
                    "hex": "a914f5916158e3e2c4551c1796708db8367207ed13bb87",
                    "reqSigs": 1,
                    "type": "scripthash",
                    "addresses": [
                        "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx"
                    ]
                }
            },
            {
                "value": 0,
                "n": 1,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_RETURN 3fc103004e57d6bbcb5ffc1e",
                    "hex": "6a0c3fc103004e57d6bbcb5ffc1e",
                    "type": "nulldata"
                }
            },
            {
                "value": 12.58423486,
                "n": 2,
                "version": 0,
                "scriptPubKey": {
                    "asm": "OP_DUP OP_HASH160 10ef8ec21265c609d709854b931ab0cf5803de00 OP_EQUALVERIFY OP_CHECKSIG",
                    "hex": "76a91410ef8ec21265c609d709854b931ab0cf5803de0088ac",
                    "reqSigs": 1,
                    "type": "pubkeyhash",
                    "addresses": [
                        "DsSWTHFrsXV77SwAcMe451kJTwWjwPYjWTM"
                    ]
                }
            }
        ],
        "blockhash": "0000000000000000ef7c9e92b6968418e99a308300950a11546dd78c0f2684dc",
        "blockheight": 246079,
        "confirmations": 10,
        "time": 1528478268,
        "blocktime": 1528478268
    },
    "error": null,
    "id": 1
}
```