### PR TITLE
txhelpers/explorer: move and test CalcMeanVotingBlocks

### DIFF
--- a/txhelpers/stake.go
+++ b/txhelpers/stake.go
@@ -1,0 +1,24 @@
+package txhelpers
+
+import (
+	"math"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+// CalcMeanVotingBlocks computes the average number of blocks a ticket will be
+// live before voting. The expected block (aka mean) of the probability
+// distribution is given by:
+//      sum(B * P(B)), B=1 to 40960
+// Where B is the block number and P(B) is the probability of voting at
+// block B.  For more information see:
+// https://github.com/decred/dcrdata/issues/471#issuecomment-390063025
+func CalcMeanVotingBlocks(params *chaincfg.Params) int64 {
+	logPoolSizeM1 := math.Log(float64(params.TicketPoolSize) - 1)
+	logPoolSize := math.Log(float64(params.TicketPoolSize))
+	var v float64
+	for i := float64(1); i <= float64(params.TicketExpiry); i++ {
+		v += math.Exp(math.Log(i) + (i-1)*logPoolSizeM1 - i*logPoolSize)
+	}
+	return int64(v)
+}

--- a/txhelpers/stake_test.go
+++ b/txhelpers/stake_test.go
@@ -1,0 +1,71 @@
+package txhelpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+type networkRewardPeriod struct {
+	params                *chaincfg.Params
+	MeanVotingBlocks      int64
+	MeanLockedBlocks      int64
+	MeanLockedNanoseconds int64
+}
+
+var networkRewardPeriods = []networkRewardPeriod{
+	{
+		&chaincfg.MainNetParams,
+		7860,
+		8372,
+		2511600000000000,
+	},
+	{
+		&chaincfg.TestNet2Params,
+		1006,
+		1038,
+		124560000000000,
+	},
+	{
+		&chaincfg.SimNetParams,
+		62,
+		94,
+		94000000000,
+	},
+}
+
+// TestRewardPeriods verifies calcMeanVotingBlocks works for each network.
+func TestRewardPeriods(t *testing.T) {
+	rewardPeriod := func(params *chaincfg.Params) networkRewardPeriod {
+		MeanVotingBlocks := CalcMeanVotingBlocks(params)
+		maturity := int64(params.TicketMaturity) + int64(params.CoinbaseMaturity)
+		return networkRewardPeriod{
+			params:                params,
+			MeanVotingBlocks:      MeanVotingBlocks,
+			MeanLockedBlocks:      MeanVotingBlocks + maturity,
+			MeanLockedNanoseconds: params.TargetTimePerBlock.Nanoseconds() * (MeanVotingBlocks + maturity),
+		}
+	}
+
+	for i := range networkRewardPeriods {
+		r0 := &networkRewardPeriods[i]
+		r := rewardPeriod(r0.params)
+
+		if r.MeanVotingBlocks != r0.MeanVotingBlocks {
+			t.Errorf("MeanVotingBlocks: got %d, expected %d", r.MeanVotingBlocks, r0.MeanVotingBlocks)
+		}
+
+		if r.MeanLockedBlocks != r0.MeanLockedBlocks {
+			t.Errorf("MeanLockedBlocks: got %d, expected %d", r.MeanLockedBlocks, r0.MeanLockedBlocks)
+		}
+
+		if r.MeanLockedNanoseconds != r0.MeanLockedNanoseconds {
+			t.Errorf("MeanLockedNanoseconds: got %d, expected %d", r.MeanLockedNanoseconds, r0.MeanLockedNanoseconds)
+		}
+
+		lockedDuration := time.Duration(r.MeanLockedNanoseconds)
+		t.Logf("%s expected locked time: %v (%.08f days)", r.params.Name,
+			lockedDuration, lockedDuration.Hours()/24)
+	}
+}


### PR DESCRIPTION
This is partly an example, and partly to ensure we don't break `CalcMeanVotingBlocks`. 

```
=== RUN   TestRewardPeriods
--- PASS: TestRewardPeriods (0.00s)
	stake_test.go:68: mainnet expected locked time: 697h40m0s (29.06944444 days)
	stake_test.go:68: testnet2 expected locked time: 34h36m0s (1.44166667 days)
	stake_test.go:68: simnet expected locked time: 1m34s (0.00108796 days)
```