### PR TITLE
rebuilddb2 batch sync flag

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -236,6 +236,10 @@ func mainCore() error {
 		}
 	}
 
+	// Note that we are doing a batch blockchain sync
+	db.InBatchSync = true
+	defer func() { db.InBatchSync = false }()
+
 	var totalTxs, totalVins, totalVouts int64
 	var lastTxs, lastVins, lastVouts int64
 	tickTime := 10 * time.Second

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -77,7 +77,7 @@ type ChainDB struct {
 	stakeDB            *stakedb.StakeDatabase
 	unspentTicketCache *TicketTxnIDGetter
 	DevFundBalance     *DevFundBalance
-	inBatchSync        bool
+	InBatchSync        bool
 }
 
 // ChainDBRPC provides an interface for storing and manipulating extracted and
@@ -1210,7 +1210,7 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 		}
 	}
 
-	if !pgb.inBatchSync {
+	if !pgb.InBatchSync {
 		pgb.addressCounts.Lock()
 		pgb.addressCounts.validHeight = int64(msgBlock.Header.Height)
 		pgb.addressCounts.balance = map[string]explorer.AddressBalance{}

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -48,8 +48,8 @@ func (db *ChainDB) SyncChainDBAsync(res chan dbtypes.SyncResult,
 func (db *ChainDB) SyncChainDB(client rpcutils.MasterBlockGetter, quit chan struct{},
 	updateAllAddresses, updateAllVotes, newIndexes bool) (int64, error) {
 	// Note that we are doing a batch blockchain sync
-	db.inBatchSync = true
-	defer func() { db.inBatchSync = false }()
+	db.InBatchSync = true
+	defer func() { db.InBatchSync = false }()
 
 	// Get chain servers's best block
 	nodeHeight, err := client.NodeHeight()
@@ -176,7 +176,7 @@ func (db *ChainDB) SyncChainDB(client rpcutils.MasterBlockGetter, quit chan stru
 		// If this is likely to be the last call to StoreBlock, allow
 		// possibly-repetative code, such as the dev balance update.
 		if ib == nodeHeight {
-			db.inBatchSync = false
+			db.InBatchSync = false
 		}
 
 		// Store data from this block in the database


### PR DESCRIPTION
This prevents each connected block from updating the dev fund balance.  The dcrdata app already does this, but rebuilddb2 was not updated.