### PR TITLE
Invalidated transaction display

### DIFF
--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -86,6 +86,13 @@ const (
 		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC
 		LIMIT 1;`
 
+	SelectFullTxsByHash = `SELECT id, block_hash, block_height, block_time, 
+		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry, 
+		size, spent, sent, fees, num_vin, vin_db_ids, num_vout, vout_db_ids,
+		is_valid, is_mainchain
+		FROM transactions WHERE tx_hash = $1
+		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC;`
+
 	SelectTxnsVinsByBlock = `SELECT vin_db_ids, is_valid, is_mainchain
 		FROM transactions WHERE block_hash = $1;`
 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -63,7 +63,7 @@ const (
 			transactions.is_valid=TRUE AND
 			transactions.is_mainchain=TRUE
 		WHERE prev_tx_hash=$1 AND vins.is_valid=TRUE AND vins.is_mainchain=TRUE;`
-	SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins
+	SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index, tx_tree FROM vins
 		WHERE prev_tx_hash=$1 AND prev_tx_index=$2;`
 	SelectFundingTxsByTx        = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1;`
 	SelectFundingTxByTxIn       = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
@@ -154,9 +154,10 @@ const (
 	SelectAddressByTxHash = `SELECT script_addresses, value FROM vouts
 		WHERE tx_hash = $1 AND tx_index = $2 AND tx_tree = $3;`
 
-	SelectPkScriptByID     = `SELECT pkscript FROM vouts WHERE id=$1;`
-	SelectVoutIDByOutpoint = `SELECT id FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
-	SelectVoutByID         = `SELECT * FROM vouts WHERE id=$1;`
+	SelectPkScriptByID       = `SELECT version, pkscript FROM vouts WHERE id=$1;`
+	SelectPkScriptByOutpoint = `SELECT version, pkscript FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
+	SelectVoutIDByOutpoint   = `SELECT id FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
+	SelectVoutByID           = `SELECT * FROM vouts WHERE id=$1;`
 
 	RetrieveVoutValue  = `SELECT value FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
 	RetrieveVoutValues = `SELECT value, tx_index, tx_tree FROM vouts WHERE tx_hash=$1;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -513,6 +513,13 @@ func (pgb *ChainDB) BlockTransactions(blockHash string) ([]string, []uint32, []i
 	return blockTransactions, blockInds, trees, err
 }
 
+// Transaction retrieves all rows from the transactions table for the given
+// transaction hash.
+func (pgb *ChainDB) Transaction(txHash string) ([]*dbtypes.Tx, error) {
+	_, dbTxs, err := RetrieveDbTxsByHash(pgb.db, txHash)
+	return dbTxs, err
+}
+
 // BlockMissedVotes retrieves the ticket IDs for all missed votes in the
 // specified block, and an error value.
 func (pgb *ChainDB) BlockMissedVotes(blockHash string) ([]string, error) {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -7,6 +7,7 @@ package dcrpg
 import (
 	"bytes"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"runtime"
@@ -1666,6 +1667,29 @@ func (pgb *ChainDB) setVinsMainchainOneTxn(vinDbIDs dbtypes.UInt64Array,
 	}
 
 	return rowsUpdated, nil
+}
+
+// VinsForTx returns a slice of dbtypes.VinTxProperty values for each vin
+// referenced by the transaction dbTx.
+func (pgb *ChainDB) VinsForTx(dbTx *dbtypes.Tx) ([]dbtypes.VinTxProperty, []string, []uint16, error) {
+	var prevPkScripts []string
+	var versions []uint16
+	for _, id := range dbTx.VinDbIds {
+		pkScript, ver, err := RetrievePkScriptByID(pgb.db, id)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		prevPkScripts = append(prevPkScripts, hex.EncodeToString(pkScript))
+		versions = append(versions, ver)
+	}
+	vins, err := RetrieveVinsByIDs(pgb.db, dbTx.VinDbIds)
+	return vins, prevPkScripts, versions, err
+}
+
+// VoutsForTx returns a slice of dbtypes.Vout values for each vout referenced by
+// the transaction dbTx.
+func (pgb *ChainDB) VoutsForTx(dbTx *dbtypes.Tx) ([]dbtypes.Vout, error) {
+	return RetrieveVoutsByIDs(pgb.db, dbTx.VoutDbIds)
 }
 
 func (pgb *ChainDB) TipToSideChain(mainRoot string) (string, int64, error) {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1677,12 +1677,15 @@ func (pgb *ChainDB) VinsForTx(dbTx *dbtypes.Tx) ([]dbtypes.VinTxProperty, []stri
 	for _, id := range dbTx.VinDbIds {
 		pkScript, ver, err := RetrievePkScriptByID(pgb.db, id)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, fmt.Errorf("RetrievePkScriptByID: %v", err)
 		}
 		prevPkScripts = append(prevPkScripts, hex.EncodeToString(pkScript))
 		versions = append(versions, ver)
 	}
 	vins, err := RetrieveVinsByIDs(pgb.db, dbTx.VinDbIds)
+	if err != nil {
+		err = fmt.Errorf("RetrieveVinsByIDs: %v", err)
+	}
 	return vins, prevPkScripts, versions, err
 }
 

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -25,7 +25,7 @@ func openDB() (func() error, error) {
 		DBName: "dcrdata",
 	}
 	var err error
-	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams)
+	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true)
 	cleanUp := func() error { return nil }
 	if db != nil {
 		cleanUp = db.Close
@@ -62,7 +62,7 @@ func TestStuff(t *testing.T) {
 	testTxBlockTree := wire.TxTreeRegular
 
 	// Test number of spent outputs / spending transactions
-	spendingTxns, err := db.SpendingTransactions(testTx)
+	spendingTxns, _, _, err := db.SpendingTransactions(testTx)
 	if err != nil {
 		t.Error("SpendingTransactions", err)
 	}
@@ -74,7 +74,7 @@ func TestStuff(t *testing.T) {
 	}
 
 	// Test a certain spending transaction is as expected
-	spendingTx, err := db.SpendingTransaction(testTx, voutInd)
+	spendingTx, _, _, err := db.SpendingTransaction(testTx, voutInd)
 	if err != nil {
 		t.Error("SpendingTransaction", err)
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -48,12 +48,12 @@ func IsUniqueIndex(db *sql.DB, indexName string) (isUnique bool, err error) {
 }
 
 func RetrievePkScriptByID(db *sql.DB, id uint64) (pkScript []byte, ver uint16, err error) {
-	err = db.QueryRow(internal.SelectPkScriptByID, id).Scan(&pkScript, &ver)
+	err = db.QueryRow(internal.SelectPkScriptByID, id).Scan(&ver, &pkScript)
 	return
 }
 
 func RetrievePkScriptByOutpoint(db *sql.DB, txHash string, voutIndex uint32) (pkScript []byte, ver uint16, err error) {
-	err = db.QueryRow(internal.SelectPkScriptByOutpoint, txHash, voutIndex).Scan(&pkScript, &ver)
+	err = db.QueryRow(internal.SelectPkScriptByOutpoint, txHash, voutIndex).Scan(&ver, &pkScript)
 	return
 }
 
@@ -1180,18 +1180,22 @@ func RetrieveDbTxsByHash(db *sql.DB, txHash string) (ids []uint64, dbTxs []*dbty
 	for rows.Next() {
 		var id uint64
 		var dbTx dbtypes.Tx
-		vinDbIDs := dbtypes.UInt64Array(dbTx.VinDbIds)
-		voutDbIDs := dbtypes.UInt64Array(dbTx.VoutDbIds)
+		var vinids, voutids dbtypes.UInt64Array
+		// vinDbIDs := dbtypes.UInt64Array(dbTx.VinDbIds)
+		// voutDbIDs := dbtypes.UInt64Array(dbTx.VoutDbIds)
 
 		err = rows.Scan(&id,
 			&dbTx.BlockHash, &dbTx.BlockHeight, &dbTx.BlockTime, &dbTx.Time,
 			&dbTx.TxType, &dbTx.Version, &dbTx.Tree, &dbTx.TxID, &dbTx.BlockIndex,
 			&dbTx.Locktime, &dbTx.Expiry, &dbTx.Size, &dbTx.Spent, &dbTx.Sent,
-			&dbTx.Fees, &dbTx.NumVin, &vinDbIDs, &dbTx.NumVout, &voutDbIDs,
+			&dbTx.Fees, &dbTx.NumVin, &vinids, &dbTx.NumVout, &voutids,
 			&dbTx.IsValidBlock, &dbTx.IsMainchainBlock)
 		if err != nil {
 			break
 		}
+
+		dbTx.VinDbIds = vinids
+		dbTx.VoutDbIds = voutids
 
 		ids = append(ids, id)
 		dbTxs = append(dbTxs, &dbTx)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1124,35 +1124,35 @@ func RetrieveFullTxByHash(db *sql.DB, txHash string) (id uint64,
 
 // RetrieveDbTxsByHash retrieves all the rows of the transactions table,
 // including the primary keys/ids, for the given transaction hash.
-// func RetrieveDbTxsByHash(db *sql.DB, txHash string) (ids []uint64, dbTxs []*dbtypes.Tx, err error) {
-// 	var rows *sql.Rows
-// 	rows, err = db.Query(internal.SelectFullTxsByHash, txHash)
-// 	if err != nil {
-// 		return
-// 	}
-// 	defer closeRows(rows)
+func RetrieveDbTxsByHash(db *sql.DB, txHash string) (ids []uint64, dbTxs []*dbtypes.Tx, err error) {
+	var rows *sql.Rows
+	rows, err = db.Query(internal.SelectFullTxsByHash, txHash)
+	if err != nil {
+		return
+	}
+	defer closeRows(rows)
 
-// 	for rows.Next() {
-// 		var id uint64
-// 		var dbTx dbtypes.Tx
-// 		vinDbIDs := dbtypes.UInt64Array(dbTx.VinDbIds)
-// 		voutDbIDs := dbtypes.UInt64Array(dbTx.VoutDbIds)
+	for rows.Next() {
+		var id uint64
+		var dbTx dbtypes.Tx
+		vinDbIDs := dbtypes.UInt64Array(dbTx.VinDbIds)
+		voutDbIDs := dbtypes.UInt64Array(dbTx.VoutDbIds)
 
-// 		err = rows.Scan(&id,
-// 			&dbTx.BlockHash, &dbTx.BlockHeight, &dbTx.BlockTime, &dbTx.Time,
-// 			&dbTx.TxType, &dbTx.Version, &dbTx.Tree, &dbTx.TxID, &dbTx.BlockIndex,
-// 			&dbTx.Locktime, &dbTx.Expiry, &dbTx.Size, &dbTx.Spent, &dbTx.Sent,
-// 			&dbTx.Fees, &dbTx.NumVin, &vinDbIDs, &dbTx.NumVout, &voutDbIDs,
-// 			&dbTx.IsValidBlock, &dbTx.IsMainchainBlock)
-// 		if err != nil {
-// 			break
-// 		}
+		err = rows.Scan(&id,
+			&dbTx.BlockHash, &dbTx.BlockHeight, &dbTx.BlockTime, &dbTx.Time,
+			&dbTx.TxType, &dbTx.Version, &dbTx.Tree, &dbTx.TxID, &dbTx.BlockIndex,
+			&dbTx.Locktime, &dbTx.Expiry, &dbTx.Size, &dbTx.Spent, &dbTx.Sent,
+			&dbTx.Fees, &dbTx.NumVin, &vinDbIDs, &dbTx.NumVout, &voutDbIDs,
+			&dbTx.IsValidBlock, &dbTx.IsMainchainBlock)
+		if err != nil {
+			break
+		}
 
-// 		ids = append(ids, id)
-// 		dbTxs = append(dbTxs, &dbTx)
-// 	}
-// 	return
-// }
+		ids = append(ids, id)
+		dbTxs = append(dbTxs, &dbTx)
+	}
+	return
+}
 
 // RetrieveTxnsVinsByBlock retrieves for all the transactions in the specified
 // block the vin_db_ids arrays, is_valid, and is_mainchain.

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1132,7 +1132,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	}
 	txraw, err := db.client.GetRawTransactionVerbose(txhash)
 	if err != nil {
-		log.Errorf("GetRawTransactionVerbose failed for %v: %v", txhash, err)
+		log.Warnf("GetRawTransactionVerbose failed for %v: %v", txhash, err)
 		return nil
 	}
 	msgTx, err := txhelpers.MsgTxFromHex(txraw.Hex)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -79,6 +79,8 @@ type explorerDataSource interface {
 	TicketPoolVisualization(interval dbtypes.ChartGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
 	Transaction(txHash string) ([]*dbtypes.Tx, error)
+	VinsForTx(*dbtypes.Tx) (vins []dbtypes.VinTxProperty, prevPkScripts []string, scriptVersions []uint16, err error)
+	VoutsForTx(*dbtypes.Tx) ([]dbtypes.Vout, error)
 }
 
 // chartDataCounter is a data cache for the historical charts.

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -78,6 +78,7 @@ type explorerDataSource interface {
 	GetOldestTxBlockTime(addr string) (int64, error)
 	TicketPoolVisualization(interval dbtypes.ChartGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
+	Transaction(txHash string) ([]*dbtypes.Tx, error)
 }
 
 // chartDataCounter is a data cache for the historical charts.

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -32,6 +32,9 @@ var (
 	zeroHashStringBytes = []byte(chainhash.Hash{}.String())
 )
 
+var CoinbaseFlags = "/dcrd/"
+var CoinbaseScript = append([]byte{0x00, 0x00}, []byte(CoinbaseFlags)...)
+
 // RawTransactionGetter is an interface satisfied by rpcclient.Client, and
 // required by functions that would otherwise require a rpcclient.Client just
 // for GetRawTransaction.

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -776,6 +776,42 @@ func DetermineTxTypeString(msgTx *wire.MsgTx) string {
 	}
 }
 
+// TxTypeToString returns a string representation of the provided transaction
+// type, which corresponds to the txn types defined for stake.TxType type.
+func TxTypeToString(txType int) string {
+	switch stake.TxType(txType) {
+	case stake.TxTypeSSGen:
+		return "Vote"
+	case stake.TxTypeSStx:
+		return "Ticket"
+	case stake.TxTypeSSRtx:
+		return "Revocation"
+	default:
+		return "Regular"
+	}
+}
+
+// TxIsTicket indicates if the transaction type is a ticket (sstx).
+func TxIsTicket(txType int) bool {
+	return stake.TxType(txType) == stake.TxTypeSStx
+}
+
+// TxIsTicket indicates if the transaction type is a vote (ssgen).
+func TxIsVote(txType int) bool {
+	return stake.TxType(txType) == stake.TxTypeSSGen
+}
+
+// TxIsTicket indicates if the transaction type is a revocation (ssrtx).
+func TxIsRevoke(txType int) bool {
+	return stake.TxType(txType) == stake.TxTypeSSRtx
+}
+
+// TxIsTicket indicates if the transaction type is a regular (non-stake)
+// transaction.
+func TxIsRegular(txType int) bool {
+	return stake.TxType(txType) == stake.TxTypeRegular
+}
+
 // IsStakeTx indicates if the input MsgTx is a stake transaction.
 func IsStakeTx(msgTx *wire.MsgTx) bool {
 	switch stake.DetermineTxType(msgTx) {

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -44,6 +44,11 @@
                         {{end}}
                         </td>
                     </tr>
+                    {{if not $.HasValidMainchain}}
+                    <tr>
+                        <span class="attention">This transaction is not included in a stakeholder-approved mainchain block.</span>
+                    </tr>
+                    {{end}}
                 {{end}}
                 {{if or (eq .Type "Vote") (eq .Type "Revocation")}}
                     {{range .Vin}}


### PR DESCRIPTION
If a transaction is not known to dcrd, it is because it has been orphaned by a reorg, invalidated via stakeholder disapproval, or both. This change will attempt to load details of the transaction from the
dcrpg database, which may have decoded and recorded the transaction.

Add a message to the transaction page when the transaction is not found in any valid and mainchain block:

![image](https://user-images.githubusercontent.com/9373513/45328299-ff345200-b520-11e8-842d-b1aa6f2a7538.png)

Tasks:
- [x] Load transaction details from DB rather than dcrd.
- [x] Handle globally-invalidated/sidechain transactions with a message on the transaction page.
- [x] Pull the vins and vouts from the db too.

Future: See if it is easier, more efficient, or feasible to pull the entire block from dcrd instead of checking the database.