### PR TITLE
[3.0] explorer: address multiple deadlocks and data races

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -41,8 +41,9 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 
 	blocks := exp.blockData.GetExplorerBlocks(height, height-5)
 
-	exp.NewBlockDataMtx.Lock()
+	// Lock for both MempoolData and ExtraInfo
 	exp.MempoolData.RLock()
+	exp.NewBlockDataMtx.RLock()
 
 	str, err := exp.templates.execTemplateToString("home", struct {
 		Info    *HomeInfo
@@ -57,8 +58,9 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		exp.Version,
 		exp.NetName,
 	})
-	exp.NewBlockDataMtx.Unlock()
+
 	exp.MempoolData.RUnlock()
+	exp.NewBlockDataMtx.RUnlock()
 
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -158,7 +160,7 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 		NetName       string
 	}{
 		data,
-		exp.NewBlockData.Height - data.Confirmations,
+		exp.Height() - data.Confirmations,
 		exp.Version,
 		exp.NetName,
 	}
@@ -317,7 +319,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				// expiry in blocks - (number of blocks since ticket purchase -
 				// ticket maturity))
 				// C is the probability (chance)
+				exp.NewBlockDataMtx.RLock()
 				pVote := float64(exp.ChainParams.TicketsPerBlock) / float64(exp.ExtraInfo.PoolInfo.Size)
+				exp.NewBlockDataMtx.RUnlock()
 				tx.TicketInfo.Probability = 100 * (math.Pow(1-pVote,
 					float64(exp.ChainParams.TicketExpiry)-float64(blocksLive)))
 			}
@@ -331,7 +335,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		NetName       string
 	}{
 		tx,
-		exp.NewBlockData.Height - tx.Confirmations,
+		exp.Height() - tx.Confirmations,
 		exp.Version,
 		exp.NetName,
 	}
@@ -579,8 +583,9 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	addrData.TxnType = txnType.String()
 
 	confirmHeights := make([]int64, len(addrData.Transactions))
+	bdHeight := exp.Height()
 	for i, v := range addrData.Transactions {
-		confirmHeights[i] = exp.NewBlockData.Height - int64(v.Confirmations)
+		confirmHeights[i] = bdHeight - int64(v.Confirmations)
 	}
 
 	sort.Slice(addrData.Transactions, func(i, j int) bool {

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -98,9 +98,9 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				case "getmempooltxs":
 					webData.EventId = msg.EventId + "Resp"
 
-					exp.MempoolData.Lock()
+					exp.MempoolData.RLock()
 					msg, err := json.Marshal(exp.MempoolData)
-					exp.MempoolData.Unlock()
+					exp.MempoolData.RUnlock()
 
 					if err != nil {
 						log.Warn("Invalid JSON message: ", err)
@@ -160,17 +160,17 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				enc := json.NewEncoder(buff)
 				switch sig {
 				case sigNewBlock:
-					exp.NewBlockDataMtx.Lock()
+					exp.NewBlockDataMtx.RLock()
 					enc.Encode(WebsocketBlock{
 						Block: exp.NewBlockData,
 						Extra: exp.ExtraInfo,
 					})
-					exp.NewBlockDataMtx.Unlock()
+					exp.NewBlockDataMtx.RUnlock()
 					webData.Message = buff.String()
 				case sigMempoolUpdate:
-					exp.MempoolData.Lock()
+					exp.MempoolData.RLock()
 					enc.Encode(exp.MempoolData.MempoolShort)
-					exp.MempoolData.Unlock()
+					exp.MempoolData.RUnlock()
 					webData.Message = buff.String()
 				case sigPingAndUserCount:
 					// ping and send user count


### PR DESCRIPTION
Backport of https://github.com/decred/dcrdata/pull/659 for 3.0.

Home page was requesting a full read-write lock when it only needed a
read lock.  Similarly, RootWebsocket was requesting full unneeded full
locks in both the send and receive loops, which caused a deadlock.
Add (*explorerUI).Height()  for thread-safe access to
NewBlockData.Height.
Remove several pointless closures.