### PR TITLE
dcrpg: fix empty prev_hash in block_chain

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -37,8 +37,12 @@ const (
 
 	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
 
-	SelectBlockByTimeRangeSQL        = `select hash, height, size, time, numtx from blocks where time between $1 and $2 ORDER BY time DESC LIMIT $3;`
-	SelectBlockByTimeRangeSQLNoLimit = `select hash, height, size, time, numtx from blocks where time between $1 and $2 ORDER BY time DESC;`
+	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
+	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC;`
+	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1;`
+	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
 
 	CreateBlockTable = `CREATE TABLE IF NOT EXISTS blocks (  
 		id SERIAL PRIMARY KEY,
@@ -93,8 +97,7 @@ const (
 	VALUES ($1, $2, $3, $4)
 	ON CONFLICT (this_hash) DO NOTHING;`
 
-	SelectBlockHashByHeight = `select hash from blocks where height = $1`
-	SelectBlockHeightByHash = `select height from blocks where hash = $1`
+	SelectBlockChainRowIDByHash = `select block_db_id from block_chain where this_hash = $1;`
 
 	UpdateBlockNext = `UPDATE block_chain set next_hash = $2 WHERE block_db_id = $1;`
 )

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1221,23 +1221,36 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 	// isValid flag in last block if votes in this block invalidated it.
 	lastBlockHash := msgBlock.Header.PrevBlock
 	lastBlockDbID, ok := pgb.lastBlock[lastBlockHash]
-	if ok {
-		lastIsValid := dbBlock.VoteBits&1 != 0
-		if !lastIsValid {
-			log.Infof("Setting last block %s as INVALID", lastBlockHash)
-			err = UpdateLastBlock(pgb.db, lastBlockDbID, lastIsValid)
-			if err != nil {
-				log.Error("UpdateLastBlock:", err)
-				return
-			}
-		}
-		err = UpdateBlockNext(pgb.db, lastBlockDbID, dbBlock.Hash)
+	if !ok {
+		log.Debugf("The previous block for block %s not found in cache, "+
+			"looking it up.", lastBlockHash)
+		lastBlockDbID, err = RetrieveBlockChainDbID(pgb.db, lastBlockHash.String())
 		if err != nil {
-			log.Error("UpdateBlockNext:", err)
+			log.Criticalf("Unable to locate block %s in block_chain table: %v",
+				lastBlockHash, err)
 			return
 		}
 	}
 
+	// Was he previous block invalidated?
+	lastIsValid := dbBlock.VoteBits&1 != 0
+	if !lastIsValid {
+		log.Infof("Setting last block %s as INVALID", lastBlockHash)
+		err = UpdateLastBlock(pgb.db, lastBlockDbID, lastIsValid)
+		if err != nil {
+			log.Error("UpdateLastBlock:", err)
+			return
+		}
+	}
+
+	// Update the previous block's next block hash
+	err = UpdateBlockNext(pgb.db, lastBlockDbID, dbBlock.Hash)
+	if err != nil {
+		log.Error("UpdateBlockNext:", err)
+		return
+	}
+
+	// If not in batch sync, lazy update the dev fund balance
 	if !pgb.InBatchSync {
 		pgb.addressCounts.Lock()
 		pgb.addressCounts.validHeight = int64(msgBlock.Header.Height)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1095,6 +1095,14 @@ func RetrieveBlockHeight(db *sql.DB, hash string) (height int64, err error) {
 	return
 }
 
+// RetrieveBlockChainDbID retrieves the row id in the block_chain table of the
+// block with the given hash, if it exists (be sure to check error against
+// sql.ErrNoRows!).
+func RetrieveBlockChainDbID(db *sql.DB, hash string) (dbID uint64, err error) {
+	err = db.QueryRow(internal.SelectBlockChainRowIDByHash, hash).Scan(&dbID)
+	return
+}
+
 func RetrieveAddressTxnOutputWithTransaction(db *sql.DB, address string, currentBlockHeight int64) ([]apitypes.AddressTxnOutput, error) {
 	var outputs []apitypes.AddressTxnOutput
 


### PR DESCRIPTION
In `StoreBlock`, if `pgb.lastBlock` does not contain the previous block row
ID, look it up in the block_chain table. Add `RetrieveBlockChainDbID` to
get the row id in the block_chain table for the block with a given hash.