### PR TITLE
Display the tiny qr code thumbnail by default

### DIFF
--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -17,7 +17,7 @@
                     {{.Address}}<a
                         id="qrcode-init"
                         href="javascript:showAddressQRCode('{{.Address}}');"
-                        class="dcricon-qrcode jsonly no-underline color-inherit p10"
+                        class="dcricon-qrcode no-underline color-inherit p10"
                     ></a>
                 </div>
                 <div class="row">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -17,7 +17,7 @@
                     {{.Address}}<a
                         id="qrcode-init"
                         href="javascript:showAddressQRCode('{{.Address}}');"
-                        class="dcricon-qrcode no-underline color-inherit p10"
+                        class="dcricon-qrcode jsonly no-underline color-inherit p10"
                     ></a>
                 </div>
                 <div class="row">
@@ -259,6 +259,8 @@
     </div>
 
     <script>
+        $(".jsonly").show()
+        
         $("#txntype").change(function(ev) {
             Turbolinks.visit(
                 window.location.pathname


### PR DESCRIPTION
Issue Fixed.
- [x] Display the Tiny QR code thumbnail by default.

**Before:**

<img width="1007" alt="screen shot 2018-08-01 at 01 23 09" src="https://user-images.githubusercontent.com/22055953/43490488-8762b5b2-9529-11e8-8d09-86f0677d4891.png">

**After:**

<img width="1021" alt="screen shot 2018-08-01 at 01 19 47" src="https://user-images.githubusercontent.com/22055953/43490498-8e0c7f7e-9529-11e8-92da-400755d6be86.png">
