### PR TITLE
reproduce unknown ticket ... spent in block 

### DIFF
--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -473,6 +473,10 @@ func (db *StakeDatabase) ConnectBlockHash(hash *chainhash.Hash) (*dcrutil.Block,
 // tickets from the input block, and any maturing tickets from the past block in
 // which those tickets would be found, and passes them to connectBlock.
 func (db *StakeDatabase) ConnectBlock(block *dcrutil.Block) error {
+	block.Bytes() // serialize block
+
+	fmt.Println("ConnectBlock:", block.MsgBlock().Header.Height)
+
 	height := block.Height()
 	maturingHeight := height - int64(db.params.TicketMaturity)
 


### PR DESCRIPTION
This helps to reproduce the #575.
Steps:
1) Clear the data folder of the `dcrdata`  (`~/.dcrdata` in unix and `C:\Users\$usename$\AppData\Local\Dcrdata` in windows)
2) Start the `dcrdata` and wait for syncing.

Should crash with:

```
ConnectBlock: %v 4093
ConnectBlock: %v 4094
ConnectBlock: %v 4095
ConnectBlock: %v 4096
2018-07-27 12:13:18.239 [INF] SQLT: resyncDBWithPoolValue() completed in 1m59.2488589s
2018-07-27 12:13:18.239 [INF] DATD: SQLite sync ended at height 4095
2018-07-27 12:13:18.239 [INF] DATD: PostgreSQL sync ended at height -1
2018-07-27 12:13:18.239 [ERR] DATD: dcrsqlite.SyncDBAsync failed at height 4095.
2018-07-27 12:13:18.239 [INF] EXPR: Stopping mempool monitor
2018-07-27 12:13:18.239 [INF] EXPR: Stopping websocket hub.
2018-07-27 12:13:18.239 [ERR] EXPR: Do not send on stopPing channel, only close it.
2018-07-27 12:13:18.771 [INF] DATD: Closing connection to dcrd.
2018-07-27 12:13:18.771 [INF] DATD: Bye!
2018-07-27 12:13:19.032 [ERR] DATD: unknown ticket a10547a4bcb59914e85d747a1acb971f2f989b9a0600ec5c4d60d6a58a679dc8 spent in block

```

I have reproduced it only on Win machine.