### PR TITLE
Transaction block list

### DIFF
--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -96,6 +96,11 @@ const (
 		FROM transactions
 		WHERE block_height BETWEEN $1 AND $2;`
 
+	SelectTxsBlocks = `SELECT block_height, block_hash, block_index, is_valid, is_mainchain
+		FROM transactions
+		WHERE tx_hash = $1
+		ORDER BY is_valid DESC, is_mainchain DESC, block_height DESC;`
+
 	UpdateRegularTxnsValidMainchainByBlock = `UPDATE transactions
 		SET is_valid=$1, is_mainchain=$2 
 		WHERE block_hash=$3 and tree=0;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -353,6 +353,30 @@ func (pgb *ChainDB) BlockStatus(hash string) (dbtypes.BlockStatus, error) {
 	return RetrieveBlockStatus(pgb.db, hash)
 }
 
+// TransactionBlocks retrieves the blocks in which the specified transaction
+// appears, along with the index of the transaction in each of the blocks. The
+// next and previous block hashes are NOT SET in each BlockStatus.
+func (pgb *ChainDB) TransactionBlocks(txHash string) ([]*dbtypes.BlockStatus, []uint32, error) {
+	hashes, heights, inds, valids, mainchains, err := RetrieveTxnsBlocks(pgb.db, txHash)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	blocks := make([]*dbtypes.BlockStatus, len(hashes))
+
+	for i := range hashes {
+		blocks[i] = &dbtypes.BlockStatus{
+			IsValid:     valids[i],
+			IsMainchain: mainchains[i],
+			Height:      heights[i],
+			Hash:        hashes[i],
+			// Next and previous hash not set
+		}
+	}
+
+	return blocks, inds, nil
+}
+
 // HeightDB queries the DB for the best block height.
 func (pgb *ChainDB) HeightDB() (uint64, error) {
 	bestHeight, _, _, err := RetrieveBestBlockHeight(pgb.db)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1199,6 +1199,35 @@ func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []s
 	return
 }
 
+// RetrieveTxnsBlocks retrieves for the specified transaction hash the following
+// data for each block containing the transactions: block_hash, block_index,
+// is_valid, is_mainchain.
+func RetrieveTxnsBlocks(db *sql.DB, txHash string) (blockHashes []string, blockHeights, blockIndexes []uint32, areValid, areMainchain []bool, err error) {
+	var rows *sql.Rows
+	rows, err = db.Query(internal.SelectTxsBlocks, txHash)
+	if err != nil {
+		return
+	}
+	defer closeRows(rows)
+
+	for rows.Next() {
+		var hash string
+		var height, idx uint32
+		var isValid, isMainchain bool
+		err = rows.Scan(&height, &hash, &idx, &isValid, &isMainchain)
+		if err != nil {
+			break
+		}
+
+		blockHeights = append(blockHeights, height)
+		blockHashes = append(blockHashes, hash)
+		blockIndexes = append(blockIndexes, idx)
+		areValid = append(areValid, isValid)
+		areMainchain = append(areMainchain, isMainchain)
+	}
+	return
+}
+
 // RetrieveBlockHash retrieves the hash of the block at the given height, if it
 // exists (be sure to check error against sql.ErrNoRows!). WARNING: this returns
 // the most recently added block at this height, but there may be others.

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1169,21 +1169,6 @@ func RetrieveTxBlockTimeByHash(db *sql.DB, txHash string) (blockTime uint64, err
 	return
 }
 
-func RetrieveTxIDHeightByHash(db *sql.DB, txHash string) (id uint64, blockHeight int64, err error) {
-	err = db.QueryRow(internal.SelectTxIDHeightByHash, txHash).Scan(&id, &blockHeight)
-	return
-}
-
-func RetrieveRegularTxByHash(db *sql.DB, txHash string) (id uint64, blockHash string, blockInd uint32, err error) {
-	err = db.QueryRow(internal.SelectRegularTxByHash, txHash).Scan(&id, &blockHash, &blockInd)
-	return
-}
-
-func RetrieveStakeTxByHash(db *sql.DB, txHash string) (id uint64, blockHash string, blockInd uint32, err error) {
-	err = db.QueryRow(internal.SelectStakeTxByHash, txHash).Scan(&id, &blockHash, &blockInd)
-	return
-}
-
 func RetrieveTxsByBlockHash(db *sql.DB, blockHash string) (ids []uint64, txs []string,
 	blockInds []uint32, trees []int8, blockTimes []uint64, err error) {
 	var rows *sql.Rows

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -77,6 +77,7 @@ type explorerDataSource interface {
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
 	GetOldestTxBlockTime(addr string) (int64, error)
 	TicketPoolVisualization(interval dbtypes.ChartGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, error)
+	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
 }
 
 // cacheChartsData holds the prepopulated data that is used to draw the charts

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -111,23 +111,23 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 	netTheme := "theme-" + strings.ToLower(netName(params))
 
 	return template.FuncMap{
-		"add": func(a int64, b int64) int64 {
+		"add": func(a, b int64) int64 {
 			return a + b
 		},
-		"subtract": func(a int64, b int64) int64 {
+		"subtract": func(a, b int64) int64 {
 			return a - b
 		},
-		"divide": func(n int64, d int64) int64 {
+		"divide": func(n, d int64) int64 {
 			return n / d
 		},
-		"multiply": func(a int64, b int64) int64 {
+		"multiply": func(a, b int64) int64 {
 			return a * b
 		},
 		"timezone": func() string {
 			t, _ := time.Now().Zone()
 			return t
 		},
-		"percentage": func(a int64, b int64) float64 {
+		"percentage": func(a, b int64) float64 {
 			return (float64(a) / float64(b)) * 100
 		},
 		"int64": toInt64,
@@ -197,7 +197,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			zeros := strings.Repeat("0", 8-len(dec))
 			return []string{integer, dec, zeros}
 		},
-		"remaining": func(idx int, max int64, t int64) string {
+		"remaining": func(idx int, max, t int64) string {
 			x := (max - int64(idx)) * t
 			allsecs := int(time.Duration(x).Seconds())
 			str := ""

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -78,8 +78,14 @@ body {
   padding-bottom: 2.1rem;
   background: #F3F5F6;
 }
+body .grayed {
+  color: rgba(33, 37, 41, 0.5);
+}
 a {
   color: #2e75ff;
+}
+a.grayed {
+  color: rgba(46, 117, 255, 0.75) !important;
 }
 h4 {
   margin-top: 10px;
@@ -127,9 +133,16 @@ body.darkBG {
   background: #3B3F45;
   color: #fdfdfd;
 }
+body .grayed {
+  color: rgba(253, 253, 253, 0.5);
+}
 body.darkBG a,
 body.darkBG a:hover {
   color: #94ffca;
+}
+body.darkBG a.grayed,
+body.darkBG a.grayed:hover {
+  color: rgba(148, 255, 202, 0.75) !important;
 }
 body.darkBG .table thead th {
   vertical-align: bottom;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -133,7 +133,7 @@ body.darkBG {
   background: #3B3F45;
   color: #fdfdfd;
 }
-body .grayed {
+body.darkBG .grayed {
   color: rgba(253, 253, 253, 0.5);
 }
 body.darkBG a,

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -31,7 +31,17 @@
                     <tr>
                         <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">INCLUDED IN BLOCK</td>
                         <td>
-                             <a href="/block/{{.BlockHeight}}" class="fs18">{{.BlockHeight}}</a>
+                        {{range $i, $b := $.Blocks}}
+                        {{$blockInd := index $.BlockInds $i}}
+                        {{$validMainchain := and $b.IsValid $b.IsMainchain}}
+                            <a href="/block/{{$b.Hash}}?ind={{$blockInd}}"
+                                {{if not $validMainchain}}
+                                class="fs18 grayed" title="Mainchain: {{$b.IsMainchain}}&#xA;Valid: {{$b.IsValid}}"
+                                {{else}}
+                                class="fs18"
+                                {{end}}>
+                                {{$b.Height}}</a>{{if lt (add (int64 $i) 1) (len $.Blocks)}}, {{end}}
+                        {{end}}
                         </td>
                     </tr>
                 {{end}}


### PR DESCRIPTION
This adds a new query to get details for all blocks containing a specified transaction. The details are block index, height, hash, is_valid, and is_mainchain.  `ChainDB.TransactionBlocks` gets these data.

On the transaction page, use the new `TransactionBlocks` function in full mode to retrieve and display a list of blocks (on the transaction view) that contain the transaction.  When a transaction is found in multiple blocks, list them all with unambiguous links by hash.  Also pass the transaction index via `?ind=`
URL parameter so that we can use it on the block page to highlight the transaction (not done in this work). Create "grayed out" colors with a `"grayed"` class for `<body>` and `<a>` elements.  Also define these for dark/night mode. Also simplify the signature for several template functions.

In day mode:

![image](https://user-images.githubusercontent.com/9373513/45111230-1088f300-b10a-11e8-8161-967c7c99e099.png)

Night mode:

![image](https://user-images.githubusercontent.com/9373513/45111404-82613c80-b10a-11e8-8b4c-412d69275e7d.png)

(previously there was just one block listed).

This resolves issue https://github.com/decred/dcrdata/issues/295.