### PR TITLE
[2.1] DB recovery and robustness.

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -137,7 +137,7 @@ func mainCore() error {
 	}
 
 	// Create/load stake database (which includes the separate ticket pool DB).
-	stakeDB, err := stakedb.NewStakeDatabase(client, activeChain, "rebuild_data")
+	stakeDB, _, err := stakedb.NewStakeDatabase(client, activeChain, "rebuild_data")
 	if err != nil {
 		return fmt.Errorf("Unable to create stake DB: %v", err)
 	}
@@ -203,7 +203,7 @@ func mainCore() error {
 			return nil
 		default:
 		}
-		if err = stakeDB.DisconnectBlock(); err != nil {
+		if err = stakeDB.DisconnectBlock(false); err != nil {
 			return err
 		}
 		stakeDBHeight = int64(stakeDB.Height())

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -138,7 +138,8 @@ func makeBlockTransactions(blockVerbose *dcrjson.GetBlockVerboseResult) *apitype
 	return blockTransactions
 }
 
-// GetBlockHash returns the hash of the block at the specified height.
+// GetBlockHash returns the hash of the block at the specified height. TODO:
+// create GetBlockHashes to return all blocks at a given height.
 func (pgb *ChainDB) GetBlockHash(idx int64) (string, error) {
 	hash, err := RetrieveBlockHash(pgb.db, idx)
 	if err != nil {

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -125,3 +125,10 @@ const (
 		ON addresses(funding_tx_hash, funding_tx_vout_index);`
 	DeindexAddressTableOnFundingTx = `DROP INDEX uix_addresses_funding_tx;`
 )
+
+func MakeAddressRowInsertStatement(checked bool) string {
+	if checked {
+		return UpsertAddressRow
+	}
+	return InsertAddressRow
+}

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -116,7 +116,7 @@ const (
 	insertVoteRow = insertVoteRow0 + `RETURNING id;`
 	// insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $3, block_hash = $4 RETURNING id;`
+		SET tx_hash = $2, block_hash = $3 RETURNING id;`
 	insertVoteRowReturnId = `WITH ins AS (` +
 		insertVoteRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -126,7 +126,7 @@ const (
 	SELECT id FROM ins
 	UNION  ALL
 	SELECT id FROM votes
-	WHERE  tx_hash = $3 AND block_hash = $4
+	WHERE  tx_hash = $2 AND block_hash = $3
 	LIMIT  1;`
 
 	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -135,6 +135,13 @@ const (
 	);`
 )
 
+func MakeVinInsertStatement(checked bool) string {
+	if checked {
+		return UpsertVinRow
+	}
+	return InsertVinRow
+}
+
 var (
 	voutCopyStmt = pq.CopyIn("vouts",
 		"tx_hash", "tx_index", "tx_tree", "value", "version",

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1294,7 +1294,7 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 		}
 
 		// Insert vins
-		dbtx.VinDbIds, err = InsertVins(pgb.db, dbTxVins[it])
+		dbtx.VinDbIds, err = InsertVins(pgb.db, dbTxVins[it], pgb.dupChecks)
 		if err != nil && err != sql.ErrNoRows {
 			log.Error("InsertVins:", err)
 			txRes.err = err

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -510,7 +510,7 @@ func SetSpendingForFundingOP(db *sql.DB,
 // need to get the funding (previous output) tx info, and then update the
 // corresponding row in the addresses table with the spending tx info.
 func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
-	spendingTxHash string, spendingTxVinIndex uint32) (int64, error) {
+	spendingTxHash string, spendingTxVinIndex uint32, checked bool) (int64, error) {
 	// get funding details for vin and set them in the address table
 	dbtx, err := db.Begin()
 	if err != nil {
@@ -1084,11 +1084,16 @@ func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []s
 	return
 }
 
+// RetrieveBlockHash retrieves the hash of the block at the given height, if it
+// exists (be sure to check error against sql.ErrNoRows!). WARNING: this returns
+// the most recently added block at this height, but there may be others.
 func RetrieveBlockHash(db *sql.DB, idx int64) (hash string, err error) {
 	err = db.QueryRow(internal.SelectBlockHashByHeight, idx).Scan(&hash)
 	return
 }
 
+// RetrieveBlockHeight retrieves the height of the block with the given hash, if
+// it exists (be sure to check error against sql.ErrNoRows!).
 func RetrieveBlockHeight(db *sql.DB, hash string) (height int64, err error) {
 	err = db.QueryRow(internal.SelectBlockHeightByHash, hash).Scan(&height)
 	return
@@ -1335,20 +1340,20 @@ func UpdateBlockNext(db *sql.DB, blockDbID uint64, next string) error {
 	return nil
 }
 
-func InsertVin(db *sql.DB, dbVin dbtypes.VinTxProperty) (id uint64, err error) {
-	err = db.QueryRow(internal.InsertVinRow,
+func InsertVin(db *sql.DB, dbVin dbtypes.VinTxProperty, checked bool) (id uint64, err error) {
+	err = db.QueryRow(internal.MakeVinInsertStatement(checked),
 		dbVin.TxID, dbVin.TxIndex, dbVin.TxTree,
 		dbVin.PrevTxHash, dbVin.PrevTxIndex, dbVin.PrevTxTree).Scan(&id)
 	return
 }
 
-func InsertVins(db *sql.DB, dbVins dbtypes.VinTxPropertyARRAY) ([]uint64, error) {
+func InsertVins(db *sql.DB, dbVins dbtypes.VinTxPropertyARRAY, checked bool) ([]uint64, error) {
 	dbtx, err := db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.InsertVinRow)
+	stmt, err := dbtx.Prepare(internal.MakeVinInsertStatement(checked))
 	if err != nil {
 		log.Errorf("Vin INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
@@ -1440,11 +1445,10 @@ func InsertVouts(db *sql.DB, dbVouts []*dbtypes.Vout, checked bool) ([]uint64, [
 	return ids, addressRows, dbtx.Commit()
 }
 
+// InsertAddressOut inserts an AddressRow (input or output), returning the row
+// ID in the addresses table of the inserted data.
 func InsertAddressOut(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck bool) (uint64, error) {
-	sqlStmt := internal.InsertAddressRow
-	if dupCheck {
-		sqlStmt = internal.UpsertAddressRow
-	}
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
 	var id uint64
 	err := db.QueryRow(sqlStmt, dbA.Address, dbA.FundingTxDbID,
 		dbA.FundingTxHash, dbA.FundingTxVoutIndex, dbA.VoutDbID,
@@ -1466,10 +1470,7 @@ func InsertAddressOuts(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck bool) ([
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	sqlStmt := internal.InsertAddressRow
-	if dupCheck {
-		sqlStmt = internal.UpsertAddressRow
-	}
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
 
 	stmt, err := dbtx.Prepare(sqlStmt)
 	if err != nil {
@@ -1614,7 +1615,8 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		return nil, nil, nil, nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.MakeVoteInsertStatement(checked))
+	voteInsert := internal.MakeVoteInsertStatement(checked)
+	stmt, err := dbtx.Prepare(voteInsert)
 	if err != nil {
 		log.Errorf("Votes INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -73,7 +73,7 @@ func (db *wiredDB) RewindStakeDB(toHeight int64, quit chan struct{}) (stakeDBHei
 			return
 		default:
 		}
-		if err = db.sDB.DisconnectBlock(); err != nil {
+		if err = db.sDB.DisconnectBlock(false); err != nil {
 			return
 		}
 		stakeDBHeight = int64(db.sDB.Height())

--- a/stakedb/ticketpool.go
+++ b/stakedb/ticketpool.go
@@ -484,10 +484,11 @@ func (tp *TicketPool) advanceTo(height int64) error {
 // AdvanceToTip advances the pool map by applying all stored diffs. Note that
 // the cursor will stop just beyond the last element of the diffs slice. It will
 // not be possible to advance further, only retreat.
-func (tp *TicketPool) AdvanceToTip() error {
+func (tp *TicketPool) AdvanceToTip() (error, int64) {
 	tp.Lock()
 	defer tp.Unlock()
-	return tp.advanceTo(tp.tip)
+	err := tp.advanceTo(tp.tip)
+	return err, tp.cursor - 1
 }
 
 // retreat applies the previous diff in reverse, moving the pool map to the

--- a/stakedb/ticketpool_test.go
+++ b/stakedb/ticketpool_test.go
@@ -84,7 +84,7 @@ func TestTicketPoolTraverseFull(t *testing.T) {
 	}
 
 	t.Log("Advancing cursor to tip (applying all diffs and building pool map).")
-	if err = p.AdvanceToTip(); err != nil {
+	if err, _ = p.AdvanceToTip(); err != nil {
 		t.Errorf("failed to advance pool to tip: %v", err)
 	}
 


### PR DESCRIPTION
This adds some automatic recovery functions.

- Add `stakedb.LoadAndRecover`, which attempts recovery of the `StakeDatabase` and its `TicketPool`.
- `NewStakeDatabase` returns the height where it stopped loading. If there is an error, the height may be passed to `LoadAndRecover`.
- `InsertVin[s]` now has an upsert option (dupcheck=true) to avoid failures requiring recovery procedures.
- Also have dupcheck option with `SetSpendingForFundingOP` / `insertSpendingTxByPrptStmt` and `SetSpendingByVinID`.
- Add `MakeAddressRowInsertStatement` to create the upsert statement if checkup=true;
- `InsertVotes` and `MakeVoteInsertStatement` similarly take checkdups option.
- Fix incorrect parameter numbers in `upsertVoteRow` and `insertVoteRowReturnId`.
- `AdvanceToTip` now returns the last valid diff index (cursor - 1).