### PR TITLE
keep spaces out of the url

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -53,7 +53,7 @@ var AddrTxnTypes = map[AddrTxnType]string{
 	AddrTxnAll:         "all",
 	AddrTxnCredit:      "credit",
 	AddrTxnDebit:       "debit",
-	AddrMergedTxnDebit: "merged debit",
+	AddrMergedTxnDebit: "merged_debit",
 	AddrTxnUnknown:     "unknown",
 }
 
@@ -75,7 +75,7 @@ func AddrTxnTypeFromStr(txnType string) AddrTxnType {
 		fallthrough
 	case "debits":
 		return AddrTxnDebit
-	case "merged debit":
+	case "merged_debit":
 		return AddrMergedTxnDebit
 	default:
 		return AddrTxnUnknown

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -75,7 +75,7 @@ func AddrTxnTypeFromStr(txnType string) AddrTxnType {
 		fallthrough
 	case "debits":
 		return AddrTxnDebit
-	case "merged_debit":
+	case "merged_debit", "merged debit":
 		return AddrMergedTxnDebit
 	default:
 		return AddrTxnUnknown

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -80,17 +80,17 @@ type AddressTx struct {
 // IOID formats an identification string for the transaction input (or output)
 // represented by the AddressTx.
 func (a *AddressTx) IOID(txType ...string) string {
-	// if transaction is of type merged debit, return unformatted transaction ID
+	// If transaction is of type merged_debit, return unformatted transaction ID
 	if len(txType) > 0 && dbtypes.AddrTxnTypeFromStr(txType[0]) == dbtypes.AddrMergedTxnDebit {
 		return a.TxID
 	}
 	// When AddressTx is used properly, at least one of ReceivedTotal or
 	// SentTotal should be zero.
 	if a.IsFunding {
-		// an outpoint receiving funds
+		// An outpoint receiving funds
 		return fmt.Sprintf("%s:out[%d]", a.TxID, a.InOutID)
 	}
-	// a transaction input referencing an outpoint being spent
+	// A transaction input referencing an outpoint being spent
 	return fmt.Sprintf("%s:in[%d]", a.TxID, a.InOutID)
 }
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -133,12 +133,12 @@
                 <table class="table table-mono-cells table-sm striped">
                     <thead>
                         <th>Input/Output ID</th>
-                        {{if eq $txType "merged debit"}}
+                        {{if eq $txType "merged_debit"}}
                             <th># of Input(s)</th>
                         {{else}}
                             <th class="text-right">Credit DCR</th>
                         {{end}}
-                        {{if eq $txType "merged debit"}}
+                        {{if eq $txType "merged_debit"}}
                             <th class="text-center">Debit DCR</th>
                         {{else}}
                             <th>Debit DCR</th>
@@ -153,7 +153,7 @@
                         <tr>
                             {{with $v}}
                             <td><a href="/tx/{{.TxID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
-                            {{if eq $txType "merged debit"}}
+                            {{if eq $txType "merged_debit"}}
                                 <td>{{.MergedTxnCount}}</td>
                             {{else}}
                                 {{if ne .ReceivedTotal 0.0}}
@@ -172,7 +172,7 @@
                             {{end}}
                             {{if ne .SentTotal 0.0}}
                                 {{if lt 0.0 .SentTotal}}
-                                   {{if eq $txType "merged debit"}}
+                                   {{if eq $txType "merged_debit"}}
                                         <td class="text-right"> {{template "decimalParts" (float64AsDecimalParts .SentTotal false)}}</td>
                                     {{else}}
                                         <td>{{template "decimalParts" (float64AsDecimalParts .SentTotal false)}}</td>
@@ -232,7 +232,7 @@
                         <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
                         <option {{if eq $txType "credit"}}selected{{end}} value="credit">Credits</option>
                         <option {{if eq $txType "debit"}}selected{{end}} value="debit">Debits</option>
-                        <option {{if eq $txType "merged debit"}}selected{{end}} value="merged debit">Merged Debits</option>
+                        <option {{if eq $txType "merged_debit"}}selected{{end}} value="merged_debit">Merged Debits</option>
                     </select>
                 </div>
                 {{if and (not .Fullmode) (ge .KnownTransactions .MaxTxLimit)}}


### PR DESCRIPTION
Change `"merged debit"` to `"merged_debit"` so we don't get `?txntype=merged%20debit` in the url.