### PR TITLE
[wip] testutil, dcrsqlite: add tooling for non-empty DB test, verifying expected outputs

### DIFF
--- a/db/dcrsqlite/dcrsqlite_test.go
+++ b/db/dcrsqlite/dcrsqlite_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/decred/dcrdata/testutil"
 )
 
+const (
+	TestDBFileName = "test-data.db"
+)
+
 // DBPathForTest produces path inside dedicated test folder for current test
 func DBPathForTest() string {
 	testName := testutil.CurrentTestSetup().Name()
@@ -45,4 +49,26 @@ func ObtainReusableEmptyDB() *DB {
 		reusableEmptyDB = InitTestDB(targetDBFile)
 	}
 	return reusableEmptyDB
+}
+
+var testDBs = make(map[string]*DB)
+
+func ObtainDB(tag string) *DB {
+	tdb := testDBs[tag]
+	if tdb == nil {
+		tdb = loadTDB(tag)
+		testDBs[tag] = tdb
+	}
+	return tdb
+}
+
+func PathToTestDBFile(tag string) string {
+	return testutil.PathToTestDataFile(tag, TestDBFileName)
+}
+
+func loadTDB(tag string) *DB {
+	testDBFile := PathToTestDBFile(tag)
+	testutil.Log("        testDBFile", testDBFile)
+	db := InitTestDB(testDBFile)
+	return db
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -46,9 +46,27 @@ testrepo () {
     exit 1
   fi
 
-  # Check tests
+  # install git lfs, temporary solution, should be handled by docker
+  #wget https://github.com/git-lfs/git-lfs/releases/download/v2.5.0/git-lfs-linux-amd64-v2.5.0.tar.gz
+  #tar xvf git-lfs-linux-amd64-v2.5.0.tar.gz
+  #./git-lfs install
+  #git config --global http.postBuffer 157286400
+
+  # download test data
+  git clone https://github.com/JFixby/dcrdata-testdata db/dcrsqlite/dcrdata-testdata
+     # unpack synced_up_to_260241
+     pushd db/dcrsqlite/dcrdata-testdata/synced_up_to_260241
+     tar xvf test-data.tar.xz
+     popd
+
+     # unpack blocks_0-5000
+     pushd db/dcrsqlite/dcrdata-testdata/blocks_0-5000
+     tar xf test-data.tar.xz
+     popd
+
+  # download bug-free-happiness
   git clone https://github.com/dcrlabs/bug-free-happiness test-data-repo
-  tar xvf test-data-repo/stakedb/test_ticket_pool.bdgr.tar.xz
+     tar xvf test-data-repo/stakedb/test_ticket_pool.bdgr.tar.xz
 
   env GORACE='halt_on_error=1' go test -v -race ./...
   if [ $? != 0 ]; then

--- a/testutil/blockio.go
+++ b/testutil/blockio.go
@@ -1,0 +1,99 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
+)
+
+// BlockFilename generates file name for a Block
+func BlockFilename(index uint64) string {
+	return "block-" + padNumberWithZero(index, 10) + ".bin"
+}
+
+func padNumberWithZero(value uint64, zeroes uint64) string {
+	return fmt.Sprintf("%0"+strconv.FormatUint(zeroes, 10)+"d", value)
+}
+
+// SaveBlockToFile writes Block to a file in the target folder
+func SaveBlockToFile(block *dcrutil.Block, targetFolder string) (*string, error) {
+	bytes, err := block.Bytes()
+	if err != nil {
+		Log(" failed", err)
+		return nil, err
+	}
+
+	index := block.MsgBlock().Header.Height
+	filename := filepath.Join(targetFolder, BlockFilename(uint64(index)))
+	filename, err = filepath.Abs(filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	Log("writing", filename)
+	parent := filepath.Dir(filename)
+	err = os.MkdirAll(parent, 0755)
+	if err != nil {
+		Log(" failed", err)
+		return nil, err
+	}
+	err = ioutil.WriteFile(filename, bytes, 0777)
+
+	if err != nil {
+		Log(" failed", err)
+		return nil, err
+	}
+
+	return &filename, nil
+}
+
+// ReadBlock reads Block from file
+func ReadBlock(file string) (*dcrutil.Block, error) {
+	//Log("reading", file)
+	file, err := filepath.Abs(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadFile(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var msgBlock wire.MsgBlock
+	err = msgBlock.Deserialize(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	block := dcrutil.NewBlock(&msgBlock)
+
+	return block, nil
+}
+
+func PreLoadBlocks(tag string, fromIndex uint64, toIndex uint64) map[int64]*dcrutil.Block {
+	testBlockchain := make(map[int64]*dcrutil.Block)
+	for i := fromIndex; i <= toIndex; i++ {
+		index := int64(i)
+		blockFileName := BlockFilename(i)
+		target := PathToTestDataFile(tag, blockFileName)
+		block, err := ReadBlock(target)
+		if err != nil {
+			ReportTestIsNotAbleToTest("error reading", target)
+		}
+
+		testBlockchain[index] = block
+		if block == nil {
+			ReportTestIsNotAbleToTest("block not found", i)
+		}
+	}
+	return testBlockchain
+}

--- a/testutil/io.go
+++ b/testutil/io.go
@@ -1,0 +1,81 @@
+package testutil
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func ToJson(object interface{}) string {
+	bytes, err := json.MarshalIndent(object, "", "    ")
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to produce json for %v: %v",
+			object,
+			err)
+	}
+	jsonString := string(bytes[:])
+	return jsonString
+}
+
+func FromJson(jsonString string, object interface{}) {
+	err := json.Unmarshal([]byte(jsonString), object)
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to parse json for %v: %v \n json: \n%v",
+			object,
+			err,
+			jsonString)
+	}
+}
+
+func WriteStringToFile(targetFile string, jsonString string) {
+	parent := filepath.Dir(targetFile)
+	err := os.MkdirAll(parent, 0755)
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to read write %v: %v",
+			targetFile,
+			err)
+	}
+	err = ioutil.WriteFile(targetFile, []byte(jsonString), 0777)
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to write file %v: %v",
+			targetFile,
+			err)
+	}
+}
+
+func ReadFileToString(targetFile string) string {
+	bytes, err := ioutil.ReadFile(targetFile)
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to read file %v: %v",
+			targetFile,
+			err)
+	}
+	string := string(bytes[:])
+	return string
+}
+
+func FullPathToFile(relative string) string {
+	abs, err := filepath.Abs(relative)
+	if err != nil {
+		ReportTestIsNotAbleToTest(
+			"Failed to build abs path for %v: %v",
+			relative,
+			err)
+	}
+	return abs
+}
+
+func MD5ofString(str string) string {
+	data := []byte(str)
+	md5arr := md5.Sum(data)
+	md5String := hex.EncodeToString(md5arr[:])
+	return md5String
+}

--- a/testutil/log.go
+++ b/testutil/log.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Log(tag string, message ...interface{}) {
+	if len(message) > 0 {
+		log(tag, message[0])
+	} else {
+		log(tag, nil)
+	}
+}
+
+func log(tag string, a interface{}) {
+	if a == nil {
+		fmt.Println(tag)
+		return
+	}
+
+	// a!=nil
+	array := reflect.ValueOf(a)
+	if array.Kind() == reflect.Array || array.Kind() == reflect.Slice {
+		fmt.Println(ArrayToString(tag, a))
+	} else {
+		fmt.Println(tag+" >", a)
+	}
+}

--- a/testutil/testdatahandler.go
+++ b/testutil/testdatahandler.go
@@ -1,0 +1,105 @@
+package testutil
+
+import (
+	"path/filepath"
+)
+
+const (
+	TestDataFolderName     = "dcrdata-testdata"
+	TestDescriptorFileName = "test-description.json"
+)
+
+type TestDataHandler struct {
+	expected TestDescriptorJson
+}
+
+type TestDescriptorJson struct {
+	TestName                                string `json:"test_name"`
+	ExpectedBestBlockHeight                 int64  `json:"expected_block_height"`
+	ExpectedStakeInfoHeight                 int64  `json:"expected_stake_info_height"`
+	ExpectedBestBlockHash                   string `json:"expected_best_block_hash"`
+	ExpectedMD5OfRetrieveBlockFeeInfoString string `json:"expected_md5_of_retrieve_block_fee_info_string"`
+	FirstBlockNumber                        uint64 `json:"first_block_number"`
+	LastBlockNumber                         uint64 `json:"last_block_number"`
+}
+
+func (db *TestDataHandler) GetFirstBlockNumber() uint64 {
+	return db.expected.FirstBlockNumber
+}
+
+func (db *TestDataHandler) GetLastBlockNumber() uint64 {
+	return db.expected.LastBlockNumber
+}
+
+func (db *TestDataHandler) GetExpectedBestBlockHeight() int64 {
+	return db.expected.ExpectedBestBlockHeight
+}
+
+func (db *TestDataHandler) GetExpectedStakeInfoHeight() int64 {
+	return db.expected.ExpectedStakeInfoHeight
+}
+
+func (db *TestDataHandler) GetExpectedBestBlockHash() string {
+	return db.expected.ExpectedBestBlockHash
+}
+func (db *TestDataHandler) GetExpectedMD5OfRetrieveBlockFeeInfoString() string {
+	return db.expected.ExpectedMD5OfRetrieveBlockFeeInfoString
+}
+
+func LoadTestDataHandler(tag string) *TestDataHandler {
+	var tdb TestDataHandler
+	testDescriptorFile := PathToTestDescriptorFile(tag)
+
+	Log("reading:")
+
+	Log("testDescriptorFile", testDescriptorFile)
+	// uncomment this to produce example descriptor file
+	//ProduceExampleTestDescriptor(PathToTestDescriptorFile(tag))
+
+	testDescriptor := ReadTestDescriptorJson(testDescriptorFile)
+	tdb = TestDataHandler{
+		expected: testDescriptor,
+	}
+
+	return &tdb
+}
+func parseTestDescriptorJson(jsonString string) TestDescriptorJson {
+	desc := TestDescriptorJson{}
+	FromJson(jsonString, &desc)
+	return desc
+}
+func ReadTestDescriptorJson(targetFile string) TestDescriptorJson {
+	jsonString := ReadFileToString(targetFile)
+	desc := parseTestDescriptorJson(jsonString)
+	return desc
+}
+
+func PathToTestDataFolder(tag string) string {
+	return FullPathToFile(
+		filepath.Join(TestDataFolderName, tag))
+}
+
+func PathToTestDataFile(tag string, filename string) string {
+	return FullPathToFile(
+		filepath.Join(PathToTestDataFolder(tag), filename))
+}
+
+func PathToTestDescriptorFile(tag string) string {
+	return PathToTestDataFile(tag, TestDescriptorFileName)
+}
+
+func ProduceExampleTestDescriptor(targetFile string) {
+	exampleDescriptor := TestDescriptorJson{
+		TestName:                                "exampleTest",
+		ExpectedBestBlockHeight:                 -1,
+		ExpectedStakeInfoHeight:                 -1,
+		ExpectedBestBlockHash:                   "",
+		ExpectedMD5OfRetrieveBlockFeeInfoString: "d41d8cd98f00b204e9800998ecf8427e",
+	}
+
+	jsonString := ToJson(exampleDescriptor)
+
+	Log("writing", targetFile)
+	Log(jsonString)
+	WriteStringToFile(targetFile, jsonString)
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -41,7 +41,7 @@ var UseSpewToPrettyPrintArrays = true
 var PanicOnTestSetupFailure = true
 
 // Set this flag "true" to print a stack stace when a test failed
-var PanicOnTestFailure = false
+var PanicOnTestFailure = !false
 
 // ReportTestIsNotAbleToTest called on failure in a test setup
 // Indicates that test needs to be fixed


### PR DESCRIPTION
The goal of this PR is to provide some functions for non-empty DB tests.

The idea is to store pre-filled DB together with expected outputs (test descriptor file) on a test-data repo.

The test setup downloads test-data, loads db, runs db-calls and compares results with expected outputs stored in related test descriptor.

Proposed changes:

1) In `testutil` there were added some basic I/O operations for testing and debugging: simplified calls `ToJson/FromJson()`, `Read/Write StringToFile()` and `FullPathToFile()`

2) `dcrsqlite` uses the functions above to load pre-filled DB and expected outputs to run DB tests.
See usage example in the [#578/getbestblockhash_test.go](https://github.com/decred/dcrdata/pull/578/commits/3f5ef98fc4834867b5dc44d73b2b39b7885a329c#diff-e8ada86f0b74b8bbdcaab02f9316862bR26) 

Test data structure:
 - Each test has a dedicated folder. The folder name is also the test name. Example: the `synced_up_to_260241`.
 - Inside each test folder, there is compressed db file `test-data.tar.xz`. Unpacking it gives `test-data.db` file.
 - Also there is the `test-description.json` containing information related to the test: name, expected values and so on.

![image](https://user-images.githubusercontent.com/1580663/43513522-3b7ba190-957e-11e8-9e43-d678df503efc.png)

`synced_up_to_260241` - is a fully synced db up to the block `# 260241`

3) In this PR testdata are stored at the https://github.com/JFixby/dcrdata-testdata-gitlfs repo.
`run_tests.sh` is modified to retrieve it. I need an opinion here about that.

