### PR TITLE
explorer/main: add no-dev-prefetch option

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -123,7 +123,7 @@ func mainCore() error {
 		DBName: cfg.DBName,
 	}
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
-	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil)
+	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false)
 	if db != nil {
 		defer db.Close()
 	}

--- a/config.go
+++ b/config.go
@@ -94,11 +94,12 @@ type config struct {
 	DumpAllMPTix       bool   `long:"dumpallmptix" description:"Dump to file the fees of all the tickets in mempool."`
 	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)."`
 
-	FullMode bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support"`
-	PGDBName string `long:"pgdbname" description:"PostgreSQL DB name."`
-	PGUser   string `long:"pguser" description:"PostgreSQL DB user."`
-	PGPass   string `long:"pgpass" description:"PostgreSQL DB password."`
-	PGHost   string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
+	FullMode      bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support"`
+	PGDBName      string `long:"pgdbname" description:"PostgreSQL DB name."`
+	PGUser        string `long:"pguser" description:"PostgreSQL DB user."`
+	PGPass        string `long:"pgpass" description:"PostgreSQL DB password."`
+	PGHost        string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
+	NoDevPrefetch bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
 
 	// WatchAddresses []string `short:"w" long:"watchaddress" description:"Watched address (receiving). One per line."`
 	// SMTPUser     string `long:"smtpuser" description:"SMTP user name"`

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -121,6 +121,7 @@ type explorerUI struct {
 	blockData       explorerDataSourceLite
 	explorerSource  explorerDataSource
 	liteMode        bool
+	devPrefetch     bool
 	templates       templates
 	wsHub           *WebsocketHub
 	NewBlockDataMtx sync.RWMutex
@@ -167,13 +168,14 @@ func (exp *explorerUI) StopWebsocketHub() {
 
 // New returns an initialized instance of explorerUI
 func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource,
-	useRealIP bool, appVersion string) *explorerUI {
+	useRealIP bool, appVersion string, devPrefetch bool) *explorerUI {
 	exp := new(explorerUI)
 	exp.Mux = chi.NewRouter()
 	exp.blockData = dataSource
 	exp.explorerSource = primaryDataSource
 	exp.MempoolData = new(MempoolInfo)
 	exp.Version = appVersion
+	exp.devPrefetch = devPrefetch
 	// explorerDataSource is an interface that could have a value of pointer
 	// type, and if either is nil this means lite mode.
 	if exp.explorerSource == nil || reflect.ValueOf(exp.explorerSource).IsNil() {
@@ -340,7 +342,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	exp.NewBlockDataMtx.Unlock()
 
-	if !exp.liteMode {
+	if !exp.liteMode && exp.devPrefetch {
 		go exp.updateDevFundBalance()
 	}
 

--- a/main.go
+++ b/main.go
@@ -302,7 +302,7 @@ func mainCore() error {
 	mempoolSavers = append(mempoolSavers, baseDB.MPC)
 
 	// Create the explorer system
-	explore := explorer.New(&baseDB, auxDB, cfg.UseRealIP, ver.String())
+	explore := explorer.New(&baseDB, auxDB, cfg.UseRealIP, ver.String(), !cfg.NoDevPrefetch)
 	if explore == nil {
 		return fmt.Errorf("failed to create new explorer (templates missing?)")
 	}

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func mainCore() error {
 			Pass:   cfg.PGPass,
 			DBName: cfg.PGDBName,
 		}
-		auxDB, err = dcrpg.NewChainDB(&dbi, activeChain, baseDB.GetStakeDB())
+		auxDB, err = dcrpg.NewChainDB(&dbi, activeChain, baseDB.GetStakeDB(), !cfg.NoDevPrefetch)
 		if auxDB != nil {
 			defer auxDB.Close()
 		}


### PR DESCRIPTION
Updated version of PR https://github.com/decred/dcrdata/pull/546 for master

explorer/main: add no-dev-prefetch option (#546)  …
The no-dev-prefetch flag does the following:
Disable automatic dev fund balance query on new blocks. When true, the
query will still be run on demand, but not automatically after new
blocks are connected.

dcrpg: respect noDevPrefetch