### PR TITLE
dcrpg: fix upgrade to 3.5.1 from <3.5.0

### DIFF
--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -183,6 +183,9 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 			return isSuccess, er
 		}
 
+		// Go on to next upgrade
+		fallthrough
+
 		// Upgrade from 3.5.0 --> 3.5.1
 	case version.major == 3 && version.minor == 5 && version.patch == 0:
 		toVersion = TableVersion{3, 5, 1}


### PR DESCRIPTION
A missing fallthrough statement ad the end of the 3.4.1 -> 3.5.0 upgrade
broke upgrading to 3.5.1 from any version but 3.5.0.