### PR TITLE
Show proper message when no agendas

### DIFF
--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -6,11 +6,17 @@
         {{template "navbar" .}}
         <div class="container">
             <div class="row justify-content-between">
-                    <div class="col-md-7 col-sm-6 d-flex">
-                        <h4 class="mb-2">Agendas
-                        </h4>
-                    </div>
+                <div class="col-md-7 col-sm-6 d-flex">
+                    <h4 class="mb-2">Agendas</h4>
                 </div>
+            </div>
+            {{ if not .Agendas }}
+            <table class="table table-sm striped">
+                <tr>
+                    <td>No agendas found for {{ .NetName }}</td>
+                </tr>
+            </table>
+            {{ else }}
             <table class="table table-mono-cells table-sm striped">
                 <thead>
                     <th>Agenda ID</th>
@@ -37,6 +43,7 @@
                 {{end}}
                 {{end}}
             </table>
+            {{ end }}
         </div>
         {{template "footer" . }}
     </body>


### PR DESCRIPTION
This displays a ""No agendas found for {{NetName}}" message when no agenda exists on network. {{NetName}} is one of "Mainnet, Testnet, Simnet" depending on the current network.

This fixes #588 