### PR TITLE
dcrpg: reorg handling

### DIFF
--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -181,7 +181,12 @@ out:
 			// Store block data with each saver
 			savers := p.dataSavers
 			if reorg {
-				savers = p.reorgDataSavers
+				// This check should be redundant with check above.
+				if reorgData.NewChainHead.IsEqual(hash) {
+					savers = p.reorgDataSavers
+				} else {
+					savers = nil
+				}
 			}
 			for _, s := range savers {
 				if s != nil {

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -204,7 +204,9 @@ out:
 
 }
 
-// ReorgHandler receives notification of a chain reorganization
+// ReorgHandler receives notification of a chain reorganization. A
+// reorganization is handled in blockdata by setting the reorganizing flag so
+// that block data is not collected as the new chain is connected.
 func (p *chainMonitor) ReorgHandler() {
 	defer p.wg.Done()
 out:

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -126,6 +126,7 @@ out:
 			// Reorg is complete
 			p.sideChain = nil
 			p.reorganizing = false
+			p.db.InReorg = false
 			log.Infof("Reorganization to block %v (height %d) complete",
 				p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
 
@@ -274,6 +275,7 @@ out:
 			}
 
 			// This is the primary action of this handler.
+			p.db.InReorg = true
 			p.reorganizing = true
 			p.reorgData = reorgData
 			p.Unlock()

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -93,47 +93,40 @@ out:
 			// If reorganizing, the block will first go to a side chain
 			reorg, reorgData := p.reorganizing, p.reorgData
 
-			if reorg {
-				p.sideChain = append(p.sideChain, *hash)
-				log.Infof("Adding block %v to sidechain", *hash)
-
-				// Just append to side chain until the new main chain tip block is reached
-				if reorgData.NewChainHead != *hash {
-					release()
-					break keepon
-				}
-
-				// Once all blocks in side chain are lined up, switch over
-				log.Info("Switching to side chain...")
-				newHeight, newHash, err := p.switchToSideChain()
-				if err != nil {
-					panic(err)
-				}
-
-				if p.reorgData.NewChainHead != *newHash ||
-					p.reorgData.NewChainHeight != newHeight {
-					panic(fmt.Sprintf("Failed to reorg to %v. Got to %v (height %d) instead.",
-						p.reorgData.NewChainHead, newHash, newHeight))
-				}
-
-				// Reorg is complete
-				p.sideChain = nil
-				p.reorganizing = false
-				log.Infof("Reorganization to block %v (height %d) complete",
-					p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
-			} else {
-				// No action unless in reorg
-
-				// Extend main chain
-				// block, err := p.db.ConnectBlockHash(hash)
-				// if err != nil {
-				// 	release()
-				// 	log.Error(err)
-				// 	break keepon
-				// }
-
-				//log.Infof("Connected block %d to stake DB.", block.Height())
+			// Otherwise this handler does nothing.
+			if !reorg {
+				release()
+				break keepon
 			}
+
+			p.sideChain = append(p.sideChain, *hash)
+			log.Infof("Adding block %v to sidechain", *hash)
+
+			// Just append to side chain until the new main chain tip block is reached
+			if reorgData.NewChainHead != *hash {
+				release()
+				break keepon
+			}
+
+			// Once all blocks in side chain are lined up, switch over
+			log.Info("Switching to side chain...")
+			newHeight, newHash, err := p.switchToSideChain()
+			if err != nil {
+				panic(err)
+			}
+
+			// Verify the hash of the new main chain tip is as expected.
+			if p.reorgData.NewChainHead != *newHash ||
+				p.reorgData.NewChainHeight != newHeight {
+				panic(fmt.Sprintf("Failed to reorg to %v. Got to %v (height %d) instead.",
+					p.reorgData.NewChainHead, newHash, newHeight))
+			}
+
+			// Reorg is complete
+			p.sideChain = nil
+			p.reorganizing = false
+			log.Infof("Reorganization to block %v (height %d) complete",
+				p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
 
 			release()
 
@@ -162,7 +155,8 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 	}
 	block := dcrutil.NewBlock(msgBlock)
 
-	prevMsgBlock, err := p.db.Client.GetBlock(&msgBlock.Header.PrevBlock)
+	mainRootHash := msgBlock.Header.PrevBlock
+	prevMsgBlock, err := p.db.Client.GetBlock(&mainRootHash)
 	if err != nil {
 		return 0, nil, fmt.Errorf("unable to get common ancestor on side chain")
 	}
@@ -173,12 +167,17 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 		panic("Failed to determine common ancestor.")
 	}
 
+	// Flag blocks from mainRoot+1 to mainTip as is_mainchain=false
 	mainTip := int64(p.db.Height())
+	mainRoot := mainRootHash.String()
+	log.Infof("Moving %d blocks to side chain...", mainTip-commonAncestorHeight)
+	newMainRoot, numBlocksmoved, err := p.db.TipToSideChain(mainRoot)
+	if err != nil || mainRoot != newMainRoot {
+		return 0, nil, fmt.Errorf("failed to flag blocks as side chain")
+	}
+	log.Infof("Moved %d blocks to side chain.", numBlocksmoved)
 
-	// TODO flag side chain blocks as is_mainchain=false
-	log.Debugf("Disconnecting %d blocks", mainTip-commonAncestorHeight)
-	// TODO
-
+	// Verify the tip is now the previous common ancestor
 	mainTip = int64(p.db.Height())
 	if mainTip != commonAncestorHeight {
 		panic(fmt.Sprintf("disconnect blocks failed: tip height %d, expected %d",
@@ -187,31 +186,57 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 
 	// Connect blocks in side chain onto main chain
 	log.Debugf("Connecting %d blocks", len(p.sideChain))
+	currentHeight := commonAncestorHeight + 1
 	for i := range p.sideChain {
-		// TODO
-		log.Infof("dcrpg sidechain block: %d", i)
+		// Try to find block in stakedb cache
+		block, found := p.db.stakeDB.BlockCached(currentHeight)
+		if found {
+			msgBlock = block.MsgBlock()
+		}
+		// Fetch the block by RPC if not found or wrong hash
+		if !found || msgBlock.BlockHash() != p.sideChain[i] {
+			log.Debugf("block %v not found in stakedb cache, fetching from dcrd", p.sideChain[i])
+			// Request MsgBlock from dcrd
+			msgBlock, err = p.db.Client.GetBlock(&p.sideChain[i])
+			if err != nil {
+				return 0, nil, fmt.Errorf("unable to get side chain block %v", p.sideChain[i])
+			}
+		}
 
-		// if block, err = p.db.ConnectBlockHash(&p.sideChain[i]); err != nil {
-		// 	mainTip = int64(p.db.Height())
-		// 	currentBlockHdr, _ := p.db.DBTipBlockHeader()
-		// 	currentBlockHash := currentBlockHdr.BlockHash()
-		// 	return int32(mainTip), &currentBlockHash,
-		// 		fmt.Errorf("error connecting block %v", p.sideChain[i])
-		// }
-		// log.Infof("Connected block %v (height %d) from side chain.",
-		// 	block.Hash(), block.Height())
+		// Get current winning votes from stakedb
+		tpi, found := p.db.stakeDB.PoolInfo(p.sideChain[i])
+		if !found {
+			return 0, nil, fmt.Errorf("stakedb.PoolInfo failed to return info for: %v", p.sideChain[i])
+		}
+		winners := tpi.Winners
+
+		// New blocks stored this way are considered part of mainchain. They are
+		// also considered valid unless invalidated by the next block
+		// (invalidation of previous handled inside StoreBlock).
+		isValid, isMainChain := true, true
+		_, _, err := p.db.StoreBlock(msgBlock, winners, isValid, isMainChain, true, true)
+		if err != nil {
+			return int32(p.db.Height()), p.db.Hash(),
+				fmt.Errorf("error connecting block %v", p.sideChain[i])
+		}
+
+		log.Infof("Connected block %v (height %d) from side chain.",
+			msgBlock.BlockHash(), msgBlock.Header.Height)
+
+		currentHeight++
 	}
 
 	mainTip = int64(p.db.Height())
-	if mainTip != block.Height() {
+	if mainTip != int64(msgBlock.Header.Height) {
 		panic("connected block height not db tip height")
 	}
 
-	return int32(mainTip), block.Hash(), nil
+	blockHash := msgBlock.BlockHash()
+	return int32(mainTip), &blockHash, nil
 }
 
 // ReorgHandler receives notification of a chain reorganization and initiates a
-// corresponding reorganization of the stakedb.StakeDatabase.
+// corresponding reorganization of the ChainDB.
 func (p *ChainMonitor) ReorgHandler() {
 	defer p.wg.Done()
 out:
@@ -237,6 +262,7 @@ out:
 				break keepon
 			}
 
+			// This is the primary action of this handler.
 			p.reorganizing = true
 			p.reorgData = reorgData
 			p.Unlock()

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
+package dcrpg
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil"
+)
+
+// ReorgData contains the information from a reoranization notification.
+type ReorgData struct {
+	OldChainHead   chainhash.Hash
+	OldChainHeight int32
+	NewChainHead   chainhash.Hash
+	NewChainHeight int32
+	WG             *sync.WaitGroup
+}
+
+// ChainMonitor responds to block connection and chain reorganization.
+type ChainMonitor struct {
+	db             *ChainDBRPC
+	quit           chan struct{}
+	wg             *sync.WaitGroup
+	blockChan      chan *chainhash.Hash
+	reorgChan      chan *ReorgData
+	syncConnect    sync.Mutex
+	ConnectingLock chan struct{}
+	DoneConnecting chan struct{}
+
+	// reorg handling
+	sync.Mutex
+	reorgData    *ReorgData
+	sideChain    []chainhash.Hash
+	reorganizing bool
+}
+
+// NewChainMonitor creates a new ChainMonitor.
+func (db *ChainDBRPC) NewChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
+	blockChan chan *chainhash.Hash, reorgChan chan *ReorgData) *ChainMonitor {
+	return &ChainMonitor{
+		db:             db,
+		quit:           quit,
+		wg:             wg,
+		blockChan:      blockChan,
+		reorgChan:      reorgChan,
+		ConnectingLock: make(chan struct{}, 1),
+		DoneConnecting: make(chan struct{}),
+	}
+}
+
+// BlockConnectedSync is the synchronous (blocking call) handler for the newly
+// connected block given by the hash.
+func (p *ChainMonitor) BlockConnectedSync(hash *chainhash.Hash) {
+	// Connections go one at a time so signals cannot be mixed
+	p.syncConnect.Lock()
+	defer p.syncConnect.Unlock()
+	// lock with buffered channel, accepting handoff in BlockConnectedHandler
+	p.ConnectingLock <- struct{}{}
+	p.blockChan <- hash
+	// wait
+	<-p.DoneConnecting
+}
+
+// BlockConnectedHandler handles block connected notifications, which trigger
+// data collection and storage.
+func (p *ChainMonitor) BlockConnectedHandler() {
+	defer p.wg.Done()
+out:
+	for {
+	keepon:
+		select {
+		case hash, ok := <-p.blockChan:
+			p.Lock()
+			release := func() { p.Unlock() }
+			select {
+			case <-p.ConnectingLock:
+				// send on unbuffered channel
+				release = func() { p.Unlock(); p.DoneConnecting <- struct{}{} }
+			default:
+			}
+
+			if !ok {
+				log.Warnf("Block connected channel closed.")
+				release()
+				break out
+			}
+
+			// If reorganizing, the block will first go to a side chain
+			reorg, reorgData := p.reorganizing, p.reorgData
+
+			if reorg {
+				p.sideChain = append(p.sideChain, *hash)
+				log.Infof("Adding block %v to sidechain", *hash)
+
+				// Just append to side chain until the new main chain tip block is reached
+				if reorgData.NewChainHead != *hash {
+					release()
+					break keepon
+				}
+
+				// Once all blocks in side chain are lined up, switch over
+				log.Info("Switching to side chain...")
+				newHeight, newHash, err := p.switchToSideChain()
+				if err != nil {
+					panic(err)
+				}
+
+				if p.reorgData.NewChainHead != *newHash ||
+					p.reorgData.NewChainHeight != newHeight {
+					panic(fmt.Sprintf("Failed to reorg to %v. Got to %v (height %d) instead.",
+						p.reorgData.NewChainHead, newHash, newHeight))
+				}
+
+				// Reorg is complete
+				p.sideChain = nil
+				p.reorganizing = false
+				log.Infof("Reorganization to block %v (height %d) complete",
+					p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
+			} else {
+				// No action unless in reorg
+
+				// Extend main chain
+				// block, err := p.db.ConnectBlockHash(hash)
+				// if err != nil {
+				// 	release()
+				// 	log.Error(err)
+				// 	break keepon
+				// }
+
+				//log.Infof("Connected block %d to stake DB.", block.Height())
+			}
+
+			release()
+
+		case _, ok := <-p.quit:
+			if !ok {
+				log.Debugf("Got quit signal. Exiting block connected handler.")
+				break out
+			}
+		}
+	}
+
+}
+
+// switchToSideChain attempts to switch to a new side chain by: determining a
+// common ancestor block, flagging elements of the old main chain as
+// is_mainchain, and connecting the side chain blocks onto the mainchain.
+func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
+	if len(p.sideChain) == 0 {
+		return 0, nil, fmt.Errorf("no side chain")
+	}
+
+	// Determine highest common ancestor of side chain and main chain
+	msgBlock, err := p.db.Client.GetBlock(&p.sideChain[0])
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to get block at root of side chain")
+	}
+	block := dcrutil.NewBlock(msgBlock)
+
+	prevMsgBlock, err := p.db.Client.GetBlock(&msgBlock.Header.PrevBlock)
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to get common ancestor on side chain")
+	}
+	prevBlock := dcrutil.NewBlock(prevMsgBlock)
+
+	commonAncestorHeight := block.Height() - 1
+	if prevBlock.Height() != commonAncestorHeight {
+		panic("Failed to determine common ancestor.")
+	}
+
+	mainTip := int64(p.db.Height())
+
+	// TODO flag side chain blocks as is_mainchain=false
+	log.Debugf("Disconnecting %d blocks", mainTip-commonAncestorHeight)
+	// TODO
+
+	mainTip = int64(p.db.Height())
+	if mainTip != commonAncestorHeight {
+		panic(fmt.Sprintf("disconnect blocks failed: tip height %d, expected %d",
+			mainTip, commonAncestorHeight))
+	}
+
+	// Connect blocks in side chain onto main chain
+	log.Debugf("Connecting %d blocks", len(p.sideChain))
+	for i := range p.sideChain {
+		// TODO
+		log.Infof("dcrpg sidechain block: %d", i)
+
+		// if block, err = p.db.ConnectBlockHash(&p.sideChain[i]); err != nil {
+		// 	mainTip = int64(p.db.Height())
+		// 	currentBlockHdr, _ := p.db.DBTipBlockHeader()
+		// 	currentBlockHash := currentBlockHdr.BlockHash()
+		// 	return int32(mainTip), &currentBlockHash,
+		// 		fmt.Errorf("error connecting block %v", p.sideChain[i])
+		// }
+		// log.Infof("Connected block %v (height %d) from side chain.",
+		// 	block.Hash(), block.Height())
+	}
+
+	mainTip = int64(p.db.Height())
+	if mainTip != block.Height() {
+		panic("connected block height not db tip height")
+	}
+
+	return int32(mainTip), block.Hash(), nil
+}
+
+// ReorgHandler receives notification of a chain reorganization and initiates a
+// corresponding reorganization of the stakedb.StakeDatabase.
+func (p *ChainMonitor) ReorgHandler() {
+	defer p.wg.Done()
+out:
+	for {
+	keepon:
+		select {
+		case reorgData, ok := <-p.reorgChan:
+			p.Lock()
+			if !ok {
+				p.Unlock()
+				log.Warnf("Reorg channel closed.")
+				break out
+			}
+
+			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
+			newHash, oldHash := reorgData.NewChainHead, reorgData.OldChainHead
+
+			if p.reorganizing {
+				log.Errorf("Reorg notified for chain tip %v (height %v), but already "+
+					"processing a reorg to block %v", newHash, newHeight,
+					p.reorgData.NewChainHead)
+				p.Unlock()
+				break keepon
+			}
+
+			p.reorganizing = true
+			p.reorgData = reorgData
+			p.Unlock()
+
+			log.Infof("Reorganize started. NEW head block %v at height %d.",
+				newHash, newHeight)
+			log.Infof("Reorganize started. OLD head block %v at height %d.",
+				oldHash, oldHeight)
+
+			reorgData.WG.Done()
+
+		case _, ok := <-p.quit:
+			if !ok {
+				log.Debugf("Got quit signal. Exiting reorg notification handler.")
+				break out
+			}
+		}
+	}
+}

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 )
 
-// ReorgData contains the information from a reoranization notification.
+// ReorgData contains the information from a reorganization notification.
 type ReorgData struct {
 	OldChainHead   chainhash.Hash
 	OldChainHeight int32

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -42,13 +42,13 @@ func (pgb *ChainDB) GetHeight() int {
 
 // SendRawTransaction attempts to decode the input serialized transaction,
 // passed as hex encoded string, and broadcast it, returning the tx hash.
-func (db *ChainDBRPC) SendRawTransaction(txhex string) (string, error) {
+func (pgb *ChainDBRPC) SendRawTransaction(txhex string) (string, error) {
 	msg, err := txhelpers.MsgTxFromHex(txhex)
 	if err != nil {
 		log.Errorf("SendRawTransaction failed: could not decode hex")
 		return "", err
 	}
-	hash, err := db.Client.SendRawTransaction(msg, true)
+	hash, err := pgb.Client.SendRawTransaction(msg, true)
 	if err != nil {
 		log.Errorf("SendRawTransaction failed: %v", err)
 		return "", err
@@ -113,7 +113,7 @@ func (pgb *ChainDBRPC) GetTransactionHex(txid string) string {
 // GetBlockVerboseByHash returns a *dcrjson.GetBlockVerboseResult for the
 // specified block hash, optionally with transaction details.
 func (pgb *ChainDBRPC) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult {
-	return rpcutils.GetBlockVerboseByHash(pgb.Client, pgb.ChainDB.chainParams,
+	return rpcutils.GetBlockVerboseByHash(pgb.Client, pgb.chainParams,
 		hash, verboseTx)
 }
 
@@ -121,7 +121,7 @@ func (pgb *ChainDBRPC) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjs
 // block with the specified hash.
 func (pgb *ChainDBRPC) GetTransactionsForBlockByHash(hash string) *apitypes.BlockTransactions {
 	blockVerbose := rpcutils.GetBlockVerboseByHash(
-		pgb.Client, pgb.ChainDB.chainParams, hash, false)
+		pgb.Client, pgb.chainParams, hash, false)
 
 	return makeBlockTransactions(blockVerbose)
 }

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -100,6 +100,12 @@ const (
 	SetAddressFundingForMatchingTxHash = `UPDATE addresses SET matching_tx_hash=$1 
 		WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
 
+	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1 
+		WHERE is_funding = true and tx_vin_vout_index=$2;`
+
+	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1 
+		WHERE is_funding = false and tx_vin_vout_index=$2;`
+
 	UpdateValidMainchainFromTransactions = `UPDATE addresses
 		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean
 		FROM transactions AS tr

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -46,6 +46,7 @@ const (
 		FROM addresses LEFT JOIN transactions AS ftxd ON funding_tx_row_id=ftxd.id 
 		WHERE address = $1 ORDER BY tx_time desc;`
 
+	// WTF?
 	SelectAddressesTxnByFundingTx = `SELECT tx_vin_vout_index, tx_hash, tx_vin_vout_index, block_height
 		FROM addresses
 		LEFT JOIN transactions ON transactions.tx_hash=tx_hash AND is_funding = FALSE
@@ -91,8 +92,8 @@ const (
 		FROM addresses WHERE address=$1 AND is_funding = TRUE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
-	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses WHERE tx_hash=$1, 
-        tx_vin_vout_index=$2 and is_funding = TRUE ORDER BY block_time DESC;`
+	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses WHERE tx_hash=$1 AND 
+		tx_vin_vout_index=$2 and is_funding = TRUE ORDER BY block_time DESC;`
 
 	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses WHERE address=$1 and 
 	    tx_vin_vout_row_id=$2 and is_funding = true;`
@@ -101,10 +102,10 @@ const (
 		WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
 
 	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1 
-		WHERE is_funding = true and tx_vin_vout_index=$2;`
+		WHERE is_funding = true and tx_vin_vout_row_id=$2;`
 
 	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1 
-		WHERE is_funding = false and tx_vin_vout_index=$2;`
+		WHERE is_funding = false and tx_vin_vout_row_id=$2;`
 
 	UpdateValidMainchainFromTransactions = `UPDATE addresses
 		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -18,7 +18,7 @@ const (
 		SELECT id FROM inserting
 		UNION  ALL
 		SELECT id FROM addresses
-		WHERE  address = $1, is_funding = true 
+		WHERE  address = $1, is_funding = TRUE 
 		AND tx_vin_vout_row_id = $5
 		LIMIT  1;`
 
@@ -46,20 +46,20 @@ const (
 		FROM addresses LEFT JOIN transactions AS ftxd ON funding_tx_row_id=ftxd.id 
 		WHERE address = $1 ORDER BY tx_time desc;`
 
-	// WTF?
+	// WTF? (select by funding tx then is funding is false???)
 	SelectAddressesTxnByFundingTx = `SELECT tx_vin_vout_index, tx_hash, tx_vin_vout_index, block_height
 		FROM addresses
 		LEFT JOIN transactions ON transactions.tx_hash=tx_hash AND is_funding = FALSE
 		WHERE address = $1 AND tx_hash=$2;`
 
-	SelectAddressUnspentCountAndValue = `SELECT COUNT(*), SUM(value) FROM addresses 
-	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = true;`
+	SelectAddressUnspentCountANDValue = `SELECT COUNT(*), SUM(value) FROM addresses 
+	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = TRUE;`
 
-	SelectAddressSpentCountAndValue = `SELECT COUNT(*), SUM(value) FROM addresses 
-	    WHERE address = $1 AND is_funding = FALSE AND matching_tx_hash != '' AND valid_mainchain = true;`
+	SelectAddressSpentCountANDValue = `SELECT COUNT(*), SUM(value) FROM addresses 
+	    WHERE address = $1 AND is_funding = FALSE AND matching_tx_hash != '' AND valid_mainchain = TRUE;`
 
 	SelectAddressesMergedSpentCount = `SELECT COUNT( distinct tx_hash ) FROM addresses
-		WHERE address = $1 and is_funding = false`
+		WHERE address = $1 AND is_funding = FALSE`
 
 	SelectAddressUnspentWithTxn = `SELECT addresses.address, addresses.tx_hash, addresses.value,
 			transactions.block_height, addresses.block_time, tx_vin_vout_index, pkscript
@@ -67,7 +67,7 @@ const (
 		JOIN transactions ON 
 			addresses.tx_hash = transactions.tx_hash
 		JOIN vouts on addresses.tx_hash = vouts.tx_hash AND addresses.tx_vin_vout_index=vouts.tx_index
-			WHERE addresses.address=$1 AND addresses.is_funding = FALSE AND valid_mainchain = true
+			WHERE addresses.address=$1 AND addresses.is_funding = FALSE AND valid_mainchain = TRUE
 			ORDER BY addresses.block_time DESC;`
 
 	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, valid_mainchain, 
@@ -93,19 +93,19 @@ const (
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses WHERE tx_hash=$1 AND 
-		tx_vin_vout_index=$2 and is_funding = TRUE ORDER BY block_time DESC;`
+		tx_vin_vout_index=$2 AND is_funding = TRUE ORDER BY block_time DESC;`
 
-	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses WHERE address=$1 and 
-	    tx_vin_vout_row_id=$2 and is_funding = true;`
+	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses WHERE address=$1 AND 
+	    tx_vin_vout_row_id=$2 AND is_funding = TRUE;`
 
 	SetAddressFundingForMatchingTxHash = `UPDATE addresses SET matching_tx_hash=$1 
-		WHERE tx_hash=$2 and is_funding = true and tx_vin_vout_index=$3;`
+		WHERE tx_hash=$2 AND is_funding = TRUE AND tx_vin_vout_index=$3;`
 
 	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1 
-		WHERE is_funding = true and tx_vin_vout_row_id=$2;`
+		WHERE is_funding = TRUE AND tx_vin_vout_row_id=$2;`
 
 	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1 
-		WHERE is_funding = false and tx_vin_vout_row_id=$2;`
+		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2;`
 
 	UpdateValidMainchainFromTransactions = `UPDATE addresses
 		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -41,7 +41,7 @@ const (
 		);`
 
 	SelectAddressAllByAddress = `SELECT * FROM addresses WHERE address=$1 ORDER BY block_time DESC;`
-	SelectAddressRecvCount    = `SELECT COUNT(*) FROM addresses WHERE address=$1;`
+	SelectAddressRecvCount    = `SELECT COUNT(*) FROM addresses WHERE address=$1 AND valid_mainchain = TRUE;`
 	SelectAddressesAllTxn     = `SELECT tx_hash, block_time AS tx_time, ftxd.block_height AS height 
 		FROM addresses LEFT JOIN transactions AS ftxd ON funding_tx_row_id=ftxd.id 
 		WHERE address = $1 ORDER BY tx_time desc;`
@@ -59,7 +59,7 @@ const (
 	    WHERE address = $1 AND is_funding = FALSE AND matching_tx_hash != '' AND valid_mainchain = TRUE;`
 
 	SelectAddressesMergedSpentCount = `SELECT COUNT( distinct tx_hash ) FROM addresses
-		WHERE address = $1 AND is_funding = FALSE`
+		WHERE address = $1 AND is_funding = FALSE AND valid_mainchain = TRUE;`
 
 	SelectAddressUnspentWithTxn = `SELECT addresses.address, addresses.tx_hash, addresses.value,
 			transactions.block_height, addresses.block_time, tx_vin_vout_index, pkscript
@@ -74,22 +74,22 @@ const (
 		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
-	    WHERE address=$1 ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+	    WHERE address=$1 AND valid_mainchain = TRUE ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
-	SelectAddressLimitNByAddressSubQry = `WITH these as (SELECT ` + addrsColumnNames +
-		` FROM addresses WHERE address=$1)
-		SELECT * FROM these order by block_time desc limit $2 offset $3;`
+	SelectAddressLimitNByAddressSubQry = `WITH these AS (SELECT ` + addrsColumnNames +
+		` FROM addresses WHERE address=$1 AND valid_mainchain = TRUE)
+		SELECT * FROM these ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressMergedDebitView = `SELECT tx_hash, valid_mainchain, block_time, sum(value), 
 		COUNT(*) FROM addresses WHERE address=$1 AND is_funding = FALSE 
 		GROUP BY (tx_hash, valid_mainchain, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
-		FROM addresses WHERE address=$1 AND is_funding = FALSE
+		FROM addresses WHERE address=$1 AND is_funding = FALSE AND valid_mainchain = TRUE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressCreditsLimitNByAddress = `SELECT ` + addrsColumnNames + `
-		FROM addresses WHERE address=$1 AND is_funding = TRUE
+		FROM addresses WHERE address=$1 AND is_funding = TRUE AND valid_mainchain = TRUE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses WHERE tx_hash=$1 AND 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -8,7 +8,7 @@ const (
 	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
 
 	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE 
-		SET address = $1, tx_vin_vout_row_id = $5 RETURNING id;`
+		SET block_time = $7, valid_mainchain = $9 RETURNING id;`
 	InsertAddressRowReturnID = `WITH inserting AS (` +
 		insertAddressRow0 +
 		`ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -80,9 +80,9 @@ const (
 		` FROM addresses WHERE address=$1)
 		SELECT * FROM these order by block_time desc limit $2 offset $3;`
 
-	SelectAddressMergedDebitView = `SELECT tx_hash, block_time, sum(value), 
+	SelectAddressMergedDebitView = `SELECT tx_hash, valid_mainchain, block_time, sum(value), 
 		COUNT(*) FROM addresses WHERE address=$1 AND is_funding = FALSE 
-		GROUP BY (tx_hash, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		GROUP BY (tx_hash, valid_mainchain, block_time) ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
 		FROM addresses WHERE address=$1 AND is_funding = FALSE

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -45,7 +45,7 @@ const (
 		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
 	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx
 		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC;`
-	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1;`
+	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
 	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
 
 	CreateBlockTable = `CREATE TABLE IF NOT EXISTS blocks (  
@@ -86,7 +86,7 @@ const (
 	DeindexBlockTableOnHash = `DROP INDEX uix_block_hash;`
 
 	RetrieveBestBlock       = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
-	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks ORDER BY height DESC LIMIT 1;`
+	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks WHERE is_mainchain = true ORDER BY height DESC LIMIT 1;`
 
 	// SelectBlocksTicketsPrice selects the ticket price and difficulty for the first block in a stake difficulty window.
 	SelectBlocksTicketsPrice = `SELECT sbits, time, difficulty FROM blocks WHERE height % $1 = 0 ORDER BY time;`

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -26,7 +26,7 @@ const (
 	insertBlockRow = insertBlockRow0 + `RETURNING id;`
 	// insertBlockRowChecked  = insertBlockRow0 + `ON CONFLICT (hash) DO NOTHING RETURNING id;`
 	upsertBlockRow = insertBlockRow0 + `ON CONFLICT (hash) DO UPDATE 
-		SET hash = $1 RETURNING id;`
+		SET is_valid = $4, is_mainchain = $5 RETURNING id;`
 	insertBlockRowReturnId = `WITH ins AS (` +
 		insertBlockRow0 +
 		`ON CONFLICT (hash) DO UPDATE

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -54,9 +54,9 @@ const (
 	SelectTicketsForAddress      = `SELECT * FROM tickets WHERE stakesubmission_address = $1;`
 	SelectTicketsForPriceAtLeast = `SELECT * FROM tickets WHERE price >= $1;`
 	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
-	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1;`
-	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1 AND is;`
-	SelectTicketStatusByHash     = `SELECT id, spend_type, pool_status FROM tickets WHERE tx_hash = $1;`
+	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1 ORDER BY is_mainchain DESC;`
+	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1 ORDER BY is_mainchain DESC;`
+	SelectTicketStatusByHash     = `SELECT id, spend_type, pool_status FROM tickets WHERE tx_hash = $1 ORDER BY is_mainchain DESC;`
 	SelectUnspentTickets         = `SELECT id, tx_hash FROM tickets WHERE spend_type = 0 OR spend_type = -1
 		AND is_mainchain = true;`
 

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -17,6 +17,7 @@ const (
 		fee FLOAT8,
 		spend_type INT2,
 		pool_status INT2,
+		is_mainchain BOOLEAN,
 		spend_height INT4,
 		spend_tx_db_id INT8
 	);`
@@ -25,11 +26,13 @@ const (
 	insertTicketRow0 = `INSERT INTO tickets (
 		tx_hash, block_hash, block_height, purchase_tx_db_id,
 		stakesubmission_address, is_multisig, is_split,
-		num_inputs, price, fee, spend_type, pool_status)
+		num_inputs, price, fee, spend_type, pool_status,
+		is_mainchain)
 	VALUES (
 		$1, $2, $3,	$4,
 		$5, $6, $7,
-		$8, $9, $10, $11, $12) `
+		$8, $9, $10, $11, $12, 
+		$13) `
 	insertTicketRow = insertTicketRow0 + `RETURNING id;`
 	// insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -52,9 +55,10 @@ const (
 	SelectTicketsForPriceAtLeast = `SELECT * FROM tickets WHERE price >= $1;`
 	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
 	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1;`
-	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1;`
+	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1 AND is;`
 	SelectTicketStatusByHash     = `SELECT id, spend_type, pool_status FROM tickets WHERE tx_hash = $1;`
-	SelectUnspentTickets         = `SELECT id, tx_hash FROM tickets WHERE spend_type = 0 OR spend_type = -1;`
+	SelectUnspentTickets         = `SELECT id, tx_hash FROM tickets WHERE spend_type = 0 OR spend_type = -1
+		AND is_mainchain = true;`
 
 	SelectTicketSpendTypeByBlock = `SELECT block_height, 
 		SUM(CASE WHEN spend_type = 0 THEN 1 ELSE 0 END) as unspent,

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -173,6 +173,10 @@ const (
 		ON votes(tx_hash, block_hash);`
 	DeindexVotesTableOnHashes = `DROP INDEX uix_votes_hashes_index;`
 
+	IndexVotesTableOnBlockHash = `CREATE INDEX uix_votes_block_hash
+		ON votes(block_hash);`
+	DeindexVotesTableOnBlockHash = `DROP INDEX uix_votes_block_hash;`
+
 	IndexVotesTableOnCandidate = `CREATE INDEX uix_votes_candidate_block
 		ON votes(candidate_block_hash);`
 	DeindexVotesTableOnCandidate = `DROP INDEX uix_votes_candidate_block;`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -74,6 +74,18 @@ const (
 	SetTicketPoolStatusForTicketDbID = `UPDATE tickets SET pool_status = $2 WHERE id = $1;`
 	SetTicketPoolStatusForHash       = `UPDATE tickets SET pool_status = $2 WHERE tx_hash = $1;`
 
+	UpdateTicketsMainchainAll = `UPDATE tickets
+		SET is_mainchain=b.is_mainchain
+		FROM (
+			SELECT hash, is_mainchain
+			FROM blocks
+		) b
+		WHERE block_hash = b.hash;`
+
+	UpdateTicketsMainchainByBlock = `UPDATE tickets
+		SET is_mainchain=$1 
+		WHERE block_hash=$2;`
+
 	// Index
 	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX uix_ticket_hashes_index
 		ON tickets(tx_hash, block_hash);`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -148,6 +148,10 @@ const (
 		) b
 		WHERE block_hash = b.hash;`
 
+	UpdateVotesMainchainByBlock = `UPDATE votes
+		SET is_mainchain=$1 
+		WHERE block_hash=$2;`
+
 	// Index
 	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX uix_votes_hashes_index
 		ON votes(tx_hash, block_hash);`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -36,7 +36,7 @@ const (
 	insertTicketRow = insertTicketRow0 + `RETURNING id;`
 	// insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $1, block_hash = $2 RETURNING id;`
+		SET is_mainchain = $13 RETURNING id;`
 	insertTicketRowReturnId = `WITH ins AS (` +
 		insertTicketRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -140,7 +140,7 @@ const (
 	insertVoteRow = insertVoteRow0 + `RETURNING id;`
 	// insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $2, block_hash = $3 RETURNING id;`
+		SET is_mainchain = $12 RETURNING id;`
 	insertVoteRowReturnId = `WITH ins AS (` +
 		insertVoteRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -84,6 +84,9 @@ const (
 	SelectTxnsVinsByBlock = `SELECT vin_db_ids, is_valid, is_mainchain
 		FROM transactions WHERE block_hash = $1;`
 
+	SelectTxnsVinsVoutsByBlock = `SELECT vin_db_ids, vout_db_ids, is_mainchain
+		FROM transactions WHERE block_hash = $1;`
+
 	UpdateRegularTxnsValidMainchainByBlock = `UPDATE transactions
 		SET is_valid=$1, is_mainchain=$2 
 		WHERE block_hash=$3 and tree=0;`
@@ -94,7 +97,8 @@ const (
 
 	UpdateTxnsMainchainByBlock = `UPDATE transactions
 		SET is_mainchain=$1 
-		WHERE block_hash=$2;`
+		WHERE block_hash=$2
+		RETURNING id;`
 
 	UpdateTxnsValidMainchainAll = `UPDATE transactions
 		SET is_valid=b.is_valid, is_mainchain=b.is_mainchain

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -101,9 +101,25 @@ const (
 		RETURNING id;`
 
 	UpdateTxnsValidMainchainAll = `UPDATE transactions
-		SET is_valid=b.is_valid, is_mainchain=b.is_mainchain
+		SET is_valid=(b.is_valid::int + tree)::boolean, is_mainchain=b.is_mainchain
 		FROM (
 			SELECT hash, is_valid, is_mainchain
+			FROM blocks
+		) b
+		WHERE block_hash = b.hash ;`
+
+	UpdateRegularTxnsValidAll = `UPDATE transactions
+		SET is_valid=b.is_valid
+		FROM (
+			SELECT hash, is_valid
+			FROM blocks
+		) b
+		WHERE block_hash = b.hash AND tree = 0;`
+
+	UpdateTxnsMainchainAll = `UPDATE transactions
+		SET is_mainchain=b.is_mainchain
+		FROM (
+			SELECT hash, is_mainchain
 			FROM blocks
 		) b
 		WHERE block_hash = b.hash;`

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -128,7 +128,7 @@ const (
 	SelectStakeTxByHash   = `SELECT id, block_hash, block_index FROM transactions WHERE tx_hash = $1 and tree=1;`
 
 	IndexTransactionTableOnBlockIn = `CREATE UNIQUE INDEX uix_tx_block_in
-		ON transactions(block_hash, block_index, tree);`
+		ON transactions(block_hash, block_index, tree);`  // with cockroach: STORING (tx_hash, block_hash)
 	DeindexTransactionTableOnBlockIn = `DROP INDEX uix_tx_block_in;`
 
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX uix_tx_hashes

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -23,7 +23,7 @@ const (
 	insertTxRow = insertTxRow0 + `RETURNING id;`
 	//insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTxRow = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET block_height = $2 RETURNING id;`
+		SET is_valid = $20, is_mainchain = $21 RETURNING id;`
 	insertTxRowReturnId = `WITH ins AS (` +
 		insertTxRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -87,7 +87,8 @@ const (
 	// not-invalidated coinbase transactions.
 	SelectCoinSupply = `SELECT block_time, sum(value_in) FROM vins WHERE
 		prev_tx_hash = '0000000000000000000000000000000000000000000000000000000000000000' AND
-		not (is_valid = false AND tx_tree = 0) GROUP BY block_time ORDER BY block_time;` // TODO is_mainchain
+		NOT (is_valid = false AND tx_tree = 0)
+		AND is_mainchain = true GROUP BY block_time ORDER BY block_time;`
 
 	CreateVinType = `CREATE TYPE vin_t AS (
 		prev_tx_hash TEXT,

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -43,12 +43,11 @@ const (
 			WHERE t.rnum > 1);`
 
 	IndexVinTableOnVins = `CREATE UNIQUE INDEX uix_vin
-		ON vins(tx_hash, tx_index, tx_tree)
-		;`  // STORING (prev_tx_hash, prev_tx_index)
+		ON vins(tx_hash, tx_index, tx_tree);`
+	DeindexVinTableOnVins = `DROP INDEX uix_vin;`
+
 	IndexVinTableOnPrevOuts = `CREATE INDEX uix_vin_prevout
-		ON vins(prev_tx_hash, prev_tx_index)
-		;`  // STORING (tx_hash, tx_index)
-	DeindexVinTableOnVins     = `DROP INDEX uix_vin;`
+		ON vins(prev_tx_hash, prev_tx_index);`
 	DeindexVinTableOnPrevOuts = `DROP INDEX uix_vin_prevout;`
 
 	SelectVinIDsALL = `SELECT id FROM vins;`
@@ -82,11 +81,11 @@ const (
 
 	// SetVinsTableCoinSupplyUpgrade does not set is_mainchain because that upgrade comes after this one
 	SetVinsTableCoinSupplyUpgrade = `UPDATE vins SET is_valid = $1, block_time = $3, value_in = $4
-		WHERE tx_hash = $5 and tx_index = $6 and tx_tree = $7;`
+		WHERE tx_hash = $5 AND tx_index = $6 AND tx_tree = $7;`
 
-	// SelectCoinSupply fetches the coin supply as of the latest block and sum
-	// represents the generated coins for all stakebase and only
-	// not-invalidated coinbase transactions.
+	// SelectCoinSupply fetches the coin supply as of the latest block, where
+	// sum represents the generated coins for all stakebase and only
+	// stake-validated coinbase transactions.
 	SelectCoinSupply = `SELECT block_time, sum(value_in) FROM vins WHERE
 		prev_tx_hash = '0000000000000000000000000000000000000000000000000000000000000000' AND
 		NOT (is_valid = false AND tx_tree = 0)

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -31,7 +31,9 @@ const (
 	// InsertVinRowChecked = InsertVinRow0 +
 	// 	`ON CONFLICT (tx_hash, tx_index, tx_tree) DO NOTHING RETURNING id;`
 	UpsertVinRow = InsertVinRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE 
-		SET tx_hash = $1, tx_index = $2, tx_tree = $3 RETURNING id;`
+		SET is_valid = $8, is_mainchain = $9, block_time = $10, 
+			prev_tx_hash = $4, prev_tx_index = $5, prev_tx_tree = $6
+		RETURNING id;`
 
 	DeleteVinsDuplicateRows = `DELETE FROM vins
 		WHERE id IN (SELECT id FROM (
@@ -42,10 +44,10 @@ const (
 
 	IndexVinTableOnVins = `CREATE UNIQUE INDEX uix_vin
 		ON vins(tx_hash, tx_index, tx_tree)
-		;` // STORING (prev_tx_hash, prev_tx_index)
+		;`  // STORING (prev_tx_hash, prev_tx_index)
 	IndexVinTableOnPrevOuts = `CREATE INDEX uix_vin_prevout
 		ON vins(prev_tx_hash, prev_tx_index)
-		;` // STORING (tx_hash, tx_index)
+		;`  // STORING (tx_hash, tx_index)
 	DeindexVinTableOnVins     = `DROP INDEX uix_vin;`
 	DeindexVinTableOnPrevOuts = `DROP INDEX uix_vin_prevout;`
 
@@ -120,7 +122,7 @@ const (
 	insertVoutRow = insertVoutRow0 + `RETURNING id;`
 	//insertVoutRowChecked  = insertVoutRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO NOTHING RETURNING id;`
 	upsertVoutRow = insertVoutRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE 
-		SET tx_hash = $1, tx_index = $2, tx_tree = $3 RETURNING id;`
+		SET version = $5 RETURNING id;`
 	insertVoutRowReturnId = `WITH inserting AS (` +
 		insertVoutRow0 +
 		`ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -60,6 +60,7 @@ const (
 	SelectFundingTxByTxIn       = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
 	SelectFundingOutpointByTxIn = `SELECT id, prev_tx_hash, prev_tx_index, prev_tx_tree FROM vins 
 		WHERE tx_hash=$1 AND tx_index=$2;`
+
 	SelectFundingOutpointByVinID = `SELECT prev_tx_hash, prev_tx_index, prev_tx_tree FROM vins WHERE id=$1;`
 	SelectFundingTxByVinID       = `SELECT prev_tx_hash FROM vins WHERE id=$1;`
 	SelectSpendingTxByVinID      = `SELECT tx_hash, tx_index, tx_tree FROM vins WHERE id=$1;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -84,8 +84,8 @@ type ChainDB struct {
 // ChainDBRPC provides an interface for storing and manipulating extracted and
 // includes the RPC Client blockchain data in a PostgreSQL database.
 type ChainDBRPC struct {
-	ChainDB *ChainDB
-	Client  *rpcclient.Client
+	*ChainDB
+	Client *rpcclient.Client
 }
 
 // NewChainDBRPC contains ChainDB and RPC client parameters. By default,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1525,7 +1525,13 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 				return
 			}
 
-			// TODO Update last block's regular transactions
+			// Update last block's regular transactions
+			_, _, err = UpdateTransactionsValid(pgb.db, lastBlockHash.String(), lastIsValid)
+			if err != nil {
+				log.Error("UpdateTransactionsValid:", err)
+				return
+			}
+
 		}
 	}
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -620,7 +620,7 @@ func (pgb *ChainDB) addressBalance(address string) (*explorer.AddressBalance, er
 func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *explorer.AddressBalance, error) {
 
-	bb, err := pgb.HeightDB()
+	bb, err := pgb.HeightDB() // TODO: should be by block hash
 	if err != nil {
 		return nil, nil, err
 	}
@@ -663,6 +663,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	// You've got all txs when the total number of fetched txs is less than the
 	// limit ,txtype is AddrTxnAll and Offset is zero.
 	if len(addressRows) < int(N) && offset == 0 && txnType == dbtypes.AddrTxnAll {
+		log.Debugf("Taking balance shortcut since address rows includes all.")
 		balanceInfo = explorer.AddressBalance{
 			Address:      address,
 			NumSpent:     addrInfo.NumSpendingTxns,
@@ -671,6 +672,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 			TotalUnspent: int64(addrInfo.AmountUnspent),
 		}
 	} else {
+		log.Debugf("Obtaining balance via DB query.")
 		var numSpent, numUnspent, totalSpent, totalUnspent, totalMergedSpent int64
 		numSpent, numUnspent, totalSpent, totalUnspent, totalMergedSpent, err =
 			RetrieveAddressSpentUnspent(pgb.db, address)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1540,6 +1540,17 @@ func UpdateVotesMainchain(db *sql.DB, blockHash string, isMainchain bool) (int64
 	return numRows, nil
 }
 
+// UpdateTicketsMainchain sets the is_mainchain column for the tickets in the
+// specified block.
+func UpdateTicketsMainchain(db *sql.DB, blockHash string, isMainchain bool) (int64, error) {
+	numRows, err := sqlExec(db, internal.UpdateTicketsMainchainByBlock,
+		"failed to update tickets is_mainchain: ", isMainchain, blockHash)
+	if err != nil {
+		return 0, err
+	}
+	return numRows, nil
+}
+
 // UpdateAddressesMainchainByIDs sets the is_mainchain column for the addresses
 // specified by their vin (spending) or vout (funding) row IDs.
 func UpdateAddressesMainchainByIDs(db *sql.DB, vinsBlk, voutsBlk []dbtypes.UInt64Array, isMainchain bool) (numSpendingRows, numFundingRows int64, err error) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2104,7 +2104,8 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 		err := stmt.QueryRow(
 			tx.TxID, tx.BlockHash, tx.BlockHeight, ticketDbIDs[i],
 			stakesubmissionAddress, isMultisig, isSplit, tx.NumVin,
-			price, fee, dbtypes.TicketUnspent, dbtypes.PoolStatusLive).Scan(&id)
+			price, fee, dbtypes.TicketUnspent, dbtypes.PoolStatusLive,
+			tx.IsMainchainBlock).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -865,7 +865,7 @@ func scanPartialAddressQueryRows(rows *sql.Rows, addr string) (addressRows []*db
 	for rows.Next() {
 		var addr = dbtypes.AddressRow{Address: addr}
 
-		err = rows.Scan(&addr.TxHash, &addr.TxBlockTime,
+		err = rows.Scan(&addr.TxHash, &addr.ValidMainChain, &addr.TxBlockTime,
 			&addr.Value, &addr.MergedDebitCount)
 		if err != nil {
 			return

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1505,6 +1505,30 @@ func UpdateTransactionsMainchain(db *sql.DB, blockHash string, isMainchain bool)
 	return numRows, txRowIDs, nil
 }
 
+// UpdateTransactionsValid sets the is_valid column of the transactions table
+// for the regular (non-stake) transactions in the specified block.
+func UpdateTransactionsValid(db *sql.DB, blockHash string, isValid bool) (int64, []uint64, error) {
+	rows, err := db.Query(internal.UpdateRegularTxnsValidByBlock, isValid, blockHash)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to update regular transactions is_valid: %v", err)
+	}
+
+	var numRows int64
+	var txRowIDs []uint64
+	for rows.Next() {
+		var id uint64
+		err = rows.Scan(&id)
+		if err != nil {
+			break
+		}
+
+		txRowIDs = append(txRowIDs, id)
+		numRows++
+	}
+
+	return numRows, txRowIDs, nil
+}
+
 // UpdateVotesMainchain sets the is_mainchain column for the votes in the
 // specified block.
 func UpdateVotesMainchain(db *sql.DB, blockHash string, isMainchain bool) (int64, error) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -739,13 +739,13 @@ func RetrieveAddressRecvCount(db *sql.DB, address string) (count int64, err erro
 }
 
 func RetrieveAddressUnspent(db *sql.DB, address string) (count, totalAmount int64, err error) {
-	err = db.QueryRow(internal.SelectAddressUnspentCountAndValue, address).
+	err = db.QueryRow(internal.SelectAddressUnspentCountANDValue, address).
 		Scan(&count, &totalAmount)
 	return
 }
 
 func RetrieveAddressSpent(db *sql.DB, address string) (count, totalAmount int64, err error) {
-	err = db.QueryRow(internal.SelectAddressSpentCountAndValue, address).
+	err = db.QueryRow(internal.SelectAddressSpentCountANDValue, address).
 		Scan(&count, &totalAmount)
 	return
 }
@@ -759,7 +759,7 @@ func RetrieveAddressSpentUnspent(db *sql.DB, address string) (numSpent, numUnspe
 	}
 
 	var nu, tu sql.NullInt64
-	err = dbtx.QueryRow(internal.SelectAddressUnspentCountAndValue, address).
+	err = dbtx.QueryRow(internal.SelectAddressUnspentCountANDValue, address).
 		Scan(&nu, &tu)
 	if err != nil && err != sql.ErrNoRows {
 		if errRoll := dbtx.Rollback(); errRoll != nil {
@@ -771,7 +771,7 @@ func RetrieveAddressSpentUnspent(db *sql.DB, address string) (numSpent, numUnspe
 	numUnspent, totalUnspent = nu.Int64, tu.Int64
 
 	var ns, ts sql.NullInt64
-	err = dbtx.QueryRow(internal.SelectAddressSpentCountAndValue, address).
+	err = dbtx.QueryRow(internal.SelectAddressSpentCountANDValue, address).
 		Scan(&ns, &ts)
 	if err != nil && err != sql.ErrNoRows {
 		if errRoll := dbtx.Rollback(); errRoll != nil {

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -39,7 +39,7 @@ var createTypeStatements = map[string]string{
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 3
+	tableMinor = 4
 )
 
 var requiredVersions = map[string]TableVersion{

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -40,19 +40,21 @@ var createTypeStatements = map[string]string{
 const (
 	tableMajor = 3
 	tableMinor = 4
+	tablePatch = 1
 )
 
+// TODO eliminiate this map since we're actually versioning each table the same.
 var requiredVersions = map[string]TableVersion{
-	"blocks":       NewTableVersion(tableMajor, tableMinor, 0),
-	"transactions": NewTableVersion(tableMajor, tableMinor, 0),
-	"vins":         NewTableVersion(tableMajor, tableMinor, 0),
-	"vouts":        NewTableVersion(tableMajor, tableMinor, 0),
-	"block_chain":  NewTableVersion(tableMajor, tableMinor, 0),
-	"addresses":    NewTableVersion(tableMajor, tableMinor, 0),
-	"tickets":      NewTableVersion(tableMajor, tableMinor, 0),
-	"votes":        NewTableVersion(tableMajor, tableMinor, 0),
-	"misses":       NewTableVersion(tableMajor, tableMinor, 0),
-	"agendas":      NewTableVersion(tableMajor, tableMinor, 0),
+	"blocks":       NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"transactions": NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"vins":         NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"vouts":        NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"block_chain":  NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"addresses":    NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"tickets":      NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"votes":        NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"misses":       NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"agendas":      NewTableVersion(tableMajor, tableMinor, tablePatch),
 }
 
 // TableVersion models a table version by major.minor.patch
@@ -447,6 +449,16 @@ func IndexVotesTableOnHashes(db *sql.DB) (err error) {
 
 func DeindexVotesTableOnHash(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexVotesTableOnHashes)
+	return
+}
+
+func IndexVotesTableOnBlockHash(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexVotesTableOnBlockHash)
+	return
+}
+
+func DeindexVotesTableOnBlockHash(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexVotesTableOnBlockHash)
 	return
 }
 

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -365,8 +365,13 @@ func updateAllVotesMainchain(db *sql.DB) (rowsUpdated int64, err error) {
 // updateAllTxnsValidMainchain sets is_mainchain and is_valid for all
 // transactions according to their containing block.
 func updateAllTxnsValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
-	return sqlExec(db, internal.UpdateTxnsValidMainchainAll,
-		"failed to update transactions validity and mainchain status")
+	rowsUpdated, err = sqlExec(db, internal.UpdateRegularTxnsValidAll,
+		"failed to update regular transactions' validity status")
+	if err != nil {
+		return
+	}
+	return sqlExec(db, internal.UpdateTxnsMainchainAll,
+		"failed to update all transactions' mainchain status")
 }
 
 // updateAllAddressesValidMainchain sets valid_mainchain for all addresses table

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1366,7 +1366,7 @@ func (db *wiredDB) UnconfirmedTxnsForAddress(address string) (*txhelpers.Address
 
 		Tx, err1 := db.client.GetRawTransaction(txhash)
 		if err1 != nil {
-			log.Warnf("Unable to GetRawTransaction(%s): %v", tx, err1)
+			log.Warnf("Unable to GetRawTransaction(%s): %v", hash, err1)
 			err = err1
 			continue
 		}

--- a/notification/ntfnchans.go
+++ b/notification/ntfnchans.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/decred/dcrdata/api/insight"
 	"github.com/decred/dcrdata/blockdata"
+	"github.com/decred/dcrdata/db/dcrpg"
 	"github.com/decred/dcrdata/db/dcrsqlite"
 	"github.com/decred/dcrdata/explorer"
 	"github.com/decred/dcrdata/mempool"
@@ -41,6 +42,8 @@ var NtfnChans struct {
 	ReorgChanWiredDB                  chan *dcrsqlite.ReorgData
 	ConnectChanStakeDB                chan *chainhash.Hash
 	ReorgChanStakeDB                  chan *stakedb.ReorgData
+	ConnectChanDcrpgDB                chan *chainhash.Hash
+	ReorgChanDcrpgDB                  chan *dcrpg.ReorgData
 	UpdateStatusNodeHeight            chan uint32
 	UpdateStatusDBHeight              chan uint32
 	SpendTxBlockChan, RecvTxBlockChan chan *txhelpers.BlockWatchedTx
@@ -65,10 +68,13 @@ func MakeNtfnChans(monitorMempool, postgresEnabled bool) {
 	// Stake DB channel for connecting new blocks - BLOCKING!
 	NtfnChans.ConnectChanStakeDB = make(chan *chainhash.Hash)
 
+	NtfnChans.ConnectChanDcrpgDB = make(chan *chainhash.Hash, blockConnChanBuffer)
+
 	// Reorg data channels
 	NtfnChans.ReorgChanBlockData = make(chan *blockdata.ReorgData)
 	NtfnChans.ReorgChanWiredDB = make(chan *dcrsqlite.ReorgData)
 	NtfnChans.ReorgChanStakeDB = make(chan *stakedb.ReorgData)
+	NtfnChans.ReorgChanDcrpgDB = make(chan *dcrpg.ReorgData)
 
 	// To update app status
 	NtfnChans.UpdateStatusNodeHeight = make(chan uint32, blockConnChanBuffer)
@@ -105,6 +111,9 @@ func CloseNtfnChans() {
 	if NtfnChans.ConnectChanStakeDB != nil {
 		close(NtfnChans.ConnectChanStakeDB)
 	}
+	if NtfnChans.ConnectChanDcrpgDB != nil {
+		close(NtfnChans.ConnectChanDcrpgDB)
+	}
 
 	if NtfnChans.ReorgChanBlockData != nil {
 		close(NtfnChans.ReorgChanBlockData)
@@ -114,6 +123,9 @@ func CloseNtfnChans() {
 	}
 	if NtfnChans.ReorgChanStakeDB != nil {
 		close(NtfnChans.ReorgChanStakeDB)
+	}
+	if NtfnChans.ReorgChanDcrpgDB != nil {
+		close(NtfnChans.ReorgChanDcrpgDB)
 	}
 
 	if NtfnChans.UpdateStatusNodeHeight != nil {

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -431,14 +431,20 @@ func (db *StakeDatabase) Height() uint32 {
 	return db.BestNode.Height()
 }
 
+// BlockCached attempts to find the block at the specified height in the block
+// cache. The returned boolean indicates if it was found.
+func (db *StakeDatabase) BlockCached(ind int64) (*dcrutil.Block, bool) {
+	db.blkMtx.RLock()
+	defer db.blkMtx.RUnlock()
+	block, found := db.blockCache[ind]
+	return block, found
+}
+
 // block first tries to find the block at the input height in cache, and if that
 // fails it will request it from the node RPC client. Don't use this casually
 // since reorganization may redefine a block at a given height.
 func (db *StakeDatabase) block(ind int64) (*dcrutil.Block, bool) {
-	db.blkMtx.RLock()
-	block, ok := db.blockCache[ind]
-	db.blkMtx.RUnlock()
-	//log.Info(ind, block, ok)
+	block, ok := db.BlockCached(ind)
 	if !ok {
 		var err error
 		block, _, err = rpcutils.GetBlock(ind, db.NodeClient)


### PR DESCRIPTION
This builds on the sidechain support in PR https://github.com/decred/dcrdata/pull/552

It adds a `ChainMonitor` to `dcrpg` and implements `switchToSideChain`.

* add `(*ChainDB).TipToSideChain`, used by `switchToSideChain` to move blocks from mainchain to sidechain, updating all related tables.
* add `(*ChainDB).SetVinsMainchainByBlock`, used by `TipToSideChain`, and add other mainchain queries for txns, votes, tickets, and addresses tables.
* notification: create block connected and reorg channels for dcrpg
* embed `ChainDB` in `ChainDBRPC` instead of having named field
* add `ChainDB.bestBlockHash`  to avoid unnecessary RPC
* Upgrade `tickets` table with `is_mainchain` column, forgotten in last PR.  This bumps the db scheme from 3.3.0 --> 3.4.0.
* Added new index `uix_votes_block_hash` to votes table for `block_hash` to reduce the index size for this column (there is a two column unique index that is 4x larger in size), and speed up scans.  This bumps table version from 3.4.0 --> 3.4.1

**First observed mainnet reorg**: https://github.com/decred/dcrdata/pull/580#issuecomment-410731974
**Second observed mainnet reorg**:  https://github.com/decred/dcrdata/pull/580#issuecomment-410896883