### PR TITLE
Fix performance issues on address page

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -369,28 +369,29 @@ type AddressRow struct {
 // ChartsData defines the fields that store the values needed to plot the charts
 // on the frontend.
 type ChartsData struct {
-	TimeStr    []string  `json:"timestr,omitempty"`
-	Difficulty []float64 `json:"difficulty,omitempty"`
-	Time       []uint64  `json:"time,omitempty"`
-	Value      []uint64  `json:"value,omitempty"`
-	Size       []uint64  `json:"size,omitempty"`
-	ChainSize  []uint64  `json:"chainsize,omitempty"`
-	Count      []uint64  `json:"count,omitempty"`
-	SizeF      []float64 `json:"sizef,omitempty"`
-	ValueF     []float64 `json:"valuef,omitempty"`
-	Unspent    []uint64  `json:"unspent,omitempty"`
-	Revoked    []uint64  `json:"revoked,omitempty"`
-	Height     []uint64  `json:"height,omitempty"`
-	Pooled     []uint64  `json:"pooled,omitempty"`
-	Solo       []uint64  `json:"solo,omitempty"`
-	RegularTx  []uint64  `json:"regularTx,omitempty"`
-	Tickets    []uint64  `json:"tickets,omitempty"`
-	Votes      []uint64  `json:"votes,omitempty"`
-	RevokeTx   []uint64  `json:"revokeTx,omitempty"`
-	Amount     []float64 `json:"amount,omitempty"`
-	Received   []float64 `json:"received,omitempty"`
-	Sent       []float64 `json:"sent,omitempty"`
-	Net        []float64 `json:"net,omitempty"`
+	TimeStr     []string  `json:"timestr,omitempty"`
+	Difficulty  []float64 `json:"difficulty,omitempty"`
+	Time        []uint64  `json:"time,omitempty"`
+	Value       []uint64  `json:"value,omitempty"`
+	Size        []uint64  `json:"size,omitempty"`
+	ChainSize   []uint64  `json:"chainsize,omitempty"`
+	Count       []uint64  `json:"count,omitempty"`
+	SizeF       []float64 `json:"sizef,omitempty"`
+	ValueF      []float64 `json:"valuef,omitempty"`
+	Unspent     []uint64  `json:"unspent,omitempty"`
+	Revoked     []uint64  `json:"revoked,omitempty"`
+	Height      []uint64  `json:"height,omitempty"`
+	Pooled      []uint64  `json:"pooled,omitempty"`
+	Solo        []uint64  `json:"solo,omitempty"`
+	SentRtx     []uint64  `json:"sentRtx,omitempty"`
+	ReceivedRtx []uint64  `json:"receivedRtx,omitempty"`
+	Tickets     []uint64  `json:"tickets,omitempty"`
+	Votes       []uint64  `json:"votes,omitempty"`
+	RevokeTx    []uint64  `json:"revokeTx,omitempty"`
+	Amount      []float64 `json:"amount,omitempty"`
+	Received    []float64 `json:"received,omitempty"`
+	Sent        []float64 `json:"sent,omitempty"`
+	Net         []float64 `json:"net,omitempty"`
 }
 
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -120,13 +120,17 @@ const (
 	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1
 		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2;`
 
-	// rtx defines Regular transactions, ssTx defines tickets, ssGen defines votes
-	// and ssRtx defines Revocation transactions
+	SelectAddressOldestTxBlockTime = `SELECT block_time FROM addresses WHERE
+		address=$1 ORDER BY block_time DESC LIMIT 1;`
+
+	// Rtx defines Regular transactions grouped into (SentRtx and ReceivedRtx),
+	// SSTx defines tickets, SSGen defines votes and SSRtx defines Revocation transactions
 	SelectAddressTxTypesByAddress = `SELECT (block_time/$1)*$1 as timestamp,
-		COUNT(CASE WHEN tx_type = 0 THEN 1 ELSE NULL END) as rtx,
-		COUNT(CASE WHEN tx_type = 1 THEN 1 ELSE NULL END) as ssTx,
-		COUNT(CASE WHEN tx_type = 2 THEN 1 ELSE NULL END) as ssGen,
-		COUNT(CASE WHEN tx_type = 3 THEN 1 ELSE NULL END) as ssRtx
+		COUNT(CASE WHEN tx_type = 0 AND is_funding = false THEN 1 ELSE NULL END) as SentRtx,
+		COUNT(CASE WHEN tx_type = 0 AND is_funding = true THEN 1 ELSE NULL END) as ReceivedRtx,
+		COUNT(CASE WHEN tx_type = 1 THEN 1 ELSE NULL END) as SSTx,
+		COUNT(CASE WHEN tx_type = 2 THEN 1 ELSE NULL END) as SSGen,
+		COUNT(CASE WHEN tx_type = 3 THEN 1 ELSE NULL END) as SSRtx
 		FROM addresses WHERE address=$2 GROUP BY timestamp ORDER BY timestamp;`
 
 	SelectAddressAmountFlowByAddress = `SELECT (block_time/$1)*$1 as timestamp,

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -131,7 +131,7 @@ const (
 	SelectStakeTxByHash   = `SELECT id, block_hash, block_index FROM transactions WHERE tx_hash = $1 and tree=1;`
 
 	IndexTransactionTableOnBlockIn = `CREATE UNIQUE INDEX uix_tx_block_in
-		ON transactions(block_hash, block_index, tree);`  // with cockroach: STORING (tx_hash, block_hash)
+		ON transactions(block_hash, block_index, tree);` // with cockroach: STORING (tx_hash, block_hash)
 	DeindexTransactionTableOnBlockIn = `DROP INDEX uix_tx_block_in;`
 
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX uix_tx_hashes

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -131,7 +131,7 @@ const (
 	SelectStakeTxByHash   = `SELECT id, block_hash, block_index FROM transactions WHERE tx_hash = $1 and tree=1;`
 
 	IndexTransactionTableOnBlockIn = `CREATE UNIQUE INDEX uix_tx_block_in
-		ON transactions(block_hash, block_index, tree);` // with cockroach: STORING (tx_hash, block_hash)
+		ON transactions(block_hash, block_index, tree);`
 	DeindexTransactionTableOnBlockIn = `DROP INDEX uix_tx_block_in;`
 
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX uix_tx_hashes

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -484,6 +484,13 @@ func (pgb *ChainDB) AgendaVotes(agendaID string, chartType int) (*dbtypes.Agenda
 	return retrieveAgendaVoteChoices(pgb.db, agendaID, chartType)
 }
 
+// GetOldestTxBlockTime returns the block time of the oldest transaction made in
+// relation to the provided address. This helps provide more meaningful graphs
+// with the addresses history plotted.
+func (pgb *ChainDB) GetOldestTxBlockTime(addr string) (int64, error) {
+	return retrieveOldestTxBlockTime(pgb.db, addr)
+}
+
 // AddressTransactions retrieves a slice of *dbtypes.AddressRow for a given
 // address and transaction type (i.e. all, credit, or debit) from the DB. Only
 // the first N transactions starting from the offset element in the set of all

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1633,6 +1633,14 @@ func closeRows(rows *sql.Rows) {
 	}
 }
 
+// retrieveOldestTxBlockTime helps choose the most appropriate address page
+// graph grouping to load by default depending on when the first transaction to
+// the specific address was made.
+func retrieveOldestTxBlockTime(db *sql.DB, addr string) (blockTime int64, err error) {
+	err = db.QueryRow(internal.SelectAddressOldestTxBlockTime, addr).Scan(&blockTime)
+	return
+}
+
 // retrieveTxHistoryByType fetches the transaction types count for all the
 // transactions associated with a given address for the given time interval.
 // The time interval is grouping records by week, month, year, day and all.
@@ -1651,14 +1659,15 @@ func retrieveTxHistoryByType(db *sql.DB, addr string,
 	defer closeRows(rows)
 
 	for rows.Next() {
-		var blockTime, regularTx, tickets, votes, revokeTx uint64
-		err = rows.Scan(&blockTime, &regularTx, &tickets, &votes, &revokeTx)
+		var blockTime, sentRtx, receivedRtx, tickets, votes, revokeTx uint64
+		err = rows.Scan(&blockTime, &sentRtx, &receivedRtx, &tickets, &votes, &revokeTx)
 		if err != nil {
 			return nil, err
 		}
 
 		items.Time = append(items.Time, blockTime)
-		items.RegularTx = append(items.RegularTx, regularTx)
+		items.SentRtx = append(items.SentRtx, sentRtx)
+		items.ReceivedRtx = append(items.ReceivedRtx, receivedRtx)
 		items.Tickets = append(items.Tickets, tickets)
 		items.Votes = append(items.Votes, votes)
 		items.RevokeTx = append(items.RevokeTx, revokeTx)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -75,6 +75,7 @@ type explorerDataSource interface {
 	SideChainBlocks() ([]*dbtypes.BlockStatus, error)
 	//SideChainTips() []*dbtypes.BlockStatus
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
+	GetOldestTxBlockTime(addr string) (int64, error)
 }
 
 // cacheChartsData holds the prepopulated data that is used to draw the charts

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -393,6 +393,8 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		ConfirmHeight []int64
 		Version       string
 		NetName       string
+		OldestTxTime  int64
+		IsLiteMode    bool
 		ChartData     *dbtypes.ChartsData
 	}
 
@@ -434,6 +436,8 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Debugf("Showing transaction types: %s (%d)", txntype, txnType)
+
+	var oldestTxBlockTime int64
 
 	// Retrieve address information from the DB and/or RPC
 	var addrData *AddressInfo
@@ -608,6 +612,14 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				NotFoundStatusType)
 			return
 		}
+
+		oldestTxBlockTime, err = exp.explorerSource.GetOldestTxBlockTime(address)
+		if err != nil {
+			log.Errorf("Unable to fetch oldest transactions block time %s: %v", address, err)
+			exp.StatusPage(w, defaultErrorCode, "oldest block time not found",
+				NotFoundStatusType)
+			return
+		}
 	}
 
 	// Set page parameters
@@ -638,6 +650,8 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	pageData := AddressPageData{
 		Data:          addrData,
 		ConfirmHeight: confirmHeights,
+		IsLiteMode:    exp.liteMode,
+		OldestTxTime:  oldestTxBlockTime,
 		Version:       exp.Version,
 		NetName:       exp.NetName,
 	}

--- a/public/css/charts.css
+++ b/public/css/charts.css
@@ -117,6 +117,7 @@ body.loading .modal {
 .dygraph-title {
     font-weight: bold;
     z-index: 10;
+    font-size: 14px;
     text-align: center;
 }
 

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -81,7 +81,7 @@
             var _this = this
             $.getScript('/js/dygraphs.min.js', () => {
                 _this.typesGraphOptions = {
-                    labels: ['Date', 'SentTx (tx)', 'ReceivedTx (tx)', 'Tickets (sstx)', 'Votes (ssgen)', 'RevokedTx (ssrtx)'],
+                    labels: ['Date', 'Sending (regular)', 'Receiving (regular)', 'Tickets', 'Votes', 'Revocations'],
                     colors: ['#69D3F5', '#2971FF', '#41BF53', 'darkorange', '#FF0090'],
                     ylabel: 'Number of Transactions by Type',
                     title: 'Transactions Types',

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -3,7 +3,7 @@
         var p = []
 
         d.time.map((n, i) => {
-            p.push([new Date(n*1000), d.regularTx[i], d.tickets[i], d.votes[i], d.revokeTx[i]])
+            p.push([new Date(n*1000), d.sentRtx[i], d.receivedRtx[i], d.tickets[i], d.votes[i], d.revokeTx[i]])
         });
         return p
     }
@@ -34,23 +34,22 @@
     }
 
     function formatter(data) {
-        if (data.x == null) return '';
-        var html = this.getLabels()[0] + ': ' + data.xHTML;
+        var html = this.getLabels()[0] + ': ' + ((data.xHTML==undefined) ? '': data.xHTML);
         data.series.map(function(series){
-            var l = `<span style="color: ` + series.color + ';">' +series.labelHTML;
-            html += '<br>' + series.dashHTML  + l + ': ' + series.y +'</span>';
+            if (series.color==undefined) return '';
+            var l = `<span style="color: ` + series.color + ';"> ' + series.labelHTML;
+            html += '<br>' + series.dashHTML  + l + ': ' + (isNaN(series.y) ? '': series.y) + '</span>';
         });
         return html;
     }
 
     function customizedFormatter(data) {
-        if (data.x == null) return '';
-        var html = this.getLabels()[0] + ': ' + data.xHTML;
+        var html = this.getLabels()[0] + ': ' + ((data.xHTML==undefined) ? '': data.xHTML);
         data.series.map(function(series){
-            if (isNaN(series.y)) return '';
+            if (series.color==undefined) return '';
             if (series.y === 0 && series.labelHTML.includes('Net')) return '';
-            var l = `<span style="color: ` + series.color + ';">' +series.labelHTML;
-            html += '<br>' + series.dashHTML  + l + ': ' + series.y +' DCR</span>';
+            var l = `<span style="color: ` + series.color + ';"> ' + series.labelHTML;
+            html += '<br>' + series.dashHTML  + l + ': ' + (isNaN(series.y) ? '': series.y + ' DCR') + '</span> ';
         });
         return html;
     }
@@ -61,7 +60,6 @@
             showRangeSelector: true,
             legend: 'follow',
             xlabel: 'Date',
-            labelsSeparateLines: true,
             fillAlpha: 0.9,
             labelsKMB: true
         }
@@ -83,11 +81,11 @@
             var _this = this
             $.getScript('/js/dygraphs.min.js', () => {
                 _this.typesGraphOptions = {
-                    labels: ['Date', 'RegularTx', 'Tickets', 'Votes', 'RevokeTx'],
-                    colors: ['#2971FF', '#41BF53', 'darkorange', '#FF0090'],
+                    labels: ['Date', 'SentTx (tx)', 'ReceivedTx (tx)', 'Tickets (sstx)', 'Votes (ssgen)', 'RevokedTx (ssrtx)'],
+                    colors: ['#69D3F5', '#2971FF', '#41BF53', 'darkorange', '#FF0090'],
                     ylabel: 'Number of Transactions by Type',
                     title: 'Transactions Types',
-                    visibility: [true, true, true, true],
+                    visibility: [true, true, true, true, true],
                     legendFormatter: formatter,
                     plotter: barchartPlotter,
                     stackedGraph: true,
@@ -139,7 +137,6 @@
                 $('#no-bal').removeClass('d-hide');
                 $('#history-chart').addClass('d-hide');
                 $('body').removeClass('loading');
-                _this.disableBtnsIfNotApplicable()
                 return
             }
 
@@ -179,7 +176,6 @@
                     }
                     _this.updateFlow()
                     _this.xVal = _this.graph.xAxisExtremes()
-                    _this.disableBtnsIfNotApplicable()
 
                     $('body').removeClass('loading');
                 }
@@ -187,8 +183,11 @@
         }
 
         changeView() {
-            $('body').addClass('loading');
             var _this = this
+            _this.disableBtnsIfNotApplicable()
+
+            $('body').addClass('loading');
+
             var divHide = 'list'
             var divShow = _this.btns
 
@@ -228,7 +227,7 @@
         }
 
         disableBtnsIfNotApplicable(){
-            var val = this.xVal[0]
+            var val = parseInt(this.addrTarget.id)
             var d = new Date()
 
             var pastYear = d.getFullYear() - 1;
@@ -236,20 +235,32 @@
             var pastWeek = d.getDate() - 7
             var pastDay = d.getDate() - 1
 
+            this.enabledButtons = []
             var setApplicableBtns = (className, ts) => {
-                var isApplicable = (val > Number(new Date(ts))) ||
+                var isDisabled = (val > Number(new Date(ts))) ||
                     (this.options === 'unspent' && this.unspent == "0")
                 var zoomElem = this.zoomTarget.getElementsByClassName(className)[0]
-                zoomElem.disabled = isApplicable
+                zoomElem.disabled = isDisabled
 
                 var intervalElem = this.intervalTarget.getElementsByClassName(className)[0]
-                intervalElem.disabled = isApplicable
+                intervalElem.disabled = isDisabled
+
+                if (className !== "year" && !isDisabled){
+                    this.enabledButtons.push(className)
+                }
             }
 
             setApplicableBtns('year', new Date().setFullYear(pastYear))
             setApplicableBtns('month', new Date().setMonth(pastMonth))
             setApplicableBtns('week', new Date().setDate(pastWeek))
             setApplicableBtns('day', new Date().setDate(pastDay))
+
+            if (parseInt(this.intervalTarget.dataset.txcount) < 20) {
+                this.enabledButtons[0] = "all"
+            }
+
+            $("input#chart-size").removeClass("btn-active")
+            $("input#chart-size." + this.enabledButtons[0]).addClass("btn-active");
         }
 
         get options(){

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -85,7 +85,7 @@
                 _this.typesGraphOptions = {
                     labels: ['Date', 'RegularTx', 'Tickets', 'Votes', 'RevokeTx'],
                     colors: ['#2971FF', '#41BF53', 'darkorange', '#FF0090'],
-                    ylabel: '# of Tx Types',
+                    ylabel: 'Number of Transactions by Type',
                     title: 'Transactions Types',
                     visibility: [true, true, true, true],
                     legendFormatter: formatter,

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -5,8 +5,6 @@
 {{template "html-head" printf "Decred Address %s" .Data.Address}}
 <body class="{{ theme }}">
     {{template "navbar" . }}
-    {{$TxTime := .OldestTxTime}}
-    {{$IsLite := .IsLiteMode}}
     {{with .Data}}
     {{$heights := $.ConfirmHeight}}
     {{$TxnCount := .TxnCount}}
@@ -16,7 +14,7 @@
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
                 <div class="mono" data-target="address.addr"
-                    id="{{$TxTime}}" style="margin-bottom: 12px;">
+                    id="{{$.OldestTxTime}}" style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"
                         href="javascript:showAddressQRCode('{{.Address}}');"
@@ -42,7 +40,7 @@
                 >
                     <input id="addr-btn" type="button" class="btn btn_sm btn-active" value="List" name="list">
                     <input id="addr-btn" type="button" class="btn btn_sm" value="Charts"
-                    name="chart" {{if $IsLite}}disabled{{end}}>
+                    name="chart" {{if $.IsLiteMode}}disabled{{end}}>
                 </div> 
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -197,7 +197,7 @@
                         </nav>
                     </div>
                     {{else}}
-                    <span class="fs12 nowrap text-right">{{intComma $TxnCount}} transaction{{if gt $TxnCount 1}}s{{end}}</span>
+                    <span class="fs12 nowrap text-right list-display">{{intComma $TxnCount}} transaction{{if gt $TxnCount 1}}s{{end}}</span>
                     {{end}}
                 </div>
                 <div class="list-display">
@@ -323,6 +323,8 @@
                             {{if lt $TxnCount 20}}disabled="disabled"{{end}}
                         >
                         <option {{if eq .Limit $TxnCount}}selected{{end}} value="{{len .Transactions}}">{{len .Transactions}}</option>
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                         </select>
                     </div>
                 </div>
@@ -338,12 +340,19 @@
         $(".jsonly").show()
         $('#list-display').hide()
 
-        $("#txntype").change(function(ev) {
+        $("#txntype").add("#pagesize").change(function(ev) {
+            var pagesize = "20"
+            var offset = "0"
+            if (ev.currentTarget.id.indexOf("pagesize") != -1){
+                pagesize = $("#pagesize option:selected").val()
+                offset = {{.Offset}}
+            }
+
             Turbolinks.visit(
                 window.location.pathname
-                + "?txntype="+ $(ev.currentTarget).val()
-                + "&n=20"
-                + "&start=0"
+                + "?txntype="+ $("#txntype option:selected").val()
+                + "&n=" + pagesize
+                + "&start=" + offset
             )
         })
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -5,6 +5,8 @@
 {{template "html-head" printf "Decred Address %s" .Data.Address}}
 <body class="{{ theme }}">
     {{template "navbar" . }}
+    {{$TxTime := .OldestTxTime}}
+    {{$IsLite := .IsLiteMode}}
     {{with .Data}}
     {{$heights := $.ConfirmHeight}}
     {{$TxnCount := .TxnCount}}
@@ -13,7 +15,8 @@
         <div class="row">
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
-                <div class="mono" data-target="address.addr" style="margin-bottom: 12px;">
+                <div class="mono" data-target="address.addr"
+                    id="{{$TxTime}}" style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"
                         href="javascript:showAddressQRCode('{{.Address}}');"
@@ -38,7 +41,8 @@
                     data-action="click->address#changeView"
                 >
                     <input id="addr-btn" type="button" class="btn btn_sm btn-active" value="List" name="list">
-                    <input id="addr-btn" type="button" class="btn btn_sm" value="Charts" name="chart">
+                    <input id="addr-btn" type="button" class="btn btn_sm" value="Charts"
+                    name="chart" {{if $IsLite}}disabled{{end}}>
                 </div> 
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">
@@ -157,6 +161,7 @@
                         <div
                             class="btn-group"
                             data-toggle="buttons"
+                            data-txcount="{{$TxnCount}}"
                             data-target="address.interval"
                             data-action="click->address#changeGraph"
                         >
@@ -164,7 +169,7 @@
                             <input id="chart-size" type="button" class="btn btn_sm month" value="Month" name="mo">
                             <input id="chart-size" type="button" class="btn btn_sm week" value="Week" name="wk">
                             <input id="chart-size" type="button" class="btn btn_sm day" value="Day" name="day">
-                            <input id="chart-size" type="button" class="btn btn_sm btn-active all" value="All Blocks" name="all">
+                            <input id="chart-size" type="button" class="btn btn_sm all btn-active" value="All Blocks" name="all">
                         </div>
                     </div>
                     <h5 class="mr-auto mb-0 list-display">History</h5>
@@ -322,9 +327,14 @@
                             class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}}"
                             {{if lt $TxnCount 20}}disabled="disabled"{{end}}
                         >
-                        <option {{if eq .Limit $TxnCount}}selected{{end}} value="{{len .Transactions}}">{{len .Transactions}}</option>
-                        <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
-                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
+                        {{$Txlen := len .Transactions}}
+                        {{if ge $TxnCount 20}}<option {{if eq $Txlen 20}}selected{{end}} value="20">20</option>{{end}}
+                        {{if ge $TxnCount 100}}<option {{if eq $Txlen 100}}selected{{end}} value="100">100</option>{{end}}
+                        {{if lt $TxnCount 1000}}
+                            {{if eq $TxnCount 20 100}}{{else}}<option {{if eq $Txlen $TxnCount}}selected{{end}}
+                                value="{{$TxnCount}}">{{$TxnCount}}</option>{{end}}
+                        {{end}}
+                        {{if ge $TxnCount 1000}}<option {{if eq $Txlen 1000}}selected{{end}} value="1000">1000</option>{{end}}
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
**Summary of Tasks Done**
- [x] Add the Page size controls back.
- [x] Implemented to a way to determine the best group by interval to use by default when accessing the chart view from the list view.
        -  Either `month`, `week`, `day` or `all blocks` interval can be selected. i.e. `month` is only select if the oldest transaction belonging to a given address was processed more than a month ago from now.  The same also happens to the rest intervals.
        - Also if the total transactions count is less than 20, interval selected defaults to `all`.
        - This helps in dealing with the network latency issues since the payload now requested by default will be smaller and more meaningful to the user.

__for Project Fund Address, it will always default to `month` interval__

<img width="1680" alt="screen shot 2018-08-24 at 04 28 00" src="https://user-images.githubusercontent.com/22055953/44560400-369cb380-a758-11e8-9717-97d66a56a34a.png">

- [x] Add the programmer names for the transactions types to the Transaction Types legend i.e. `Tickets` becomes  `Tickets (sstx)`

- [x] Split the Regular Txs into Sent and Received Regular Txs.
<img width="1234" alt="screen shot 2018-08-24 at 04 31 04" src="https://user-images.githubusercontent.com/22055953/44560378-21c02000-a758-11e8-8fab-ae7607977c57.png">

- [x] Deactivate the chart view button when running lite mode


