### PR TITLE
html/tx: unconfirmed tickets/votes have no maturity status

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1151,7 +1151,8 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 
 	}
 	if tx.Type == "Vote" || tx.Type == "Ticket" {
-		if db.GetBestBlockHeight() >= (int64(db.params.TicketMaturity) + tx.BlockHeight) {
+		if tx.Confirmations > 0 && db.GetBestBlockHeight() >=
+			(int64(db.params.TicketMaturity)+tx.BlockHeight) {
 			tx.Mature = "True"
 		} else {
 			tx.Mature = "False"

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -61,8 +61,12 @@
                 {{end}}
                 {{if eq .Mature "True"}}
                     <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td></tr>
+                {{else}}
+                {{if and (eq .Confirmations 0) (or (eq .Type "Ticket") (eq .Type "Vote")) }}
+                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>N/A</td></tr>
                 {{end}}
-                {{if and (eq .Mature "False") (eq .Type "Ticket")}}
+                {{end}}
+                {{if and (gt .Confirmations 0) (and (eq .Mature "False") (eq .Type "Ticket"))}}
                     <tr>
                         <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                         <td>


### PR DESCRIPTION
(db *wiredDB) GetExplorerTx: set Mature="false" when confirmations==0
tx.tmpl: Unconfirmed tickets and votes read "N/A"  for MATURITY, must be
confirmed to show progress meter.