### PR TITLE
missing defer in sqlite, lots of linting

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg"
@@ -42,8 +41,6 @@ type insightApiContext struct {
 	params     *chaincfg.Params
 	MemPool    DataSourceLite
 	Status     apitypes.Status
-	statusMtx  sync.RWMutex
-
 	JSONIndent string
 }
 

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -91,7 +91,7 @@ func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 		FreshStake:             b.Header.FreshStake,
 		StakeDiff:              b.Header.SBits,
 		BlockExplorerExtraInfo: extra,
-		Time: b.Header.Time,
+		Time:                   b.Header.Time,
 	}
 }
 

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -5,6 +5,7 @@
 package blockdata
 
 import (
+	"reflect"
 	"sync"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -185,7 +186,9 @@ out:
 			for _, s := range savers {
 				if s != nil {
 					// save data to wherever the saver wants to put it
-					s.Store(blockData, msgBlock)
+					if err = s.Store(blockData, msgBlock); err != nil {
+						log.Errorf("(%v).Store failed: %v", reflect.TypeOf(s), err)
+					}
 				}
 			}
 

--- a/db/agendadb/db.go
+++ b/db/agendadb/db.go
@@ -179,7 +179,7 @@ func (db *AgendaDB) Updatedb(voteVersion int64, client *rpcclient.Client) {
 }
 
 // CheckForUpdates checks for update at the start of the process and will
-// proceed to update when neccessary.
+// proceed to update when necessary.
 func CheckForUpdates(client *rpcclient.Client) error {
 	adb, err := Open(dbName)
 	if err != nil {

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -108,13 +108,11 @@ const (
 	SelectStakeTxByHash   = `SELECT id, block_hash, block_index FROM transactions WHERE tx_hash = $1 and tree=1;`
 
 	IndexTransactionTableOnBlockIn = `CREATE UNIQUE INDEX uix_tx_block_in
-		ON transactions(block_hash, block_index, tree)
-		;` // STORING (tx_hash, block_hash)
+		ON transactions(block_hash, block_index, tree);`
 	DeindexTransactionTableOnBlockIn = `DROP INDEX uix_tx_block_in;`
 
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX uix_tx_hashes
-		 ON transactions(tx_hash, block_hash)
-		 ;` // STORING (block_hash, block_index, tree)
+		 ON transactions(tx_hash, block_hash);`
 	DeindexTransactionTableOnHashes = `DROP INDEX uix_tx_hashes;`
 
 	//SelectTxByPrevOut = `SELECT * FROM transactions WHERE vins @> json_build_array(json_build_object('prevtxhash',$1)::jsonb)::jsonb;`

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -908,7 +908,8 @@ func scanAddressQueryRows(rows *sql.Rows) (ids []uint64, addressRows []*dbtypes.
 	return
 }
 
-// Retreive All AddressIDs for a given Hash and Index
+// RetrieveAddressIDsByOutpoint fetches all address row IDs for a given outpoint
+// (hash:index).
 // Update Vin due to DCRD AMOUNTIN - START - DO NOT MERGE CHANGES IF DCRD FIXED
 func RetrieveAddressIDsByOutpoint(db *sql.DB, txHash string,
 	voutIndex uint32) ([]uint64, []string, int64, error) {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1344,7 +1344,7 @@ func (db *wiredDB) CountUnconfirmedTransactions(address string) (int64, error) {
 
 // UnconfirmedTxnsForAddress returns the chainhash.Hash of all transactions in
 // mempool that (1) pay to the given address, or (2) spend a previous outpoint
-// that payed to the address.
+// that paid to the address.
 func (db *wiredDB) UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error) {
 	// Mempool transactions
 	var numUnconfirmed int64

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -487,11 +487,11 @@ func (db *DB) RetrievePoolValAndSizeRange(ind0, ind1 int64) ([]float64, []float6
 	return poolvals, poolsizes, nil
 }
 
-// RetrieveAllPoolValAndSize returns all the pool values and sizes
-// stored since the first value was recorded up current height.
+// RetrieveAllPoolValAndSize returns all the pool values and sizes stored since
+// the first value was recorded up current height.
 func (db *DB) RetrieveAllPoolValAndSize() (*dbtypes.ChartsData, error) {
 	db.RLock()
-	db.RUnlock()
+	defer db.RUnlock()
 
 	var chartsData = new(dbtypes.ChartsData)
 	var stmt, err = db.Prepare(db.getAllPoolValSize)
@@ -528,10 +528,10 @@ func (db *DB) RetrieveAllPoolValAndSize() (*dbtypes.ChartsData, error) {
 	return chartsData, nil
 }
 
-// RetrieveBlockFeeInfo fetches the block median fee chart data
+// RetrieveBlockFeeInfo fetches the block median fee chart data.
 func (db *DB) RetrieveBlockFeeInfo() (*dbtypes.ChartsData, error) {
 	db.RLock()
-	db.RUnlock()
+	defer db.RUnlock()
 
 	var chartsData = new(dbtypes.ChartsData)
 	var stmt, err = db.Prepare(db.getAllFeeInfoPerBlock)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -331,8 +331,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	// The actual Reward of a ticket needs to also take into consideration the
 	// ticket maturity (time from ticket purchase until its eligible to vote)
-	// and coinbase maturity (time after vote until funds distributed to
-	// ticket holder are avaliable to use)
+	// and coinbase maturity (time after vote until funds distributed to ticket
+	// holder are available to use).
 	exp.ExtraInfo.RewardPeriod = func() string {
 		PosAvgTotalBlocks := float64(
 			exp.ExtraInfo.Params.MeanVotingBlocks +

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func mainCore() error {
 
 	// Start with version info
 	ver := &version.Ver
-	log.Infof("%s version %v (Go version %s)\n", version.AppName, ver, runtime.Version())
+	log.Infof("%s version %v (Go version %s)", version.AppName, ver, runtime.Version())
 
 	// PostgreSQL
 	usePG := cfg.FullMode

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -25,7 +25,6 @@ testrepo () {
 
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m \
-    --enable=gofmt \
     --enable=vet \
     --enable=gosimple \
     --enable=unconvert \

--- a/stakedb/ticketpool.go
+++ b/stakedb/ticketpool.go
@@ -109,7 +109,7 @@ func NewTicketPool(dataDir, dbSubDir string) (*TicketPool, error) {
 	}, nil
 }
 
-// MigrateFromStorm attemps to load the storm DB specified by the given file
+// MigrateFromStorm attempts to load the storm DB specified by the given file
 // name, and migrate all ticket pool diffs to the badger db.
 func MigrateFromStorm(stormDBFile string, db *badger.DB) (bool, error) {
 	// Check for the storm DB file


### PR DESCRIPTION
`defer`s were missing in two sqlite functions, causing empty critical sections.

Any errors from `BlockDataSaver.Store` in `blockdata`'s `BlockConnectedHandler` were unhanded.  Now it logs the error and which saver it came from.

Fixes lots of misspelings.