### PR TITLE
limit CI to go1.11 and fix some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ services:
   - docker
 
 env:
-  - GOVERSION=1.9
-  - GOVERSION=1.10
+  - GOVERSION=1.11
 
 install: true
 

--- a/testutil/tempfiles.go
+++ b/testutil/tempfiles.go
@@ -16,8 +16,7 @@ const (
 func TempFolderPath() string {
 	testDir, err := filepath.Abs(DefaultDataDirname)
 	if err != nil {
-		ReportTestIsNotAbleToTest(
-			"Failed to produce DB-test folder path", err)
+		ReportTestIsNotAbleToTest("Failed to produce DB-test folder path: %v", err)
 	}
 	return testDir
 }
@@ -34,8 +33,7 @@ func ResetTempFolder(testSubFolder *string) string {
 	err := os.RemoveAll(testFolderPath)
 	// Failed to clear test-files
 	if err != nil {
-		ReportTestIsNotAbleToTest(
-			"Failed to clear temp folder: %v", err)
+		ReportTestIsNotAbleToTest("Failed to clear temp folder: %v", err)
 	}
 	return testFolderPath
 }
@@ -46,8 +44,8 @@ func FilePathInsideTempDir(pathInsideTempFolder string) string {
 	targetPath := filepath.Join(tempDir, pathInsideTempFolder)
 	targetPath, err := filepath.Abs(targetPath)
 	if err != nil {
-		ReportTestIsNotAbleToTest(
-			"Failed to build a path: "+pathInsideTempFolder, err)
+		ReportTestIsNotAbleToTest("Failed to build path %s: %v",
+			pathInsideTempFolder, err)
 	}
 	return targetPath
 }


### PR DESCRIPTION
This limits Travis to testing Go 1.11 only, and uses go modules exclusively, no dep.

GO111MODULE=on is set, and the vendor folder is not populated with dep or go mod vendor.  As such, linters are disabled until such time that the linter authors can figure out how to make them work with modules.

Also fix some testing issues:
- stakedb (ticketpool) test data in wrong folder.
- Missing formatting directives in testutil functions.