### PR TITLE
README: update for 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,11 +308,21 @@ default in a reduced functionality ("lite") mode that does not require
 PostgreSQL. To enable the PostgreSQL backend (and the expanded functionality),
 dcrdata may be started with the `--pg` switch.
 
-### JSON REST API
+### Insight API (EXPERIMENTAL)
 
-The API serves JSON data over HTTP(S). **All API endpoints are currently
-prefixed with `/api`** (e.g. `http://localhost:7777/api/stake`).  The Insight
-API endpoints (not described in this section) are prefixed with `/insight/api`.
+The [Insight API](https://github.com/bitpay/insight-api) is accessible via HTTP
+at the `/insight/api` URL path prefix, and via WebSocket at the
+`/insight/socket.io` URL path prefix.
+
+The following endpoints are not implemented: `status`, `sync`, `peer`, `email`,
+and `rates`.
+
+### dcrdata API
+
+dcrdata has its own JSON HTTP API in addition to the experimental Insight API
+implementation. **dcrdata's API endpoints are prefixed with `/api`** (e.g.
+`http://localhost:7777/api/stake`).  The Insight API endpoints (not described in
+this section) are prefixed with `/insight/api`.
 
 #### Endpoint List
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The dcrdata repository is a collection of golang packages and apps for [Decred](
 ├── blockdata           Package blockdata is the primary data collection and
 |                         storage hub, and chain monitor.
 ├── cmd
-│   ├── rebuilddb       rebuilddb utility, for SQLite backend. Not requried.
-│   ├── rebuilddb2      rebuilddb2 utility, for PostgreSQL backend. Not requried.
-│   └── scanblocks      scanblocks utility. Not requried.
+│   ├── rebuilddb       rebuilddb utility, for SQLite backend. Not required.
+│   ├── rebuilddb2      rebuilddb2 utility, for PostgreSQL backend. Not required.
+│   └── scanblocks      scanblocks utility. Not required.
 ├── dcrdataapi          Package dcrdataapi for golang API clients.
 ├── db
 │   ├── agendadb        Package agendadb is a basic PoS voting agenda database.
@@ -52,7 +52,8 @@ The dcrdata repository is a collection of golang packages and apps for [Decred](
 * Running `dcrd` (>=1.3.0) synchronized to the current best block on the
   network. This is a strict requirement as testnet2 support is removed from
   dcrdata v3.0.0.
-* (Optional) PostgreSQL 9.6+, if running in "full" mode.
+* (Optional) PostgreSQL 9.6+, if running in "full" mode. v10.x is recommended
+  for improved dump/restore formats and utilities.
 
 ## Installation
 
@@ -102,10 +103,12 @@ vendor folders and run `dep ensure -vendor-only` again.
 
 The config file, logs, and data files are stored in the application data folder,
 which may be specified via the `-A/--appdata` and `-b/--datadir` settings.
-However, the location of the config file may be set with `-C/--configfile`.
+However, the location of the config file may be set with `-C/--configfile`. If
+encountering errors involving file system paths, check the permissions on these
+folders to ensure that *the user running dcrdata* is able to access these paths.
 
 The "public" and "views" folders *must* be in the same folder as the `dcrdata`
-executable.
+executable. Set read-only permissions as appropriate.
 
 ## Updating
 
@@ -218,6 +221,10 @@ dcrd.conf:
 txindex=1
 addrindex=1
 ```
+
+If these parameters are not set, dcrdata will be unable to retrieve transaction
+details and perform address searches, and will exit with an error mentioning
+these indexes.
 
 ### Starting dcrdata
 


### PR DESCRIPTION
Remove github releaes badge (only tags matter).
Update repository overview with new folders and better descriptions.
Update required dcrd to 1.3 (testnet3).
Clean up and clarify Upgrading Instructions.
Add more about PostgreSQL tuning.
Add System hardware requirements section.
Update JSON API tables with new endpoints (block subsidy, tx vinfo,
tx hex, tx decoded, address totals).