### PR TITLE
explorer: votes filter now flags votes instead of excluding them.

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -482,7 +482,7 @@ func (c *appContext) getDecodedTransactions(w http.ResponseWriter, r *http.Reque
 	for i := range txids {
 		tx := c.BlockData.GetTrimmedTransaction(txids[i])
 		if tx == nil {
-			apiLog.Errorf("Unable to get transaction %s", tx)
+			apiLog.Errorf("Unable to get transaction %v", tx)
 			http.Error(w, http.StatusText(422), 422)
 			return
 		}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -138,6 +138,7 @@ type VoteInfo struct {
 	Choices            []*txhelpers.VoteChoice `json:"vote_choices"`
 	TicketSpent        string                  `json:"ticket_spent"`
 	MempoolTicketIndex int                     `json:"mempool_ticket_index"`
+	ForLastBlock       bool                    `json:"last_block"`
 }
 
 // BlockValidation models data about a vote's decision on a block
@@ -304,18 +305,31 @@ type MempoolInfo struct {
 
 // MempoolShort represents the mempool data sent as the mempool update
 type MempoolShort struct {
-	LastBlockHeight    int64          `json:"block_height"`
-	LastBlockTime      int64          `json:"block_time"`
-	TotalOut           float64        `json:"total"`
-	TotalSize          int32          `json:"size"`
-	NumTickets         int            `json:"num_tickets"`
-	NumVotes           int            `json:"num_votes"`
-	NumRegular         int            `json:"num_regular"`
-	NumRevokes         int            `json:"num_revokes"`
-	NumAll             int            `json:"num_all"`
-	LatestTransactions []MempoolTx    `json:"latest"`
-	FormattedTotalSize string         `json:"formatted_size"`
-	TicketIndexes      map[string]int `json:"ticket_indexes"`
+	LastBlockHeight    int64                    `json:"block_height"`
+	LastBlockHash      string                   `json:"block_hash"`
+	LastBlockTime      int64                    `json:"block_time"`
+	TotalOut           float64                  `json:"total"`
+	TotalSize          int32                    `json:"size"`
+	NumTickets         int                      `json:"num_tickets"`
+	NumVotes           int                      `json:"num_votes"`
+	NumRegular         int                      `json:"num_regular"`
+	NumRevokes         int                      `json:"num_revokes"`
+	NumAll             int                      `json:"num_all"`
+	LatestTransactions []MempoolTx              `json:"latest"`
+	FormattedTotalSize string                   `json:"formatted_size"`
+	TicketIndexes      map[int64]map[string]int `json:"ticket_indexes"`
+	VotingInfo         VotingInfo               `json:"voting_info"`
+}
+
+// VotingInfo models data about the validity of the next block from mempool
+type VotingInfo struct {
+	Valids         uint16 `json:"choice_valid"`
+	Invalids       uint16 `json:"choice_invalid"`
+	TotalCollected uint16 `json:"total_votes_collected"`
+	TotalNeeded    uint16 `json:"total_votes_required"`
+	Required       uint16 `json:"total_choices_required"`
+	BlockValid     bool   `json:"block_valid"`
+	voted          map[string]bool
 }
 
 // ChainParams models simple data about the chain server's parameters used for some

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -317,7 +317,7 @@ type MempoolShort struct {
 	NumAll             int                      `json:"num_all"`
 	LatestTransactions []MempoolTx              `json:"latest"`
 	FormattedTotalSize string                   `json:"formatted_size"`
-	TicketIndexes      map[int64]map[string]int `json:"ticket_indexes"`
+	TicketIndexes      map[int64]map[string]int `json:"-"`
 	VotingInfo         VotingInfo               `json:"voting_info"`
 }
 

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -284,7 +284,6 @@ func (exp *explorerUI) getLastBlock() (lastBlockHash string, lastBlock int64, la
 	if err != nil {
 		log.Warnf("Could not get bloch hash for last block")
 	}
-	log.Debug("Last Block Hash: ", lastBlockHash)
 	return
 }
 

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -57,9 +57,6 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 		var voteInfo *VoteInfo
 		if ok := stake.IsSSGen(msgTx); ok {
 			validation, version, bits, choices, err := txhelpers.SSGenVoteChoices(msgTx, exp.ChainParams)
-			if !voteForLastBlock(lastBlockHash, validation.Hash.String()) {
-				continue
-			}
 			if err != nil {
 				log.Debugf("Cannot get vote choices for %s", hash)
 			} else {
@@ -69,10 +66,11 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 						Height:   validation.Height,
 						Validity: validation.Validity,
 					},
-					Version:     version,
-					Bits:        bits,
-					Choices:     choices,
-					TicketSpent: msgTx.TxIn[1].PreviousOutPoint.Hash.String(),
+					Version:      version,
+					Bits:         bits,
+					Choices:      choices,
+					TicketSpent:  msgTx.TxIn[1].PreviousOutPoint.Hash.String(),
+					ForLastBlock: voteForLastBlock(lastBlockHash, validation.Hash.String()),
 				}
 			}
 		}
@@ -94,15 +92,20 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			exp.MempoolData.Tickets = append([]MempoolTx{tx}, exp.MempoolData.Tickets...)
 			exp.MempoolData.NumTickets++
 		case "Vote":
-			if idx, ok := exp.MempoolData.TicketIndexes[tx.VoteInfo.TicketSpent]; ok {
-				tx.VoteInfo.MempoolTicketIndex = idx
-			} else {
-				idx := len(exp.MempoolData.TicketIndexes) + 1
-				exp.MempoolData.TicketIndexes[tx.VoteInfo.TicketSpent] = idx
-				tx.VoteInfo.MempoolTicketIndex = idx
-			}
+			addVoteIndex(tx.VoteInfo, exp.MempoolData.TicketIndexes)
 			exp.MempoolData.Votes = append([]MempoolTx{tx}, exp.MempoolData.Votes...)
+			sort.Sort(byHeight(exp.MempoolData.Votes))
 			exp.MempoolData.NumVotes++
+			if tx.VoteInfo.ForLastBlock && !exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] {
+				exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] = true
+				exp.MempoolData.VotingInfo.TotalCollected++
+				if tx.VoteInfo.Validation.Validity {
+					exp.MempoolData.VotingInfo.Valids++
+				} else {
+					exp.MempoolData.VotingInfo.Invalids++
+				}
+				updateBlockValidity(&exp.MempoolData.VotingInfo)
+			}
 		case "Regular":
 			exp.MempoolData.Transactions = append([]MempoolTx{tx}, exp.MempoolData.Transactions...)
 			exp.MempoolData.NumRegular++
@@ -180,23 +183,30 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 
 	var totalOut float64
 	var totalSize int32
+	var votingInfo VotingInfo
 
-	// Categorize the transactions, and bin votes by ticket spent
-	txindexes := make(map[string]int)
+	lastBlockHash, lastBlock, lastBlockTime = exp.getLastBlock()
+
+	votingInfo.TotalNeeded = exp.ChainParams.TicketsPerBlock
+	votingInfo.Required = exp.ChainParams.StakeRewardProportion
+
+	votingInfo.voted = make(map[string]bool)
+
+	txindexes := make(map[int64]map[string]int)
 	for _, tx := range memtxs {
 		switch tx.Type {
 		case "Ticket":
 			tickets = append(tickets, tx)
 		case "Vote":
-			if !voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash) {
-				continue
-			}
-			if idx, ok := txindexes[tx.VoteInfo.TicketSpent]; ok {
-				tx.VoteInfo.MempoolTicketIndex = idx
-			} else {
-				idx := len(txindexes) + 1
-				txindexes[tx.VoteInfo.TicketSpent] = idx
-				tx.VoteInfo.MempoolTicketIndex = idx
+			addVoteIndex(tx.VoteInfo, txindexes)
+			if tx.VoteInfo.ForLastBlock = voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash); tx.VoteInfo.ForLastBlock && !votingInfo.voted[tx.VoteInfo.TicketSpent] {
+				votingInfo.voted[tx.VoteInfo.TicketSpent] = true
+				votingInfo.TotalCollected++
+				if tx.VoteInfo.Validation.Validity {
+					votingInfo.Valids++
+				} else {
+					votingInfo.Invalids++
+				}
 			}
 			votes = append(votes, tx)
 		case "Revocation":
@@ -207,10 +217,11 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 		totalOut += tx.TotalOut
 		totalSize += tx.Size
 	}
-
-	// Store the results in MempoolData for the web page
+	updateBlockValidity(&votingInfo)
 	exp.MempoolData.Lock()
 	defer exp.MempoolData.Unlock()
+
+	sort.Sort(byHeight(votes))
 
 	exp.MempoolData.Transactions = regular
 	exp.MempoolData.Tickets = tickets
@@ -219,6 +230,7 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 
 	exp.MempoolData.MempoolShort = MempoolShort{
 		LastBlockHeight:    lastBlock,
+		LastBlockHash:      lastBlockHash,
 		LastBlockTime:      lastBlockTime,
 		TotalOut:           totalOut,
 		TotalSize:          totalSize,
@@ -230,12 +242,36 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 		LatestTransactions: latest,
 		FormattedTotalSize: humanize.Bytes(uint64(totalSize)),
 		TicketIndexes:      txindexes,
+		VotingInfo:         votingInfo,
 	}
 	return
 }
 
+// addVoteIndex sets v.MempoolTicketIndex to the corresponding map value if it exits in
+// txindexes and creates a new index map if it doesn't
+func addVoteIndex(v *VoteInfo, txindexes map[int64]map[string]int) {
+	if idxs, ok := txindexes[v.Validation.Height]; ok {
+		if idx, ok := idxs[v.TicketSpent]; ok {
+			v.MempoolTicketIndex = idx
+		} else {
+			idx := len(idxs) + 1
+			idxs[v.TicketSpent] = idx
+			v.MempoolTicketIndex = idx
+		}
+	} else {
+		idxs := make(map[string]int)
+		idxs[v.TicketSpent] = 1
+		txindexes[v.Validation.Height] = idxs
+		v.MempoolTicketIndex = 1
+	}
+}
+
 func voteForLastBlock(blockHash, validationHash string) bool {
 	return blockHash == validationHash && blockHash != ""
+}
+
+func updateBlockValidity(votingInfo *VotingInfo) {
+	votingInfo.BlockValid = votingInfo.Valids+votingInfo.Invalids >= votingInfo.TotalNeeded && votingInfo.Valids >= votingInfo.Required
 }
 
 // getLastBlock returns the last block hash, height and time
@@ -248,7 +284,7 @@ func (exp *explorerUI) getLastBlock() (lastBlockHash string, lastBlock int64, la
 	if err != nil {
 		log.Warnf("Could not get bloch hash for last block")
 	}
-
+	log.Debug("Last Block Hash: ", lastBlockHash)
 	return
 }
 
@@ -264,4 +300,21 @@ func (txs byTime) Len() int {
 
 func (txs byTime) Swap(i, j int) {
 	txs[i], txs[j] = txs[j], txs[i]
+}
+
+type byHeight []MempoolTx
+
+func (votes byHeight) Less(i, j int) bool {
+	if votes[i].VoteInfo.Validation.Height == votes[j].VoteInfo.Validation.Height {
+		return votes[i].VoteInfo.MempoolTicketIndex < votes[j].VoteInfo.MempoolTicketIndex
+	}
+	return votes[i].VoteInfo.Validation.Height > votes[j].VoteInfo.Validation.Height
+}
+
+func (votes byHeight) Len() int {
+	return len(votes)
+}
+
+func (votes byHeight) Swap(i, j int) {
+	votes[i], votes[j] = votes[j], votes[i]
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -768,3 +768,7 @@ body.darkBG .keynav-target {
 .opacity-transition{
   transition: opacity .42s ease-in-out;
 }
+
+.old-vote {
+  background-color: pink;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -769,10 +769,10 @@ body.darkBG .keynav-target {
   transition: opacity .42s ease-in-out;
 }
 
+/*mempool Vote Table*/
 .old-vote {
-  background-color: pink;
+  background-color: #ff3d001f;
 }
-
 .upcoming-vote {
-  background-color: lightgrey;
+  background: #0078ff1c;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -772,3 +772,7 @@ body.darkBG .keynav-target {
 .old-vote {
   background-color: pink;
 }
+
+.upcoming-vote {
+  background-color: lightgrey;
+}

--- a/public/js/controllers/mempool.js
+++ b/public/js/controllers/mempool.js
@@ -8,12 +8,6 @@
         }
     }
 
-    function emptyRow(txnType, colspan) {
-        return `<tr>
-            <td colspan="${colspan}">No ${txnType} in mempool</td>
-        </tr>`
-    }
-
     function txTableRow(tx) {
         return `<tr class="flash">
             <td class="break-word"><span><a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a></span></td>
@@ -59,47 +53,6 @@
         var rows = $(target).find('tr')
         var newRowHtml = $.parseHTML(rowFn(tx))
         $(newRowHtml).insertBefore(rows.first())
-    }
-
-    function filterVotesLastBlock(target) {
-        var best_block_hash=$(target).data("hash");
-        var best_block_height=$(target).text();
-        console.log(best_block_height);
-        $('*[data-target="mempool.voteTransactions"] tr').each(function(i,el) {
-            var vote_validation_hash=$(this).data("blockhash");
-            var vote_block_height=$(this).data("height");
-            if(vote_block_height>best_block_height) {
-                $(this).closest("tr").addClass("upcoming-vote");
-                $(this).closest("tr").removeClass("old-vote");
-            }else if(vote_validation_hash!=best_block_hash){
-                $(this).closest("tr").addClass("old-vote");
-                $(this).closest("tr").removeClass("upcoming-vote");
-                $(this).find("td.last_block").text("Invalid");
-            }else{
-                $(this).closest("tr").removeClass("old-vote");
-                $(this).closest("tr").removeClass("upcoming-vote");
-                $(this).find("td.last_block").text("Valid");  
-            }
-        })
-    };
-
-    function sortVotesTable() {
-        var $table = $('*[data-target="mempool.voteTransactions"] tr').parent();
-        var $rows =$('*[data-target="mempool.voteTransactions"] tr');
-        $rows.sort(function(a, b){
-            var heightA = parseInt($('td:nth-child(2)',a).text());
-            var heightB = parseInt($('td:nth-child(2)',b).text());
-            if(heightA == heightB) {
-                 var indexA = parseInt($('td:nth-child(3)',a).text());
-                 var indexB = parseInt($('td:nth-child(3)',b).text());
-                 return (indexA - indexB);
-            }else{
-                return (heightB - heightA);
-            }
-        });
-        $.each($rows, function(index, row){
-          $table.append(row);
-        });
     }
 
     app.register("homepageMempool", class extends Stimulus.Controller {
@@ -150,7 +103,6 @@
         }
     })
 
-
     app.register("mempool", class extends Stimulus.Controller {
         static get targets() {
             return [
@@ -174,8 +126,8 @@
         connect() {
             ws.registerEvtHandler("newtx", (evt) => {
                 this.renderNewTxns(evt)
-                filterVotesLastBlock(this.bestBlockTarget);
-                sortVotesTable();
+                this.filterVotesLastBlock();
+                this.sortVotesTable();
                 keyNav(evt, false, true)
             })
             ws.registerEvtHandler("mempool", (evt) => {
@@ -184,10 +136,10 @@
             });
             ws.registerEvtHandler("getmempooltxsResp", (evt) => {
                 this.handleTxsResp(evt)
-                filterVotesLastBlock(this.bestBlockTarget);
-                sortVotesTable();
+                this.filterVotesLastBlock();
+                this.sortVotesTable();
                 keyNav(evt, false, true)
-            })    
+            })
         }
 
         disconnect() {
@@ -213,7 +165,7 @@
             $(this.totalNeededTarget).text(m.voting_info.total_votes_required)
             $(this.totalOutTarget).html(`${humanize.decimalParts(m.total, false, 8, true)}`);
             $(this.mempoolSizeTarget).text(m.formatted_size);
-            filterVotesLastBlock(this.bestBlockTarget);
+            this.filterVotesLastBlock();
         }
 
         handleTxsResp(event) {
@@ -231,6 +183,43 @@
                 var rowFn = tx.Type === "Vote" ? voteTxTableRow : txTableRow
                 addTxRow(tx, this[tx.Type.toLowerCase() + "TransactionsTarget"], rowFn)
             })
+        }
+
+        filterVotesLastBlock() {
+            var bestBlockHash=$(this.bestBlockTarget).data("hash");
+            var bestBlockHeight=$(this.bestBlockTarget).text();
+            $(this.voteTransactionsTarget).children("tr").each(function(i,el) {
+                var voteValidationHash=$(this).data("blockhash");
+                var voteBlockHeight=$(this).data("height");
+                if(voteBlockHeight>bestBlockHeight) {
+                    $(this).closest("tr").addClass("upcoming-vote");
+                    $(this).closest("tr").removeClass("old-vote");
+                }else if(voteValidationHash!=bestBlockHash){
+                    $(this).closest("tr").addClass("old-vote");
+                    $(this).closest("tr").removeClass("upcoming-vote");
+                    $(this).find("td.last_block").text("Invalid");
+                }else{
+                    $(this).closest("tr").removeClass("old-vote");
+                    $(this).closest("tr").removeClass("upcoming-vote");
+                    $(this).find("td.last_block").text("Valid");
+                }
+            })
+        };
+
+        sortVotesTable() {
+            var $rows = $(this.voteTransactionsTarget).children("tr");
+            $rows.sort(function(a, b){
+                var heightA = parseInt($('td:nth-child(2)',a).text());
+                var heightB = parseInt($('td:nth-child(2)',b).text());
+                if(heightA == heightB) {
+                     var indexA = parseInt($('td:nth-child(3)',a).text());
+                     var indexB = parseInt($('td:nth-child(3)',b).text());
+                     return (indexA - indexB);
+                }else{
+                    return (heightB - heightA);
+                }
+            });
+            $(this.voteTransactionsTarget).html($rows);
         }
     })
 })()

--- a/public/js/controllers/mempool.js
+++ b/public/js/controllers/mempool.js
@@ -186,19 +186,19 @@
         }
 
         filterVotesLastBlock() {
-            var bestBlockHash=$(this.bestBlockTarget).data("hash");
-            var bestBlockHeight=$(this.bestBlockTarget).text();
+            var bestBlockHash = $(this.bestBlockTarget).data("hash");
+            var bestBlockHeight = $(this.bestBlockTarget).text();
             $(this.voteTransactionsTarget).children("tr").each(function(i,el) {
-                var voteValidationHash=$(this).data("blockhash");
-                var voteBlockHeight=$(this).data("height");
-                if(voteBlockHeight>bestBlockHeight) {
+                var voteValidationHash = $(this).data("blockhash");
+                var voteBlockHeight = $(this).data("height");
+                if (voteBlockHeight > bestBlockHeight) {
                     $(this).closest("tr").addClass("upcoming-vote");
                     $(this).closest("tr").removeClass("old-vote");
-                }else if(voteValidationHash!=bestBlockHash){
+                } else if (voteValidationHash != bestBlockHash) {
                     $(this).closest("tr").addClass("old-vote");
                     $(this).closest("tr").removeClass("upcoming-vote");
                     $(this).find("td.last_block").text("Invalid");
-                }else{
+                } else {
                     $(this).closest("tr").removeClass("old-vote");
                     $(this).closest("tr").removeClass("upcoming-vote");
                     $(this).find("td.last_block").text("Valid");
@@ -211,11 +211,11 @@
             $rows.sort(function(a, b){
                 var heightA = parseInt($('td:nth-child(2)',a).text());
                 var heightB = parseInt($('td:nth-child(2)',b).text());
-                if(heightA == heightB) {
+                if (heightA == heightB) {
                      var indexA = parseInt($('td:nth-child(3)',a).text());
                      var indexB = parseInt($('td:nth-child(3)',b).text());
                      return (indexA - indexB);
-                }else{
+                } else {
                     return (heightB - heightA);
                 }
             });

--- a/public/js/controllers/mempool.js
+++ b/public/js/controllers/mempool.js
@@ -126,7 +126,7 @@
         connect() {
             ws.registerEvtHandler("newtx", (evt) => {
                 this.renderNewTxns(evt)
-                this.filterVotesLastBlock();
+                this.labelVotes();
                 this.sortVotesTable();
                 keyNav(evt, false, true)
             })
@@ -136,7 +136,7 @@
             });
             ws.registerEvtHandler("getmempooltxsResp", (evt) => {
                 this.handleTxsResp(evt)
-                this.filterVotesLastBlock();
+                this.labelVotes();
                 this.sortVotesTable();
                 keyNav(evt, false, true)
             })
@@ -165,7 +165,7 @@
             $(this.totalNeededTarget).text(m.voting_info.total_votes_required)
             $(this.totalOutTarget).html(`${humanize.decimalParts(m.total, false, 8, true)}`);
             $(this.mempoolSizeTarget).text(m.formatted_size);
-            this.filterVotesLastBlock();
+            this.labelVotes();
         }
 
         handleTxsResp(event) {
@@ -185,7 +185,7 @@
             })
         }
 
-        filterVotesLastBlock() {
+        labelVotes() {
             var bestBlockHash = $(this.bestBlockTarget).data("hash");
             var bestBlockHeight = $(this.bestBlockTarget).text();
             $(this.voteTransactionsTarget).children("tr").each(function(i,el) {

--- a/public/js/controllers/mempool.js
+++ b/public/js/controllers/mempool.js
@@ -68,11 +68,16 @@
         $('*[data-target="mempool.voteTransactions"] tr').each(function(i,el) {
             var vote_validation_hash=$(this).data("blockhash");
             var vote_block_height=$(this).data("height");
-            if(vote_block_height<=best_block_height&&vote_validation_hash!=best_block_hash) {
+            if(vote_block_height>best_block_height) {
+                $(this).closest("tr").addClass("upcoming-vote");
+                $(this).closest("tr").removeClass("old-vote");
+            }else if(vote_validation_hash!=best_block_hash){
                 $(this).closest("tr").addClass("old-vote");
+                $(this).closest("tr").removeClass("upcoming-vote");
                 $(this).find("td.last_block").text("Invalid");
             }else{
                 $(this).closest("tr").removeClass("old-vote");
+                $(this).closest("tr").removeClass("upcoming-vote");
                 $(this).find("td.last_block").text("Valid");  
             }
         })

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -194,7 +194,7 @@
                         <thead>
                             <th>Transactions ID</th>
                             <th>Vote Version</th>
-                            <th>Vote Choice</th>
+                            <th>Last Block</th>
                             <th class="text-right">Total DCR</th>
                             <th class="text-right">Size</th>
                         </thead>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -193,12 +193,10 @@
                     <table class="table table-sm striped">
                         <thead>
                             <th>Transactions ID</th>
-                            <th>Version</th>
-                            <th>Last Block Valid</th>
-                            <th>Issue ID</th>
-                            <th>Choice ID</th>
+                            <th>Vote Version</th>
+                            <th>Vote Choice</th>
                             <th class="text-right">Total DCR</th>
-                            <th>Size</th>
+                            <th class="text-right">Size</th>
                         </thead>
                         <tbody>
                             {{range .Votes}}
@@ -209,19 +207,9 @@
                                     </span>
                                 </td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td>{{.VoteInfo.Validation.Validity}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).ID}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).Choice.Id}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
+                                <td>{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .Total false)}}</td>
-                                <td class="mono fs15">{{.FormattedSize}}</td>
+                                <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                             </tr>
                             {{end}}
                         </tbody>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -37,9 +37,9 @@
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTE CHOICES</td>
-                            <td id="mempool_vote_choices" class="lh1rem"><span data-target="mempool.totalCollected">
+                            <td class="lh1rem"><span data-target="mempool.totalCollected">
                             {{.VotingInfo.TotalCollected}}</span>/<span data-target="mempool.totalNeeded">{{.VotingInfo.TotalNeeded}}</span>
-                            <span id="mempool_block_validity" class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
+                            <span class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
                             </td>
                         </tr>
                     </table>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -71,7 +71,7 @@
                             <th>Vote Block</th>
                             <th>Vote Index</th>
                             <th>Vote Version</th>
-                            <th>Vote Choice</th>
+                            <th>Last Block</th>
                             <th>Total DCR</th>
                             <th class="text-right">Size</th>
                             <th class="text-right">Time</th>
@@ -84,7 +84,7 @@
                                 <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Height}}">{{.VoteInfo.Validation.Height}}</a></td>
                                 <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td class="mono fs15">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
+                                <td class="mono fs15 last_block">{{if .VoteInfo.ForLastBlock}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
                                 <td class="mono fs15 text-right">{{.Size}} B</td>
                                 <td class="mono fs15 text-right" data-target="main.age" data-age="{{.Time}}"></td>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -14,7 +14,7 @@
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117 w120">TOTAL SENT</td>
-                        <td class="fs28 mono fs16-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}<span class="pl-1 unit">DCR</span></td>
+                        <td class="fs28 mono fs16-decimal d-flex align-items-center" data-target="mempool.totalOut" >{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}<span class="pl-1 unit">DCR</span></td>
                     </tr>
                 </table>
             </div>
@@ -25,7 +25,7 @@
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">LAST BLOCK</td>
-                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-keynav-priority>{{.LastBlockHeight}}</a> (<span data-target="main.age mempool.bestBlockTime" data-age="{{.LastBlockTime}}"></span> ago)</td>
+                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a> (<span data-target="mempool.bestBlockTime  main.age" data-age="{{.LastBlockTime}}"></span> ago)</td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTES</td>
@@ -34,6 +34,13 @@
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">TICKETS</td>
                             <td data-target="mempool.numTicket" class="lh1rem">{{.NumTickets}}</td>
+                        </tr>
+                        <tr>
+                            <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTE CHOICES</td>
+                            <td id="mempool_vote_choices" class="lh1rem"><span data-target="mempool.totalCollected">
+                            {{.VotingInfo.TotalCollected}}</span>/<span data-target="mempool.totalNeeded">{{.VotingInfo.TotalNeeded}}</span>
+                            <span id="mempool_block_validity" class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
+                            </td>
                         </tr>
                     </table>
                 </div>
@@ -61,37 +68,25 @@
                     <table class="table table-sm striped">
                         <thead>
                             <th>Transactions ID</th>
-                            <th>Version</th>
-                            <th>Last Block Valid</th>
-                            <th>Issue ID</th>
-                            <th>Choice ID</th>
-                            <th class="text-right">Total DCR</th>
-                            <th>Size</th>
-                            <th class="text-right">Time in Mempool</th>
+                            <th>Vote Block</th>
+                            <th>Vote Index</th>
+                            <th>Vote Version</th>
+                            <th>Vote Choice</th>
+                            <th>Total DCR</th>
+                            <th class="text-right">Size</th>
+                            <th class="text-right">Time</th>
                         </thead>
                         <tbody data-target="mempool.voteTransactions">
                             {{if gt .NumVotes 0}}
                             {{range .Votes}}
-                            <tr>
-                                <td class="break-word">
-                                    <span>
-                                        <a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a>
-                                    </span>
-                                </td>
+                            <tr {{if not .VoteInfo.ForLastBlock}}class="old-vote"{{end}} data-blockhash="{{.VoteInfo.Validation.Hash}}" data-height="{{.VoteInfo.Validation.Height}}">
+                                <td class="break-word"><a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a></td>
+                                <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Height}}">{{.VoteInfo.Validation.Height}}</a></td>
+                                <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td>{{.VoteInfo.Validation.Validity}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).ID}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).Choice.Id}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
+                                <td class="mono fs15">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
-                                <td class="mono fs15">{{.Size}} B</td>
+                                <td class="mono fs15 text-right">{{.Size}} B</td>
                                 <td class="mono fs15 text-right" data-target="main.age" data-age="{{.Time}}"></td>
                             </tr>
                             {{end}}


### PR DESCRIPTION
This PR replaces PR #419 .  Progress so far:

- [x]  Modified js to match current websocket stimulus architecture
- [x] minor change to fix metalinter issue with unrelated code (%s to %v)
- [x] TOTAL SENT updates on mempool ws message
- [x] SIZE updates with mempool ws message
- [x] newtx for votes are incrementally updated and sorted in the votes table and colored if they are not for the most recent block.
- [x] last block time ago fixed when new block us updated with ws.
- [x] confirm vote choice X/5 is working properly and does not count duplicates (avoid 7/5 issue)
- [x] "pink bgcolor tweaked for dark mode" what color do you want it in dark mode?  
- [x] Is "Vote Choice" the right name for the column that says the vote is valid or invalid?

Issues:
It looks like all the votes are sent through the WS interface first as newTX before the new block (and thus mempool update) is sent.  The result is that we get a bunch of new vote transactions on the next block before we update the block.  Since the block hashes don't match they are colored pink.

Possible solutions:
1.  Investigate why we are getting newtx votes before a new block message (is this DCRD or pehaps in our websocket controller in go?) and reverse the order so we get a new block before we get any votes for that block.
2.  do not color votes pink if height is greater than current best height (it will still look a little strange but at least the votes will not stand out).

Below I captured how this looks on block updates.

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/11194546/43051372-d1676440-8dcd-11e8-9f50-fd4dbef23654.gif)



