### PR TITLE
api: add block rewards endpoints

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -44,6 +44,7 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/hash", app.getBlockHash)
 			rd.Get("/header", app.getBlockHeader)
 			rd.Get("/size", app.getBlockSize)
+			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {
@@ -58,6 +59,7 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/height", app.getBlockHeight)
 			rd.Get("/header", app.getBlockHeader)
 			rd.Get("/size", app.getBlockSize)
+			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {
@@ -72,6 +74,7 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/header", app.getBlockHeader)
 			rd.Get("/hash", app.getBlockHash)
 			rd.Get("/size", app.getBlockSize)
+			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -750,10 +750,15 @@ func (c *appContext) blockSubsidies(w http.ResponseWriter, r *http.Request) {
 	}
 	hash := c.getBlockHashCtx(r)
 
-	numVotes, err := c.AuxDataSource.VotesInBlock(hash)
-	if err != nil {
-		http.NotFound(w, r)
-		return
+	// Unless this is a mined block, assume all votes.
+	numVotes := int16(c.Params.TicketsPerBlock)
+	if hash != "" {
+		var err error
+		numVotes, err = c.AuxDataSource.VotesInBlock(hash)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
 	}
 
 	work, stake, tax := txhelpers.RewardsAtBlock(idx, uint16(numVotes), c.Params)

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -773,7 +773,7 @@ func (c *appContext) blockSubsidies(w http.ResponseWriter, r *http.Request) {
 		Total:      work + stake*int64(numVotes) + tax,
 	}
 
-	writeJSON(w, rewards, "")
+	writeJSON(w, rewards, c.getIndentQuery(r))
 }
 
 func (c *appContext) getBlockRangeSize(w http.ResponseWriter, r *http.Request) {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -317,7 +317,7 @@ type BlockTransactionCounts struct {
 // votes.
 type BlockSubsidies struct {
 	BlockNum   int64  `json:"height"`
-	BlockHash  string `json:"hash"`
+	BlockHash  string `json:"hash,omitempty"`
 	Work       int64  `json:"work_reward"`
 	Stake      int64  `json:"stake_reward"`
 	NumVotes   int16  `json:"num_votes,omitempty"`

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -312,6 +312,20 @@ type BlockTransactionCounts struct {
 	STx int `json:"stx"`
 }
 
+// BlockSubsidies contains the block reward proportions for a certain block
+// height. The stake_reward is per vote, while total is for a certain number of
+// votes.
+type BlockSubsidies struct {
+	BlockNum   int64  `json:"height"`
+	BlockHash  string `json:"hash"`
+	Work       int64  `json:"work_reward"`
+	Stake      int64  `json:"stake_reward"`
+	NumVotes   int16  `json:"num_votes,omitempty"`
+	TotalStake int64  `json:"stake_reward_total,omitempty"`
+	Tax        int64  `json:"project_subsidy"`
+	Total      int64  `json:"total,omitempty"`
+}
+
 // StakeDiff represents data about the evaluated stake difficulty and estimates
 type StakeDiff struct {
 	dcrjson.GetStakeDifficultyResult

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -97,6 +97,8 @@ const (
 
 	SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`
 
+	SelectBlockVoteCount = `SELECT voters FROM blocks WHERE hash = $1;`
+
 	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = $2 WHERE hash = $1 RETURNING previous_hash;`
 
 	IndexBlocksTableOnHeight = `CREATE INDEX uix_block_height ON blocks(height);`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -322,6 +322,17 @@ func (pgb *ChainDB) Height() uint64 {
 	return uint64(pgb.bestBlock)
 }
 
+// VotesInBlock returns the number of votes mined in the block with the
+// specified hash.
+func (pgb *ChainDB) VotesInBlock(hash string) (int16, error) {
+	voters, err := RetrieveBlockVoteCount(pgb.db, hash)
+	if err != nil {
+		log.Errorf("Unable to get block voter count for hash %s: %v", hash, err)
+		return -1, err
+	}
+	return voters, nil
+}
+
 // SpendingTransactions retrieves all transactions spending outpoints from the
 // specified funding transaction. The spending transaction hashes, the spending
 // tx input indexes, and the corresponding funding tx output indexes, and an

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1254,6 +1254,12 @@ func RetrieveBlockHeight(db *sql.DB, hash string) (height int64, err error) {
 	return
 }
 
+// RetrieveBlockVoteCount gets the number of votes mined in a block.
+func RetrieveBlockVoteCount(db *sql.DB, hash string) (numVotes int16, err error) {
+	err = db.QueryRow(internal.SelectBlockVoteCount, hash).Scan(&numVotes)
+	return
+}
+
 // RetrieveBlocksHashesAll retrieve the hash of every block in the blocks table,
 // ordered by their row ID.
 func RetrieveBlocksHashesAll(db *sql.DB) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -491,7 +491,7 @@ func mainCore() error {
 	}
 
 	// Start web API
-	app := api.NewContext(dcrdClient, &baseDB, auxDB, cfg.IndentJSON)
+	app := api.NewContext(dcrdClient, activeChain, &baseDB, auxDB, cfg.IndentJSON)
 	// Start notification hander to keep /status up-to-date
 	wg.Add(1)
 	go app.StatusNtfnHandler(&wg, quit)

--- a/txhelpers/subsidy.go
+++ b/txhelpers/subsidy.go
@@ -51,3 +51,13 @@ func UltimateSubsidy(params *chaincfg.Params) int64 {
 	}
 	return totalSubsidy
 }
+
+// RewardsAtBlock computes the PoW, PoS (per vote), and project fund subsidies
+// at for the specified block index, assuming a certain number of votes.
+func RewardsAtBlock(blockIdx int64, votes uint16, p *chaincfg.Params) (work, stake, tax int64) {
+	subsidyCache := blockchain.NewSubsidyCache(0, p)
+	work = blockchain.CalcBlockWorkSubsidy(subsidyCache, blockIdx, votes, p)
+	stake = blockchain.CalcStakeVoteSubsidy(subsidyCache, blockIdx, p)
+	tax = blockchain.CalcBlockTaxSubsidy(subsidyCache, blockIdx, votes, p)
+	return
+}


### PR DESCRIPTION
This adds .../subsidy paths to the block API endpoints (best, idx, hash), addressing Issue https://github.com/decred/dcrdata/issues/590.

The dcrd RPC:

```
$ dcrctl --notls getblocksubsidy 262307 5
{
  "developer": 205399222,
  "pos": 616197665,
  "pow": 1232395335,
  "total": 2053992222
}
```

The new API (any of: /block/262307/subsidy, /block/best/subsidy, or /block/hash/0000000000000000a42c701ea78a6f4a9d21979b820eb8100ab900d01744eebe/subsidy):

```
{
  "height": 262307,
  "hash": "0000000000000000a42c701ea78a6f4a9d21979b820eb8100ab900d01744eebe",
  "work_reward": 1232395335,
  "stake_reward": 123239533,
  "num_votes": 5,
  "stake_reward_total": 616197665,
  "project_subsidy": 205399222,
  "total": 2053992222
}
```

txhelpers: add RewardsAtBlock
api/types: add BlockSubsidies JSON-tagged type
api: add VotesInBlock(string) to DataSourceAux interface
api: add *chaincfg.Params to appContext
api: and add (*appContext).blockSubsidies
dcrpg: add (*ChainDB).VotesInBlock, and RetrieveBlockVoteCount & query