### PR TITLE
dcrsqlite: test GetBestBlockHash, GetBestBlockHeight, GetStakeInfoHeight, tier 2

### DIFF
--- a/db/dcrsqlite/blocksretrieval_test.go
+++ b/db/dcrsqlite/blocksretrieval_test.go
@@ -48,3 +48,41 @@ func TestEmptyDBRetrieveBlockFeeInfo(t *testing.T) {
 			cmp.Diff(*result, defaultChartsData))
 	}
 }
+
+func TestEmptyDBGetBestBlockHash(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	str := db.GetBestBlockHash()
+	if str != "" {
+		testutil.ReportTestFailed(
+			"GetBestBlockHash() failed: expected empty string, returned %v",
+			str)
+	}
+}
+
+func TestEmptyDBGetBestBlockHeight(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	h := db.GetBestBlockHeight()
+	if h != -1 {
+		testutil.ReportTestFailed(
+			"db.GetBestBlockHeight() returned %d, expected -1",
+			h)
+	}
+}
+
+func TestEmptyDBGetStakeInfoHeight(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	endHeight, err := db.GetStakeInfoHeight()
+	if err != nil {
+		testutil.ReportTestFailed(
+			"GetStakeInfoHeight() failed: %v",
+			err)
+	}
+	if endHeight != -1 {
+		testutil.ReportTestFailed(
+			"GetStakeInfoHeight() failed: returned %d, expected -1",
+			endHeight)
+	}
+}


### PR DESCRIPTION
This is tier 2 of the #514 
Testing:
- `dcrsqlite/sqlite.go` `DB.GetBestBlockHash()`
- `dcrsqlite/sqlite.go` `DB.GetBestBlockHeight()`
- `dcrsqlite/sqlite.go` `DB.GetStakeInfoHeight()`

