### PR TITLE
multi: show maturity ETA in hours

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1166,9 +1166,9 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 		}
 		tx.Maturity = int64(db.params.CoinbaseMaturity) + 1 // Add one to reflect < instead of <=
 	}
-	CoinbaseMaturityInDay := (db.params.TargetTimePerBlock.Hours() * float64(db.params.CoinbaseMaturity)) / 24
+	CoinbaseMaturityInHours := (db.params.TargetTimePerBlock.Hours() * float64(db.params.CoinbaseMaturity))
 	tx.MaturityTimeTill = ((float64(db.params.CoinbaseMaturity) -
-		float64(tx.Confirmations)) / float64(db.params.CoinbaseMaturity)) * CoinbaseMaturityInDay
+		float64(tx.Confirmations)) / float64(db.params.CoinbaseMaturity)) * CoinbaseMaturityInHours
 
 	outputs := make([]explorer.Vout, 0, len(txraw.Vout))
 	for i, vout := range txraw.Vout {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -252,9 +252,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				tx.TicketInfo.TicketPoolSize = int64(exp.ChainParams.TicketPoolSize) * int64(exp.ChainParams.TicketsPerBlock)
 				tx.TicketInfo.TicketExpiry = int64(exp.ChainParams.TicketExpiry)
 				expirationInDays := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(exp.ChainParams.TicketExpiry)) / 24
-				maturityInDay := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(tx.TicketInfo.TicketMaturity)) / 24
+				maturityInHours := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(tx.TicketInfo.TicketMaturity))
 				tx.TicketInfo.TimeTillMaturity = ((float64(exp.ChainParams.TicketMaturity) -
-					float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInDay
+					float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInHours
 				ticketExpiryBlocksLeft := int64(exp.ChainParams.TicketExpiry) - blocksLive
 				tx.TicketInfo.TicketExpiryDaysLeft = (float64(ticketExpiryBlocksLeft) /
 					float64(exp.ChainParams.TicketExpiry)) * expirationInDays

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -85,14 +85,14 @@ type TxInfo struct {
 	Mature           string
 	VoteFundsLocked  string
 	Maturity         int64   // Total number of blocks before mature
-	MaturityTimeTill float64 // Time in days until mature
+	MaturityTimeTill float64 // Time in hours until mature
 	TicketInfo
 }
 
 // TicketInfo is used to represent data shown for a sstx transaction.
 type TicketInfo struct {
 	TicketMaturity       int64
-	TimeTillMaturity     float64 // Time before a particular ticket reaches maturity
+	TimeTillMaturity     float64 // Time before a particular ticket reaches maturity, in hours
 	PoolStatus           string
 	SpendStatus          string
 	TicketPoolSize       int64   // Total number of ticket in the pool

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -78,7 +78,7 @@
                                             aria-valuemax="256"
                                         >
                                             <span class="nowrap pl-1 pr-1">
-                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} days remaining){{end}}
+                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining){{end}}
                                             </span>
                                         </div>
                                     </div>
@@ -103,7 +103,7 @@
                                             aria-valuemax="256"
                                         >
                                             <span class="nowrap pl-1 pr-1">
-                                                Immature, spendable in {{ if eq (add .Confirmations 1) .Maturity }}next block{{else}}{{subtract .Maturity .Confirmations}} blocks ({{printf "%.1f" .MaturityTimeTill}} days remaining){{end}}
+                                                Immature, spendable in {{ if eq (add .Confirmations 1) .Maturity }}next block{{else}}{{subtract .Maturity .Confirmations}} blocks ({{printf "%.1f" .MaturityTimeTill}} hours remaining){{end}}
                                             </span>
                                         </div>
                                     </div>


### PR DESCRIPTION
This PR will change ticket ETAs to use hours.

Examples:
"Immature, spendable in 28 blocks (2.2 hours remaining)"
"Immature, eligible to vote in 145 blocks (12.0 hours remaining)"

Not "0.37 days remaining"