### PR TITLE
api: add /txs route for batch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ prefixed with `/api`** (e.g. `http://localhost:7777/api/stake`).
 | Height |  `/block/hash/H/height` | `int` |
 | Size | `/block/hash/H/size` | `int32` |
 | Transactions | `/block/hash/H/tx` | `types.BlockTransactions` |
-| Transactions Count | `/block/hash/H/tx/count` | `types.BlockTransactionCounts` |
+| Transactions count | `/block/hash/H/tx/count` | `types.BlockTransactionCounts` |
 | Verbose block result | `/block/hash/H/verbose` | `dcrjson.GetBlockVerboseResult` |
 
 | Block range (X < Y) | Path | Type |
@@ -236,11 +236,17 @@ prefixed with `/api`** (e.g. `http://localhost:7777/api/stake`).
 
 | Transaction T (transaction id) | Path | Type |
 | --- | --- | --- |
-| Transaction Details | `/tx/T` | `types.Tx` |
+| Transaction details | `/tx/T` | `types.Tx` |
+| Transaction details w/o block info | `/tx/trimmed/T` | `types.TrimmedTx` |
 | Inputs | `/tx/T/in` | `[]types.TxIn` |
 | Details for input at index `X` | `/tx/T/in/X` | `types.TxIn` |
 | Outputs | `/tx/T/out` | `[]types.TxOut` |
 | Details for output at index `X` | `/tx/T/out/X` | `types.TxOut` |
+
+| Transactions (batch) | Path | Type |
+| --- | --- | --- |
+| Transaction details (POST body is JSON of `types.Txns`) | `/txs` | `[]types.Tx` |
+| Transaction details w/o block info | `/txs/trimmed` | `[]types.TrimmedTx` |
 
 | Address A | Path | Type |
 | --- | --- | --- |

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -123,6 +123,7 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rt.Route("/{txid}", func(rd chi.Router) {
 				rd.Use(m.TransactionHashCtx)
 				rd.Get("/", app.getTransaction)
+				rd.Get("/trimmed", app.getDecodedTransactions)
 				rd.Route("/out", func(ro chi.Router) {
 					ro.Get("/", app.getTransactionOutputs)
 					ro.With(m.TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionOutput)
@@ -136,6 +137,13 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 		})
 		r.With(m.TransactionHashCtx).Get("/hex/{txid}", app.getTransactionHex)
 		r.With(m.TransactionHashCtx).Get("/decoded/{txid}", app.getDecodedTx)
+	})
+
+	mux.Route("/txs", func(r chi.Router) {
+		r.Use(middleware.AllowContentType("application/json"),
+			m.ValidateTxnsPostCtx, m.PostTxnsCtx)
+		r.Post("/", app.getTransactions)
+		r.Post("/trimmed", app.getDecodedTransactions)
 	})
 
 	mux.Route("/address", func(r chi.Router) {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -449,6 +449,48 @@ func (c *appContext) getDecodedTx(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, tx, c.getIndentQuery(r))
 }
 
+func (c *appContext) getTransactions(w http.ResponseWriter, r *http.Request) {
+	txids := m.GetTxnsCtx(r)
+	if txids == nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	txns := make([]*apitypes.Tx, 0, len(txids))
+	for i := range txids {
+		tx := c.BlockData.GetRawTransaction(txids[i])
+		if tx == nil {
+			apiLog.Errorf("Unable to get transaction %s", txids[i])
+			http.Error(w, http.StatusText(422), 422)
+			return
+		}
+		txns = append(txns, tx)
+	}
+
+	writeJSON(w, txns, c.getIndentQuery(r))
+}
+
+func (c *appContext) getDecodedTransactions(w http.ResponseWriter, r *http.Request) {
+	txids := m.GetTxnsCtx(r)
+	if txids == nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	txns := make([]*apitypes.TrimmedTx, 0, len(txids))
+	for i := range txids {
+		tx := c.BlockData.GetTrimmedTransaction(txids[i])
+		if tx == nil {
+			apiLog.Errorf("Unable to get transaction %s", tx)
+			http.Error(w, http.StatusText(422), 422)
+			return
+		}
+		txns = append(txns, tx)
+	}
+
+	writeJSON(w, txns, c.getIndentQuery(r))
+}
+
 func (c *appContext) getTxVoteInfo(w http.ResponseWriter, r *http.Request) {
 	txid := m.GetTxIDCtx(r)
 	if txid == "" {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -54,6 +54,11 @@ type TrimmedTx struct {
 	Vout     []Vout        `json:"vout"`
 }
 
+// Txns models the multi transaction post data structure
+type Txns struct {
+	Transactions []string `json:"transactions"`
+}
+
 // VoteInfo models data about a SSGen transaction (vote)
 type VoteInfo struct {
 	Validation BlockValidation         `json:"block_validation"`

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -461,7 +461,7 @@ func (db *wiredDB) getRawTransaction(txid string) (*apitypes.Tx, string) {
 
 	txraw, err := db.client.GetRawTransactionVerbose(txhash)
 	if err != nil {
-		log.Errorf("GetRawTransactionVerbose failed for: %v", txhash)
+		log.Errorf("GetRawTransactionVerbose failed for %v: %v", txhash, err)
 		return nil, ""
 	}
 
@@ -1092,7 +1092,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	}
 	txraw, err := db.client.GetRawTransactionVerbose(txhash)
 	if err != nil {
-		log.Errorf("GetRawTransactionVerbose failed for: %v", txhash)
+		log.Errorf("GetRawTransactionVerbose failed for %v: %v", txhash, err)
 		return nil
 	}
 	msgTx, err := txhelpers.MsgTxFromHex(txraw.Hex)
@@ -1329,7 +1329,7 @@ func (db *wiredDB) UnconfirmedTxnsForAddress(address string) (*txhelpers.Address
 		Tx, err1 := db.client.GetRawTransaction(txhash)
 
 		if err1 != nil {
-			log.Warnf("Unable to GetRawTransactions(%s): %v", tx, err1)
+			log.Warnf("Unable to GetRawTransaction(%s): %v", tx, err1)
 			err = err1
 			continue
 		}

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -31,6 +32,7 @@ const (
 	ctxBlockStep
 	ctxBlockHash
 	ctxTxHash
+	ctxTxns
 	ctxTxInOutIndex
 	ctxSearch
 	ctxN
@@ -127,6 +129,60 @@ func GetTxIDCtx(r *http.Request) string {
 		return ""
 	}
 	return hash
+}
+
+// GetTxnsCtx retrieves the ctxTxns data from the request context. If not set,
+// the return value is an empty string slice.
+func GetTxnsCtx(r *http.Request) []string {
+	hashes, ok := r.Context().Value(ctxTxns).([]string)
+	if !ok {
+		apiLog.Trace("ctxTxns not set")
+		return nil
+	}
+	return hashes
+}
+
+// PostTxnsCtx extract transaction IDs from the POST body
+func PostTxnsCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := apitypes.Txns{}
+		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil {
+			apiLog.Debugf("No/invalid txns: %v", err)
+			http.Error(w, "error reading JSON message", http.StatusBadRequest)
+			return
+		}
+		err = json.Unmarshal(body, &req)
+		if err != nil {
+			apiLog.Debugf("failed to unmarshal JSON request to apitypes.Txns: %v", err)
+			http.Error(w, "failed to unmarshal JSON request", http.StatusBadRequest)
+			return
+		}
+		// Successful extraction of body JSON
+		ctx := context.WithValue(r.Context(), ctxTxns, req.Transactions)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ValidateTxnsPostCtx will confirm Post content length is valid.
+func ValidateTxnsPostCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentLengthString := r.Header.Get("Content-Length")
+		contentLength, err := strconv.Atoi(contentLengthString)
+		if err != nil {
+			http.Error(w, "Unable to parse Content-Length", http.StatusBadRequest)
+			return
+		}
+		// Broadcast Tx has the largest possible body.
+		maxPayload := 1 << 22
+		if contentLength > maxPayload {
+			http.Error(w, fmt.Sprintf("Maximum Content-Length is %d", maxPayload), http.StatusBadRequest)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // GetBlockHashCtx retrieves the ctxBlockHash data from the request context. If

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ type Version struct {
 var Ver = Version{
 	Major: 2,
 	Minor: 0,
-	Patch: 0,
+	Patch: 1,
 	Label: ""}
 
 // CommitHash may be set on the build command line:


### PR DESCRIPTION
This adds the /txs and /txs/trimmed routes for batch requesting transaction details.  The transaction hashes are transmitted in the http request body as JSON.  The structure is `api/types.Txns`. The request
Content-Type must be "application/json".
The return type for /txs is `[]*types.Tx`.
The return type for /txs/trimmed is `[]*types.TrimmedTx`.

version: bump to 2.0.1