### PR TITLE
dcrsqlite: test RetrievePoolValAndSizeRange, tier 10

### DIFF
--- a/db/dcrsqlite/retrieveblocksizerange_test.go
+++ b/db/dcrsqlite/retrieveblocksizerange_test.go
@@ -1,0 +1,101 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/testutil"
+)
+
+func TestEmptyDBRetrieveBlockSizeRange(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	// testing zero offset
+	{
+		checkEmptyDBRetrieveBlockSizeRangeSame(0, db)
+		checkEmptyDBRetrieveBlockSizeRangeSame(1, db)
+		checkEmptyDBRetrieveBlockSizeRangeSame(2, db)
+	}
+	// testing positive offset
+	{
+		checkEmptyDBRetrieveBlockSizeRangePlus(0, 0, db)
+		checkEmptyDBRetrieveBlockSizeRangePlus(1, 0, db)
+		checkEmptyDBRetrieveBlockSizeRangePlus(2, 0, db)
+
+		checkEmptyDBRetrieveBlockSizeRangePlus(0, 1, db)
+		checkEmptyDBRetrieveBlockSizeRangePlus(1, 1, db)
+
+		checkEmptyDBRetrieveBlockSizeRangePlus(0, 2, db)
+	}
+	// testing incorrect range (negative offset)
+	{
+		checkEmptyDBRetrieveBlockSizeRangeNegative(0, -1, db)
+		checkEmptyDBRetrieveBlockSizeRangeNegative(1, -1, db)
+		checkEmptyDBRetrieveBlockSizeRangeNegative(2, -1, db)
+
+		checkEmptyDBRetrieveBlockSizeRangeNegative(1, -2, db)
+		checkEmptyDBRetrieveBlockSizeRangeNegative(2, -2, db)
+
+		checkEmptyDBRetrieveBlockSizeRangeNegative(2, -3, db)
+	}
+}
+
+// checkEmptyDBRetrieveBlockSizeRangeSame calls RetrieveBlockSizeRange
+// on empty DB expecting empty result
+func checkEmptyDBRetrieveBlockSizeRangeSame(fromIndex int64, db *DB) {
+	arr, err := db.RetrieveBlockSizeRange(fromIndex, fromIndex-1)
+	// Should return []
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed: %v",
+			err)
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}
+
+// checkEmptyDBRetrieveBlockSizeRangeNegative calls RetrieveBlockSizeRange
+// on empty DB with incorrect input
+func checkEmptyDBRetrieveBlockSizeRangeNegative(from int64, negativeOffset int64, db *DB) {
+	if negativeOffset >= 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"negativeOffset must be below 0, %v passed",
+			negativeOffset)
+	}
+	to := from + negativeOffset - 1
+	arr, err := db.RetrieveBlockSizeRange(from, to)
+	// Should return "Cannot retrieve block size range [from > to]"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed: error expected")
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}
+
+// checkEmptyDBRetrieveBlockSizeRangePlus calls RetrieveBlockSizeRange
+// on empty DB for non-empty range
+func checkEmptyDBRetrieveBlockSizeRangePlus(from int64, positiveOffset int64, db *DB) {
+	if positiveOffset < 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"positiveOffset must be above or equal 0, %v passed",
+			positiveOffset)
+	}
+	to := from + positiveOffset
+	arr, err := db.RetrieveBlockSizeRange(from, to)
+	// Should return "Cannot retrieve block size range [from,to] have height -1"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed: error expected")
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveBlockSizeRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}

--- a/db/dcrsqlite/retrievepoolInforange_test.go
+++ b/db/dcrsqlite/retrievepoolInforange_test.go
@@ -1,0 +1,116 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/testutil"
+)
+
+func TestEmptyDBRetrievePoolInfoRange(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	// testing zero offset
+	{
+		checkEmptyDBRetrievePoolInfoRangeSame(0, db)
+		checkEmptyDBRetrievePoolInfoRangeSame(1, db)
+		checkEmptyDBRetrievePoolInfoRangeSame(2, db)
+	}
+	// testing positive offset
+	{
+		checkEmptyDBRetrievePoolInfoRangePlus(0, 0, db)
+		checkEmptyDBRetrievePoolInfoRangePlus(1, 0, db)
+		checkEmptyDBRetrievePoolInfoRangePlus(2, 0, db)
+
+		checkEmptyDBRetrievePoolInfoRangePlus(0, 1, db)
+		checkEmptyDBRetrievePoolInfoRangePlus(1, 1, db)
+
+		checkEmptyDBRetrievePoolInfoRangePlus(0, 2, db)
+	}
+	// testing incorrect range (negative offset)
+	{
+		checkEmptyDBRetrievePoolInfoRangeNegative(0, -1, db)
+		checkEmptyDBRetrievePoolInfoRangeNegative(1, -1, db)
+		checkEmptyDBRetrievePoolInfoRangeNegative(2, -1, db)
+
+		checkEmptyDBRetrievePoolInfoRangeNegative(1, -2, db)
+		checkEmptyDBRetrievePoolInfoRangeNegative(2, -2, db)
+
+		checkEmptyDBRetrievePoolInfoRangeNegative(2, -3, db)
+	}
+}
+
+// checkEmptyDBRetrievePoolInfoRangeSame calls RetrievePoolInfoRange
+// on empty DB expecting empty result
+func checkEmptyDBRetrievePoolInfoRangeSame(fromIndex int64, db *DB) {
+	values, sizes, err := db.RetrievePoolInfoRange(fromIndex, fromIndex-1)
+	// Should return [] []
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed: %v",
+			err)
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}
+
+// checkEmptyDBRetrievePoolInfoRangeNegative calls RetrievePoolInfoRange
+// on empty DB with incorrect input
+func checkEmptyDBRetrievePoolInfoRangeNegative(from int64, negativeOffset int64, db *DB) {
+	if negativeOffset >= 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"negativeOffset must be below 0, %v passed",
+			negativeOffset)
+	}
+	to := from + negativeOffset - 1
+	values, sizes, err := db.RetrievePoolInfoRange(from, to)
+	// Should return "Cannot retrieve block size range [from > to]"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed: error expected")
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}
+
+// checkEmptyDBRetrievePoolInfoRangePlus calls RetrievePoolInfoRange
+// on empty DB for non-empty range
+func checkEmptyDBRetrievePoolInfoRangePlus(from int64, positiveOffset int64, db *DB) {
+	if positiveOffset < 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"positiveOffset must be above or equal 0, %v passed",
+			positiveOffset)
+	}
+	to := from + positiveOffset
+	values, sizes, err := db.RetrievePoolInfoRange(from, to)
+	// Should return "Cannot retrieve block size range [from,to] have height -1"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed: error expected")
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolInfoRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}

--- a/db/dcrsqlite/retrievepoolvalandsizerange_test.go
+++ b/db/dcrsqlite/retrievepoolvalandsizerange_test.go
@@ -1,0 +1,116 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/testutil"
+)
+
+func TestEmptyDBRetrievePoolValAndSizeRange(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	// testing zero offset
+	{
+		checkEmptyDBRetrievePoolValAndSizeRangeSame(0, db)
+		checkEmptyDBRetrievePoolValAndSizeRangeSame(1, db)
+		checkEmptyDBRetrievePoolValAndSizeRangeSame(2, db)
+	}
+	// testing positive offset
+	{
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(0, 0, db)
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(1, 0, db)
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(2, 0, db)
+
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(0, 1, db)
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(1, 1, db)
+
+		checkEmptyDBRetrievePoolValAndSizeRangePlus(0, 2, db)
+	}
+	// testing incorrect range (negative offset)
+	{
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(0, -1, db)
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(1, -1, db)
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(2, -1, db)
+
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(1, -2, db)
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(2, -2, db)
+
+		checkEmptyDBRetrievePoolValAndSizeRangeNegative(2, -3, db)
+	}
+}
+
+// checkEmptyDBRetrievePoolValAndSizeRangeSame calls RetrievePoolValAndSizeRange
+// on empty DB expecting empty result
+func checkEmptyDBRetrievePoolValAndSizeRangeSame(fromIndex int64, db *DB) {
+	values, sizes, err := db.RetrievePoolValAndSizeRange(fromIndex, fromIndex-1)
+	// Should return [] []
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed: %v",
+			err)
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}
+
+// checkEmptyDBRetrievePoolValAndSizeRangeNegative calls RetrievePoolValAndSizeRange
+// on empty DB with incorrect input
+func checkEmptyDBRetrievePoolValAndSizeRangeNegative(from int64, negativeOffset int64, db *DB) {
+	if negativeOffset >= 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"negativeOffset must be below 0, %v passed",
+			negativeOffset)
+	}
+	to := from + negativeOffset - 1
+	values, sizes, err := db.RetrievePoolValAndSizeRange(from, to)
+	// Should return "Cannot retrieve block size range [from > to]"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed: error expected")
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}
+
+// checkEmptyDBRetrievePoolValAndSizeRangePlus calls RetrievePoolValAndSizeRange
+// on empty DB for non-empty range
+func checkEmptyDBRetrievePoolValAndSizeRangePlus(from int64, positiveOffset int64, db *DB) {
+	if positiveOffset < 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"positiveOffset must be above or equal 0, %v passed",
+			positiveOffset)
+	}
+	to := from + positiveOffset
+	values, sizes, err := db.RetrievePoolValAndSizeRange(from, to)
+	// Should return "Cannot retrieve block size range [from,to] have height -1"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed: error expected")
+	}
+	if len(values) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, values is not empty\n%v",
+			testutil.ArrayToString("values", values))
+	}
+	if len(sizes) > 0 {
+		testutil.ReportTestFailed(
+			"RetrievePoolValAndSizeRange() failed, sizes is not empty\n%v",
+			testutil.ArrayToString("sizes", sizes))
+	}
+}

--- a/db/dcrsqlite/retrievesdiffrange_test.go
+++ b/db/dcrsqlite/retrievesdiffrange_test.go
@@ -1,0 +1,101 @@
+package dcrsqlite
+
+import (
+	"testing"
+
+	"github.com/decred/dcrdata/testutil"
+)
+
+func TestEmptyDBRetrieveSDiffRange(t *testing.T) {
+	testutil.BindCurrentTestSetup(t)
+	db := ObtainReusableEmptyDB()
+	// testing zero offset
+	{
+		checkEmptyDBRetrieveSDiffRangeSame(0, db)
+		checkEmptyDBRetrieveSDiffRangeSame(1, db)
+		checkEmptyDBRetrieveSDiffRangeSame(2, db)
+	}
+	// testing positive offset
+	{
+		checkEmptyDBRetrieveSDiffRangePlus(0, 0, db)
+		checkEmptyDBRetrieveSDiffRangePlus(1, 0, db)
+		checkEmptyDBRetrieveSDiffRangePlus(2, 0, db)
+
+		checkEmptyDBRetrieveSDiffRangePlus(0, 1, db)
+		checkEmptyDBRetrieveSDiffRangePlus(1, 1, db)
+
+		checkEmptyDBRetrieveSDiffRangePlus(0, 2, db)
+	}
+	// testing incorrect range (negative offset)
+	{
+		checkEmptyDBRetrieveSDiffRangeNegative(0, -1, db)
+		checkEmptyDBRetrieveSDiffRangeNegative(1, -1, db)
+		checkEmptyDBRetrieveSDiffRangeNegative(2, -1, db)
+
+		checkEmptyDBRetrieveSDiffRangeNegative(1, -2, db)
+		checkEmptyDBRetrieveSDiffRangeNegative(2, -2, db)
+
+		checkEmptyDBRetrieveSDiffRangeNegative(2, -3, db)
+	}
+}
+
+// checkEmptyDBRetrieveSDiffRangeSame calls RetrieveSDiffRange
+// on empty DB expecting empty result
+func checkEmptyDBRetrieveSDiffRangeSame(fromIndex int64, db *DB) {
+	arr, err := db.RetrieveSDiffRange(fromIndex, fromIndex-1)
+	// Should return []
+	if err != nil {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed: %v",
+			err)
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}
+
+// checkEmptyDBRetrieveSDiffRangeNegative calls RetrieveSDiffRange
+// on empty DB with incorrect input
+func checkEmptyDBRetrieveSDiffRangeNegative(from int64, negativeOffset int64, db *DB) {
+	if negativeOffset >= 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"negativeOffset must be below 0, %v passed",
+			negativeOffset)
+	}
+	to := from + negativeOffset - 1
+	arr, err := db.RetrieveSDiffRange(from, to)
+	// Should return "Cannot retrieve block size range [from > to]"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed: error expected")
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}
+
+// checkEmptyDBRetrieveSDiffRangePlus calls RetrieveSDiffRange
+// on empty DB for non-empty range
+func checkEmptyDBRetrieveSDiffRangePlus(from int64, positiveOffset int64, db *DB) {
+	if positiveOffset < 0 {
+		testutil.ReportTestIsNotAbleToTest(
+			"positiveOffset must be above or equal 0, %v passed",
+			positiveOffset)
+	}
+	to := from + positiveOffset
+	arr, err := db.RetrieveSDiffRange(from, to)
+	// Should return "Cannot retrieve block size range [from,to] have height -1"
+	if err == nil {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed: error expected")
+	}
+	if len(arr) > 0 {
+		testutil.ReportTestFailed(
+			"RetrieveSDiffRange() failed, array is not empty\n%v",
+			testutil.ArrayToString("array", arr))
+	}
+}


### PR DESCRIPTION
This is tier 10 of the #514 
Testing:
- `dcrsqlite/sqlite.go` `DB.RetrievePoolValAndSizeRange()`

Waiting for #566, #564 and #568