### PR TITLE
dcrpg: start proper side chain handling, upgrades

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -336,8 +336,9 @@ func mainCore() error {
 		}
 
 		var numVins, numVouts int64
+		isValid, isMainchain := true, true
 		numVins, numVouts, err = db.StoreBlock(block.MsgBlock(), winners,
-			true, cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch)
+			isValid, isMainchain, cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch)
 		if err != nil {
 			return fmt.Errorf("StoreBlock failed: %v", err)
 		}

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -81,23 +81,25 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 		}
 		fees := spent - sent
 		dbTx := &Tx{
-			BlockHash:   blockHash.String(),
-			BlockHeight: int64(blockHeight),
-			BlockTime:   blockTime,
-			Time:        blockTime, // TODO, receive time?
-			TxType:      int16(stake.DetermineTxType(tx)),
-			Version:     tx.Version,
-			Tree:        tree,
-			TxID:        tx.TxHash().String(),
-			BlockIndex:  uint32(txIndex),
-			Locktime:    tx.LockTime,
-			Expiry:      tx.Expiry,
-			Size:        uint32(tx.SerializeSize()),
-			Spent:       spent,
-			Sent:        sent,
-			Fees:        fees,
-			NumVin:      uint32(len(tx.TxIn)),
-			NumVout:     uint32(len(tx.TxOut)),
+			BlockHash:        blockHash.String(),
+			BlockHeight:      int64(blockHeight),
+			BlockTime:        blockTime,
+			Time:             blockTime, // TODO, receive time?
+			TxType:           int16(stake.DetermineTxType(tx)),
+			Version:          tx.Version,
+			Tree:             tree,
+			TxID:             tx.TxHash().String(),
+			BlockIndex:       uint32(txIndex),
+			Locktime:         tx.LockTime,
+			Expiry:           tx.Expiry,
+			Size:             uint32(tx.SerializeSize()),
+			Spent:            spent,
+			Sent:             sent,
+			Fees:             fees,
+			NumVin:           uint32(len(tx.TxIn)),
+			NumVout:          uint32(len(tx.TxOut)),
+			IsValidBlock:     isValid,
+			IsMainchainBlock: isMainchain,
 		}
 
 		//dbTx.Vins = make([]VinTxProperty, 0, dbTx.NumVin)

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -37,17 +37,17 @@ func DevSubsidyAddress(params *chaincfg.Params) (string, error) {
 // wire.MsgBlock and returns the processed information in slices of the dbtypes
 // Tx, Vout, and VinTxPropertyARRAY.
 func ExtractBlockTransactions(msgBlock *wire.MsgBlock, txTree int8,
-	chainParams *chaincfg.Params, isValid bool) ([]*Tx, [][]*Vout, []VinTxPropertyARRAY) {
+	chainParams *chaincfg.Params, isValid, isMainchain bool) ([]*Tx, [][]*Vout, []VinTxPropertyARRAY) {
 	dbTxs, dbTxVouts, dbTxVins := processTransactions(msgBlock, txTree,
-		chainParams, isValid)
+		chainParams, isValid, isMainchain)
 	if txTree != wire.TxTreeRegular && txTree != wire.TxTreeStake {
 		fmt.Printf("Invalid transaction tree: %v", txTree)
 	}
 	return dbTxs, dbTxVouts, dbTxVins
 }
 
-func processTransactions(msgBlock *wire.MsgBlock, tree int8,
-	chainParams *chaincfg.Params, isValid bool) ([]*Tx, [][]*Vout, []VinTxPropertyARRAY) {
+func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chaincfg.Params,
+	isValid, isMainchain bool) ([]*Tx, [][]*Vout, []VinTxPropertyARRAY) {
 
 	var txs []*wire.MsgTx
 	switch tree {
@@ -118,6 +118,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8,
 				BlockIndex:  txin.BlockIndex,
 				ScriptHex:   txin.SignatureScript,
 				IsValid:     isValid,
+				IsMainchain: isMainchain,
 			})
 		}
 

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -300,9 +300,10 @@ type Vout struct {
 // AddressRow represents a row in the addresses table
 type AddressRow struct {
 	// id int64
-	Address string
-	// MatchingTxHash that provides the relationship
-	// between spending tx inputs and funding tx outputs
+	Address        string
+	ValidMainChain bool
+	// MatchingTxHash provides the relationship between spending tx inputs and
+	// funding tx outputs.
 	MatchingTxHash   string
 	IsFunding        bool
 	TxBlockTime      uint64
@@ -354,6 +355,7 @@ type VinTxProperty struct {
 	BlockIndex  uint32 `json:"blockindex"`
 	ScriptHex   []byte `json:"scripthex"`
 	IsValid     bool   `json:"is_valid"`
+	IsMainchain bool   `json:"is_mainchain"`
 	Time        int64  `json:"time"`
 }
 
@@ -417,6 +419,8 @@ type Tx struct {
 	VoutDbIds []uint64 `json:"voutdbids"`
 	// NOTE: VoutDbIds may not be needed if there is a vout table since each
 	// vout will have a tx_dbid
+	IsValidBlock     bool `json:"valid_block"`
+	IsMainchainBlock bool `json:"mainchain"`
 }
 
 // Block models a Decred block.

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -40,22 +40,22 @@ const (
 		tx_vin_vout_row_id INT8
 		);`
 
-	SelectAddressAllByAddress = `SELECT * FROM addresses WHERE address=$1 order by block_time desc;`
+	SelectAddressAllByAddress = `SELECT * FROM addresses WHERE address=$1 ORDER BY block_time DESC;`
 	SelectAddressRecvCount    = `SELECT COUNT(*) FROM addresses WHERE address=$1;`
-	SelectAddressesAllTxn     = `SELECT tx_hash, block_time as tx_time, ftxd.block_height as height 
-		from addresses left join transactions as ftxd on funding_tx_row_id=ftxd.id 
-		where address = $1 order by tx_time desc;`
+	SelectAddressesAllTxn     = `SELECT tx_hash, block_time AS tx_time, ftxd.block_height AS height 
+		FROM addresses LEFT JOIN transactions AS ftxd ON funding_tx_row_id=ftxd.id 
+		WHERE address = $1 ORDER BY tx_time desc;`
 
-	SelectAddressesTxnByFundingTx = `SELECT tx_vin_vout_index, tx_hash, tx_vin_vout_index, 
-		block_height FROM addresses LEFT JOIN 
-		transactions on transactions.tx_hash=tx_hash and is_funding = FALSE WHERE 
-		address = $1 and tx_hash=$2;`
+	SelectAddressesTxnByFundingTx = `SELECT tx_vin_vout_index, tx_hash, tx_vin_vout_index, block_height
+		FROM addresses
+		LEFT JOIN transactions ON transactions.tx_hash=tx_hash AND is_funding = FALSE
+		WHERE address = $1 AND tx_hash=$2;`
 
 	SelectAddressUnspentCountAndValue = `SELECT COUNT(*), SUM(value) FROM addresses 
-	    WHERE address = $1 and is_funding = TRUE and matching_tx_hash = '';`
+	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = true;`
 
 	SelectAddressSpentCountAndValue = `SELECT COUNT(*), SUM(value) FROM addresses 
-		WHERE address = $1 and is_funding = FALSE and matching_tx_hash != '';`
+	    WHERE address = $1 AND is_funding = FALSE AND matching_tx_hash != '' AND valid_mainchain = true;`
 
 	SelectAddressesMergedSpentCount = `SELECT COUNT( distinct tx_hash ) FROM addresses
 		WHERE address = $1 and is_funding = false`
@@ -66,10 +66,11 @@ const (
 		JOIN transactions ON 
 			addresses.tx_hash = transactions.tx_hash
 		JOIN vouts on addresses.tx_hash = vouts.tx_hash AND addresses.tx_vin_vout_index=vouts.tx_index
-			WHERE addresses.address=$1 AND addresses.is_funding = FALSE 
+			WHERE addresses.address=$1 AND addresses.is_funding = FALSE AND valid_mainchain = true
 			ORDER BY addresses.block_time DESC;`
 
-	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
+	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, valid_mainchain, 
+		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
 	    WHERE address=$1 ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
@@ -83,11 +84,11 @@ const (
 		GROUP BY (tx_hash, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
-		FROM addresses WHERE address=$1 and is_funding = FALSE
+		FROM addresses WHERE address=$1 AND is_funding = FALSE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressCreditsLimitNByAddress = `SELECT ` + addrsColumnNames + `
-		FROM addresses WHERE address=$1 and is_funding = TRUE
+		FROM addresses WHERE address=$1 AND is_funding = TRUE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses WHERE tx_hash=$1, 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -99,11 +99,10 @@ const (
 	SetAddressFundingForMatchingTxHash = `UPDATE addresses SET matching_tx_hash=$1 
 		WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
 
-	UpdateValidMainchainFromTransactions = `FOR tx IN 
-		SELECT tx_hash, valid_mainchain AS (is_valid && is_mainchain) FROM transactions
-		LOOP
-			UPDATE addresses SET valid_mainchain = tx.valid_mainchain WHERE tx_hash = tx.tx_hash
-		END LOOP;`
+	UpdateValidMainchainFromTransactions = `UPDATE addresses
+		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean
+		FROM transactions AS tr
+		WHERE addresses.tx_hash = tr.tx_hash;`
 
 	IndexBlockTimeOnTableAddress   = `CREATE INDEX block_time_index ON addresses (block_time);`
 	DeindexBlockTimeOnTableAddress = `DROP INDEX block_time_index;`

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -97,7 +97,13 @@ const (
 	    tx_vin_vout_row_id=$2 and is_funding = true;`
 
 	SetAddressFundingForMatchingTxHash = `UPDATE addresses SET matching_tx_hash=$1 
-	    WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
+		WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
+
+	UpdateValidMainchainFromTransactions = `FOR tx IN 
+		SELECT tx_hash, valid_mainchain AS (is_valid && is_mainchain) FROM transactions
+		LOOP
+			UPDATE addresses SET valid_mainchain = tx.valid_mainchain WHERE tx_hash = tx.tx_hash
+		END LOOP;`
 
 	IndexBlockTimeOnTableAddress   = `CREATE INDEX block_time_index ON addresses (block_time);`
 	DeindexBlockTimeOnTableAddress = `DROP INDEX block_time_index;`

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -2,8 +2,8 @@ package internal
 
 const (
 	insertAddressRow0 = `INSERT INTO addresses (address, matching_tx_hash, tx_hash,
-		tx_vin_vout_index, tx_vin_vout_row_id, value, block_time, is_funding)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8) `
+		tx_vin_vout_index, tx_vin_vout_row_id, value, block_time, is_funding, valid_mainchain)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) `
 
 	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
 
@@ -31,6 +31,7 @@ const (
 		id SERIAL8 PRIMARY KEY,
 		address TEXT,
 		tx_hash TEXT,
+		valid_mainchain BOOLEAN,
 		matching_tx_hash TEXT,
 		value INT8,
 		block_time INT8 NOT NULL,

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -93,7 +93,7 @@ const (
 
 	SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`
 
-	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = true WHERE hash = $1 RETURNING previous_hash;`
+	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = $2 WHERE hash = $1 RETURNING previous_hash;`
 
 	IndexBlocksTableOnHeight = `CREATE INDEX uix_block_height ON blocks(height);`
 

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -93,7 +93,7 @@ const (
 
 	SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`
 
-	UpdateBlockMainchain = `UPDATE blocks SET mainchain=true WHERE hash = $1 RETURNING previous_hash;`
+	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = true WHERE hash = $1 RETURNING previous_hash;`
 
 	IndexBlocksTableOnHeight = `CREATE INDEX uix_block_height ON blocks(height);`
 

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	// Block insert
+	// Block insert. is_valid refers to blocks that have been validated by
+	// stakeholders (voting on the previous block), while is_mainchain
+	// distinguishes blocks that are on the main chain from those that are
+	// on side chains and/or orphaned.
+
 	insertBlockRow0 = `INSERT INTO blocks (
 		hash, height, size, is_valid, is_mainchain, version, merkle_root, stake_root,
 		numtx, num_rtx, tx, txDbIDs, num_stx, stx, stxDbIDs,

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -91,6 +91,8 @@ const (
 
 	SelectBlocksPreviousHash = `SELECT previous_hash FROM blocks WHERE hash = $1;`
 
+	SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`
+
 	UpdateBlockMainchain = `UPDATE blocks SET mainchain=true WHERE hash = $1 RETURNING previous_hash;`
 
 	IndexBlocksTableOnHeight = `CREATE INDEX uix_block_height ON blocks(height);`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -104,7 +104,8 @@ const (
 		ticket_hash TEXT,
 		ticket_tx_db_id INT8,
 		ticket_price FLOAT8,
-		vote_reward FLOAT8
+		vote_reward FLOAT8,
+		is_mainchain BOOLEAN
 	);`
 
 	// Insert
@@ -112,12 +113,14 @@ const (
 		height, tx_hash,
 		block_hash, candidate_block_hash,
 		version, vote_bits, block_valid,
-		ticket_hash, ticket_tx_db_id, ticket_price, vote_reward)
+		ticket_hash, ticket_tx_db_id, ticket_price, vote_reward,
+		is_mainchain)
 	VALUES (
 		$1, $2,
 		$3, $4,
 		$5, $6, $7,
-		$8, $9, $10, $11) `
+		$8, $9, $10, $11,
+		$12) `
 	insertVoteRow = insertVoteRow0 + `RETURNING id;`
 	// insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -140,6 +140,14 @@ const (
 	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`
 	SelectAllVoteDbIDsHeightsTicketDbIDs  = `SELECT id, height, ticket_tx_db_id FROM votes;`
 
+	UpdateVotesMainchainAll = `UPDATE votes
+		SET is_mainchain=b.is_mainchain
+		FROM (
+			SELECT hash, is_mainchain
+			FROM blocks
+		) b
+		WHERE block_hash = b.hash;`
+
 	// Index
 	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX uix_votes_hashes_index
 		ON votes(tx_hash, block_hash);`

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -57,7 +57,9 @@ const (
 		num_vin INT4,
 		vin_db_ids INT8[],
 		num_vout INT4,
-		vout_db_ids INT8[]
+		vout_db_ids INT8[],
+		is_valid BOOLEAN,
+		is_mainchain BOOLEAN
 	);`
 
 	SelectTxByHash       = `SELECT id, block_hash, block_index, tree FROM transactions WHERE tx_hash = $1;`

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -78,7 +78,7 @@ const (
 		is_valid, is_mainchain
 		FROM transactions WHERE tx_hash = $1;`
 
-	SelectTxnsVinsByBlock = `SELECT vin_db_idss, is_valid, is_mainchain,
+	SelectTxnsVinsByBlock = `SELECT vin_db_ids, is_valid, is_mainchain
 		FROM transactions WHERE block_hash = $1;`
 
 	UpdateTxnsValidMainchainByBlock = `UPDATE transactions

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -62,15 +62,18 @@ const (
 		is_mainchain BOOLEAN
 	);`
 
-	SelectTxByHash       = `SELECT id, block_hash, block_index, tree FROM transactions WHERE tx_hash = $1;`
-	SelectTxsByBlockHash = `SELECT id, tx_hash, block_index, tree, block_time FROM transactions WHERE block_hash = $1;`
+	SelectTxByHash = `SELECT id, block_hash, block_index, tree
+		FROM transactions WHERE tx_hash = $1;`
+	SelectTxsByBlockHash = `SELECT id, tx_hash, block_index, tree, block_time
+		FROM transactions WHERE block_hash = $1;`
 
 	SelectTxBlockTimeByHash = `SELECT block_time FROM transactions where tx_hash = $1 
 		ORDER BY block_time DESC LIMIT 1;`
 
 	SelectTxIDHeightByHash = `SELECT id, block_height FROM transactions WHERE tx_hash = $1;`
 
-	SelectTxsPerDay = `SELECT to_timestamp(time)::date as date, count(*) FROM transactions GROUP BY date ORDER BY date;`
+	SelectTxsPerDay = `SELECT to_timestamp(time)::date as date, count(*) FROM transactions
+		GROUP BY date ORDER BY date;`
 
 	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time, 
 		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry, 
@@ -81,9 +84,17 @@ const (
 	SelectTxnsVinsByBlock = `SELECT vin_db_ids, is_valid, is_mainchain
 		FROM transactions WHERE block_hash = $1;`
 
-	UpdateTxnsValidMainchainByBlock = `UPDATE transactions
+	UpdateRegularTxnsValidMainchainByBlock = `UPDATE transactions
 		SET is_valid=$1, is_mainchain=$2 
-		WHERE block_hash=$3;`
+		WHERE block_hash=$3 and tree=0;`
+
+	UpdateRegularTxnsValidByBlock = `UPDATE transactions
+		SET is_valid=$1 
+		WHERE block_hash=$2 and tree=0;`
+
+	UpdateTxnsMainchainByBlock = `UPDATE transactions
+		SET is_mainchain=$1 
+		WHERE block_hash=$2;`
 
 	UpdateTxnsValidMainchainAll = `UPDATE transactions
 		SET is_valid=b.is_valid, is_mainchain=b.is_mainchain

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -64,9 +64,18 @@ const (
 	SelectSpendingTxByVinID      = `SELECT tx_hash, tx_index, tx_tree FROM vins WHERE id=$1;`
 	SelectAllVinInfoByID         = `SELECT tx_hash, tx_index, tx_tree, is_valid, is_mainchain, block_time,
 		prev_tx_hash, prev_tx_index, prev_tx_tree, value_in FROM vins WHERE id = $1;`
+
 	SetIsValidIsMainchainByTxHash = `UPDATE vins SET is_valid = $1, is_mainchain = $2
 		WHERE tx_hash = $3 AND block_time = $4 AND tx_tree = $5;`
 	SetIsValidIsMainchainByVinID = `UPDATE vins SET is_valid = $2, is_mainchain = $3
+		WHERE id = $1;`
+	SetIsValidByTxHash = `UPDATE vins SET is_valid = $1
+		WHERE tx_hash = $2 AND block_time = $3 AND tx_tree = $4;`
+	SetIsValidByVinID = `UPDATE vins SET is_valid = $2
+		WHERE id = $1;`
+	SetIsMainchainByTxHash = `UPDATE vins SET is_mainchain = $1
+		WHERE tx_hash = $2 AND block_time = $3 AND tx_tree = $4;`
+	SetIsMainchainByVinID = `UPDATE vins SET is_mainchain = $2
 		WHERE id = $1;`
 
 	// SetVinsTableCoinSupplyUpgrade does not set is_mainchain because that upgrade comes after this one

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1425,12 +1425,12 @@ type MsgBlockPG struct {
 
 // storeTxns stores the transactions of a given block
 func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
-	chainParams *chaincfg.Params, TxDbIDs *[]uint64, isTxValid, isMainchain bool,
+	chainParams *chaincfg.Params, TxDbIDs *[]uint64, isValid, isMainchain bool,
 	updateAddressesSpendingInfo, updateTicketsSpendingInfo bool) storeTxnsResult {
 	// For the given block, transaction tree, and network, extract the
 	// transactions, vins, and vouts.
 	dbTransactions, dbTxVouts, dbTxVins := dbtypes.ExtractBlockTransactions(
-		msgBlock.MsgBlock, txTree, chainParams, isTxValid, isMainchain)
+		msgBlock.MsgBlock, txTree, chainParams, isValid, isMainchain)
 
 	// The return value, containing counts of inserted vins/vouts/txns, and an
 	// error value.
@@ -1443,7 +1443,8 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 
 	var err error
 	for it, dbtx := range dbTransactions {
-		// Insert vouts, and collect rows to add to address table
+		// Insert vouts, and collect AddressRows to add to address table for
+		// each output.
 		dbtx.VoutDbIds, dbAddressRows[it], err = InsertVouts(pgb.db, dbTxVouts[it], pgb.dupChecks)
 		if err != nil && err != sql.ErrNoRows {
 			log.Error("InsertVouts:", err)
@@ -1481,7 +1482,7 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 
 	// If processing stake tree, insert tickets, votes, misses
 	if txTree == wire.TxTreeStake {
-		// Tickets
+		// Tickets: Insert new (unspent) tickets
 		newTicketDbIDs, newTicketTx, err := InsertTickets(pgb.db, dbTransactions, *TxDbIDs, pgb.dupChecks)
 		if err != nil && err != sql.ErrNoRows {
 			log.Error("InsertTickets:", err)
@@ -1489,8 +1490,8 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 			return txRes
 		}
 
-		// Get tickets table row IDs for newly spent tickets, if we are updating
-		// them as we go as opposed to batch mode at the end of a sync.
+		// Cache the unspent ticket DB row IDs and and their hashes. Needed do
+		// efficiently update their spend status later.
 		var unspentTicketCache *TicketTxnIDGetter
 		if updateTicketsSpendingInfo {
 			for it, tdbid := range newTicketDbIDs {
@@ -1500,7 +1501,9 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 		}
 
 		// Get information for transactions spending tickets (votes and
-		// revokes), and the ticket DB row IDs themselves.
+		// revokes), and the ticket DB row IDs themselves. Also return tickets
+		// table row IDs for newly spent tickets, if we are updating them as we
+		// go (SetSpendingForTickets).
 		spendingTxDbIDs, spendTypes, spentTicketHashes, ticketDbIDs, err :=
 			pgb.CollectTicketSpendDBInfo(dbTransactions, *TxDbIDs, msgBlock.MsgBlock)
 		if err != nil {
@@ -1509,7 +1512,11 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 			return txRes
 		}
 
-		// Votes
+		// Votes: insert votes and misses (tickets that did not vote when
+		// called). Return the ticket hash of all misses, which may include
+		// revokes at this point. Unrevoked misses are identified when updating
+		// ticket spend info below.
+
 		// voteDbIDs, voteTxns, spentTicketHashes, ticketDbIDs, missDbIDs, err := ...
 		var missesHashIDs map[string]uint64
 		_, _, _, _, missesHashIDs, err = InsertVotes(pgb.db,
@@ -1525,15 +1532,15 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 			// Get a consistent view of the stake node at its present height
 			pgb.stakeDB.LockStakeNode()
 
-			// To update spending info in tickets table, get the spent tickets' DB
-			// row IDs and block heights.
-			//ticketDbIDs := make([]uint64, len(spentTicketHashes))
+			// Classify and record the height of each ticket spend (vote or
+			// revoke). For revokes, further distinguish miss or expire.
 			revokes := make(map[string]uint64)
 			blockHeights := make([]int64, len(spentTicketHashes))
 			poolStatuses := make([]dbtypes.TicketPoolStatus, len(spentTicketHashes))
 			for iv := range spentTicketHashes {
 				blockHeights[iv] = int64(msgBlock.Header.Height) /* voteDbTxns[iv].BlockHeight */
 
+				// Vote or revoke
 				switch spendTypes[iv] {
 				case dbtypes.TicketVoted:
 					poolStatuses[iv] = dbtypes.PoolStatusVoted
@@ -1553,18 +1560,21 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 				}
 			}
 
-			// Update tickets table with spending info from new votes
+			// Update tickets table with spending info.
 			_, err = SetSpendingForTickets(pgb.db, ticketDbIDs, spendingTxDbIDs,
 				blockHeights, spendTypes, poolStatuses)
 			if err != nil {
 				log.Warn("SetSpendingForTickets:", err)
 			}
 
+			// Unspent not-live tickets are also either expired or missed.
+
 			// Missed but not revoked
 			//var unspentMissedTicketDbIDs []uint64
 			var unspentMissedTicketHashes []string
 			var missStatuses []dbtypes.TicketPoolStatus
 			unspentMisses := make(map[string]struct{})
+			// missesHashIDs refers to lottery winners that did not vote.
 			for miss := range missesHashIDs {
 				if _, ok := revokes[miss]; !ok {
 					// unrevoked miss
@@ -1577,17 +1587,21 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 
 			// Expired but not revoked
 			unspentEnM := make([]string, len(unspentMissedTicketHashes))
+			// Start with the unspent misses and append unspent expires to get
+			// "unspent expired and missed".
 			copy(unspentEnM, unspentMissedTicketHashes)
 			unspentExpiresAndMisses := pgb.stakeDB.BestNode.MissedByBlock()
 			for _, missHash := range unspentExpiresAndMisses {
-				// MissedByBlock includes tickets that missed votes or expired;
-				// we just want the expires, and not the revoked ones.
+				// MissedByBlock includes tickets that missed votes or expired
+				// (and which may be revoked in this block); we just want the
+				// expires, and not the revoked ones. Screen each ticket from
+				// MissedByBlock for the actual unspent expires.
 				if pgb.stakeDB.BestNode.ExistsExpiredTicket(missHash) {
 					emHash := missHash.String()
 					// Next check should not be unnecessary. Make sure not in
-					// unspent misses from above and not just revoked.
-					_, justMissed := unspentMisses[emHash]
-					_, justRevoked := revokes[emHash]
+					// unspent misses from above, and not just revoked.
+					_, justMissed := unspentMisses[emHash] // should be redundant
+					_, justRevoked := revokes[emHash]      // exclude if revoked
 					if !justMissed && !justRevoked {
 						unspentEnM = append(unspentEnM, emHash)
 						missStatuses = append(missStatuses, dbtypes.PoolStatusExpired)
@@ -1598,32 +1612,39 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 			// Release the stake node
 			pgb.stakeDB.UnlockStakeNode()
 
+			// Update status of the the unspent expired and missed tickets
 			numUnrevokedMisses, err := SetPoolStatusForTicketsByHash(pgb.db, unspentEnM, missStatuses)
 			if err != nil {
-				log.Warn("SetPoolStatusForTickets", err)
+				log.Warnf("SetPoolStatusForTicketsByHash: %v", err)
 			} else if numUnrevokedMisses > 0 {
 				log.Tracef("Noted %d unrevoked newly-missed tickets.", numUnrevokedMisses)
 			}
-		}
-	}
+		} // updateTicketsSpendingInfo
+	} // txTree == wire.TxTreeStake
 
-	// Store tx block time in AddressRows, and set IsFunding
-	// to true since since this are funding tx inputs.
+	// Store txn block time and mainchain validity status in AddressRows, and
+	// set IsFunding to true since InsertVouts is supplying the AddressRows.
 	dbAddressRowsFlat := make([]*dbtypes.AddressRow, 0, totalAddressRows)
 	for it, tx := range dbTransactions {
-		// Set the tx BlockTime and IsFunding of the funding transactions
 		for iv := range dbAddressRows[it] {
 			// Transaction that pays to the address
 			dba := &dbAddressRows[it][iv]
+
+			// Set fields not set by InsertVouts: TxBlockTime, IsFunding,
+			// ValidMainChain, and MatchingTxHash. Only MatchingTxHash goes
+			// unset initially, later set by insertSpendingTxByPrptStmt (called
+			// by SetSpendingForFundingOP below, and other places).
 			dba.TxBlockTime = uint64(tx.BlockTime)
 			dba.IsFunding = true
+			dba.ValidMainChain = isMainchain && isValid
+
 			// Funding tx hash, vout id, value, and address are already assigned
 			// by InsertVouts. Only the block time and is_funding was needed.
 			dbAddressRowsFlat = append(dbAddressRowsFlat, dba)
 		}
 	}
 
-	// Insert each new AddressRow, absent spending fields
+	// Insert each new AddressRow, absent MatchingTxHash (spending txn).
 	_, err = InsertAddressRows(pgb.db, dbAddressRowsFlat, pgb.dupChecks)
 	if err != nil {
 		log.Error("InsertAddressRows:", err)
@@ -1635,7 +1656,7 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 		return txRes
 	}
 
-	// Check the new vins and update spending tx data in Addresses table
+	// Check the new vins and update matching_tx_hash in addresses table.
 	for it, tx := range dbTransactions {
 		// vins array for this transaction
 		txVins := dbTxVins[it]
@@ -1643,13 +1664,15 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 			// Transaction that spends an outpoint paying to >=0 addresses
 			vin := &txVins[iv]
 
-			// Skip coinbase inputs
+			// Skip coinbase inputs (they are generated and thus have no
+			// previous outpoint funding them).
 			if bytes.Equal(zeroHashStringBytes, []byte(vin.PrevTxHash)) {
 				continue
 			}
 
-			// address table
-			vinDbID := dbTransactions[it].VinDbIds[iv]
+			// Insert spending txn data in addresses table, and updated spend
+			// status for the previous outpoints' rows in the same table.
+			vinDbID := tx.VinDbIds[iv]
 			numAddressRowsSet, err := SetSpendingForFundingOP(pgb.db,
 				vin.PrevTxHash, vin.PrevTxIndex, int8(vin.PrevTxTree), vin.TxID,
 				vin.TxIndex, uint64(tx.BlockTime), vinDbID, pgb.dupChecks,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -828,7 +828,7 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 	if pgb == nil {
 		return nil
 	}
-	// New blocks stored this way are considered valid and mainchain
+	// New blocks stored this way are considered valid and part of mainchain.
 	_, _, err := pgb.StoreBlock(msgBlock, blockData.WinningTickets, true, true, true, true)
 	return err
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -282,9 +282,19 @@ func (pgb *ChainDB) VersionCheck(client *rpcclient.Client) error {
 			}
 		}
 
+		// ensure all tables have "ok" status
+		OK := true
 		for _, u := range tableUpgrades {
-			log.Warnf(u.String())
+			if u.UpgradeType != "ok" {
+				log.Warnf(u.String())
+				OK = false
+			}
 		}
+		if OK {
+			log.Debugf("All tables at correct version (%v)", tableUpgrades[0].RequiredVer)
+			return nil
+		}
+
 		return fmt.Errorf("rebuild of PostgreSQL tables required (drop with rebuilddb2 -D)")
 	}
 	return nil

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -309,6 +309,7 @@ func SetPoolStatusForTicketsByHash(db *sql.DB, tickets []string,
 		if rowsAffected[i] != 1 {
 			log.Warnf("Updated pool status for %d tickets, expecting just 1 (%s, %v)!",
 				rowsAffected[i], ticket, poolStatuses[i])
+			// TODO: go get the info to add it to the tickets table
 		}
 	}
 
@@ -1854,7 +1855,8 @@ func InsertVouts(db *sql.DB, dbVouts []*dbtypes.Vout, checked bool) ([]uint64, [
 				TxVinVoutIndex: vout.TxIndex,
 				VinVoutDbID:    id,
 				Value:          vout.Value,
-				// ValidMainChain: ?
+				// Not set here are: ValidMainchain, MatchingTxHash, IsFunding,
+				// and TxBlockTime.
 			})
 		}
 		ids = append(ids, id)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1471,8 +1471,9 @@ func UpdateLastBlock(db *sql.DB, blockDbID uint64, isValid bool) error {
 	return nil
 }
 
-// UpdateLastVins updates the is_valid column in the vins table for all of the
-// transactions in the block specified by the given block hash.
+// UpdateLastVins updates the is_valid and is_mainchain columns in the vins
+// table for all of the transactions in the block specified by the given block
+// hash.
 func UpdateLastVins(db *sql.DB, blockHash string, isValid, isMainchain bool) error {
 	_, txs, _, trees, timestamps, err := RetrieveTxsByBlockHash(db, blockHash)
 	if err != nil {
@@ -1546,8 +1547,8 @@ func RetrievePreviousHashByBlockHash(db *sql.DB, hash string) (previous_hash str
 	return
 }
 
-func SetMainchainByBlockHash(db *sql.DB, hash string) (previous_hash string, err error) {
-	err = db.QueryRow(internal.UpdateBlockMainchain, hash).Scan(&previous_hash)
+func SetMainchainByBlockHash(db *sql.DB, hash string, isMainchain bool) (previous_hash string, err error) {
+	err = db.QueryRow(internal.UpdateBlockMainchain, hash, isMainchain).Scan(&previous_hash)
 	return
 }
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -719,7 +719,7 @@ func sqlExec(db *sql.DB, stmt, execErrPrefix string, args ...interface{}) (int64
 func sqlExecStmt(stmt *sql.Stmt, execErrPrefix string, args ...interface{}) (int64, error) {
 	res, err := stmt.Exec(args...)
 	if err != nil {
-		return 0, fmt.Errorf(execErrPrefix + err.Error())
+		return 0, fmt.Errorf("%v %v", execErrPrefix, err)
 	}
 	if res == nil {
 		return 0, nil
@@ -1237,20 +1237,6 @@ func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []s
 	}
 
 	return
-}
-
-// UpdateAllTxnsValidMainchain sets is_mainchain and is_valid for all
-// transactions according to their containing block.
-func UpdateAllTxnsValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
-	return sqlExec(db, internal.UpdateTxnsValidMainchainAll,
-		"failed to update transactions validity and mainchain status")
-}
-
-// UpdateAllAddressesValidMainchain sets valid_mainchain for all addresses table
-// rows according to their corresponding transaction.
-func UpdateAllAddressesValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
-	return sqlExec(db, internal.UpdateValidMainchainFromTransactions,
-		"failed to update addresses rows valid_mainchain status")
 }
 
 // RetrieveBlockHash retrieves the hash of the block at the given height, if it

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -412,9 +412,9 @@ func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, erro
 		var prevOutVoutInd, txVinInd uint32
 		var prevOutTree, txTree int8
 		var valueIn, blockTime int64
-		var isValid bool
+		var isValid, isMainchain bool
 		err = vinGetStmt.QueryRow(vinDbID).Scan(
-			&txHash, &txVinInd, &txTree, &isValid, &blockTime,
+			&txHash, &txVinInd, &txTree, &isValid, &isMainchain, &blockTime,
 			&prevOutHash, &prevOutVoutInd, &prevOutTree, &valueIn)
 		if err != nil {
 			return addressRowsUpdated, 0, fmt.Errorf(`SelectAllVinInfoByID: `+
@@ -428,7 +428,8 @@ func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, erro
 
 		// Set the spending tx info (addresses table) for the vin DB ID
 		addressRowsUpdated[iv], err = insertSpendingTxByPrptStmt(dbtx,
-			prevOutHash, prevOutVoutInd, prevOutTree, txHash, txVinInd, vinDbID, false)
+			prevOutHash, prevOutVoutInd, prevOutTree,
+			txHash, txVinInd, vinDbID, false, isValid && isMainchain)
 		if err != nil {
 			return addressRowsUpdated, 0, fmt.Errorf(`insertSpendingTxByPrptStmt: `+
 				`%v + %v (rollback)`, err, bail())
@@ -454,10 +455,10 @@ func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
 	var prevOutHash, txHash string
 	var prevOutVoutInd, txVinInd uint32
 	var prevOutTree, txTree int8
-	var isValid bool
+	var isValid, isMainchain bool
 	var valueIn, blockTime int64
 	err = dbtx.QueryRow(internal.SelectAllVinInfoByID, vinDbID).
-		Scan(&txHash, &txVinInd, &txTree, &isValid, &blockTime,
+		Scan(&txHash, &txVinInd, &txTree, &isValid, &isMainchain, &blockTime,
 			&prevOutHash, &prevOutVoutInd, &prevOutTree, &valueIn)
 	if err != nil {
 		return 0, fmt.Errorf(`SetSpendingByVinID: %v + %v `+
@@ -471,7 +472,7 @@ func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
 
 	// Insert the spending tx info (addresses table) for the vin DB ID
 	N, err := insertSpendingTxByPrptStmt(dbtx, prevOutHash, prevOutVoutInd,
-		prevOutTree, txHash, txVinInd, vinDbID, false)
+		prevOutTree, txHash, txVinInd, vinDbID, false, isValid && isMainchain)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -484,7 +485,8 @@ func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
 // corresponding funding tx row.
 func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 	fundingTxVoutIndex uint32, fundingTxTree int8, spendingTxHash string,
-	spendingTxVinIndex uint32, spendingTXBlockTime, vinDbID uint64, checked bool) (int64, error) {
+	spendingTxVinIndex uint32, spendingTXBlockTime, vinDbID uint64,
+	checked, isValidMainchain bool) (int64, error) {
 
 	// Only allow atomic transactions to happen
 	dbtx, err := db.Begin()
@@ -492,8 +494,9 @@ func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 		return 0, fmt.Errorf(`unable to begin database transaction: %v`, err)
 	}
 
-	c, err := insertSpendingTxByPrptStmt(dbtx, fundingTxHash, fundingTxVoutIndex, fundingTxTree,
-		spendingTxHash, spendingTxVinIndex, vinDbID, checked, spendingTXBlockTime)
+	c, err := insertSpendingTxByPrptStmt(dbtx, fundingTxHash, fundingTxVoutIndex,
+		fundingTxTree, spendingTxHash, spendingTxVinIndex, vinDbID, checked,
+		isValidMainchain, spendingTXBlockTime)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -506,7 +509,7 @@ func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 // into the addresses table.
 func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutIndex uint32,
 	fundingTxTree int8, spendingTxHash string, spendingTxVinIndex uint32,
-	vinDbID uint64, checked bool, blockT ...uint64) (int64, error) {
+	vinDbID uint64, checked, validMainchain bool, blockT ...uint64) (int64, error) {
 	var addr string
 	var value, rowID, blockTime uint64
 
@@ -541,7 +544,8 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 	var isFunding bool
 	sqlStmt := internal.MakeAddressRowInsertStatement(checked)
 	err = tx.QueryRow(sqlStmt, newAddr, fundingTxHash, spendingTxHash,
-		spendingTxVinIndex, vinDbID, value, blockTime, isFunding).Scan(&rowID)
+		spendingTxVinIndex, vinDbID, value, blockTime, isFunding,
+		validMainchain).Scan(&rowID)
 	if err != nil {
 		return 0, fmt.Errorf("InsertAddressRow: %v", err)
 	}
@@ -561,7 +565,7 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 // need to get the funding (previous output) tx info, and then update the
 // corresponding row in the addresses table with the spending tx info.
 func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
-	spendingTxHash string, spendingTxVinIndex uint32, checked bool) (int64, error) {
+	spendingTxHash string, spendingTxVinIndex uint32, checked, isValidMainchain bool) (int64, error) {
 	// get funding details for vin and set them in the address table
 	dbtx, err := db.Begin()
 	if err != nil {
@@ -586,7 +590,7 @@ func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
 
 	// Insert the spending tx info (addresses table) for the vin DB ID
 	N, err := insertSpendingTxByPrptStmt(dbtx, fundingTxHash, fundingTxVoutIndex,
-		tree, spendingTxHash, spendingTxVinIndex, vinDbID, checked)
+		tree, spendingTxHash, spendingTxVinIndex, vinDbID, checked, isValidMainchain)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -877,7 +881,8 @@ func scanAddressQueryRows(rows *sql.Rows) (ids []uint64, addressRows []*dbtypes.
 		var txHash sql.NullString
 		var blockTime, txVinIndex, vinDbID sql.NullInt64
 		err = rows.Scan(&id, &addr.Address, &addr.MatchingTxHash, &txHash,
-			&txVinIndex, &blockTime, &vinDbID, &addr.Value, &addr.IsFunding)
+			&txVinIndex, &blockTime, &vinDbID, &addr.Value, &addr.IsFunding,
+			&addr.ValidMainChain)
 		if err != nil {
 			return
 		}
@@ -978,9 +983,9 @@ func RetrieveFundingOutpointByVinID(db *sql.DB, vinDbID uint64) (tx string, inde
 func RetrieveVinByID(db *sql.DB, vinDbID uint64) (prevOutHash string, prevOutVoutInd uint32,
 	prevOutTree int8, txHash string, txVinInd uint32, txTree int8, valueIn int64, err error) {
 	var blockTime uint64
-	var isValid bool
+	var isValid, isMainchain bool
 	err = db.QueryRow(internal.SelectAllVinInfoByID, vinDbID).
-		Scan(&txHash, &txVinInd, &txTree, &isValid, &blockTime,
+		Scan(&txHash, &txVinInd, &txTree, &isValid, &isMainchain, &blockTime,
 			&prevOutHash, &prevOutVoutInd, &prevOutTree, &valueIn)
 	return
 }
@@ -1124,7 +1129,8 @@ func RetrieveDbTxByHash(db *sql.DB, txHash string) (id uint64, dbTx *dbtypes.Tx,
 		&dbTx.BlockHash, &dbTx.BlockHeight, &dbTx.BlockTime, &dbTx.Time,
 		&dbTx.TxType, &dbTx.Version, &dbTx.Tree, &dbTx.TxID, &dbTx.BlockIndex,
 		&dbTx.Locktime, &dbTx.Expiry, &dbTx.Size, &dbTx.Spent, &dbTx.Sent,
-		&dbTx.Fees, &dbTx.NumVin, &vinDbIDs, &dbTx.NumVout, &voutDbIDs)
+		&dbTx.Fees, &dbTx.NumVin, &vinDbIDs, &dbTx.NumVout, &voutDbIDs,
+		&dbTx.IsValidBlock, &dbTx.IsMainchainBlock)
 	return
 }
 
@@ -1133,16 +1139,27 @@ func RetrieveFullTxByHash(db *sql.DB, txHash string) (id uint64,
 	txType int16, version int32, tree int8, blockInd uint32,
 	lockTime, expiry int32, size uint32, spent, sent, fees int64,
 	numVin int32, vinDbIDs []int64, numVout int32, voutDbIDs []int64,
-	err error) {
+	isValidBlock, isMainchainBlock bool, err error) {
 	var hash string
 	err = db.QueryRow(internal.SelectFullTxByHash, txHash).Scan(&id, &blockHash,
 		&blockHeight, &blockTime, &time, &txType, &version, &tree,
 		&hash, &blockInd, &lockTime, &expiry, &size, &spent, &sent, &fees,
-		&numVin, &vinDbIDs, &numVout, &voutDbIDs)
+		&numVin, &vinDbIDs, &numVout, &voutDbIDs,
+		&isValidBlock, &isMainchainBlock)
 	return
 }
 
-func RetrieveTxByHash(db *sql.DB, txHash string) (id uint64, blockHash string, blockInd uint32, tree int8, err error) {
+// RetrieveTxnsVinsByBlock retrieves for all the transactions in the specified
+// block the vin_db_ids arrays, is_valid, and is_mainchain.
+func RetrieveTxnsVinsByBlock(db *sql.DB, blockHash string) (vinDbIDs []dbtypes.UInt64Array,
+	areValid []bool, areMainchain []bool, err error) {
+	err = db.QueryRow(internal.SelectTxnsVinsByBlock, blockHash).Scan(&vinDbIDs,
+		&areValid, &areMainchain)
+	return
+}
+
+func RetrieveTxByHash(db *sql.DB, txHash string) (id uint64, blockHash string,
+	blockInd uint32, tree int8, err error) {
 	err = db.QueryRow(internal.SelectTxByHash, txHash).Scan(&id, &blockHash, &blockInd, &tree)
 	return
 }
@@ -1197,6 +1214,11 @@ func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []s
 	}
 
 	return
+}
+
+func UpdateAllTxnsValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
+	return sqlExec(db, internal.UpdateTxnsValidMainchainAll,
+		"failed to update transactions validity and mainchain status")
 }
 
 // RetrieveBlockHash retrieves the hash of the block at the given height, if it
@@ -1363,12 +1385,12 @@ func RetrieveBlockSummaryByTimeRange(db *sql.DB, minTime, maxTime int64, limit i
 	return blocks, nil
 }
 
-func InsertBlock(db *sql.DB, dbBlock *dbtypes.Block, isValid, checked bool) (uint64, error) {
+func InsertBlock(db *sql.DB, dbBlock *dbtypes.Block, isValid, isMainchain, checked bool) (uint64, error) {
 	insertStatement := internal.MakeBlockInsertStatement(dbBlock, checked)
 	var id uint64
 	err := db.QueryRow(insertStatement,
-		dbBlock.Hash, dbBlock.Height, dbBlock.Size, isValid, dbBlock.Version,
-		dbBlock.MerkleRoot, dbBlock.StakeRoot,
+		dbBlock.Hash, dbBlock.Height, dbBlock.Size, isValid, isMainchain,
+		dbBlock.Version, dbBlock.MerkleRoot, dbBlock.StakeRoot,
 		dbBlock.NumTx, dbBlock.NumRegTx, dbBlock.NumStakeTx,
 		dbBlock.Time, dbBlock.Nonce, dbBlock.VoteBits,
 		dbBlock.FinalState, dbBlock.Voters, dbBlock.FreshStake,
@@ -1394,16 +1416,16 @@ func UpdateLastBlock(db *sql.DB, blockDbID uint64, isValid bool) error {
 
 // UpdateLastVins updates the is_valid column in the vins table for all of the
 // transactions in the block specified by the given block hash.
-func UpdateLastVins(db *sql.DB, blockHash string, isValid bool) error {
+func UpdateLastVins(db *sql.DB, blockHash string, isValid, isMainchain bool) error {
 	_, txs, _, trees, timestamps, err := RetrieveTxsByBlockHash(db, blockHash)
 	if err != nil {
 		return err
 	}
 
 	for i, txHash := range txs {
-		n, err := sqlExec(db, internal.SetIsValidByTxHash,
-			"failed to update last vins tx validity: ", isValid, txHash,
-			timestamps[i], trees[i])
+		n, err := sqlExec(db, internal.SetIsValidIsMainchainByTxHash,
+			"failed to update last vins tx validity: ", isValid, isMainchain,
+			txHash, timestamps[i], trees[i])
 		if err != nil {
 			return err
 		}
@@ -1460,6 +1482,16 @@ func RetrieveTicketsPriceByHeight(db *sql.DB, val int64) (*dbtypes.ChartsData, e
 	}
 
 	return items, nil
+}
+
+func RetrievePreviousHashByBlockHash(db *sql.DB, hash string) (previous_hash string, err error) {
+	err = db.QueryRow(internal.SelectBlocksPreviousHash, hash).Scan(&previous_hash)
+	return
+}
+
+func SetMainchainByBlockHash(db *sql.DB, hash string) (previous_hash string, err error) {
+	err = db.QueryRow(internal.UpdateBlockMainchain, hash).Scan(&previous_hash)
+	return
 }
 
 // retrieveCoinSupply fetches the coin supply data
@@ -1654,11 +1686,26 @@ func UpdateBlockNext(db *sql.DB, blockDbID uint64, next string) error {
 	return nil
 }
 
+func UpdateBlockNextByHash(db *sql.DB, this, next string) error {
+	res, err := db.Exec(internal.UpdateBlockNextByHash, this, next)
+	if err != nil {
+		return err
+	}
+	numRows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if numRows != 1 {
+		return fmt.Errorf("UpdateBlockNextByHash failed to update exactly 1 row (%d)", numRows)
+	}
+	return nil
+}
+
 func InsertVin(db *sql.DB, dbVin dbtypes.VinTxProperty, checked bool) (id uint64, err error) {
 	err = db.QueryRow(internal.MakeVinInsertStatement(checked),
 		dbVin.TxID, dbVin.TxIndex, dbVin.TxTree,
 		dbVin.PrevTxHash, dbVin.PrevTxIndex, dbVin.PrevTxTree,
-		dbVin.ValueIn, dbVin.IsValid, dbVin.Time).Scan(&id)
+		dbVin.ValueIn, dbVin.IsValid, dbVin.IsMainchain, dbVin.Time).Scan(&id)
 	return
 }
 
@@ -1682,7 +1729,7 @@ func InsertVins(db *sql.DB, dbVins dbtypes.VinTxPropertyARRAY, checked bool) ([]
 		var id uint64
 		err = stmt.QueryRow(vin.TxID, vin.TxIndex, vin.TxTree,
 			vin.PrevTxHash, vin.PrevTxIndex, vin.PrevTxTree,
-			vin.ValueIn, vin.IsValid, vin.Time).Scan(&id)
+			vin.ValueIn, vin.IsValid, vin.IsMainchain, vin.Time).Scan(&id)
 		if err != nil {
 			_ = stmt.Close() // try, but we want the QueryRow error back
 			if errRoll := dbtx.Rollback(); errRoll != nil {
@@ -1751,6 +1798,7 @@ func InsertVouts(db *sql.DB, dbVouts []*dbtypes.Vout, checked bool) ([]uint64, [
 				TxVinVoutIndex: vout.TxIndex,
 				VinVoutDbID:    id,
 				Value:          vout.Value,
+				// ValidMainChain: ?
 			})
 		}
 		ids = append(ids, id)
@@ -1769,7 +1817,7 @@ func InsertAddressRow(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck bool) (uint6
 	var id uint64
 	err := db.QueryRow(sqlStmt, dbA.Address, dbA.MatchingTxHash, dbA.TxHash,
 		dbA.TxVinVoutIndex, dbA.VinVoutDbID, dbA.Value, dbA.TxBlockTime,
-		dbA.IsFunding).Scan(&id)
+		dbA.IsFunding, dbA.ValidMainChain).Scan(&id)
 	return id, err
 }
 
@@ -1803,7 +1851,7 @@ func InsertAddressRows(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck bool) ([
 		var id uint64
 		err := stmt.QueryRow(dbA.Address, dbA.MatchingTxHash, dbA.TxHash,
 			dbA.TxVinVoutIndex, dbA.VinVoutDbID, dbA.Value, dbA.TxBlockTime,
-			dbA.IsFunding).Scan(&id)
+			dbA.IsFunding, dbA.ValidMainChain).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				log.Errorf("failed to insert/update an AddressRow: %v", *dbA)
@@ -1937,7 +1985,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 	}
 
 	voteInsert := internal.MakeVoteInsertStatement(checked)
-	stmt, err := dbtx.Prepare(voteInsert)
+	voteStmt, err := dbtx.Prepare(voteInsert)
 	if err != nil {
 		log.Errorf("Votes INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
@@ -1975,7 +2023,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		if fTx != nil {
 			t, err := fTx.TxnDbID(stakeSubmissionTxHash, true)
 			if err != nil {
-				_ = stmt.Close() // try, but we want the QueryRow error back
+				_ = voteStmt.Close() // try, but we want the QueryRow error back
 				if errRoll := dbtx.Rollback(); errRoll != nil {
 					log.Errorf("Rollback failed: %v", errRoll)
 				}
@@ -2001,6 +2049,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 			return nil, nil, nil, nil, nil, err
 		}
 
+		// agendas
 		var rowID uint64
 		for _, val := range choices {
 			index, err := dbtypes.ChoiceIndexFromStr(val.Choice.Id)
@@ -2017,15 +2066,16 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		}
 
 		var id uint64
-		err = stmt.QueryRow(
+		err = voteStmt.QueryRow(
 			tx.BlockHeight, tx.TxID, tx.BlockHash, candidateBlockHash,
 			voteVersion, voteBits, validBlock.Validity,
-			stakeSubmissionTxHash, ticketTxDbID, stakeSubmissionAmount, voteReward).Scan(&id)
+			stakeSubmissionTxHash, ticketTxDbID, stakeSubmissionAmount,
+			voteReward, tx.IsMainchainBlock).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue
 			}
-			_ = stmt.Close() // try, but we want the QueryRow error back
+			_ = voteStmt.Close() // try, but we want the QueryRow error back
 			if errRoll := dbtx.Rollback(); errRoll != nil {
 				log.Errorf("Rollback failed: %v", errRoll)
 			}
@@ -2035,7 +2085,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 	}
 
 	// Close prepared statement. Ignore errors as we'll Commit regardless.
-	_ = stmt.Close()
+	_ = voteStmt.Close()
 
 	if len(ids)+len(misses) != 5 {
 		fmt.Println(misses)
@@ -2086,7 +2136,8 @@ func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked bool) (uint64, error) {
 		dbTx.TxType, dbTx.Version, dbTx.Tree, dbTx.TxID, dbTx.BlockIndex,
 		dbTx.Locktime, dbTx.Expiry, dbTx.Size, dbTx.Spent, dbTx.Sent, dbTx.Fees,
 		dbTx.NumVin, dbtypes.UInt64Array(dbTx.VinDbIds),
-		dbTx.NumVout, dbtypes.UInt64Array(dbTx.VoutDbIds)).Scan(&id)
+		dbTx.NumVout, dbtypes.UInt64Array(dbTx.VoutDbIds),
+		dbTx.IsValidBlock, dbTx.IsMainchainBlock).Scan(&id)
 	return id, err
 }
 
@@ -2111,7 +2162,8 @@ func InsertTxns(db *sql.DB, dbTxns []*dbtypes.Tx, checked bool) ([]uint64, error
 			tx.TxType, tx.Version, tx.Tree, tx.TxID, tx.BlockIndex,
 			tx.Locktime, tx.Expiry, tx.Size, tx.Spent, tx.Sent, tx.Fees,
 			tx.NumVin, dbtypes.UInt64Array(tx.VinDbIds),
-			tx.NumVout, dbtypes.UInt64Array(tx.VoutDbIds)).Scan(&id)
+			tx.NumVout, dbtypes.UInt64Array(tx.VoutDbIds), tx.IsValidBlock,
+			tx.IsMainchainBlock).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -881,9 +881,10 @@ func scanAddressQueryRows(rows *sql.Rows) (ids []uint64, addressRows []*dbtypes.
 		var addr dbtypes.AddressRow
 		var txHash sql.NullString
 		var blockTime, txVinIndex, vinDbID sql.NullInt64
+		// Scan values in order of columns listed in internal.addrsColumnNames
 		err = rows.Scan(&id, &addr.Address, &addr.MatchingTxHash, &txHash,
-			&txVinIndex, &blockTime, &vinDbID, &addr.Value, &addr.IsFunding,
-			&addr.ValidMainChain)
+			&addr.ValidMainChain, &txVinIndex, &blockTime, &vinDbID,
+			&addr.Value, &addr.IsFunding)
 		if err != nil {
 			return
 		}

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -181,7 +181,7 @@ func (db *ChainDB) SyncChainDB(client rpcutils.MasterBlockGetter, quit chan stru
 
 		// Store data from this block in the database
 		numVins, numVouts, err := db.StoreBlock(block.MsgBlock(), winners, true,
-			!updateAllAddresses, !updateAllVotes)
+			true, !updateAllAddresses, !updateAllVotes)
 		if err != nil {
 			return ib - 1, fmt.Errorf("StoreBlock failed: %v", err)
 		}

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -261,14 +261,12 @@ func TableUpgradesRequired(versions map[string]TableVersion) []TableUpgrade {
 			continue
 		}
 		versionCompatibility := TableVersionCompatible(req, act)
-		if versionCompatibility != "ok" {
-			tableUpgrades = append(tableUpgrades, TableUpgrade{
-				TableName:   t,
-				UpgradeType: versionCompatibility,
-				CurrentVer:  act,
-				RequiredVer: req,
-			})
-		}
+		tableUpgrades = append(tableUpgrades, TableUpgrade{
+			TableName:   t,
+			UpgradeType: versionCompatibility,
+			CurrentVer:  act,
+			RequiredVer: req,
+		})
 	}
 	return tableUpgrades
 }

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -39,7 +39,7 @@ var createTypeStatements = map[string]string{
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 2
+	tableMinor = 3
 )
 
 var requiredVersions = map[string]TableVersion{

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -110,21 +110,22 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 
 		// Go on to next upgrade
 		// fallthrough
-		// or be done
-		log.Infof("Table upgrades completed.")
-		return true, nil
-
+		// or be done.
 	default:
+		// UpgradeType == "upgrade", but no supported case.
 		return false, fmt.Errorf("no upgrade path available for version %v --> %v",
 			version, needVersion)
 	}
 
+	// Ensure the required version was reached.
 	upgradeInfo = TableUpgradesRequired(TableVersions(pgb.db))
 	if upgradeInfo[0].UpgradeType != "ok" {
 		return false, fmt.Errorf("failed to upgrade tables to required version %v", needVersion)
 	}
 
-	return false, nil
+	// Unsupported upgrades caught by default case, so we've succeeded.
+	log.Infof("Table upgrades completed.")
+	return true, nil
 }
 
 // handleUpgrades the individual upgrade and returns a bool and an error
@@ -347,7 +348,7 @@ func (pgb *ChainDB) handleBlocksTableMainchainUpgrade(bestBlock string) (int64, 
 	for !bytes.Equal(zeroHashStringBytes, []byte(previousHash)) {
 		// set is_mainchain=1 and get previous_hash
 		var err error
-		previousHash, err = SetMainchainByBlockHash(pgb.db, thisBlockHash)
+		previousHash, err = SetMainchainByBlockHash(pgb.db, thisBlockHash, true)
 		if err != nil {
 			return blocksUpdated, err
 		}

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -119,7 +119,7 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 
 	// Ensure the required version was reached.
 	upgradeInfo = TableUpgradesRequired(TableVersions(pgb.db))
-	if upgradeInfo[0].UpgradeType != "ok" {
+	if len(upgradeInfo) > 0 && upgradeInfo[0].UpgradeType != "ok" {
 		return false, fmt.Errorf("failed to upgrade tables to required version %v", needVersion)
 	}
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -364,6 +364,9 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 	var received, sent int64
 	var transactions, creditTxns, debitTxns []*AddressTx
 	for _, addrOut := range addrHist {
+		if !addrOut.ValidMainChain {
+			continue
+		}
 		coin := dcrutil.Amount(addrOut.Value).ToCoin()
 		tx := AddressTx{
 			BlockTime: addrOut.TxBlockTime,


### PR DESCRIPTION
This PR adds support for tracking blocks and transactions that are in side chains.

- [x] Add is_mainchain and is_valid to tables: blocks, transactions, vins, addresses.
- [x] Automatic postgresql table upgrades.
- [x] Change all insert and update functions to use appropriate IsMainchain and IsValid values.
- [x] Modify balance (and other relevant) queries to only consider is_mainchain = true.

For followup PR:
- Modify reorg handling to patch up the IsMainchain values.