### PR TITLE
Insight API sync status and cleanup

### DIFF
--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -58,6 +58,7 @@ func NewInsightApiRouter(app *insightApiContext, userRealIP bool) ApiMux {
 
 	// Status and Utility
 	mux.With(app.StatusInfoCtx).Get("/status", app.getStatusInfo)
+	mux.Get("/sync", app.getSyncInfo)
 	mux.With(app.NbBlocksCtx).Get("/utils/estimatefee", app.getEstimateFee)
 	mux.Get("/peer", app.GetPeerStatus)
 


### PR DESCRIPTION
This PR closes out the last remaining Insight API endpoint - `sync status`.  I have also done a little cleanup of unused functions left over from previous versions of Insight API implementation.

This PR should allow us to close #638,  #400 and #260.

finished status:
```
{
    "status": "finished",
    "blockChainHeight": 269385,
    "syncPercentage": 100,
    "height": 269385,
    "error": null,
    "type": "from RPC calls"
}
```

syncing status:
```
{
    "status": "syncing",
    "blockChainHeight": 269388,
    "syncPercentage": 99,
    "height": 269385,
    "error": null,
    "type": "from RPC calls"
}
```


Reference bitpay insight URL endpoint:
```
{
    "status": "finished",
    "blockChainHeight": 538770,
    "syncPercentage": 100,
    "height": 538770,
    "error": null,
    "type": "bitcore node"
}
```

reference existing insight api at mainnet.decred.org
```
{
    "status": "finished",
    "blockChainHeight": 266495,
    "syncPercentage": "100.000",
    "height": 266495,
    "error": null,
    "type": "from RPC calls",
    "startTs": 1534565901925,
    "endTs": 1534565901958
}
```
