### PR TITLE
dcrpg: fix the 3.2.0 -> 3.3.0 upgrade

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -85,8 +85,9 @@ const (
 		ON blocks(hash);`
 	DeindexBlockTableOnHash = `DROP INDEX uix_block_hash;`
 
-	RetrieveBestBlock       = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
-	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks WHERE is_mainchain = true ORDER BY height DESC LIMIT 1;`
+	RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
+	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks ORDER BY height DESC LIMIT 1;`
+	RetrieveBestBlockHeight    = `SELECT id, hash, height FROM blocks WHERE is_mainchain = true ORDER BY height DESC LIMIT 1;`
 
 	// SelectBlocksTicketsPrice selects the ticket price and difficulty for the first block in a stake difficulty window.
 	SelectBlocksTicketsPrice = `SELECT sbits, time, difficulty FROM blocks WHERE height % $1 = 0 ORDER BY time;`

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1623,6 +1623,11 @@ func RetrieveBestBlockHeight(db *sql.DB) (height uint64, hash string, id uint64,
 	return
 }
 
+func RetrieveBestBlockHeightAny(db *sql.DB) (height uint64, hash string, id uint64, err error) {
+	err = db.QueryRow(internal.RetrieveBestBlockHeightAny).Scan(&id, &hash, &height)
+	return
+}
+
 func RetrieveVoutValue(db *sql.DB, txHash string, voutIndex uint32) (value uint64, err error) {
 	err = db.QueryRow(internal.RetrieveVoutValue, txHash, voutIndex).Scan(&value)
 	return

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -281,7 +281,7 @@ func (pgb *ChainDB) handleUpgrades(client *rpcutils.BlockGate,
 
 	case blocksTableMainchainUpgrade:
 		// blocks table upgrade proceeds from best block back to genesis
-		blockHash, err := pgb.HashDB()
+		_, blockHash, _, err := RetrieveBestBlockHeightAny(pgb.db)
 		if err != nil {
 			return false, fmt.Errorf("failed to retrieve best block from DB: %v", err)
 		}


### PR DESCRIPTION
The `HashDB` function required the `is_mainchain` column, but it did not
yet exist at the time of upgrade.  This was added to the query after
the upgrade was initially tested.