### PR TITLE
dcrpg/dcrsqlite: no transactions found for address is not an error

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -776,7 +776,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	if err != nil {
 		return nil, nil, err
 	}
-	if fresh {
+	if fresh || len(addressRows) == 0 {
 		return addressRows, &balanceInfo, nil
 	}
 
@@ -951,6 +951,13 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 	addrData, _, err := pgb.addressInfo(addr, count, skip, txnType)
 	if err != nil {
 		return nil, err
+	}
+	// No transactions found. Not an error.
+	if addrData == nil {
+		return &apitypes.Address{
+			Address:      addr,
+			Transactions: make([]*apitypes.AddressTxShort, 0), // not nil for JSON formatting
+		}, nil
 	}
 
 	// Convert each explorer.AddressTx to apitypes.AddressTxShort

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -821,8 +821,15 @@ func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) 
 		return nil
 	}
 	txs, err := db.client.SearchRawTransactionsVerbose(address, skip, count, false, true, nil)
+	if err != nil && err.Error() == "-32603: No Txns available" {
+		log.Debugf("GetAddressTransactionsWithSkip: No transactions found for address %s: %v", addr, err)
+		return &apitypes.Address{
+			Address:      addr,
+			Transactions: make([]*apitypes.AddressTxShort, 0), // not nil for JSON formatting
+		}
+	}
 	if err != nil {
-		log.Warnf("GetAddressTransactions failed for address %s: %v", addr, err)
+		log.Errorf("GetAddressTransactionsWithSkip failed for address %s: %v", addr, err)
 		return nil
 	}
 	tx := make([]*apitypes.AddressTxShort, 0, len(txs))
@@ -1263,7 +1270,7 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 	txs, err := db.client.SearchRawTransactionsVerbose(addr,
 		int(offset), int(maxcount), true, true, nil)
 	if err != nil && err.Error() == "-32603: No Txns available" {
-		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
+		log.Debugf("GetExplorerAddress: No transactions found for address %s: %v", addr, err)
 
 		if !ValidateNetworkAddress(addr, db.params) {
 			log.Warnf("Address %s is not valid for this network", address)
@@ -1274,7 +1281,7 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 			MaxTxLimit: maxcount,
 		}
 	} else if err != nil {
-		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
+		log.Warnf("GetExplorerAddress: SearchRawTransactionsVerbose failed for address %s: %v", addr, err)
 		return nil
 	}
 


### PR DESCRIPTION
In both dcrpg (for full mode) and dcrsqlite (for lite mode), this
responds to address history requests without error when there are no
known transactions for a given address but no other error.

For the API, this means returning a non-nil *apitypes.Address with the
Transactions field set to a non-nil zero-length slice.  The slice must
be non-nil so that when marshalled to JSON, "address_transactions"
shows as [] instead of null.

So instead of code 422 and "Unprocessible Entity", the API  now responds
with code 200 and a valid JSON struct like:

```json
{
"address": "TsmSGofXA4hqx9XRNgWoRZtNMXXshhMLByA",
"address_transactions": []
}
```

This resolves issue https://github.com/decred/dcrdata/issues/662.