### PR TITLE
Consolidated debit view

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -874,7 +874,7 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 
 	// Get Confirmed Balances
 	var unconfirmedBalanceSat int64
-	_, _, totalSpent, totalUnspent, err := c.BlockData.ChainDB.RetrieveAddressSpentUnspent(address)
+	_, _, totalSpent, totalUnspent, _, err := c.BlockData.ChainDB.RetrieveAddressSpentUnspent(address)
 	if err != nil {
 		return
 	}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -44,15 +44,17 @@ const (
 	AddrTxnAll AddrTxnType = iota
 	AddrTxnCredit
 	AddrTxnDebit
+	AddrMergedTxnDebit
 	AddrTxnUnknown
 )
 
 // AddrTxnTypes is the canonical mapping from AddrTxnType to string.
 var AddrTxnTypes = map[AddrTxnType]string{
-	AddrTxnAll:     "all",
-	AddrTxnCredit:  "credit",
-	AddrTxnDebit:   "debit",
-	AddrTxnUnknown: "unknown",
+	AddrTxnAll:         "all",
+	AddrTxnCredit:      "credit",
+	AddrTxnDebit:       "debit",
+	AddrMergedTxnDebit: "merged debit",
+	AddrTxnUnknown:     "unknown",
 }
 
 func (a AddrTxnType) String() string {
@@ -73,6 +75,8 @@ func AddrTxnTypeFromStr(txnType string) AddrTxnType {
 		fallthrough
 	case "debits":
 		return AddrTxnDebit
+	case "merged debit":
+		return AddrMergedTxnDebit
 	default:
 		return AddrTxnUnknown
 	}
@@ -297,15 +301,16 @@ type Vout struct {
 type AddressRow struct {
 	// id int64
 	Address string
-	// MatchingTxHash provides the relationship between spending tx inputs and
-	// funding tx outputs.
-	MatchingTxHash string
-	IsFunding      bool
-	TxBlockTime    uint64
-	TxHash         string
-	TxVinVoutIndex uint32
-	Value          uint64
-	VinVoutDbID    uint64
+	// MatchingTxHash that provides the relationship
+	// between spending tx inputs and funding tx outputs
+	MatchingTxHash   string
+	IsFunding        bool
+	TxBlockTime      uint64
+	TxHash           string
+	TxVinVoutIndex   uint32
+	Value            uint64
+	VinVoutDbID      uint64
+	MergedDebitCount uint64
 }
 
 // ChartsData defines the fields that store the values needed to plot the charts

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -65,7 +65,7 @@ func (pgb *ChainDB) InsightPgGetAddressTransactions(addr []string,
 
 // RetrieveAddressSpentUnspent retrieves balance information for a specific
 // address.
-func (pgb *ChainDB) RetrieveAddressSpentUnspent(address string) (int64, int64, int64, int64, error) {
+func (pgb *ChainDB) RetrieveAddressSpentUnspent(address string) (int64, int64, int64, int64, int64, error) {
 	return RetrieveAddressSpentUnspent(pgb.db, address)
 }
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -54,7 +54,10 @@ const (
 	    WHERE address = $1 and is_funding = TRUE and matching_tx_hash = '';`
 
 	SelectAddressSpentCountAndValue = `SELECT COUNT(*), SUM(value) FROM addresses 
-	    WHERE address = $1 and is_funding = FALSE and matching_tx_hash != '';`
+		WHERE address = $1 and is_funding = FALSE and matching_tx_hash != '';`
+
+	SelectAddressesMergedSpentCount = `SELECT COUNT( distinct tx_hash ) FROM addresses
+		WHERE address = $1 and is_funding = false`
 
 	SelectAddressUnspentWithTxn = `SELECT addresses.address, addresses.tx_hash, addresses.value,
 			transactions.block_height, addresses.block_time, tx_vin_vout_index, pkscript
@@ -72,7 +75,11 @@ const (
 
 	SelectAddressLimitNByAddressSubQry = `WITH these as (SELECT ` + addrsColumnNames +
 		` FROM addresses WHERE address=$1)
-        SELECT * FROM these ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		SELECT * FROM these order by block_time desc limit $2 offset $3;`
+
+	SelectAddressMergedDebitView = `SELECT address, tx_hash, block_time,
+	sum(value), COUNT(*) FROM addresses WHERE address=$1 AND is_funding = FALSE GROUP BY
+	(address, tx_hash, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
 		FROM addresses WHERE address=$1 and is_funding = FALSE

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -77,9 +77,9 @@ const (
 		` FROM addresses WHERE address=$1)
 		SELECT * FROM these order by block_time desc limit $2 offset $3;`
 
-	SelectAddressMergedDebitView = `SELECT address, tx_hash, block_time,
-	sum(value), COUNT(*) FROM addresses WHERE address=$1 AND is_funding = FALSE GROUP BY
-	(address, tx_hash, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+	SelectAddressMergedDebitView = `SELECT tx_hash, block_time, sum(value), 
+		COUNT(*) FROM addresses WHERE address=$1 AND is_funding = FALSE 
+		GROUP BY (tx_hash, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
 		FROM addresses WHERE address=$1 and is_funding = FALSE

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -415,11 +415,6 @@ func IndexAddressTableOnAddress(db *sql.DB) (err error) {
 	return
 }
 
-func IndexBlockTimeOnTableAddress(db *sql.DB) (err error) {
-	_, err = db.Exec(internal.IndexBlockTimeOnTableAddress)
-	return
-}
-
 func DeindexAddressTableOnAddress(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexAddressTableOnAddress)
 	return

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -415,6 +415,11 @@ func IndexAddressTableOnAddress(db *sql.DB) (err error) {
 	return
 }
 
+func IndexBlockTimeOnTableAddress(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexBlockTimeOnTableAddress)
+	return
+}
+
 func DeindexAddressTableOnAddress(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexAddressTableOnAddress)
 	return

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -465,11 +465,12 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		addrData.KnownTransactions = (balance.NumSpent * 2) + balance.NumUnspent
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.KnownSpendingTxns = balance.NumSpent
+		addrData.KnownMergedSpendingTxns = balance.NumMergedSpent
 
 		// Transactions to fetch with FillAddressTransactions. This should be a
 		// noop if ReduceAddressHistory is working right.
 		switch txnType {
-		case dbtypes.AddrTxnAll:
+		case dbtypes.AddrTxnAll, dbtypes.AddrMergedTxnDebit:
 		case dbtypes.AddrTxnCredit:
 			addrData.Transactions = addrData.TxnsFunding
 		case dbtypes.AddrTxnDebit:

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -50,24 +50,29 @@ type ChartDataCounter struct {
 
 // AddressTx models data for transactions on the address page
 type AddressTx struct {
-	TxID          string
-	InOutID       uint32
-	Size          uint32
-	FormattedSize string
-	Total         float64
-	Confirmations uint64
-	Time          int64
-	FormattedTime string
-	ReceivedTotal float64
-	SentTotal     float64
-	IsFunding     bool
-	MatchedTx     string
-	BlockTime     uint64
+	TxID           string
+	InOutID        uint32
+	Size           uint32
+	FormattedSize  string
+	Total          float64
+	Confirmations  uint64
+	Time           int64
+	FormattedTime  string
+	ReceivedTotal  float64
+	SentTotal      float64
+	IsFunding      bool
+	MatchedTx      string
+	BlockTime      uint64
+	MergedTxnCount uint64 `json:"MergedTxnCount,omitempty"`
 }
 
 // IOID formats an identification string for the transaction input (or output)
 // represented by the AddressTx.
-func (a *AddressTx) IOID() string {
+func (a *AddressTx) IOID(txType ...string) string {
+	// if transaction is of type merged debit, return unformatted transaction ID
+	if len(txType) > 0 && dbtypes.AddrTxnTypeFromStr(txType[0]) == dbtypes.AddrMergedTxnDebit {
+		return a.TxID
+	}
 	// When AddressTx is used properly, at least one of ReceivedTotal or
 	// SentTotal should be zero.
 	if a.IsFunding {
@@ -237,6 +242,10 @@ type AddressInfo struct {
 	KnownTransactions int64
 	KnownFundingTxns  int64
 	KnownSpendingTxns int64
+
+	// KnownMergedSpendingTxns refers to the total count of unique debit transactions
+	// that appear in the merged debit view.
+	KnownMergedSpendingTxns int64
 }
 
 // TxnCount returns the number of transaction "rows" available.
@@ -251,6 +260,8 @@ func (a *AddressInfo) TxnCount() int64 {
 		return a.KnownFundingTxns
 	case dbtypes.AddrTxnDebit:
 		return a.KnownSpendingTxns
+	case dbtypes.AddrMergedTxnDebit:
+		return a.KnownMergedSpendingTxns
 	default:
 		log.Warnf("Unknown address transaction type: %v", a.TxnType)
 		return 0
@@ -260,11 +271,12 @@ func (a *AddressInfo) TxnCount() int64 {
 // AddressBalance represents the number and value of spent and unspent outputs
 // for an address.
 type AddressBalance struct {
-	Address      string `json:"address"`
-	NumSpent     int64  `json:"num_stxos"`
-	NumUnspent   int64  `json:"num_utxos"`
-	TotalSpent   int64  `json:"amount_spent"`
-	TotalUnspent int64  `json:"amount_unspent"`
+	Address        string `json:"address"`
+	NumSpent       int64  `json:"num_stxos"`
+	NumUnspent     int64  `json:"num_utxos"`
+	TotalSpent     int64  `json:"amount_spent"`
+	TotalUnspent   int64  `json:"amount_unspent"`
+	NumMergedSpent int64  `json:"num_merged_spent,omitempty"`
 }
 
 // HomeInfo represents data used for the home page
@@ -359,6 +371,8 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 			// Spending transaction
 			sent += int64(addrOut.Value)
 			tx.SentTotal = coin
+			tx.MergedTxnCount = addrOut.MergedDebitCount
+
 			debitTxns = append(debitTxns, &tx)
 		}
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -63,7 +63,7 @@ type AddressTx struct {
 	IsFunding      bool
 	MatchedTx      string
 	BlockTime      uint64
-	MergedTxnCount uint64 `json:"MergedTxnCount,omitempty"`
+	MergedTxnCount uint64 `json:",omitempty"`
 }
 
 // IOID formats an identification string for the transaction input (or output)

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -8,6 +8,7 @@
     {{with .Data}}
     {{$heights := $.ConfirmHeight}}
     {{$TxnCount := .TxnCount}}
+    {{$txType := .TxnType}}
     <div class="container" data-controller="main">
         <div class="row">
             <div class="col-md-8 col-sm-6">
@@ -109,14 +110,14 @@
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}&txntype={{.TxnType}}"
+                                        href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}&txntype={{$txType}}"
                                         id="prev"
                                     >Previous</a>
                                 </li>
-                                <li class="page-item {{if lt (subtract .KnownTransactions .Offset) (add .Limit 1)}}disabled{{end}}">
+                                <li class="page-item {{if lt (subtract $TxnCount .Offset) (add .Limit 1)}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}&txntype={{.TxnType}}"
+                                        href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}&txntype={{$txType}}"
                                         id="next">
                                         Next
                                     </a>
@@ -132,7 +133,11 @@
                 <table class="table table-mono-cells table-sm striped">
                     <thead>
                         <th>Input/Output ID</th>
-                        <th class="text-right">Credit DCR</th>
+                        {{if eq $txType "merged debit"}}
+                            <th># of Input(s)</th>
+                        {{else}}
+                            <th class="text-right">Credit DCR</th>
+                        {{end}}
                         <th>Debit DCR</th>
                         <th>Time</th>
                         <th>Age</th>
@@ -143,17 +148,21 @@
                         {{range $i, $v := .Transactions}}
                         <tr>
                             {{with $v}}
-                            <td><a href="/tx/{{.TxID}}" class="hash" data-keynav-priority>{{.IOID}}</a></td>
-                            {{if ne .ReceivedTotal 0.0}}
-                                <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal false)}}</td>
+                            <td><a href="/tx/{{.TxID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
+                            {{if eq $txType "merged debit"}}
+                                <td>{{.MergedTxnCount}}</td>
                             {{else}}
-                                {{if eq .SentTotal 0.0}}
-                                <td class="text-right">sstxcommitment</td>
+                                {{if ne .ReceivedTotal 0.0}}
+                                    <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal false)}}</td>
                                 {{else}}
-                                    {{if ne .MatchedTx ""}}
-                                      <td class="text-right"><a href="/tx/{{.MatchedTx}}" class="hash">source</a></td>
+                                    {{if eq .SentTotal 0.0}}
+                                    <td class="text-right">sstxcommitment</td>
                                     {{else}}
-                                      <td>N/A</td>
+                                        {{if ne .MatchedTx ""}}
+                                        <td class="text-right"><a href="/tx/{{.MatchedTx}}" class="hash">source</a></td>
+                                        {{else}}
+                                        <td>N/A</td>
+                                        {{end}}
                                     {{end}}
                                 {{end}}
                             {{end}}
@@ -166,6 +175,13 @@
                             {{else}}
                                 {{if ne .MatchedTx ""}}
                                     <td><a href="/tx/{{.MatchedTx}}" class="hash">spent</a></td>
+                                {{else}}
+                                    <td>unspent</td>
+                                {{end}}
+                            {{end}}
+                            {{if gt .MatchedTx 0}}
+                                {{if .IsFunding}}
+                                    <td><a href="/tx/AddrId/{{.MatchedTx}}" class="hash">Funded By</a></td>
                                 {{else}}
                                     <td>unspent</td>
                                 {{end}}
@@ -212,9 +228,10 @@
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if not .Fullmode}}disabled{{end}}"
                         {{if not .Fullmode}}disabled="disabled"{{end}}
                     >
-                        <option {{if eq .TxnType "all"}}selected{{end}} value="all">All</option>
-                        <option {{if eq .TxnType "credit"}}selected{{end}} value="credit">Credits</option>
-                        <option {{if eq .TxnType "debit"}}selected{{end}} value="debit">Debits</option>
+                        <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
+                        <option {{if eq $txType "credit"}}selected{{end}} value="credit">Credits</option>
+                        <option {{if eq $txType "debit"}}selected{{end}} value="debit">Debits</option>
+                        <option {{if eq $txType "merged debit"}}selected{{end}} value="merged debit">Merged Debits</option>
                     </select>
                 </div>
                 {{if and (not .Fullmode) (ge .KnownTransactions .MaxTxLimit)}}
@@ -246,7 +263,7 @@
                 window.location.pathname
                 + "?txntype="+ $(ev.currentTarget).val()
                 + "&n="+ parseInt($("#pagesize").val())
-                + "&start=" + {{.Offset}}
+                + "&start=0"
             )
         })
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -138,8 +138,12 @@
                         {{else}}
                             <th class="text-right">Credit DCR</th>
                         {{end}}
-                        <th>Debit DCR</th>
-                        <th>Time</th>
+                        {{if eq $txType "merged debit"}}
+                            <th class="text-center">Debit DCR</th>
+                        {{else}}
+                            <th>Debit DCR</th>
+                        {{end}}
+                        <th>Time UTC</th>
                         <th>Age</th>
                         <th>Confirms</th>
                         <th>Size</th>
@@ -168,7 +172,11 @@
                             {{end}}
                             {{if ne .SentTotal 0.0}}
                                 {{if lt 0.0 .SentTotal}}
-                                    <td>{{template "decimalParts" (float64AsDecimalParts .SentTotal false)}}</td>
+                                   {{if eq $txType "merged debit"}}
+                                        <td class="text-right"> {{template "decimalParts" (float64AsDecimalParts .SentTotal false)}}</td>
+                                    {{else}}
+                                        <td>{{template "decimalParts" (float64AsDecimalParts .SentTotal false)}}</td>
+                                    {{end}}
                                 {{else}}
                                     <td>N/A</td>
                                 {{end}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -179,13 +179,6 @@
                                     <td>unspent</td>
                                 {{end}}
                             {{end}}
-                            {{if gt .MatchedTx 0}}
-                                {{if .IsFunding}}
-                                    <td><a href="/tx/AddrId/{{.MatchedTx}}" class="hash">Funded By</a></td>
-                                {{else}}
-                                    <td>unspent</td>
-                                {{end}}
-                            {{end}}
                             <td>
                                 {{if eq .Time 0}}
                                     Unconfirmed


### PR DESCRIPTION
This PR is based of dcrdata 3.0.0.

- It introduces a new merged view debit page on the addresses history page the list only unique transactions where similar transactions appear.

- It also fixes a bug with the next button on the same page.

![2018-06-30 06 35 10](https://user-images.githubusercontent.com/22055953/42121084-cd9295d8-7c2f-11e8-966b-13229706d5ff.jpg)
