### PR TITLE
 dcrsqlite: test retrieve BlockHash, PoolInfo, SDiff, tier 9

### DIFF
--- a/db/dcrsqlite/blocksretrieval_test.go
+++ b/db/dcrsqlite/blocksretrieval_test.go
@@ -86,3 +86,36 @@ func TestEmptyDBGetStakeInfoHeight(t *testing.T) {
 			endHeight)
 	}
 }
+
+func TestEmptyDBRetrieveSDiff(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	checkEmptyDBRetrieveSDiff(db, 0)
+	checkEmptyDBRetrieveSDiff(db, 1)
+	checkEmptyDBRetrieveSDiff(db, 2)
+}
+
+func checkEmptyDBRetrieveSDiff(db *DB, i int64) {
+	_, err := db.RetrieveSDiff(i)
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveSDiff() failed: error expected")
+	}
+}
+
+func TestEmptyDBRetrieveBlockHash(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+
+	checkEmptyDBRetrieveBlockHash(db, 0)
+	checkEmptyDBRetrieveBlockHash(db, 1)
+	checkEmptyDBRetrieveBlockHash(db, 2)
+}
+
+func checkEmptyDBRetrieveBlockHash(db *DB, i int64) {
+	_, err := db.RetrieveBlockHash(i)
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockHash() failed: error expected")
+	}
+}

--- a/db/dcrsqlite/stakesretrieval_test.go
+++ b/db/dcrsqlite/stakesretrieval_test.go
@@ -90,3 +90,42 @@ func TestEmptyDBRetrieveLatestStakeInfoExtended(t *testing.T) {
 			result)
 	}
 }
+
+func TestEmptyDBRetrievePoolInfoByHash(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	result, err := db.RetrievePoolInfoByHash("")
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoByHash() failed: error expected")
+	}
+	if result == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoByHash() failed: default result expected, nil returned")
+	}
+	if len(result.Winners) != 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoByHash() failed: empty array expected\n%v",
+			testutil.ArrayToString("result.Winners", result.Winners))
+	}
+}
+
+func TestEmptyDBRetrievePoolInfo(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	result, err := db.RetrievePoolInfo(0)
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfo() failed: error expected")
+	}
+	if result == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfo() failed: default result expected," +
+				" nil returned")
+	}
+	if len(result.Winners) != 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfo() failed: empty array expected\n%v",
+			testutil.ArrayToString("result.Winners", result.Winners))
+	}
+}

--- a/db/dcrsqlite/stakesretrieval_test.go
+++ b/db/dcrsqlite/stakesretrieval_test.go
@@ -1,0 +1,92 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/testutil"
+)
+
+func TestEmptyDBRetrieveBlockHeight(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	height, err := db.RetrieveBlockHeight("")
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockHeight() failed: error expected")
+	}
+	if height != 0 {
+		testutil.ReportTestFailed(
+			"RetrieveBlockHeight() failed: height=%d, 0 expected",
+			height)
+	}
+}
+
+func TestEmptyDBRetrieveWinnersByHash(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	nullresult, zero, err := db.RetrieveWinnersByHash("")
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveWinnersByHash() failed: error expected")
+	}
+	if nullresult != nil {
+		testutil.ReportTestFailed(
+			"RetrieveWinnersByHash() failed: nil expected, %v returned",
+			nullresult)
+	}
+	if zero != 0 {
+		testutil.ReportTestFailed(
+			"RetrieveWinnersByHash() failed: 0 expected, %d returned",
+			zero)
+	}
+}
+
+func TestEmptyDBRetrieveWinners(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	nullresult, empty, err := db.RetrieveWinners(0)
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveWinners() failed: error expected")
+	}
+	if nullresult != nil {
+		testutil.ReportTestFailed(
+			"RetrieveWinners() failed: nil expected, %v returned",
+			nullresult)
+	}
+	if empty != "" {
+		testutil.ReportTestFailed(
+			"RetrieveWinners() failed: empty string expected, %v provided",
+			empty)
+	}
+}
+
+func TestEmptyDBRetrieveStakeInfoExtended(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	info, err := db.RetrieveStakeInfoExtended(0)
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveStakeInfoExtended() failed: error expected")
+	}
+	if info != nil {
+		testutil.ReportTestFailed(
+			"RetrieveStakeInfoExtended() failed: nil expected, %v returned",
+			info)
+	}
+}
+
+func TestEmptyDBRetrieveLatestStakeInfoExtended(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	result, err := db.RetrieveLatestStakeInfoExtended()
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveLatestStakeInfoExtended() failed: error expected")
+	}
+	if result != nil {
+		testutil.ReportTestFailed(
+			"RetrieveLatestStakeInfoExtended() failed: nil  expected, %v returned",
+			result)
+	}
+}


### PR DESCRIPTION
Testing:
- `dcrsqlite/sqlite.go` `DB.RetrieveBlockHash()`
- `dcrsqlite/sqlite.go` `DB.RetrievePoolInfo()`
- `dcrsqlite/sqlite.go` `DB.RetrievePoolInfoByHash()`
- `dcrsqlite/sqlite.go` `DB.RetrieveSDiff()`

Depends on the #567