### PR TITLE
dcrsqlite: correctly splits given string into array of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ffldb_stake*/
 testnet/
 .DS_Store
 testdata/
+\.project


### PR DESCRIPTION
Fixes number of issues similar to the one described in the #532
`strings.Split(winners, ";")` is not a correct way to split the `winners` string.