### PR TITLE
special handling for genesis block coinbase transaction

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -590,7 +590,7 @@ body.darkBG .progress {
 #address-qrcode img {
   width: 280px;
 }
-.sidechain-tag {
+.attention {
   color: red;
   font-size: 14pt;
 }

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -846,3 +846,10 @@ func TotalVout(vouts []dcrjson.Vout) dcrutil.Amount {
 	}
 	return total
 }
+
+// GenesisTxHash returns the hash of the single coinbase transaction in the
+// genesis block of the specified network. This transaction is hard coded, and
+// the pubkey script for its one output only decodes for simnet.
+func GenesisTxHash(params *chaincfg.Params) chainhash.Hash {
+	return params.GenesisBlock.Transactions[0].TxHash()
+}

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/decred/dcrd/chaincfg"
+
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/dcrutil"
@@ -211,5 +213,33 @@ func TestFilterHashSlice(t *testing.T) {
 
 	if HashInSlice(blackList[2], hashList) {
 		t.Errorf("filtered slice still has hash %v", blackList[2])
+	}
+}
+
+func TestGenesisTxHash(t *testing.T) {
+	// Mainnet
+	genesisTxHash := GenesisTxHash(&chaincfg.MainNetParams).String()
+	if genesisTxHash == "" {
+		t.Errorf("Failed to get genesis transaction hash for mainnet.")
+	}
+	t.Logf("Genesis transaction hash (mainnet): %s", genesisTxHash)
+
+	mainnetExpectedTxHash := "e7dfbceac9fccd6025c70a1dfa9302b3e7b5aa22fa51c98a69164ad403d60a2c"
+	if genesisTxHash != mainnetExpectedTxHash {
+		t.Errorf("Incorrect genesis transaction hash (mainnet). Expected %s, got %s",
+			mainnetExpectedTxHash, genesisTxHash)
+	}
+
+	// Simnet
+	genesisTxHash = GenesisTxHash(&chaincfg.SimNetParams).String()
+	if genesisTxHash == "" {
+		t.Errorf("Failed to get genesis transaction hash for simnet.")
+	}
+	t.Logf("Genesis transaction hash (mainnet): %s", genesisTxHash)
+
+	simnetExpectedTxHash := "a216ea043f0d481a072424af646787794c32bcefd3ed181a090319bbf8a37105"
+	if genesisTxHash != simnetExpectedTxHash {
+		t.Errorf("Incorrect genesis transaction hash (simnet). Expected %s, got %s",
+			mainnetExpectedTxHash, genesisTxHash)
 	}
 }

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -11,7 +11,7 @@
                 <h4 class="mb-2">
                     Block #{{.Height}}
                     {{ if not .MainChain }}
-                        <span class="sidechain-tag">(side chain)</span>
+                        <span class="attention">(side chain)</span>
                     {{else}}
                         {{ if gt .Confirmations 1 }}
                             <span class="op60 fs12">( <span data-confirmation-block-height="{{$.ConfirmHeight}}">{{.Confirmations}}</span> confirmations)</span>
@@ -177,9 +177,15 @@
                             <tbody>
                                 <tr>
                                     <td class="break-word">
+                                    {{if $.Data.Nonce}}
                                         <span>
                                             <a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a>
                                         </span>
+                                    {{else}}
+                                        <span title="The Genesis block coinbase transaction is invalid on mainnet.">
+                                            <span class="attention">&#9888;</span> <a class="hash" href="https://github.com/decred/dcrd/blob/2a18beb4d56fe59d614a7309308d84891a0cba96/chaincfg/genesis.go#L17-L53">{{.TxID}}</a>
+                                        </span>
+                                    {{end}}
                                     </td>
                                     <td class="mono fs15 text-right">{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}</td>
                                     <td class="mono fs15">{{.FormattedSize}}</td>


### PR DESCRIPTION
This changes the block page to recognize the genesis block and handle the (invalid) coinbase transaction differently.

- Show a UTF8 attention symbol in red next to the tx hash.
- Add a title (hover text) explaining why it is special.
- Change the link to point to code (chaincfg/genesis.go).

![image](https://user-images.githubusercontent.com/9373513/44934934-6c333500-ad34-11e8-8163-e5942d4a74d4.png)

This also adds a function `GenesisTxHash` in package txhelpers to retrieve the expected hash of the genesis coinbase transaction for the given network.