### PR TITLE
config: disable dev balance prefetch with invalid fund

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/version"
 	"github.com/decred/dcrwallet/netparams"
 	"github.com/decred/slog"
@@ -384,6 +385,14 @@ func loadConfig() (*config, error) {
 		fmt.Fprintln(os.Stderr, err)
 		parser.WriteHelp(os.Stderr)
 		return loadConfigError(err)
+	}
+
+	// Disable dev balance prefetch if network has invalid script.
+	_, err = dbtypes.DevSubsidyAddress(activeChain)
+	if !cfg.NoDevPrefetch && err != nil {
+		cfg.NoDevPrefetch = true
+		log.Warnf("%v. Disabling balance prefetch (--no-dev-prefetch).",
+			err, activeChain.Name)
 	}
 
 	// Append the network type to the data directory so it is "namespaced" per

--- a/config.go
+++ b/config.go
@@ -387,14 +387,6 @@ func loadConfig() (*config, error) {
 		return loadConfigError(err)
 	}
 
-	// Disable dev balance prefetch if network has invalid script.
-	_, err = dbtypes.DevSubsidyAddress(activeChain)
-	if !cfg.NoDevPrefetch && err != nil {
-		cfg.NoDevPrefetch = true
-		log.Warnf("%v. Disabling balance prefetch (--no-dev-prefetch).",
-			err, activeChain.Name)
-	}
-
 	// Append the network type to the data directory so it is "namespaced" per
 	// network.  In addition to the block database, there are other pieces of
 	// data that are saved to disk such as address manager state. All data is
@@ -424,6 +416,13 @@ func loadConfig() (*config, error) {
 
 	log.Infof("Log folder:  %s", cfg.LogDir)
 	log.Infof("Config file: %s", configFile)
+
+	// Disable dev balance prefetch if network has invalid script.
+	_, err = dbtypes.DevSubsidyAddress(activeChain)
+	if !cfg.NoDevPrefetch && err != nil {
+		cfg.NoDevPrefetch = true
+		log.Warnf("%v. Disabling balance prefetch (--no-dev-prefetch).", err)
+	}
 
 	// Set the host names and ports to the default if the user does not specify
 	// them.

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -21,6 +21,7 @@ func DevSubsidyAddress(params *chaincfg.Params) (string, error) {
 	case "testnet2":
 		// TestNet2 uses an invalid organization PkScript
 		devSubsidyAddress = "TccTkqj8wFqrUemmHMRSx8SYEueQYLmuuFk"
+		err = fmt.Errorf("testnet2 has invalid project fund script")
 	default:
 		_, devSubsidyAddresses, _, err0 := txscript.ExtractPkScriptAddrs(
 			params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)


### PR DESCRIPTION
dbtypes: DevSubsidyAddress now returns a non-nil error in special
cases (e.g. testnet2).

When parsing config, check chain params via DevSubsidyAddress to
automatically disable the dev fund prefetch when it would not be
possible to fetch a non-zero balance.