### PR TITLE
explorer: address multiple deadlocks and data races

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -248,6 +248,13 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 	return exp
 }
 
+// Height returns the height of the current block data.
+func (exp *explorerUI) Height() int64 {
+	exp.NewBlockDataMtx.RLock()
+	defer exp.NewBlockDataMtx.RUnlock()
+	return exp.NewBlockData.Height
+}
+
 // prePopulateChartsData should run in the background the first time the system
 // is initialized and when new blocks are added.
 func (exp *explorerUI) prePopulateChartsData() {
@@ -282,7 +289,6 @@ func (exp *explorerUI) prePopulateChartsData() {
 }
 
 func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) error {
-	exp.NewBlockDataMtx.Lock()
 	bData := blockData.ToBlockExplorerSummary()
 
 	// Update the charts data after every five blocks or if no charts data
@@ -290,6 +296,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	if !exp.liteMode && bData.Height%5 == 0 || len(cacheChartsData.Data) == 0 {
 		go exp.prePopulateChartsData()
 	}
+
+	// Lock for explorerUI's NewBlockData and ExtraInfo
+	exp.NewBlockDataMtx.Lock()
 
 	newBlockData := &BlockBasic{
 		Height:         int64(bData.Height),
@@ -304,9 +313,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		Revocations:    uint32(bData.Revocations),
 	}
 	exp.NewBlockData = newBlockData
-	percentage := func(a float64, b float64) float64 {
-		return (a / b) * 100
-	}
+	bdHeight := newBlockData.Height
 
 	stakePerc := blockData.PoolInfo.Value / dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin()
 
@@ -317,7 +324,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	exp.ExtraInfo.NextExpectedBoundsMin = blockData.EstStakeDiff.Min
 	exp.ExtraInfo.NextExpectedBoundsMax = blockData.EstStakeDiff.Max
 	exp.ExtraInfo.IdxBlockInWindow = blockData.IdxBlockInWindow
-	exp.ExtraInfo.IdxInRewardWindow = int(newBlockData.Height % exp.ChainParams.SubsidyReductionInterval)
+	exp.ExtraInfo.IdxInRewardWindow = int(bdHeight % exp.ChainParams.SubsidyReductionInterval)
 	exp.ExtraInfo.Difficulty = blockData.Header.Difficulty
 	exp.ExtraInfo.NBlockSubsidy.Dev = blockData.ExtraInfo.NextBlockSubsidy.Developer
 	exp.ExtraInfo.NBlockSubsidy.PoS = blockData.ExtraInfo.NextBlockSubsidy.PoS
@@ -328,34 +335,28 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 	exp.ExtraInfo.PoolInfo.ValAvg = blockData.PoolInfo.ValAvg
 	exp.ExtraInfo.PoolInfo.Percentage = stakePerc * 100
 
-	exp.ExtraInfo.PoolInfo.PercentTarget = func() float64 {
-		target := float64(exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock)
-		return float64(blockData.PoolInfo.Size) / target * 100
-	}()
+	exp.ExtraInfo.PoolInfo.PercentTarget = 100 * float64(blockData.PoolInfo.Size) /
+		float64(exp.ChainParams.TicketPoolSize*exp.ChainParams.TicketsPerBlock)
 
-	exp.ExtraInfo.TicketReward = func() float64 {
-		PosSubPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() / float64(exp.ChainParams.TicketsPerBlock)
-		return percentage(PosSubPerVote, blockData.CurrentStakeDiff.CurrentStakeDifficulty)
-	}()
+	posSubsPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() /
+		float64(exp.ChainParams.TicketsPerBlock)
+	exp.ExtraInfo.TicketReward = 100 * posSubsPerVote /
+		blockData.CurrentStakeDiff.CurrentStakeDifficulty
 
-	// The actual Reward of a ticket needs to also take into consideration the
+	// The actual reward of a ticket needs to also take into consideration the
 	// ticket maturity (time from ticket purchase until its eligible to vote)
 	// and coinbase maturity (time after vote until funds distributed to ticket
 	// holder are available to use).
-	exp.ExtraInfo.RewardPeriod = func() string {
-		PosAvgTotalBlocks := float64(
-			exp.ExtraInfo.Params.MeanVotingBlocks +
-				int64(exp.ChainParams.TicketMaturity) +
-				int64(exp.ChainParams.CoinbaseMaturity))
-		return fmt.Sprintf("%.2f days", exp.ChainParams.TargetTimePerBlock.Seconds()*PosAvgTotalBlocks/86400)
-	}()
+	avgSSTxToSSGenMaturity := exp.ExtraInfo.Params.MeanVotingBlocks +
+		int64(exp.ChainParams.TicketMaturity) +
+		int64(exp.ChainParams.CoinbaseMaturity)
+	exp.ExtraInfo.RewardPeriod = fmt.Sprintf("%.2f days", float64(avgSSTxToSSGenMaturity)*
+		exp.ChainParams.TargetTimePerBlock.Hours()/24)
 
-	asr, _ := exp.simulateASR(1000, false, stakePerc,
+	exp.ExtraInfo.ASR, _ = exp.simulateASR(1000, false, stakePerc,
 		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(),
-		float64(exp.NewBlockData.Height),
+		float64(bdHeight),
 		blockData.CurrentStakeDiff.CurrentStakeDifficulty)
-
-	exp.ExtraInfo.ASR = asr
 
 	exp.NewBlockDataMtx.Unlock()
 
@@ -373,7 +374,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 		}
 	}()
 
-	log.Debugf("Got new block %d for the explorer.", newBlockData.Height)
+	log.Debugf("Got new block %d for the explorer.", bdHeight)
 
 	return nil
 }
@@ -386,12 +387,12 @@ func (exp *explorerUI) updateDevFundBalance() {
 
 	// yield processor to other goroutines
 	runtime.Gosched()
-	exp.NewBlockDataMtx.Lock()
-	defer exp.NewBlockDataMtx.Unlock()
 
 	devBalance, err := exp.explorerSource.DevBalance()
 	if err == nil && devBalance != nil {
+		exp.NewBlockDataMtx.Lock()
 		exp.ExtraInfo.DevFund = devBalance.TotalUnspent
+		exp.NewBlockDataMtx.Unlock()
 	} else {
 		log.Errorf("explorerUI.updateDevFundBalance failed: %v", err)
 	}

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -98,9 +98,9 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				case "getmempooltxs":
 					webData.EventId = msg.EventId + "Resp"
 
-					exp.MempoolData.Lock()
+					exp.MempoolData.RLock()
 					msg, err := json.Marshal(exp.MempoolData)
-					exp.MempoolData.Unlock()
+					exp.MempoolData.RUnlock()
 
 					if err != nil {
 						log.Warn("Invalid JSON message: ", err)
@@ -160,17 +160,17 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				enc := json.NewEncoder(buff)
 				switch sig {
 				case sigNewBlock:
-					exp.NewBlockDataMtx.Lock()
+					exp.NewBlockDataMtx.RLock()
 					enc.Encode(WebsocketBlock{
 						Block: exp.NewBlockData,
 						Extra: exp.ExtraInfo,
 					})
-					exp.NewBlockDataMtx.Unlock()
+					exp.NewBlockDataMtx.RUnlock()
 					webData.Message = buff.String()
 				case sigMempoolUpdate:
-					exp.MempoolData.Lock()
+					exp.MempoolData.RLock()
 					enc.Encode(exp.MempoolData.MempoolShort)
-					exp.MempoolData.Unlock()
+					exp.MempoolData.RUnlock()
 					webData.Message = buff.String()
 				case sigPingAndUserCount:
 					// ping and send user count


### PR DESCRIPTION
The home page was requesting a full read/write lock when it only needed a read lock.  Similarly, `RootWebsocket` was requesting unneeded full
locks in both the send and receive loops, which caused a deadlock. This resolves the issues.

Several accesses to `explorerUI.ExtraInfo` were not guarded with a read lock.  These data races are also fixed.
This also adds `(*explorerUI).Height()` for thread-safe access to `NewBlockData.Height`.
Remove several pointless closures.