### PR TITLE
dcrsqlite: test RetrieveAllPoolValAndSize and RetrieveBlockFeeInfo, tier 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ testnet/
 testdata/
 \.project
 test-data-repo
+dcrdata-testdata-gitlfs
+dcrdata-testdata
+.vendor-new

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -273,6 +273,17 @@
 
 [[projects]]
   digest = "1:e22469bf84466c427efe488bdb825101c527ecfd79f7829f72505c5ec64a7c06"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value"
+    ]
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   name = "github.com/google/gops"
   packages = [
     "agent",

--- a/db/dcrsqlite/blocksretrieval_test.go
+++ b/db/dcrsqlite/blocksretrieval_test.go
@@ -1,0 +1,50 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/db/dbtypes"
+	"github.com/decred/dcrdata/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEmptyDBRetrieveAllPoolValAndSize(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+
+	result, err := db.RetrieveAllPoolValAndSize()
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrieveAllPoolValAndSize() failed: default result expected: %v",
+			err)
+	}
+
+	// Expected value:
+	var defaultChartsData dbtypes.ChartsData
+
+	if !cmp.Equal(*result, defaultChartsData) {
+		testutil.ReportTestFailed(
+			"RetrieveAllPoolValAndSize() failed: default result expected:\n%v",
+			cmp.Diff(*result, defaultChartsData))
+	}
+}
+
+func TestEmptyDBRetrieveBlockFeeInfo(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	result, err := db.RetrieveBlockFeeInfo()
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockFeeInfo() failed: default result expected: %v",
+			err)
+	}
+
+	// Expected value:
+	var defaultChartsData dbtypes.ChartsData
+
+	if !cmp.Equal(*result, defaultChartsData) {
+		testutil.ReportTestFailed(
+			"RetrieveBlockFeeInfo() failed: default result expected:\n%v",
+			cmp.Diff(*result, defaultChartsData))
+	}
+}

--- a/db/dcrsqlite/dcrsqlite_test.go
+++ b/db/dcrsqlite/dcrsqlite_test.go
@@ -30,3 +30,19 @@ func InitTestDB(targetDBFile string) *DB {
 	}
 	return db //is not nil
 }
+
+var reusableEmptyDB *DB = nil
+
+// ObtainReusableEmptyDB returns a single reusable instance of an empty DB. The instance
+// is created once during the first call. All the subsequent calls will return
+// result cached in the reusableEmptyDB variable above.
+func ObtainReusableEmptyDB() *DB {
+	if reusableEmptyDB == nil {
+		testName := "reusableEmptyDB"
+		testutil.ResetTempFolder(&testName)
+		target := filepath.Join(testName, testutil.DefaultDBFileName)
+		targetDBFile := testutil.FilePathInsideTempDir(target)
+		reusableEmptyDB = InitTestDB(targetDBFile)
+	}
+	return reusableEmptyDB
+}


### PR DESCRIPTION
This is tier 3 of the #514 
Testing:
- `dcrsqlite/sqlite.go` `DB.RetrieveAllPoolValAndSize()`
- `dcrsqlite/sqlite.go` `DB.RetrieveBlockFeeInfo()`
