### PR TITLE
Address page tx highlighting

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1,6 +1,7 @@
 package dbtypes
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -357,6 +358,7 @@ type AddressRow struct {
 	// MatchingTxHash provides the relationship between spending tx inputs and
 	// funding tx outputs.
 	MatchingTxHash   string
+	MatchingTxIndex  sql.NullInt64
 	IsFunding        bool
 	TxBlockTime      uint64
 	TxHash           string

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -227,12 +227,13 @@ const (
 		tx_vin_vout_row_id=$2 AND is_funding=$3;`
 
 	UpdateMatchingFundingTxIdFromVins = `UPDATE addresses SET matching_tx_index=tx_index
-		FROM vins WHERE matching_tx_hash=vins.tx_hash AND addresses.tx_hash=prev_tx_hash
-		AND addresses.tx_vin_vout_index=prev_tx_index AND matching_tx_hash !=''
+		FROM vins WHERE addresses.tx_hash=prev_tx_hash
+		AND addresses.tx_vin_vout_index=prev_tx_index
+		AND vins.is_valid=addresses.valid_mainchain
 		AND is_funding=true AND addresses.id >= $1 AND addresses.id < $2;`
 
 	UpdateMatchingSpendingTxIdFromVins = `UPDATE addresses SET matching_tx_index=vins.prev_tx_index
-		FROM vins WHERE vins.id=tx_vin_vout_row_id AND is_funding=false AND matching_tx_hash != ''
+		FROM vins WHERE vins.id=tx_vin_vout_row_id AND is_funding=false
 		AND addresses.id >= $1 AND addresses.id < $2;`
 
 	IndexBlockTimeOnTableAddress   = `CREATE INDEX block_time_index ON addresses (block_time);`

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -40,7 +40,7 @@ var createTypeStatements = map[string]string{
 const (
 	tableMajor = 3
 	tableMinor = 5
-	tablePatch = 3
+	tablePatch = 4
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1180,6 +1180,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 			},
 			Addresses:       addresses,
 			FormattedAmount: humanize.Commaf(ValueIn.ToCoin()),
+			Index:           uint32(i),
 		})
 	}
 	tx.Vin = inputs
@@ -1233,6 +1234,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 			OP_RETURN:       opReturn,
 			Type:            vout.ScriptPubKey.Type,
 			Spent:           txout == nil,
+			Index:           vout.N,
 		})
 	}
 	tx.Vout = outputs

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -20,6 +20,8 @@ const (
 	ctxBlockIndex
 	ctxBlockHash
 	ctxTxHash
+	ctxTxInOut
+	ctxTxInOutId
 	ctxAddress
 	ctxAgendaId
 )
@@ -83,15 +85,6 @@ func getBlockHeightCtx(r *http.Request) int64 {
 	return idx
 }
 
-func getTxIDCtx(r *http.Request) string {
-	hash, ok := r.Context().Value(ctxTxHash).(string)
-	if !ok {
-		log.Trace("Txid not set")
-		return ""
-	}
-	return hash
-}
-
 func getAgendaIDCtx(r *http.Request) string {
 	hash, ok := r.Context().Value(ctxAgendaId).(string)
 	if !ok {
@@ -106,6 +99,17 @@ func TransactionHashCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		txid := chi.URLParam(r, "txid")
 		ctx := context.WithValue(r.Context(), ctxTxHash, txid)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// TransactionIoIndexCtx embeds "inout" and "inoutid" into the request context
+func TransactionIoIndexCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inout := chi.URLParam(r, "inout")
+		inoutid := chi.URLParam(r, "inoutid")
+		ctx := context.WithValue(r.Context(), ctxTxInOut, inout)
+		ctx = context.WithValue(ctx, ctxTxInOutId, inoutid)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -319,8 +319,18 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Initially try to get the transaction information from the "lite" mode
-	// data source, which relies on RPCs to dcrd.
+	inout, ok := r.Context().Value(ctxTxInOut).(string)
+	if !ok {
+		inout = ""
+	}
+
+	ioid, ok := r.Context().Value(ctxTxInOutId).(string)
+	var inoutid int64
+	inoutid, err := strconv.ParseInt(ioid, 10, 0)
+	if !ok || err != nil {
+		inoutid = 0
+	}
+
 	tx := exp.blockData.GetExplorerTx(hash)
 	// If dcrd has no information about the transaction, pull the transaction
 	// details from the full mode database.
@@ -647,6 +657,8 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		ConfirmHeight     int64
 		Version           string
 		NetName           string
+		HighlightInOut    string
+		HighlightInOutID  int64
 	}{
 		tx,
 		blocks,
@@ -655,6 +667,8 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		exp.Height() - tx.Confirmations,
 		exp.Version,
 		exp.NetName,
+		inout,
+		inoutid,
 	}
 
 	str, err := exp.templates.execTemplateToString("tx", pageData)
@@ -907,7 +921,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 				NotFoundStatusType)
 			return
 		}
-
 
 	}
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -69,6 +69,7 @@ type AddressTx struct {
 	SentTotal      float64
 	IsFunding      bool
 	MatchedTx      string
+	MatchedTxIndex int64
 	BlockTime      uint64
 	MergedTxnCount uint64 `json:",omitempty"`
 }
@@ -165,6 +166,7 @@ type Vin struct {
 	*dcrjson.Vin
 	Addresses       []string
 	FormattedAmount string
+	Index           uint32
 }
 
 // Vout models basic data about a tx output for display
@@ -175,6 +177,7 @@ type Vout struct {
 	Type            string
 	Spent           bool
 	OP_RETURN       string
+	Index           uint32
 }
 
 // BlockInfo models data for display on the block page
@@ -397,6 +400,9 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 			TxID:      addrOut.TxHash,
 			MatchedTx: addrOut.MatchingTxHash,
 			IsFunding: addrOut.IsFunding,
+		}
+		if addrOut.MatchingTxIndex.Valid {
+			tx.MatchedTxIndex = addrOut.MatchingTxIndex.Int64
 		}
 
 		if addrOut.IsFunding {

--- a/main.go
+++ b/main.go
@@ -558,6 +558,7 @@ func mainCore() error {
 	webMux.Get("/parameters", explore.ParametersPage)
 	webMux.With(explore.BlockHashPathOrIndexCtx).Get("/block/{blockhash}", explore.Block)
 	webMux.With(explorer.TransactionHashCtx).Get("/tx/{txid}", explore.TxPage)
+	webMux.With(explorer.TransactionHashCtx,explorer.TransactionIoIndexCtx).Get("/tx/{txid}/{inout}/{inoutid}", explore.TxPage)
 	webMux.With(explorer.AddressPathCtx).Get("/address/{address}", explore.AddressPage)
 	webMux.Get("/agendas", explore.AgendasPage)
 	webMux.With(explorer.AgendaPathCtx).Get("/agenda/{agendaid}", explore.AgendaPage)

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -953,6 +953,6 @@ body.darkBG .keynav-target {
 .old-vote {
   background-color: #ff3d001f;
 }
-.upcoming-vote {
+.upcoming-vote, .matching-hash {
   background: #0078ff1c;
 }

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -227,7 +227,7 @@
                             {{range $i, $v := .Transactions}}
                             <tr>
                                 {{with $v}}
-                                <td><a href="/tx/{{.TxID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
+                                <td><a href="/tx/{{.TxID}}/{{if .IsFunding}}out{{else}}in{{end}}/{{.InOutID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
                                 {{if eq $txType "merged_debit"}}
                                     <td class="text-right">{{.MergedTxnCount}}</td>
                                 {{else}}
@@ -238,7 +238,7 @@
                                         <td class="text-right">sstxcommitment</td>
                                         {{else}}
                                             {{if ne .MatchedTx ""}}
-                                            <td class="text-right"><a href="/tx/{{.MatchedTx}}" class="hash">source</a></td>
+                                            <td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" class="matchhash">source</a></td>
                                             {{else}}
                                             <td class="text-right">N/A</td>
                                             {{end}}
@@ -257,7 +257,7 @@
                                     {{end}}
                                 {{else}}
                                     {{if ne .MatchedTx ""}}
-                                        <td><a href="/tx/{{.MatchedTx}}" class="hash">spent</a></td>
+                                        <td><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}" class="matchhash">spent</a></td>
                                     {{else}}
                                         <td>unspent</td>
                                     {{end}}
@@ -385,6 +385,22 @@
                 opacity: 0
             })
             .html("")
+        }
+        $('.matchhash').hover(function() {
+            hashHighLight( $(this).attr('href'), true);
+        },function() {
+            hashHighLight( $(this).attr('href'), false);
+        });
+
+        function hashHighLight(matchHash, hoverOn) {
+            $('.hash').each(function() {
+                var thisHash =$(this).attr('href');
+                if(thisHash == matchHash && hoverOn) {
+                    $(this).addClass("matching-hash");
+                }else{
+                    $(this).removeClass("matching-hash");
+                }
+            })
         }
 
         $('input[type=button]').on('click', function(){

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -142,7 +142,7 @@
                             </td>
                         </tr>
                     {{end}}
-                    
+
                     {{if and (and (eq .Mature "True")  (ne .TicketInfo.SpendStatus "Voted")) (eq .TicketInfo.PoolStatus "live")}}
                         {{if ge .TicketInfo.TicketExpiry .TicketInfo.TicketLiveBlocks}}
                             <tr>
@@ -265,7 +265,7 @@
                 </thead>
                 <tbody>
                     {{range .Vin}}
-                    <tr>
+                    <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="break-word mono fs13">
                             <div class="outpoint">
                             {{if .Coinbase}}
@@ -273,7 +273,7 @@
                             {{else if .Stakebase}}
                                 Stakebase: {{ .Stakebase }}
                             {{else}}
-                                <a data-keynav-priority href="/tx/{{.Txid}}">{{.Txid}}:{{.Vout}}</a>
+                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{.Txid}}:{{.Vout}}</a>
                             {{end}}
                             </div>
                         </td>
@@ -304,7 +304,7 @@
                             <td></td>
                             <td></td>
                             <td class="mono fs13 text-right">{{template "decimalParts" (amountAsDecimalParts .BlockMiningFee false)}}</td>
-                        </tr>        
+                        </tr>
                     {{end}}
                 </tbody>
             </table>
@@ -320,7 +320,7 @@
                 </thead>
                 <tbody>
                     {{range $i, $v := .Vout}}
-                    <tr>
+                    <tr {{if and (eq $.HighlightInOut "out") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="break-word mono fs13 addressAndScriptData">
                             {{range .Addresses}}
                                 <div class="address sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
@@ -343,7 +343,7 @@
                         </td>
                         <td class="text-left fs13">{{with $spending := (index $.Data.SpendingTxns $i) }}
                             {{if $spending.Hash}}
-                                <a href="/tx/{{$spending.Hash}}">{{$v.Spent}}</a>
+                                <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
                             {{else}}
                                 {{if gt $v.Amount 0.0}}
                                 {{$v.Spent}}


### PR DESCRIPTION
This PR is for issue #642.  There are three potential aspects to this issue - I have finished only the first one:

1.  This version will highlight the transactions on the page.  The matched transaction Vin/out is not easily available in the address page raw data and thus right now all we are doing is highlighting the transaction, but if there are multiple identical transactions they all get highlighted.

See example gif below. (address: DsiJmwqFbsCEc1H3HF8UeRjoqJtKt9ZFRKw)
![recording 67](https://user-images.githubusercontent.com/11194546/45069346-e93a1380-b080-11e8-9acf-aa75cd1e7bfd.gif)

2.  I can update the address page to also pull the matched tx vin/vout index but that will likely require changes to the query and/or a secondary query.  I don't know that its that critical to be able to isolate each vin/vout index.

3.  @chappjc mentions also adding a url parameter to the source/spent links to allow the relevant in/out to be highlighted when visiting the tx page as well from that url.  To do that we would also need the vin/vout of the matched tx.

Please let me know if you want me to proceed with steps 2 and 3 here to get the matched tx vin/out index. 