### PR TITLE
Adds ability to use environment variables as configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,6 +90,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:52bfb87fc34164f7f35ce3711e8bb4ba885f9de258c2ee538ad5d52e1f6b76c3"
+  name = "github.com/caarlos0/env"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bc122c26dc2d72f6904a9e0cb940ca508660067c"
+
+[[projects]]
+  branch = "master"
   digest = "1:5716c51d611dd699ea9ec471febe2096535a24ba63bbde053e592d51fec40689"
   name = "github.com/chappjc/logrus-prefix"
   packages = ["."]
@@ -494,6 +502,7 @@
   input-imports = [
     "github.com/asdine/storm",
     "github.com/btcsuite/go-flags",
+    "github.com/caarlos0/env",
     "github.com/chappjc/logrus-prefix",
     "github.com/chappjc/trylock",
     "github.com/davecgh/go-spew/spew",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,9 @@
 #   non-go = false
 #   go-tests = true
 #   unused-packages = true
-
+[[constraint]]
+  name = "github.com/caarlos0/env"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/asdine/storm"
@@ -97,7 +99,7 @@
   branch = "master"
   name = "golang.org/x/net"
 
-  
+
 [[constraint]]
   name = "github.com/decred/slog"
   version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -195,6 +195,68 @@ cp sample-dcrdata.conf ~/.dcrdata/dcrdata.conf
 Then edit dcrdata.conf with your dcrd RPC settings. See the output of `dcrdata --help`
 for a list of all options and their default values.
 
+### Using Configuration Environment Variables
+There will be times when you don't want to fuss with a config file or
+cannot use command line args such as when using docker, heroku, kubernetes or other cloud
+platform.  
+
+Almost all configuation items are avaiable to set via environment variables.
+To have a look at what you can set please see config.go source code and the config struct (line 68).
+
+Each config setting uses the env tag to specify the name of the environment variable.
+
+ie. `env:"USE_TESTNET"`
+
+So when starting dcrdata you can now use with environment variables `USE_TESTNET=true dcrdata`
+
+Config precedence:
+  1. Command line flags have top priority
+  2. Config file settings
+  3. Environment variables
+  4. default config embedded in source code
+
+Any variable that starts with USE, ENABLE, DISABLE or otherwise asks a question must be a true/false value.
+
+List of variables that can be set:
+
+|Description|Name|
+|-----------|----|
+|Path to application home directory| DCRDATA_APPDATA_DIR|
+|Path to configuration file|DCRDATA_CONFIG_FILE|
+|Directory to store data|DCRDATA_DATA_DIR|
+|Directory to log output|DCRDATA_LOG_DIR|
+|Folder for file outputs|DCRDATA_OUT_FOLDER|
+|Use the test network (default mainnet)|DCRDATA_USE_TESTNET|
+|Use the simulation test network (default mainnet)|DCRDATA_USE_SIMNET|
+|Logging level {trace, debug, info, warn, error, critical}|DCRDATA_LOG_LEVEL|
+|Easy way to set debuglevel to error|DCRDATA_QUIET|
+|Start HTTP profiler.|DCRDATA_ENABLE_HTTP_PROFILER|
+|URL path prefix for the HTTP profiler.| DCRDATA_HTTP_PROFILER_PREFIX|
+|File for CPU profiling.|DCRDATA_CPU_PROFILER_FILE|
+|Run with gops diagnostics agent listening. See github.com/google/gops for more information.|DCRDATA_USE_GOPS|
+|Protocol for API (http or https)|DCRDATA_ENABLE_HTTPS|
+|Listen address for API|DCRDATA_LISTEN_URL|
+|Use the RealIP to get the client's real IP from the X-Forwarded-For or X-Real-IP headers, in that order.|DCRDATA_USE_REAL_IP|
+|Set CacheControl in the HTTP response header|DCRDATA_MAX_CACHE_AGE|
+|Monitor mempool for new transactions, and report ticketfee info when new tickets are added.|DCRDATA_ENABLE_MEMPOOL_MONITOR|
+|The minimum time in seconds between mempool reports, regarless of number of new tickets seen.|DCRDATA_MEMPOOL_MIN_INTERVAL|
+|The maximum time in seconds between mempool reports (within a couple seconds), regarless of number of new tickets seen.|DCRDATA_MEMPOOL_MAX_INTERVAL|
+|The number minimum number of new tickets that must be seen to trigger a new mempool report.|DCRDATA_MP_TRIGGER_TICKETS|
+|Dump to file the fees of all the tickets in mempool.|DCRDATA_ENABLE_DUMP_ALL_MP_TIX|
+|SQLite DB file name (default is dcrdata.sqlt.db)|DCRDATA_SQLITE_DB_FILE_NAME|
+|Run in "Full Mode" mode,  enables postgresql support|DCRDATA_ENABLE_FULL_MODE|
+|PostgreSQL DB name.|DCRDATA_PG_DB_NAME|
+|PostgreSQL DB user|DCRDATA_POSTGRES_USER|
+|PostgreSQL DB password.|DCRDATA_POSTGRES_PASS|
+port or UNIX socket (e.g. /run/postgresql).|DCRDATA_POSTGRES_HOST_URL|
+|Disable automatic dev fund balance query on new blocks.|DCRDATA_DISABLE_DEV_PREFETCH|
+|Sync to the best block and exit. Do not start the explorer or API.|DCRDATA_ENABLE_SYNC_N_QUIT|
+|Daemon RPC user name|DCRDATA_DCRD_USER|
+|Daemon RPC password|DCRDATA_DCRD_PASS|
+|Hostname/IP and port of dcrd RPC server|DCRDATA_DCRD_URL|
+|File containing the dcrd certificate file|DCRDATA_DCRD_CERT|
+|Disable TLS for the daemon RPC client *see source code|DCRDATA_DCRD_DISABLE_TLS|
+
 ### Indexing the Blockchain
 
 If dcrdata has not previously been run with the PostgreSQL database backend, it

--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ cannot use command line args such as when using docker, heroku, kubernetes or ot
 platform.  
 
 Almost all configuation items are avaiable to set via environment variables.
-To have a look at what you can set please see config.go source code and the config struct (line 68).
+To have a look at what you can set please see config.go file and the config struct.
 
 Each config setting uses the env tag to specify the name of the environment variable.
 
-ie. `env:"USE_TESTNET"`
+ie. `env:"DCRDATA_USE_TESTNET"`
 
-So when starting dcrdata you can now use with environment variables `USE_TESTNET=true dcrdata`
+So when starting dcrdata you can now use with environment variables `DCRDATA_USE_TESTNET=true ./dcrdata`
 
 Config precedence:
   1. Command line flags have top priority
@@ -255,7 +255,7 @@ port or UNIX socket (e.g. /run/postgresql).|DCRDATA_POSTGRES_HOST_URL|
 |Daemon RPC password|DCRDATA_DCRD_PASS|
 |Hostname/IP and port of dcrd RPC server|DCRDATA_DCRD_URL|
 |File containing the dcrd certificate file|DCRDATA_DCRD_CERT|
-|Disable TLS for the daemon RPC client *see source code|DCRDATA_DCRD_DISABLE_TLS|
+|Disable TLS for the daemon RPC client|DCRDATA_DCRD_DISABLE_TLS|
 
 ### Indexing the Blockchain
 

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	flags "github.com/btcsuite/go-flags"
+	"github.com/caarlos0/env"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
@@ -65,43 +66,43 @@ var (
 
 type config struct {
 	// General application behavior
-	HomeDir      string `short:"A" long:"appdata" description:"Path to application home directory"`
-	ConfigFile   string `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir      string `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir       string `long:"logdir" description:"Directory to log output."`
-	OutFolder    string `short:"f" long:"outfolder" description:"Folder for file outputs"`
+	HomeDir      string `short:"A" long:"appdata" description:"Path to application home directory" env:"DCRDATA_APPDATA_DIR"`
+	ConfigFile   string `short:"C" long:"configfile" description:"Path to configuration file" env:"DCRDATA_CONFIG_FILE"`
+	DataDir      string `short:"b" long:"datadir" description:"Directory to store data" env:"DCRDATA_DATA_DIR"`
+	LogDir       string `long:"logdir" description:"Directory to log output." env:"DCRDATA_LOG_DIR"`
+	OutFolder    string `short:"f" long:"outfolder" description:"Folder for file outputs" env:"DCRDATA_OUT_FOLDER"`
 	ShowVersion  bool   `short:"V" long:"version" description:"Display version information and exit"`
-	TestNet      bool   `long:"testnet" description:"Use the test network (default mainnet)"`
-	SimNet       bool   `long:"simnet" description:"Use the simulation test network (default mainnet)"`
-	DebugLevel   string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
-	Quiet        bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
-	HTTPProfile  bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
-	HTTPProfPath string `long:"httpprofprefix" description:"URL path prefix for the HTTP profiler."`
-	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling."`
-	UseGops      bool   `short:"g" long:"gops" description:"Run with gops diagnostics agent listening. See github.com/google/gops for more information."`
+	TestNet      bool   `long:"testnet" description:"Use the test network (default mainnet)" env:"DCRDATA_USE_TESTNET"`
+	SimNet       bool   `long:"simnet" description:"Use the simulation test network (default mainnet)" env:"DCRDATA_USE_SIMNET"`
+	DebugLevel   string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}" env:"DCRDATA_LOG_LEVEL"`
+	Quiet        bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error" env:"DCRDATA_QUIET"`
+	HTTPProfile  bool   `long:"httpprof" short:"p" description:"Start HTTP profiler." env:"DCRDATA_ENABLE_HTTP_PROFILER"`
+	HTTPProfPath string `long:"httpprofprefix" description:"URL path prefix for the HTTP profiler." env:"DCRDATA_HTTP_PROFILER_PREFIX"`
+	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling." env:"DCRDATA_CPU_PROFILER_FILE"`
+	UseGops      bool   `short:"g" long:"gops" description:"Run with gops diagnostics agent listening. See github.com/google/gops for more information." env:"DCRDATA_USE_GOPS"`
 
 	// API
-	APIProto           string `long:"apiproto" description:"Protocol for API (http or https)"`
-	APIListen          string `long:"apilisten" description:"Listen address for API"`
+	APIProto           string `long:"apiproto" description:"Protocol for API (http or https)" env:"DCRDATA_ENABLE_HTTPS"`
+	APIListen          string `long:"apilisten" description:"Listen address for API" env:"DCRDATA_LISTEN_URL"`
 	IndentJSON         string `long:"indentjson" description:"String for JSON indentation (default is \"   \"), when indentation is requested via URL query."`
-	UseRealIP          bool   `long:"userealip" description:"Use the RealIP middleware from the pressly/chi/middleware package to get the client's real IP from the X-Forwarded-For or X-Real-IP headers, in that order."`
-	CacheControlMaxAge int    `long:"cachecontrol-maxage" description:"Set CacheControl in the HTTP response header to a value in seconds for clients to cache the response. This applies only to FileServer routes."`
+	UseRealIP          bool   `long:"userealip" description:"Use the RealIP middleware from the pressly/chi/middleware package to get the client's real IP from the X-Forwarded-For or X-Real-IP headers, in that order." env:"DCRDATA_USE_REAL_IP"`
+	CacheControlMaxAge int    `long:"cachecontrol-maxage" description:"Set CacheControl in the HTTP response header to a value in seconds for clients to cache the response. This applies only to FileServer routes." env:"DCRDATA_MAX_CACHE_AGE"`
 
 	// Data I/O
-	MonitorMempool     bool   `short:"m" long:"mempool" description:"Monitor mempool for new transactions, and report ticketfee info when new tickets are added."`
-	MempoolMinInterval int    `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regarless of number of new tickets seen."`
-	MempoolMaxInterval int    `long:"mp-max-interval" description:"The maximum time in seconds between mempool reports (within a couple seconds), regarless of number of new tickets seen."`
-	MPTriggerTickets   int    `long:"mp-ticket-trigger" description:"The number minimum number of new tickets that must be seen to trigger a new mempool report."`
-	DumpAllMPTix       bool   `long:"dumpallmptix" description:"Dump to file the fees of all the tickets in mempool."`
-	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)."`
+	MonitorMempool     bool   `short:"m" long:"mempool" description:"Monitor mempool for new transactions, and report ticketfee info when new tickets are added." env:"DCRDATA_ENABLE_MEMPOOL_MONITOR"`
+	MempoolMinInterval int    `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regarless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`
+	MempoolMaxInterval int    `long:"mp-max-interval" description:"The maximum time in seconds between mempool reports (within a couple seconds), regarless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MAX_INTERVAL"`
+	MPTriggerTickets   int    `long:"mp-ticket-trigger" description:"The number minimum number of new tickets that must be seen to trigger a new mempool report." env:"DCRDATA_MP_TRIGGER_TICKETS"`
+	DumpAllMPTix       bool   `long:"dumpallmptix" description:"Dump to file the fees of all the tickets in mempool." env:"DCRDATA_ENABLE_DUMP_ALL_MP_TIX"`
+	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)." env:"DCRDATA_SQLITE_DB_FILE_NAME"`
 
-	FullMode      bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support"`
-	PGDBName      string `long:"pgdbname" description:"PostgreSQL DB name."`
-	PGUser        string `long:"pguser" description:"PostgreSQL DB user."`
-	PGPass        string `long:"pgpass" description:"PostgreSQL DB password."`
-	PGHost        string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
-	NoDevPrefetch bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
-	SyncAndQuit   bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API."`
+	FullMode      bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support" env:"DCRDATA_ENABLE_FULL_MODE"`
+	PGDBName      string `long:"pgdbname" description:"PostgreSQL DB name." env:"DCRDATA_PG_DB_NAME"`
+	PGUser        string `long:"pguser" description:"PostgreSQL DB user." env:"DCRDATA_POSTGRES_USER"`
+	PGPass        string `long:"pgpass" description:"PostgreSQL DB password." env:"DCRDATA_POSTGRES_PASS"`
+	PGHost        string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)." env:"DCRDATA_POSTGRES_HOST_URL"`
+	NoDevPrefetch bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
+	SyncAndQuit   bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`
 
 	// WatchAddresses []string `short:"w" long:"watchaddress" description:"Watched address (receiving). One per line."`
 	// SMTPUser     string `long:"smtpuser" description:"SMTP user name"`
@@ -111,11 +112,11 @@ type config struct {
 	// EmailSubject string `long:"emailsubj" description:"Email subject. (default \"dcrdataapi transaction notification\")"`
 
 	// RPC client options
-	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name"`
-	DcrdPass         string `long:"dcrdpass" description:"Daemon RPC password"`
-	DcrdServ         string `long:"dcrdserv" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:19556)"`
-	DcrdCert         string `long:"dcrdcert" description:"File containing the dcrd certificate file"`
-	DisableDaemonTLS bool   `long:"nodaemontls" description:"Disable TLS for the daemon RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost"`
+	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name" env:"DCRDATA_DCRD_USER"`
+	DcrdPass         string `long:"dcrdpass" description:"Daemon RPC password" env:"DCRDATA_DCRD_PASS"`
+	DcrdServ         string `long:"dcrdserv" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:19556)" env:"DCRDATA_DCRD_URL"`
+	DcrdCert         string `long:"dcrdcert" description:"File containing the dcrd certificate file" env:"DCRDATA_DCRD_CERT"`
+	DisableDaemonTLS bool   `long:"nodaemontls" description:"Disable TLS for the daemon RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost" env:"DCRDATA_DCRD_DISABLE_TLS"`
 }
 
 var (
@@ -269,17 +270,22 @@ func loadConfig() (*config, error) {
 	loadConfigError := func(err error) (*config, error) {
 		return nil, err
 	}
-
 	// Default config.
 	cfg := defaultConfig
-
+	// Load environment variables into the config overriding the default config
+	err := env.Parse(&cfg)
+	if err != nil {
+		return loadConfigError(err)
+	}
 	// Pre-parse the command line options to see if an alternative config
 	// file or the version flag was specified.
+	// Override any environment variables with parsed command flags
 	preCfg := cfg
 	preParser := flags.NewParser(&preCfg, flags.HelpFlag|flags.PassDoubleDash)
-	_, err := preParser.Parse()
-	if err != nil {
-		e, ok := err.(*flags.Error)
+	_, flagerr := preParser.Parse()
+
+	if flagerr != nil {
+		e, ok := flagerr.(*flags.Error)
 		if !ok || e.Type != flags.ErrHelp {
 			preParser.WriteHelp(os.Stderr)
 		}
@@ -287,7 +293,7 @@ func loadConfig() (*config, error) {
 			preParser.WriteHelp(os.Stdout)
 			os.Exit(0)
 		}
-		return loadConfigError(err)
+		return loadConfigError(flagerr)
 	}
 
 	// Show the version and exit if the version flag was specified.
@@ -457,7 +463,6 @@ func loadConfig() (*config, error) {
 		parser.WriteHelp(os.Stderr)
 		return loadConfigError(err)
 	}
-
 	return &cfg, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	"github.com/decred/dcrd/dcrutil"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/decred/dcrd/dcrutil"
 )
 
 func TestMain(m *testing.M) {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"flag"
+	"github.com/decred/dcrd/dcrutil"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Temp config file is used to ensure there are no external influences
+	// from previously set env variables or default config files.
+	file, _ := ioutil.TempFile("", "dcrdata_test_file.cfg")
+	defer os.Remove(file.Name())
+	os.Setenv("DCRDATA_CONFIG_FILE", file.Name())
+
+	// Parse the -test.* flags before removing them from the command line
+	// arguments list, which we do to allow go-flags to succeed.
+	flag.Parse()
+	os.Args = os.Args[:1]
+	// Run the tests now that the testing package flags have been parsed.
+	m.Run()
+	os.Setenv("DCRDATA_CONFIG_FILE", "")
+}
+
+func TestDefaultConfig(t *testing.T) {
+	c := defaultConfig
+	if c.ConfigFile != defaultConfigFile {
+		t.Errorf("expected %s config %s ", c.ConfigFile, defaultConfigFile)
+	}
+}
+
+func TestDefaultConfigFile(t *testing.T) {
+	appdir := dcrutil.AppDataDir("dcrdata", false)
+	dcrpath := filepath.Join(appdir, "dcrdata.conf")
+	if defaultConfigFile != dcrpath {
+		t.Errorf("expected %s config %s ", defaultConfigFile, dcrpath)
+		t.Errorf("Failed to load default dcrdata config")
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	_, err := loadConfig()
+	if err != nil {
+		t.Errorf("Failed to load dcrdata config: %s\n", err.Error())
+	}
+}
+
+func TestDefaultConfigAPIListen(t *testing.T) {
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Errorf("Failed to load dcrdata config: %s\n", err.Error())
+	} else {
+		v := cfg.APIListen
+		if v != "127.0.0.1:7777" {
+			t.Errorf("config expected %s but returned %s", "127.0.0.1:7777", v)
+		}
+	}
+
+}
+
+func TestDefaultConfigAPIListenWithEnv(t *testing.T) {
+	os.Setenv("DCRDATA_LISTEN_URL", "0.0.0.0:7777")
+	cfg, _ := loadConfig()
+	v := cfg.APIListen
+	if v != "0.0.0.0:7777" {
+		t.Errorf("config expected %s but returned %s", "0.0.0.0:7777", v)
+	}
+}
+
+func TestDefaultConfigAppDataDir(t *testing.T) {
+	appdir := dcrutil.AppDataDir("dcrdata", false)
+	cfg, _ := loadConfig()
+	v := cfg.HomeDir
+	expected := appdir
+	if v != expected {
+		t.Errorf("config expected %s but returned %s", expected, v)
+	}
+}
+
+func TestDefaultConfigHomeDirWithEnv(t *testing.T) {
+	os.Setenv("DCRDATA_APPDATA_DIR", "/tmp/test")
+	cfg, _ := loadConfig()
+	v := cfg.HomeDir
+	expected := "/tmp/test"
+	if v != expected {
+		t.Errorf("config expected %s but returned %s", expected, v)
+	}
+}
+
+// Test to ensure that the flags override env variables.
+func TestDefaultConfigHomeDirWithEnvAndFlag(t *testing.T) {
+	os.Args = append(os.Args, "--appdata=/tmp/test2")
+	os.Setenv("DCRDATA_APPDATA_DIR", "/tmp/test")
+	cfg, _ := loadConfig()
+	v := cfg.HomeDir
+	expected := filepath.Join("/tmp/test2")
+	if v != expected {
+		t.Errorf("config expected %s but returned %s", expected, v)
+	}
+}
+
+func TestDefaultConfigTestNet(t *testing.T) {
+	cfg, _ := loadConfig()
+	v := cfg.TestNet
+	if v {
+		t.Errorf("config expected true but returned %+v", v)
+	}
+}
+
+func TestDefaultConfigTestNetWithEnv(t *testing.T) {
+	os.Setenv("DCRDATA_USE_TESTNET", "true")
+	cfg, _ := loadConfig()
+	v := cfg.TestNet
+	if !v {
+		t.Errorf("config expected true but returned %+v", v)
+	}
+}
+
+func TestDefaultConfigTestNetWithEnvAndBadValue(t *testing.T) {
+	os.Setenv("DCRDATA_USE_TESTNET", "no")
+	_, err := loadConfig()
+	if err == nil {
+		t.Errorf("Failed to throw error when bad value is passed")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Sereal/Sereal v0.0.0-20180727013122-68c42fd7bfdf // indirect
 	github.com/asdine/storm v2.1.1+incompatible
 	github.com/btcsuite/go-flags v0.0.0-20150116065318-6c288d648c1c
+	github.com/caarlos0/env v3.3.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
 	github.com/chappjc/trylock v1.0.0
 	github.com/coreos/bbolt v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79il
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
 github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJGQE=
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
+github.com/caarlos0/env v3.3.0+incompatible h1:jCfY0ilpzC2FFViyZyDKCxKybDESTwaR+ebh8zm6AOE=
+github.com/caarlos0/env v3.3.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb h1:aZTKxMminKeQWHtzJBbV8TttfTxzdJ+7iEJFE6FmUzg=
 github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb/go.mod h1:xzXc1S/L+64uglB3pw54o8kqyM6KFYpTeC9Q6+qZIu8=
 github.com/chappjc/trylock v1.0.0 h1:WR9J1cP/+h0x9RoKsxf4I0AnYg7aONYjiwYwys8nibA=


### PR DESCRIPTION
  * Adds a new packgae env that allows us to declare env variables
    as a struct tag.

  * previously in order to set config data one had to use a config
    file or set a bunch of command line arguments.

  * This adds the ability to use environment variables
    which makes this more compatabile with 12 factor app design,
    in addition to docker and docker-compose.

  * Without this users are forced to invoke dcrdata in a non dynamic
    way because config files and command line args must be hard coded.

  * Adds simple config test file as no testing existed before