### PR TITLE
cache the ticket pool data to avoid unnecessary DB queries

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -186,7 +186,7 @@ func NewAPIRouter(app *appContext, userRealIP bool) apiMux {
 	mux.Route("/chart", func(r chi.Router) {
 		// Return default chart data (ticket price)
 		r.Get("/", app.getTicketPriceChartData)
-		r.With(m.ChartTypeCtx).Get("/{charttype}", app.getChartTypeData)
+		r.With(m.ChartTypeCtx).Get("/{charttype}", app.ChartTypeData)
 	})
 
 	mux.Route("/ticketpool", func(r chi.Router) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1428,11 +1428,11 @@ func retrieveTicketByPrice(db *sql.DB, maturityBlock int64) (*dbtypes.PoolTicket
 	return tickets, nil
 }
 
-// retrieveTickesGroupedByType fetches the count of tickets in the current ticketpool
-// grouped by ticket type (inferred by their output counts). The grouping used
-// here i.e. solo, pooled and tixsplit is just a guessing based on commonly
-// structured ticket purchases.
-func retrieveTickesGroupedByType(db *sql.DB) (*dbtypes.PoolTicketsData, error) {
+// retrieveTicketsGroupedByType fetches the count of tickets in the current
+// ticketpool grouped by ticket type (inferred by their output counts). The
+// grouping used here i.e. solo, pooled and tixsplit is just a guessing based on
+// commonly structured ticket purchases.
+func retrieveTicketsGroupedByType(db *sql.DB) (*dbtypes.PoolTicketsData, error) {
 	var entry dbtypes.PoolTicketsData
 	rows, err := db.Query(internal.SelectTicketsByType)
 	if err != nil {
@@ -1445,7 +1445,7 @@ func retrieveTickesGroupedByType(db *sql.DB) (*dbtypes.PoolTicketsData, error) {
 		err = rows.Scan(&txType, &txTypeCount)
 
 		if err != nil {
-			return nil, fmt.Errorf("retrieveTickesGroupedByType %v", err)
+			return nil, fmt.Errorf("retrieveTicketsGroupedByType %v", err)
 		}
 
 		switch txType {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -61,6 +61,19 @@ type ChartDataCounter struct {
 	Data map[string]*dbtypes.ChartsData
 }
 
+// ticketPoolDataCache stores the most recent ticketpool graphs information
+// fetched to minimize the possibility of making multiple queries to the db
+// fetching the same information.
+type ticketPoolDataCache struct {
+	sync.RWMutex
+	Height int64
+	// BarGraphsCache persists data for the Ticket purchase distribution chart
+	// and Ticket Price Distribution chart
+	BarGraphsCache map[dbtypes.ChartGrouping][]*dbtypes.PoolTicketsData
+	// DonutGraphCache persist data for the Number of tickets outputs pie chart.
+	DonutGraphCache map[dbtypes.ChartGrouping]*dbtypes.PoolTicketsData
+}
+
 // AddressTx models data for transactions on the address page
 type AddressTx struct {
 	TxID           string

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -55,25 +55,6 @@ type TxBasic struct {
 	Coinbase      bool
 }
 
-// ChartDataCounter is a data cache for the historical charts.
-type ChartDataCounter struct {
-	sync.RWMutex
-	Data map[string]*dbtypes.ChartsData
-}
-
-// ticketPoolDataCache stores the most recent ticketpool graphs information
-// fetched to minimize the possibility of making multiple queries to the db
-// fetching the same information.
-type ticketPoolDataCache struct {
-	sync.RWMutex
-	Height int64
-	// BarGraphsCache persists data for the Ticket purchase distribution chart
-	// and Ticket Price Distribution chart
-	BarGraphsCache map[dbtypes.ChartGrouping][]*dbtypes.PoolTicketsData
-	// DonutGraphCache persist data for the Number of tickets outputs pie chart.
-	DonutGraphCache map[dbtypes.ChartGrouping]*dbtypes.PoolTicketsData
-}
-
 // AddressTx models data for transactions on the address page
 type AddressTx struct {
 	TxID           string

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -106,20 +106,29 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					webData.Message = string(msg)
 
 				case "getticketpooldata":
-					// TODO: Implement a cache to control websocket connections
-					// meant to serve the same data.
-					cData, gData, err := exp.explorerSource.TicketPoolVisualization(
-						dbtypes.ChartGroupingFromStr(msg.Message),
-					)
-					if err != nil {
-						if strings.HasPrefix(err.Error(), "unknown interval") {
-							log.Debugf("Invalid ticket pool interval provided via getticketpooldata: %s", msg.Message)
-							webData.Message = "Error: " + err.Error()
+					interval := dbtypes.ChartGroupingFromStr(msg.Message)
+
+					cData, gData, ok := GetTicketPoolData(interval)
+					// If cached data matched the needed data, no need to query the db.
+					if !ok {
+						var err error
+						cData, gData, err =
+							exp.explorerSource.TicketPoolVisualization(interval)
+						if err != nil {
+							if strings.HasPrefix(err.Error(), "unknown interval") {
+								log.Debugf("invalid ticket pool interval "+
+									"provided via getticketpooldata: %s",
+									msg.Message)
+								webData.Message = "Error: " + err.Error()
+								break
+							}
+							log.Errorf("TicketPoolVisualization error: %v", err)
+							webData.Message = "Error: failed to fetch ticketpool data"
 							break
 						}
-						log.Errorf("TicketPoolVisualization error: %v", err)
-						webData.Message = "Error: Failed to fetch ticketpool data"
-						break
+
+						// Update the newly fetched data to the ticket pool cache.
+						UpdateTicketPoolData(interval, cData, gData)
 					}
 
 					exp.MempoolData.RLock()

--- a/public/js/controllers/ticketpool.js
+++ b/public/js/controllers/ticketpool.js
@@ -221,7 +221,7 @@ function barchartPlotter(e) {
                 if (evt === "") {
                     return
                 }
-                var v = JSON.parse(evt);
+                var v = JSON.parse(evt).ticket_pool_data;
                 mpl = v.Mempool
                 this.purchasesGraph.updateOptions({'file': purchasesGraphData(v.BarGraphs[0], mpl), 
                     dateWindow: getWindow(this.zoom)});
@@ -256,7 +256,7 @@ function barchartPlotter(e) {
                     $("body").removeClass("loading");
                 },
                 success: function(data) {
-                    _this.purchasesGraph.updateOptions({'file': purchasesGraphData(data, mpl)});
+                    _this.purchasesGraph.updateOptions({'file': purchasesGraphData(data.ticket_pool_data, mpl)});
                     $("body").removeClass("loading");
                 }
             });


### PR DESCRIPTION
This implements a cache for the ticket pool data at the dcrpg package level.  The cache automatically updates on the first request when the data is stale.  Requests made when an update is already running are served with stale data.

So that the APIs and the explorer can easily leverage the cache but not even know about it, the cache should live entirely within `ChainDB` in the `dcrpg` package.  Also, consumers only need use `TicketPoolVisualization`, not the cache query and update functions. `ticketPoolDataCache` lives in pgblockchain.go (dcrpg) now, and it is managed entirely by `ChainDB`.
Modify tickets pool by date API response to include height of the data. Also pass `ChartsHeight` to the /ticketpool page template, for future use.
The `ticketPoolVisualization` function now ensures that the DB height hasn't changed from the beginning of the queries to the end.
Move `ChartDataCounter` out of explorertypes.go, which is intended to help importers of the explore package find useful exported types.

This also disables the ticketpool page when running in lite mode.