### PR TITLE
explorer: flag non-mainchain votes

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -489,7 +489,7 @@ func (c *appContext) getDecodedTransactions(w http.ResponseWriter, r *http.Reque
 	for i := range txids {
 		tx := c.BlockData.GetTrimmedTransaction(txids[i])
 		if tx == nil {
-			apiLog.Errorf("Unable to get transaction %s", tx)
+			apiLog.Errorf("Unable to get transaction %v", tx)
 			http.Error(w, http.StatusText(422), 422)
 			return
 		}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -908,6 +908,7 @@ func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, ski
 func makeExplorerBlockBasic(data *dcrjson.GetBlockVerboseResult) *explorer.BlockBasic {
 	block := &explorer.BlockBasic{
 		Height:         data.Height,
+		Hash:           data.Hash,
 		Size:           data.Size,
 		Valid:          true, // we do not know this, TODO with DB v2
 		Voters:         data.Voters,
@@ -1016,7 +1017,6 @@ func (db *wiredDB) GetExplorerBlock(hash string) *explorer.BlockInfo {
 	// Explorer Block Info
 	block := &explorer.BlockInfo{
 		BlockBasic:            makeExplorerBlockBasic(data),
-		Hash:                  data.Hash,
 		Version:               data.Version,
 		Confirmations:         data.Confirmations,
 		StakeRoot:             data.StakeRoot,

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -277,7 +277,7 @@ func (exp *explorerUI) prePopulateChartsData() {
 	log.Info("Done Pre-populating the charts data")
 }
 
-func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBlock) error {
+func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) error {
 	exp.NewBlockDataMtx.Lock()
 	bData := blockData.ToBlockExplorerSummary()
 
@@ -289,6 +289,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	newBlockData := &BlockBasic{
 		Height:         int64(bData.Height),
+		Hash:           blockData.Header.Hash,
 		Voters:         bData.Voters,
 		FreshStake:     bData.FreshStake,
 		Size:           int32(bData.Size),

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -345,7 +345,7 @@ type MempoolShort struct {
 	NumAll             int                      `json:"num_all"`
 	LatestTransactions []MempoolTx              `json:"latest"`
 	FormattedTotalSize string                   `json:"formatted_size"`
-	TicketIndexes      map[int64]map[string]int `json:"ticket_indexes"`
+	TicketIndexes      map[int64]map[string]int `json:"-"`
 	VotingInfo         VotingInfo               `json:"voting_info"`
 }
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -31,6 +31,7 @@ const (
 // BlockBasic models data for the explorer's explorer page
 type BlockBasic struct {
 	Height         int64  `json:"height"`
+	Hash           string `json:"hash"`
 	Size           int32  `json:"size"`
 	Valid          bool   `json:"valid"`
 	Voters         uint16 `json:"votes"`
@@ -184,7 +185,6 @@ type Vout struct {
 // BlockInfo models data for display on the block page
 type BlockInfo struct {
 	*BlockBasic
-	Hash                  string
 	Version               int32
 	Confirmations         int64
 	StakeRoot             string
@@ -331,33 +331,39 @@ type MempoolInfo struct {
 	Revocations  []MempoolTx `json:"revs"`
 }
 
+// TicketIndex is used to assign an index to a ticket hash.
+type TicketIndex map[string]int
+
+// BlockValidatorIndex keeps a list of arbitrary indexes for unique combinations
+// of block hash and the ticket being spent to validate the block, i.e.
+// map[validatedBlockHash]map[ticketHash]index.
+type BlockValidatorIndex map[string]TicketIndex
+
 // MempoolShort represents the mempool data sent as the mempool update
 type MempoolShort struct {
-	LastBlockHeight    int64                    `json:"block_height"`
-	LastBlockHash      string                   `json:"block_hash"`
-	LastBlockTime      int64                    `json:"block_time"`
-	TotalOut           float64                  `json:"total"`
-	TotalSize          int32                    `json:"size"`
-	NumTickets         int                      `json:"num_tickets"`
-	NumVotes           int                      `json:"num_votes"`
-	NumRegular         int                      `json:"num_regular"`
-	NumRevokes         int                      `json:"num_revokes"`
-	NumAll             int                      `json:"num_all"`
-	LatestTransactions []MempoolTx              `json:"latest"`
-	FormattedTotalSize string                   `json:"formatted_size"`
-	TicketIndexes      map[int64]map[string]int `json:"-"`
-	VotingInfo         VotingInfo               `json:"voting_info"`
+	LastBlockHeight    int64               `json:"block_height"`
+	LastBlockHash      string              `json:"block_hash"`
+	LastBlockTime      int64               `json:"block_time"`
+	TotalOut           float64             `json:"total"`
+	TotalSize          int32               `json:"size"`
+	NumTickets         int                 `json:"num_tickets"`
+	NumVotes           int                 `json:"num_votes"`
+	NumRegular         int                 `json:"num_regular"`
+	NumRevokes         int                 `json:"num_revokes"`
+	NumAll             int                 `json:"num_all"`
+	LatestTransactions []MempoolTx         `json:"latest"`
+	FormattedTotalSize string              `json:"formatted_size"`
+	TicketIndexes      BlockValidatorIndex `json:"-"`
+	VotingInfo         VotingInfo          `json:"voting_info"`
+	InvRegular         map[string]struct{} `json:"-"`
+	InvStake           map[string]struct{} `json:"-"`
 }
 
-// VotingInfo models data about the validity of the next block from mempool
+// VotingInfo models data about the validity of the next block from mempool.
 type VotingInfo struct {
-	Valids         uint16 `json:"choice_valid"`
-	Invalids       uint16 `json:"choice_invalid"`
-	TotalCollected uint16 `json:"total_votes_collected"`
-	TotalNeeded    uint16 `json:"total_votes_required"`
-	Required       uint16 `json:"total_choices_required"`
-	BlockValid     bool   `json:"block_valid"`
-	voted          map[string]bool
+	TicketsVoted     uint16 `json:"tickets_voted"`
+	MaxVotesPerBlock uint16 `json:"max_votes_per_block"`
+	votedTickets     map[string]bool
 }
 
 // ChainParams models simple data about the chain server's parameters used for some

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -154,6 +154,7 @@ type VoteInfo struct {
 	Choices            []*txhelpers.VoteChoice `json:"vote_choices"`
 	TicketSpent        string                  `json:"ticket_spent"`
 	MempoolTicketIndex int                     `json:"mempool_ticket_index"`
+	ForLastBlock       bool                    `json:"last_block"`
 }
 
 // BlockValidation models data about a vote's decision on a block
@@ -332,18 +333,31 @@ type MempoolInfo struct {
 
 // MempoolShort represents the mempool data sent as the mempool update
 type MempoolShort struct {
-	LastBlockHeight    int64          `json:"block_height"`
-	LastBlockTime      int64          `json:"block_time"`
-	TotalOut           float64        `json:"total"`
-	TotalSize          int32          `json:"size"`
-	NumTickets         int            `json:"num_tickets"`
-	NumVotes           int            `json:"num_votes"`
-	NumRegular         int            `json:"num_regular"`
-	NumRevokes         int            `json:"num_revokes"`
-	NumAll             int            `json:"num_all"`
-	LatestTransactions []MempoolTx    `json:"latest"`
-	FormattedTotalSize string         `json:"formatted_size"`
-	TicketIndexes      map[string]int `json:"ticket_indexes"`
+	LastBlockHeight    int64                    `json:"block_height"`
+	LastBlockHash      string                   `json:"block_hash"`
+	LastBlockTime      int64                    `json:"block_time"`
+	TotalOut           float64                  `json:"total"`
+	TotalSize          int32                    `json:"size"`
+	NumTickets         int                      `json:"num_tickets"`
+	NumVotes           int                      `json:"num_votes"`
+	NumRegular         int                      `json:"num_regular"`
+	NumRevokes         int                      `json:"num_revokes"`
+	NumAll             int                      `json:"num_all"`
+	LatestTransactions []MempoolTx              `json:"latest"`
+	FormattedTotalSize string                   `json:"formatted_size"`
+	TicketIndexes      map[int64]map[string]int `json:"ticket_indexes"`
+	VotingInfo         VotingInfo               `json:"voting_info"`
+}
+
+// VotingInfo models data about the validity of the next block from mempool
+type VotingInfo struct {
+	Valids         uint16 `json:"choice_valid"`
+	Invalids       uint16 `json:"choice_invalid"`
+	TotalCollected uint16 `json:"total_votes_collected"`
+	TotalNeeded    uint16 `json:"total_votes_required"`
+	Required       uint16 `json:"total_choices_required"`
+	BlockValid     bool   `json:"block_valid"`
+	voted          map[string]bool
 }
 
 // ChainParams models simple data about the chain server's parameters used for some

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -96,6 +96,8 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			exp.MempoolData.Votes = append([]MempoolTx{tx}, exp.MempoolData.Votes...)
 			sort.Sort(byHeight(exp.MempoolData.Votes))
 			exp.MempoolData.NumVotes++
+			// Multiple transactions can be in mempool from the same ticket.  We
+			// need to insure we do not double count these votes.
 			if tx.VoteInfo.ForLastBlock && !exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] {
 				exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] = true
 				exp.MempoolData.VotingInfo.TotalCollected++
@@ -199,7 +201,8 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 			tickets = append(tickets, tx)
 		case "Vote":
 			addVoteIndex(tx.VoteInfo, txindexes)
-			if tx.VoteInfo.ForLastBlock = voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash); tx.VoteInfo.ForLastBlock && !votingInfo.voted[tx.VoteInfo.TicketSpent] {
+			tx.VoteInfo.ForLastBlock = voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash)
+			if tx.VoteInfo.ForLastBlock && !votingInfo.voted[tx.VoteInfo.TicketSpent] {
 				votingInfo.voted[tx.VoteInfo.TicketSpent] = true
 				votingInfo.TotalCollected++
 				if tx.VoteInfo.Validation.Validity {
@@ -247,8 +250,9 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 	return
 }
 
-// addVoteIndex sets v.MempoolTicketIndex to the corresponding map value if it exits in
-// txindexes and creates a new index map if it doesn't
+// addVoteIndex assigns a unique index for a vote in a block if an index has not
+// already been assigned.  This index is used for sorting in views and counting
+// total unique votes for a block.
 func addVoteIndex(v *VoteInfo, txindexes map[int64]map[string]int) {
 	if idxs, ok := txindexes[v.Validation.Height]; ok {
 		if idx, ok := idxs[v.TicketSpent]; ok {
@@ -284,7 +288,6 @@ func (exp *explorerUI) getLastBlock() (lastBlockHash string, lastBlock int64, la
 	if err != nil {
 		log.Warnf("Could not get bloch hash for last block")
 	}
-	log.Debug("Last Block Hash: ", lastBlockHash)
 	return
 }
 

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -57,9 +57,6 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 		var voteInfo *VoteInfo
 		if ok := stake.IsSSGen(msgTx); ok {
 			validation, version, bits, choices, err := txhelpers.SSGenVoteChoices(msgTx, exp.ChainParams)
-			if !voteForLastBlock(lastBlockHash, validation.Hash.String()) {
-				continue
-			}
 			if err != nil {
 				log.Debugf("Cannot get vote choices for %s", hash)
 			} else {
@@ -69,10 +66,11 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 						Height:   validation.Height,
 						Validity: validation.Validity,
 					},
-					Version:     version,
-					Bits:        bits,
-					Choices:     choices,
-					TicketSpent: msgTx.TxIn[1].PreviousOutPoint.Hash.String(),
+					Version:      version,
+					Bits:         bits,
+					Choices:      choices,
+					TicketSpent:  msgTx.TxIn[1].PreviousOutPoint.Hash.String(),
+					ForLastBlock: voteForLastBlock(lastBlockHash, validation.Hash.String()),
 				}
 			}
 		}
@@ -94,15 +92,20 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			exp.MempoolData.Tickets = append([]MempoolTx{tx}, exp.MempoolData.Tickets...)
 			exp.MempoolData.NumTickets++
 		case "Vote":
-			if idx, ok := exp.MempoolData.TicketIndexes[tx.VoteInfo.TicketSpent]; ok {
-				tx.VoteInfo.MempoolTicketIndex = idx
-			} else {
-				idx := len(exp.MempoolData.TicketIndexes) + 1
-				exp.MempoolData.TicketIndexes[tx.VoteInfo.TicketSpent] = idx
-				tx.VoteInfo.MempoolTicketIndex = idx
-			}
+			addVoteIndex(tx.VoteInfo, exp.MempoolData.TicketIndexes)
 			exp.MempoolData.Votes = append([]MempoolTx{tx}, exp.MempoolData.Votes...)
+			sort.Sort(byHeight(exp.MempoolData.Votes))
 			exp.MempoolData.NumVotes++
+			if tx.VoteInfo.ForLastBlock && !exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] {
+				exp.MempoolData.VotingInfo.voted[tx.VoteInfo.TicketSpent] = true
+				exp.MempoolData.VotingInfo.TotalCollected++
+				if tx.VoteInfo.Validation.Validity {
+					exp.MempoolData.VotingInfo.Valids++
+				} else {
+					exp.MempoolData.VotingInfo.Invalids++
+				}
+				updateBlockValidity(&exp.MempoolData.VotingInfo)
+			}
 		case "Regular":
 			exp.MempoolData.Transactions = append([]MempoolTx{tx}, exp.MempoolData.Transactions...)
 			exp.MempoolData.NumRegular++
@@ -180,23 +183,30 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 
 	var totalOut float64
 	var totalSize int32
+	var votingInfo VotingInfo
 
-	// Categorize the transactions, and bin votes by ticket spent
-	txindexes := make(map[string]int)
+	lastBlockHash, lastBlock, lastBlockTime = exp.getLastBlock()
+
+	votingInfo.TotalNeeded = exp.ChainParams.TicketsPerBlock
+	votingInfo.Required = exp.ChainParams.StakeRewardProportion
+
+	votingInfo.voted = make(map[string]bool)
+
+	txindexes := make(map[int64]map[string]int)
 	for _, tx := range memtxs {
 		switch tx.Type {
 		case "Ticket":
 			tickets = append(tickets, tx)
 		case "Vote":
-			if !voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash) {
-				continue
-			}
-			if idx, ok := txindexes[tx.VoteInfo.TicketSpent]; ok {
-				tx.VoteInfo.MempoolTicketIndex = idx
-			} else {
-				idx := len(txindexes) + 1
-				txindexes[tx.VoteInfo.TicketSpent] = idx
-				tx.VoteInfo.MempoolTicketIndex = idx
+			addVoteIndex(tx.VoteInfo, txindexes)
+			if tx.VoteInfo.ForLastBlock = voteForLastBlock(lastBlockHash, tx.VoteInfo.Validation.Hash); tx.VoteInfo.ForLastBlock && !votingInfo.voted[tx.VoteInfo.TicketSpent] {
+				votingInfo.voted[tx.VoteInfo.TicketSpent] = true
+				votingInfo.TotalCollected++
+				if tx.VoteInfo.Validation.Validity {
+					votingInfo.Valids++
+				} else {
+					votingInfo.Invalids++
+				}
 			}
 			votes = append(votes, tx)
 		case "Revocation":
@@ -207,10 +217,11 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 		totalOut += tx.TotalOut
 		totalSize += tx.Size
 	}
-
-	// Store the results in MempoolData for the web page
+	updateBlockValidity(&votingInfo)
 	exp.MempoolData.Lock()
 	defer exp.MempoolData.Unlock()
+
+	sort.Sort(byHeight(votes))
 
 	exp.MempoolData.Transactions = regular
 	exp.MempoolData.Tickets = tickets
@@ -219,6 +230,7 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 
 	exp.MempoolData.MempoolShort = MempoolShort{
 		LastBlockHeight:    lastBlock,
+		LastBlockHash:      lastBlockHash,
 		LastBlockTime:      lastBlockTime,
 		TotalOut:           totalOut,
 		TotalSize:          totalSize,
@@ -230,12 +242,36 @@ func (exp *explorerUI) storeMempoolInfo() (lastBlockHash string, lastBlock int64
 		LatestTransactions: latest,
 		FormattedTotalSize: humanize.Bytes(uint64(totalSize)),
 		TicketIndexes:      txindexes,
+		VotingInfo:         votingInfo,
 	}
 	return
 }
 
+// addVoteIndex sets v.MempoolTicketIndex to the corresponding map value if it exits in
+// txindexes and creates a new index map if it doesn't
+func addVoteIndex(v *VoteInfo, txindexes map[int64]map[string]int) {
+	if idxs, ok := txindexes[v.Validation.Height]; ok {
+		if idx, ok := idxs[v.TicketSpent]; ok {
+			v.MempoolTicketIndex = idx
+		} else {
+			idx := len(idxs) + 1
+			idxs[v.TicketSpent] = idx
+			v.MempoolTicketIndex = idx
+		}
+	} else {
+		idxs := make(map[string]int)
+		idxs[v.TicketSpent] = 1
+		txindexes[v.Validation.Height] = idxs
+		v.MempoolTicketIndex = 1
+	}
+}
+
 func voteForLastBlock(blockHash, validationHash string) bool {
 	return blockHash == validationHash && blockHash != ""
+}
+
+func updateBlockValidity(votingInfo *VotingInfo) {
+	votingInfo.BlockValid = votingInfo.Valids+votingInfo.Invalids >= votingInfo.TotalNeeded && votingInfo.Valids >= votingInfo.Required
 }
 
 // getLastBlock returns the last block hash, height and time
@@ -248,7 +284,7 @@ func (exp *explorerUI) getLastBlock() (lastBlockHash string, lastBlock int64, la
 	if err != nil {
 		log.Warnf("Could not get bloch hash for last block")
 	}
-
+	log.Debug("Last Block Hash: ", lastBlockHash)
 	return
 }
 
@@ -264,4 +300,21 @@ func (txs byTime) Len() int {
 
 func (txs byTime) Swap(i, j int) {
 	txs[i], txs[j] = txs[j], txs[i]
+}
+
+type byHeight []MempoolTx
+
+func (votes byHeight) Less(i, j int) bool {
+	if votes[i].VoteInfo.Validation.Height == votes[j].VoteInfo.Validation.Height {
+		return votes[i].VoteInfo.MempoolTicketIndex < votes[j].VoteInfo.MempoolTicketIndex
+	}
+	return votes[i].VoteInfo.Validation.Height > votes[j].VoteInfo.Validation.Height
+}
+
+func (votes byHeight) Len() int {
+	return len(votes)
+}
+
+func (votes byHeight) Swap(i, j int) {
+	votes[i], votes[j] = votes[j], votes[i]
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -920,7 +920,10 @@ body.darkBG .keynav-target {
   }
 }
 
+/*mempool Vote Table*/
 .old-vote {
-  background-color: pink;
+  background-color: #ff3d001f;
 }
-
+.upcoming-vote {
+  background: #0078ff1c;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -919,3 +919,8 @@ body.darkBG .keynav-target {
     transform: rotate(360deg);
   }
 }
+
+.old-vote {
+  background-color: pink;
+}
+

--- a/public/js/controllers/mempool.js
+++ b/public/js/controllers/mempool.js
@@ -18,12 +18,13 @@
     }
 
     function voteTxTableRow(tx) {
+        console.debug("new vote row: ", tx)
         return `<tr class="flash" data-height="${tx.vote_info.block_validation.height}" data-blockhash="${tx.vote_info.block_validation.hash}">
             <td class="break-word"><span><a class="hash" href="/tx/${tx.hash}">${tx.hash}</a></span></td>
-            <td class="mono fs15"><span><a href="/block/${tx.vote_info.block_validation.height}">${tx.vote_info.block_validation.height}</a></span></td>
+            <td class="mono fs15"><span><a href="/block/${tx.vote_info.block_validation.hash}">${tx.vote_info.block_validation.height}</a></span></td>
+            <td class="mono fs15 last_block">${tx.vote_info.last_block?'True':'False'}</td>
             <td class="mono fs15"><a href="/tx/${tx.vote_info.ticket_spent}">${tx.vote_info.mempool_ticket_index}<a/></td>
             <td class="mono fs15">${tx.vote_info.vote_version}</td>
-            <td class="mono fs15 last_block">${tx.vote_info.last_block?'Valid':'Invalid'}</td>
             <td class="mono fs15 text-right">${humanize.decimalParts(tx.total, false, 8, true)}</td>
             <td class="mono fs15">${tx.size} B</td>
             <td class="mono fs15 text-right" data-target="main.age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
@@ -117,8 +118,8 @@
                 "ticketTransactions",
                 "revokeTransactions",
                 "regularTransactions",
-                "totalCollected",
-                "totalNeeded",
+                "ticketsVoted",
+                "maxVotesPerBlock",
                 "totalOut",
             ]
         }
@@ -157,12 +158,12 @@
             $(this.bestBlockTarget).text(m.block_height)
             $(this.bestBlockTarget).data("hash",m.block_hash)
             $(this.bestBlockTarget).attr("data-hash",m.block_hash)
-            $(this.bestBlockTarget).attr('href', '/block/' + m.block_height)
+            $(this.bestBlockTarget).attr('href', '/block/' + m.block_hash)
             $(this.bestBlockTimeTarget).data('age', m.block_time)
             $(this.bestBlockTimeTarget).attr('data-age', m.block_time)
             $(this.mempoolSizeTarget).text(m.formatted_size)
-            $(this.totalCollectedTarget).text(m.voting_info.total_votes_collected)
-            $(this.totalNeededTarget).text(m.voting_info.total_votes_required)
+            $(this.ticketsVoted).text(m.voting_info.tickets_voted)
+            $(this.maxVotesPerBlock).text(m.voting_info.max_votes_per_block)
             $(this.totalOutTarget).html(`${humanize.decimalParts(m.total, false, 8, true)}`);
             $(this.mempoolSizeTarget).text(m.formatted_size);
             this.labelVotes();
@@ -197,11 +198,11 @@
                 } else if (voteValidationHash != bestBlockHash) {
                     $(this).closest("tr").addClass("old-vote");
                     $(this).closest("tr").removeClass("upcoming-vote");
-                    $(this).find("td.last_block").text("Invalid");
+                    $(this).find("td.last_block").text("False");
                 } else {
                     $(this).closest("tr").removeClass("old-vote");
                     $(this).closest("tr").removeClass("upcoming-vote");
-                    $(this).find("td.last_block").text("Valid");
+                    $(this).find("td.last_block").text("True");
                 }
             })
         };
@@ -212,8 +213,8 @@
                 var heightA = parseInt($('td:nth-child(2)',a).text());
                 var heightB = parseInt($('td:nth-child(2)',b).text());
                 if (heightA == heightB) {
-                     var indexA = parseInt($('td:nth-child(3)',a).text());
-                     var indexB = parseInt($('td:nth-child(3)',b).text());
+                     var indexA = parseInt($('td:nth-child(4)',a).text());
+                     var indexB = parseInt($('td:nth-child(4)',b).text());
                      return (indexA - indexB);
                 } else {
                     return (heightB - heightA);

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -194,7 +194,7 @@
                         <thead>
                             <th>Transactions ID</th>
                             <th>Vote Version</th>
-                            <th>Vote Choice</th>
+                            <th>Last Block</th>
                             <th class="text-right">Total DCR</th>
                             <th class="text-right">Size</th>
                         </thead>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -193,12 +193,10 @@
                     <table class="table table-sm striped">
                         <thead>
                             <th>Transactions ID</th>
-                            <th>Version</th>
-                            <th>Last Block Valid</th>
-                            <th>Issue ID</th>
-                            <th>Choice ID</th>
+                            <th>Vote Version</th>
+                            <th>Vote Choice</th>
                             <th class="text-right">Total DCR</th>
-                            <th>Size</th>
+                            <th class="text-right">Size</th>
                         </thead>
                         <tbody>
                             {{range .Votes}}
@@ -209,19 +207,9 @@
                                     </span>
                                 </td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td>{{.VoteInfo.Validation.Validity}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).ID}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).Choice.Id}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
+                                <td>{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .Total false)}}</td>
-                                <td class="mono fs15">{{.FormattedSize}}</td>
+                                <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                             </tr>
                             {{end}}
                         </tbody>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -36,10 +36,9 @@
                             <td data-target="mempool.numTicket" class="lh1rem">{{.NumTickets}}</td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTE CHOICES</td>
-                            <td class="lh1rem"><span data-target="mempool.totalCollected">
-                            {{.VotingInfo.TotalCollected}}</span>/<span data-target="mempool.totalNeeded">{{.VotingInfo.TotalNeeded}}</span>
-                            <span class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
+                            <td class="text-right pr-2 lh1rem nowrap p03rem0">TICKETS VOTED ON LAST BLOCK</td>
+                            <td class="lh1rem"><span data-target="mempool.ticketsVoted">
+                            {{.VotingInfo.TicketsVoted}}</span>/<span data-target="mempool.maxVotesPerBlock">{{.VotingInfo.MaxVotesPerBlock}}</span>
                             </td>
                         </tr>
                     </table>
@@ -67,11 +66,11 @@
 
                     <table class="table table-sm striped">
                         <thead>
-                            <th>Transactions ID</th>
-                            <th>Vote Block</th>
-                            <th>Vote Index</th>
+                            <th>Transaction ID</th>
+                            <th>Voting On</th>
+                            <th>Best Block</th>
+                            <th>Validator ID</th>
                             <th>Vote Version</th>
-                            <th>Last Block</th>
                             <th>Total DCR</th>
                             <th class="text-right">Size</th>
                             <th class="text-right">Time</th>
@@ -81,10 +80,10 @@
                             {{range .Votes}}
                             <tr {{if not .VoteInfo.ForLastBlock}}class="old-vote"{{end}} data-blockhash="{{.VoteInfo.Validation.Hash}}" data-height="{{.VoteInfo.Validation.Height}}">
                                 <td class="break-word"><a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a></td>
-                                <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Height}}">{{.VoteInfo.Validation.Height}}</a></td>
+                                <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Hash}}">{{.VoteInfo.Validation.Height}}</a></td>
+                                <td class="mono fs15 last_block">{{if .VoteInfo.ForLastBlock}}True{{else}}False{{end}}</td>
                                 <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td class="mono fs15 last_block">{{if .VoteInfo.ForLastBlock}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
                                 <td class="mono fs15 text-right">{{.Size}} B</td>
                                 <td class="mono fs15 text-right" data-target="main.age" data-age="{{.Time}}"></td>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -14,7 +14,7 @@
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117 w120">TOTAL SENT</td>
-                        <td class="fs28 mono fs16-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}<span class="pl-1 unit">DCR</span></td>
+                        <td class="fs28 mono fs16-decimal d-flex align-items-center" data-target="mempool.totalOut" >{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}<span class="pl-1 unit">DCR</span></td>
                     </tr>
                 </table>
             </div>
@@ -25,7 +25,7 @@
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">LAST BLOCK</td>
-                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-keynav-priority>{{.LastBlockHeight}}</a> (<span data-target="main.age mempool.bestBlockTime" data-age="{{.LastBlockTime}}"></span> ago)</td>
+                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a> (<span data-target="mempool.bestBlockTime  main.age" data-age="{{.LastBlockTime}}"></span> ago)</td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTES</td>
@@ -34,6 +34,13 @@
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">TICKETS</td>
                             <td data-target="mempool.numTicket" class="lh1rem">{{.NumTickets}}</td>
+                        </tr>
+                        <tr>
+                            <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTE CHOICES</td>
+                            <td id="mempool_vote_choices" class="lh1rem"><span data-target="mempool.totalCollected">
+                            {{.VotingInfo.TotalCollected}}</span>/<span data-target="mempool.totalNeeded">{{.VotingInfo.TotalNeeded}}</span>
+                            <span id="mempool_block_validity" class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
+                            </td>
                         </tr>
                     </table>
                 </div>
@@ -61,37 +68,25 @@
                     <table class="table table-sm striped">
                         <thead>
                             <th>Transactions ID</th>
-                            <th>Version</th>
-                            <th>Last Block Valid</th>
-                            <th>Issue ID</th>
-                            <th>Choice ID</th>
-                            <th class="text-right">Total DCR</th>
-                            <th>Size</th>
-                            <th class="text-right">Time in Mempool</th>
+                            <th>Vote Block</th>
+                            <th>Vote Index</th>
+                            <th>Vote Version</th>
+                            <th>Vote Choice</th>
+                            <th>Total DCR</th>
+                            <th class="text-right">Size</th>
+                            <th class="text-right">Time</th>
                         </thead>
                         <tbody data-target="mempool.voteTransactions">
                             {{if gt .NumVotes 0}}
                             {{range .Votes}}
-                            <tr>
-                                <td class="break-word">
-                                    <span>
-                                        <a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a>
-                                    </span>
-                                </td>
+                            <tr {{if not .VoteInfo.ForLastBlock}}class="old-vote"{{end}} data-blockhash="{{.VoteInfo.Validation.Hash}}" data-height="{{.VoteInfo.Validation.Height}}">
+                                <td class="break-word"><a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a></td>
+                                <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Height}}">{{.VoteInfo.Validation.Height}}</a></td>
+                                <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td>{{.VoteInfo.Validation.Validity}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).ID}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
-                                <td class="mono fs15">{{if (len .VoteInfo.Choices) gt 0}}
-                                    {{(index .VoteInfo.Choices 0).Choice.Id}}
-                                {{else}}
-                                    -
-                                {{end}}</td>
+                                <td class="mono fs15">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
-                                <td class="mono fs15">{{.Size}} B</td>
+                                <td class="mono fs15 text-right">{{.Size}} B</td>
                                 <td class="mono fs15 text-right" data-target="main.age" data-age="{{.Time}}"></td>
                             </tr>
                             {{end}}

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -37,9 +37,9 @@
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTE CHOICES</td>
-                            <td id="mempool_vote_choices" class="lh1rem"><span data-target="mempool.totalCollected">
+                            <td class="lh1rem"><span data-target="mempool.totalCollected">
                             {{.VotingInfo.TotalCollected}}</span>/<span data-target="mempool.totalNeeded">{{.VotingInfo.TotalNeeded}}</span>
-                            <span id="mempool_block_validity" class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
+                            <span class="lh1rem {{if lt .VotingInfo.TotalCollected .VotingInfo.TotalNeeded}}hidden{{end}}">({{if .VotingInfo.BlockValid}}Valid{{else}}Invalid{{end}})</span>
                             </td>
                         </tr>
                     </table>
@@ -71,7 +71,7 @@
                             <th>Vote Block</th>
                             <th>Vote Index</th>
                             <th>Vote Version</th>
-                            <th>Vote Choice</th>
+                            <th>Last Block</th>
                             <th>Total DCR</th>
                             <th class="text-right">Size</th>
                             <th class="text-right">Time</th>
@@ -84,7 +84,7 @@
                                 <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Height}}">{{.VoteInfo.Validation.Height}}</a></td>
                                 <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
                                 <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                                <td class="mono fs15">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
+                                <td class="mono fs15 last_block">{{if .VoteInfo.ForLastBlock}}Valid{{else}}Invalid{{end}}</td>
                                 <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .TotalOut false)}}</td>
                                 <td class="mono fs15 text-right">{{.Size}} B</td>
                                 <td class="mono fs15 text-right" data-target="main.age" data-age="{{.Time}}"></td>


### PR DESCRIPTION
Votes for the current best block have the usual background, while older or side chain votes have a reddish background.

The header table with a summary of the mempool is updated so that it show the vote and ticket counts, and "TICKETS VOTED ON LAST BLOCK  x/5".  There is no longer any attempt to compute the expected validity of the previous block based on the votes in mempool.  There are several reasons, but the most important is that it is up to the miners what to include in the mined block.  Further, duplicating the consensus rules to decide what's valid (e.g. 2 yes / 2 no == ?, it is no, but we're not coding up these rules) is not something we should pursue in dcrdata.

The columns are also renamed and reordered.  Best Block is yes/no to indicate if the vote is for the main chain tip.  So old votes or votes on side chains at the same height would say "no".  The Block column is now "Voting On" to be clear that the vote is "voting on" the validity of the block listed.  The column text is block height, but the link is via hash to support side-chains.  The ticket index column is now "Validator ID" to represent that it is an identifier (arbitrary) for the ticket hash chosen to validate the block, and as such it links to the ticket hash that won the lottery and is being spent in the vote.

![image](https://user-images.githubusercontent.com/9373513/44601012-c9614080-a7a0-11e8-943b-795196f18804.png)

There are a number of fixes to the mempool transactions handling:
* Duplicates are screened out in both the fresh mempool update and the mempool monitor by tracking known mempool txns at the current best block.
* A javascript race is also worked around.  It is possible for a new txn notification to be sent for a vote on a block that has not yet been seen, and when the full mempool update is handled, that transaction is included again.  If JS handled it in the same order, it would be fine (removing the transaction that came early and starting with the full update), however, if JS processes the new block update of mempool and *then* the early vote's notification, it will end up on the table twice.
* The unique ticket indexes (now a.k.a. Validator ID) were based on block height and ticket hash, but this did not support side chains where multiple blocks would have the same height.  The index map (`BlockValidatorIndex`) is changed to use block hash.
* `explorerUI.NewBlockData` now contains `Hash` to that and RPC call may be skipped, and to support this, `explorer.BlockBasic` now includes `Hash`.