### PR TITLE
dcrpg: fix concurrent map write

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -955,7 +955,9 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	log.Infof("Caching address receive count for address %s: "+
 		"count = %d at block %d.", address,
 		balanceInfo.NumSpent+balanceInfo.NumUnspent, bestBlock)
+	totals.Lock()
 	totals.balance[address] = balanceInfo
+	totals.Unlock()
 
 	return addressRows, &balanceInfo, nil
 }


### PR DESCRIPTION
This addresses an unguarded map write on the project fund balance map.