### PR TITLE
explorer: compute ticket matruity times in lite mode

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1150,7 +1150,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 		tx.Maturity = int64(db.params.CoinbaseMaturity)
 
 	}
-	if tx.Type == "Vote" || tx.Type == "Ticket" {
+	if tx.IsVote() || tx.IsTicket() {
 		if tx.Confirmations > 0 && db.GetBestBlockHeight() >=
 			(int64(db.params.TicketMaturity)+tx.BlockHeight) {
 			tx.Mature = "True"
@@ -1159,7 +1159,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 			tx.TicketInfo.TicketMaturity = int64(db.params.TicketMaturity)
 		}
 	}
-	if tx.Type == "Vote" {
+	if tx.IsVote() {
 		if tx.Confirmations < int64(db.params.CoinbaseMaturity) {
 			tx.VoteFundsLocked = "True"
 		} else {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -237,7 +237,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				Index: spendingTxVinInds[i],
 			}
 		}
-		if tx.Type == "Ticket" {
+		if tx.IsTicket() {
 			spendStatus, poolStatus, err := exp.explorerSource.PoolStatusForTicket(hash)
 			if err != nil {
 				log.Errorf("Unable to retrieve ticket spend and pool status for %s: %v", hash, err)
@@ -248,16 +248,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 					tx.TicketInfo.PoolStatus = poolStatus.String()
 				}
 				tx.TicketInfo.SpendStatus = spendStatus.String()
+
+				// Ticket luck and probability of voting
 				blocksLive := tx.Confirmations - int64(exp.ChainParams.TicketMaturity)
-				tx.TicketInfo.TicketPoolSize = int64(exp.ChainParams.TicketPoolSize) * int64(exp.ChainParams.TicketsPerBlock)
-				tx.TicketInfo.TicketExpiry = int64(exp.ChainParams.TicketExpiry)
-				expirationInDays := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(exp.ChainParams.TicketExpiry)) / 24
-				maturityInHours := (exp.ChainParams.TargetTimePerBlock.Hours() * float64(tx.TicketInfo.TicketMaturity))
-				tx.TicketInfo.TimeTillMaturity = ((float64(exp.ChainParams.TicketMaturity) -
-					float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInHours
-				ticketExpiryBlocksLeft := int64(exp.ChainParams.TicketExpiry) - blocksLive
-				tx.TicketInfo.TicketExpiryDaysLeft = (float64(ticketExpiryBlocksLeft) /
-					float64(exp.ChainParams.TicketExpiry)) * expirationInDays
 				if tx.TicketInfo.SpendStatus == "Voted" {
 					// Blocks from eligible until voted (actual luck)
 					tx.TicketInfo.TicketLiveBlocks = exp.blockData.TxHeight(tx.SpendingTxns[0].Hash) -
@@ -307,6 +300,23 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 					float64(exp.ChainParams.TicketExpiry)-float64(blocksLive)))
 			}
 		}
+	}
+
+	// Set ticket-related parameters for both full and lite mode
+	if tx.IsTicket() {
+		blocksLive := tx.Confirmations - int64(exp.ChainParams.TicketMaturity)
+		tx.TicketInfo.TicketPoolSize = int64(exp.ChainParams.TicketPoolSize) *
+			int64(exp.ChainParams.TicketsPerBlock)
+		tx.TicketInfo.TicketExpiry = int64(exp.ChainParams.TicketExpiry)
+		expirationInDays := (exp.ChainParams.TargetTimePerBlock.Hours() *
+			float64(exp.ChainParams.TicketExpiry)) / 24
+		maturityInHours := (exp.ChainParams.TargetTimePerBlock.Hours() *
+			float64(tx.TicketInfo.TicketMaturity))
+		tx.TicketInfo.TimeTillMaturity = ((float64(exp.ChainParams.TicketMaturity) -
+			float64(tx.Confirmations)) / float64(exp.ChainParams.TicketMaturity)) * maturityInHours
+		ticketExpiryBlocksLeft := int64(exp.ChainParams.TicketExpiry) - blocksLive
+		tx.TicketInfo.TicketExpiryDaysLeft = (float64(ticketExpiryBlocksLeft) /
+			float64(exp.ChainParams.TicketExpiry)) * expirationInDays
 	}
 
 	pageData := struct {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -92,6 +92,14 @@ type TxInfo struct {
 	TicketInfo
 }
 
+func (t *TxInfo) IsTicket() bool {
+	return t.Type == "Ticket"
+}
+
+func (t *TxInfo) IsVote() bool {
+	return t.Type == "Vote"
+}
+
 // TicketInfo is used to represent data shown for a sstx transaction.
 type TicketInfo struct {
 	TicketMaturity       int64

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -51,7 +51,7 @@
                         {{.Type}}
                     </td>
                 </tr>
-                {{if and (eq .Type "Ticket") (gt .Confirmations 0)}}
+                {{if and (ne .TicketInfo.PoolStatus "") (and (eq .Type "Ticket") (gt .Confirmations 0))}}
                     <tr>
                         <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
                         <td>


### PR DESCRIPTION
Resolving issue https://github.com/decred/dcrdata/issues/511

Intoduces `(*TxInfo).IsTicket/IsVote`