### PR TITLE
[2.0] dcrpg: backport block_chain fix and upsert additions

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -77,3 +77,10 @@ const (
 		ON addresses(funding_tx_hash, funding_tx_vout_index);`
 	DeindexAddressTableOnFundingTx = `DROP INDEX uix_addresses_funding_tx;`
 )
+
+func MakeAddressRowInsertStatement(checked bool) string {
+	if checked {
+		return UpsertAddressRow
+	}
+	return InsertAddressRow
+}

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -37,6 +37,13 @@ const (
 
 	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
 
+	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
+	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC;`
+	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1;`
+	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
+
 	CreateBlockTable = `CREATE TABLE IF NOT EXISTS blocks (  
 		id SERIAL PRIMARY KEY,
 		hash TEXT NOT NULL, -- UNIQUE
@@ -89,6 +96,8 @@ const (
 		block_db_id, prev_hash, this_hash, next_hash)
 	VALUES ($1, $2, $3, $4)
 	ON CONFLICT (this_hash) DO NOTHING;`
+
+	SelectBlockChainRowIDByHash = `select block_db_id from block_chain where this_hash = $1;`
 
 	UpdateBlockNext = `UPDATE block_chain set next_hash = $2 WHERE block_db_id = $1;`
 )

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -116,7 +116,7 @@ const (
 	insertVoteRow = insertVoteRow0 + `RETURNING id;`
 	// insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $3, block_hash = $4 RETURNING id;`
+		SET tx_hash = $2, block_hash = $3 RETURNING id;`
 	insertVoteRowReturnId = `WITH ins AS (` +
 		insertVoteRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -126,7 +126,7 @@ const (
 	SELECT id FROM ins
 	UNION  ALL
 	SELECT id FROM votes
-	WHERE  tx_hash = $3 AND block_hash = $4
+	WHERE  tx_hash = $2 AND block_hash = $3
 	LIMIT  1;`
 
 	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -135,6 +135,13 @@ const (
 	);`
 )
 
+func MakeVinInsertStatement(checked bool) string {
+	if checked {
+		return UpsertVinRow
+	}
+	return InsertVinRow
+}
+
 var (
 	voutCopyStmt = pq.CopyIn("vouts",
 		"tx_hash", "tx_index", "tx_tree", "value", "version",

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -827,21 +827,33 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 	// isValid flag in last block if votes in this block invalidated it.
 	lastBlockHash := msgBlock.Header.PrevBlock
 	lastBlockDbID, ok := pgb.lastBlock[lastBlockHash]
-	if ok {
-		lastIsValid := dbBlock.VoteBits&1 != 0
-		if !lastIsValid {
-			log.Infof("Setting last block %s as INVALID", lastBlockHash)
-			err = UpdateLastBlock(pgb.db, lastBlockDbID, lastIsValid)
-			if err != nil {
-				log.Error("UpdateLastBlock:", err)
-				return
-			}
-		}
-		err = UpdateBlockNext(pgb.db, lastBlockDbID, dbBlock.Hash)
+	if !ok {
+		log.Debugf("The previous block for block %s not found in cache, "+
+			"looking it up.", lastBlockHash)
+		lastBlockDbID, err = RetrieveBlockChainDbID(pgb.db, lastBlockHash.String())
 		if err != nil {
-			log.Error("UpdateBlockNext:", err)
+			log.Criticalf("Unable to locate block %s in block_chain table: %v",
+				lastBlockHash, err)
 			return
 		}
+	}
+
+	// Was he previous block invalidated?
+	lastIsValid := dbBlock.VoteBits&1 != 0
+	if !lastIsValid {
+		log.Infof("Setting last block %s as INVALID", lastBlockHash)
+		err = UpdateLastBlock(pgb.db, lastBlockDbID, lastIsValid)
+		if err != nil {
+			log.Error("UpdateLastBlock:", err)
+			return
+		}
+	}
+
+	// Update the previous block's next block hash
+	err = UpdateBlockNext(pgb.db, lastBlockDbID, dbBlock.Hash)
+	if err != nil {
+		log.Error("UpdateBlockNext:", err)
+		return
 	}
 
 	pgb.addressCounts.Lock()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -917,7 +917,7 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 		}
 
 		// Insert vins
-		dbtx.VinDbIds, err = InsertVins(pgb.db, dbTxVins[it])
+		dbtx.VinDbIds, err = InsertVins(pgb.db, dbTxVins[it], pgb.dupChecks)
 		if err != nil && err != sql.ErrNoRows {
 			log.Error("InsertVins:", err)
 			txRes.err = err

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1048,6 +1048,14 @@ func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []s
 	return
 }
 
+// RetrieveBlockChainDbID retrieves the row id in the block_chain table of the
+// block with the given hash, if it exists (be sure to check error against
+// sql.ErrNoRows!).
+func RetrieveBlockChainDbID(db *sql.DB, hash string) (dbID uint64, err error) {
+	err = db.QueryRow(internal.SelectBlockChainRowIDByHash, hash).Scan(&dbID)
+	return
+}
+
 func InsertBlock(db *sql.DB, dbBlock *dbtypes.Block, isValid, checked bool) (uint64, error) {
 	insertStatement := internal.MakeBlockInsertStatement(dbBlock, checked)
 	var id uint64

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -508,7 +508,7 @@ func SetSpendingForFundingOP(db *sql.DB,
 // need to get the funding (previous output) tx info, and then update the
 // corresponding row in the addresses table with the spending tx info.
 func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
-	spendingTxHash string, spendingTxVinIndex uint32) (int64, error) {
+	spendingTxHash string, spendingTxVinIndex uint32, checked bool) (int64, error) {
 	// get funding details for vin and set them in the address table
 	dbtx, err := db.Begin()
 	if err != nil {
@@ -1148,20 +1148,20 @@ func UpdateBlockNext(db *sql.DB, blockDbID uint64, next string) error {
 	return nil
 }
 
-func InsertVin(db *sql.DB, dbVin dbtypes.VinTxProperty) (id uint64, err error) {
-	err = db.QueryRow(internal.InsertVinRow,
+func InsertVin(db *sql.DB, dbVin dbtypes.VinTxProperty, checked bool) (id uint64, err error) {
+	err = db.QueryRow(internal.MakeVinInsertStatement(checked),
 		dbVin.TxID, dbVin.TxIndex, dbVin.TxTree,
 		dbVin.PrevTxHash, dbVin.PrevTxIndex, dbVin.PrevTxTree).Scan(&id)
 	return
 }
 
-func InsertVins(db *sql.DB, dbVins dbtypes.VinTxPropertyARRAY) ([]uint64, error) {
+func InsertVins(db *sql.DB, dbVins dbtypes.VinTxPropertyARRAY, checked bool) ([]uint64, error) {
 	dbtx, err := db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.InsertVinRow)
+	stmt, err := dbtx.Prepare(internal.MakeVinInsertStatement(checked))
 	if err != nil {
 		log.Errorf("Vin INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
@@ -1253,11 +1253,10 @@ func InsertVouts(db *sql.DB, dbVouts []*dbtypes.Vout, checked bool) ([]uint64, [
 	return ids, addressRows, dbtx.Commit()
 }
 
+// InsertAddressOut inserts an AddressRow (input or output), returning the row
+// ID in the addresses table of the inserted data.
 func InsertAddressOut(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck bool) (uint64, error) {
-	sqlStmt := internal.InsertAddressRow
-	if dupCheck {
-		sqlStmt = internal.UpsertAddressRow
-	}
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
 	var id uint64
 	err := db.QueryRow(sqlStmt, dbA.Address, dbA.FundingTxDbID,
 		dbA.FundingTxHash, dbA.FundingTxVoutIndex, dbA.VoutDbID,
@@ -1279,10 +1278,7 @@ func InsertAddressOuts(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck bool) ([
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	sqlStmt := internal.InsertAddressRow
-	if dupCheck {
-		sqlStmt = internal.UpsertAddressRow
-	}
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
 
 	stmt, err := dbtx.Prepare(sqlStmt)
 	if err != nil {
@@ -1427,7 +1423,8 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		return nil, nil, nil, nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.MakeVoteInsertStatement(checked))
+	voteInsert := internal.MakeVoteInsertStatement(checked)
+	stmt, err := dbtx.Prepare(voteInsert)
 	if err != nil {
 		log.Errorf("Votes INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back

--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ type version struct {
 var ver = version{
 	Major: 2,
 	Minor: 0,
-	Patch: 2,
+	Patch: 3,
 	Label: ""}
 
 // CommitHash may be set on the build command line:


### PR DESCRIPTION
Two fixes and enhancements:

dcrpg: fix empty prev_hash in block_chain
    
    In StoreBlock, if pgb.lastBlock does not contain the previous block row
    ID, look it up in the block_chain table. Add RetrieveBlockChainDbID to
    get the row id in the block_chain table for the block with a given hash.

dcrpg: improve robustness.
    
    InsertVin[s] now has upsert option (dupcheck=true) to avoid failures
    requiring recovery procedures.
    Add MakeAddressRowInsertStatement to greate the upsert statement if
    checkdups=true;
    InsertVotes and MakeVoteInsertStatement similarly take dupCheck option.
    Fix incorrect parameter numbers in upsertVoteRow and insertVoteRowReturnId.