### PR TITLE
config: add --sync-and-quit flag to only sync

### DIFF
--- a/config.go
+++ b/config.go
@@ -100,6 +100,7 @@ type config struct {
 	PGPass        string `long:"pgpass" description:"PostgreSQL DB password."`
 	PGHost        string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
 	NoDevPrefetch bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
+	SyncAndQuit   bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API."`
 
 	// WatchAddresses []string `short:"w" long:"watchaddress" description:"Watched address (receiving). One per line."`
 	// SMTPUser     string `long:"smtpuser" description:"SMTP user name"`

--- a/main.go
+++ b/main.go
@@ -366,6 +366,10 @@ func mainCore() error {
 	}
 	log.Infof("All ready, at height %d.", baseDBHeight)
 
+	if cfg.SyncAndQuit {
+		return nil
+	}
+
 	// Register for notifications from dcrd
 	cerr := notify.RegisterNodeNtfnHandlers(dcrdClient)
 	if cerr != nil {


### PR DESCRIPTION
This adds the flag `--sync-and-quit` to the dcrdata executable that will caus dcrdata to sync to the best block and then exit.  It will not start the explorer or API.