### PR TITLE
[2.1] guard concurrent maps write

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -629,7 +629,9 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	log.Infof("Caching address receive count for address %s: "+
 		"count = %d at block %d.", address,
 		balanceInfo.NumSpent+balanceInfo.NumUnspent, bestBlock)
+	totals.Lock()
 	totals.balance[address] = balanceInfo
+	totals.Unlock()
 
 	return addressRows, &balanceInfo, nil
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,11 +20,8 @@ DOCKER_IMAGE_TAG=decred-golang-builder-$GOVERSION
 testrepo () {
   TMPFILE=$(mktemp)
 
-  # Check lockfile
-  dep ensure -no-vendor -dry-run
-
-  # All good, so run for real
-  dep ensure
+  # Dependencies
+  dep ensure -vendor-only
 
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m \

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ type Version struct {
 var Ver = Version{
 	Major: 2,
 	Minor: 1,
-	Patch: 2,
+	Patch: 3,
 	Label: ""}
 
 // CommitHash may be set on the build command line:


### PR DESCRIPTION
This fixes a concurrent map write on the dev balance.
Version is bumped to 2.1.3.
CI now ignores changes in dep lock.