### PR TITLE
dcrpg: valid_mainchain addresses table patch

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -184,7 +184,7 @@ const (
 	// false according to the transactions table. Should is defined as any
 	// occurence of a given transaction (hash) being flagged as is_valid AND
 	// is_mainchain.
-	SelectAddressesGloballyInvalid = `SELECT id
+	SelectAddressesGloballyInvalid = `SELECT id, valid_mainchain
 		FROM addresses
 		JOIN
 			(  -- globally_invalid transactions with no (is_valid && is_mainchain)=true occurrence
@@ -213,6 +213,10 @@ const (
 		) AS incorrectly_valid
 		WHERE incorrectly_valid.id=addresses.id;`
 
+	// UpdateValidMainchainFromTransactions sets valid_mainchain in all rows of
+	// the addresses table according to the transactions table, unlike
+	// UpdateAddressesGloballyInvalid that does it selectively for only the
+	// incorrectly set addresses table rows.  This is much slower.
 	UpdateValidMainchainFromTransactions = `UPDATE addresses
 		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean
 		FROM transactions AS tr

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -96,6 +96,9 @@ const (
 		FROM transactions
 		WHERE block_height BETWEEN $1 AND $2;`
 
+	SelectRegularTxnsVinsVoutsByBlock = `SELECT vin_db_ids, vout_db_ids, is_mainchain
+		FROM transactions WHERE block_hash = $1 AND tree = 0;`
+
 	SelectTxsBlocks = `SELECT block_height, block_hash, block_index, is_valid, is_mainchain
 		FROM transactions
 		WHERE tx_hash = $1

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -40,7 +40,7 @@ var createTypeStatements = map[string]string{
 const (
 	tableMajor = 3
 	tableMinor = 5
-	tablePatch = 2
+	tablePatch = 3
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -37,6 +37,7 @@ const (
 	addressesTxHistogramUpgrade
 	agendasVotingMilestonesUpgrade
 	ticketsTableBlockTimeUpgrade
+	addressesTableValidMainchainPatch
 )
 
 type TableUpgradeType struct {
@@ -203,12 +204,28 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 		// Go on to next upgrade
 		fallthrough
 
-		// Upgrade from 3.5.1 --> 3.5.2
+	// Upgrade from 3.5.1 --> 3.5.2
 	case version.major == 3 && version.minor == 5 && version.patch == 1:
 		toVersion = TableVersion{3, 5, 2}
 
 		theseUpgrades := []TableUpgradeType{
 			{"tickets", ticketsTableBlockTimeUpgrade},
+		}
+
+		isSuccess, er := pgb.initiatePgUpgrade(nil, theseUpgrades)
+		if !isSuccess {
+			return isSuccess, er
+		}
+
+		// Go on to next upgrade
+		fallthrough
+
+	// Upgrade from 3.5.2 --> 3.5.3
+	case version.major == 3 && version.minor == 5 && version.patch == 2:
+		toVersion = TableVersion{3, 5, 3}
+
+		theseUpgrades := []TableUpgradeType{
+			{"addresses", addressesTableValidMainchainPatch},
 		}
 
 		isSuccess, er := pgb.initiatePgUpgrade(nil, theseUpgrades)
@@ -308,6 +325,9 @@ func (pgb *ChainDB) handleUpgrades(client *rpcutils.BlockGate,
 	case ticketsTableBlockTimeUpgrade:
 		tableReady = true
 		tableName, upgradeTypeStr = "tickets", "new index"
+	case addressesTableValidMainchainPatch:
+		tableReady = true
+		tableName, upgradeTypeStr = "addresses", "patch valid_mainchain value"
 	default:
 		return false, fmt.Errorf(`upgrade "%v" is unknown`, tableUpgrade)
 	}
@@ -414,8 +434,12 @@ func (pgb *ChainDB) handleUpgrades(client *rpcutils.BlockGate,
 		rowsUpdated, err = pgb.handleTxTypeHistogramUpgrade(height, tableUpgrade)
 
 	case agendasVotingMilestonesUpgrade:
-		log.Infof("Set the agendas voting milestones...")
+		log.Infof("Setting the agendas voting milestones...")
 		rowsUpdated, err = pgb.handleAgendasVotingMilestonesUpgrade()
+
+	case addressesTableValidMainchainPatch:
+		log.Infof("Patching valid_mainchain in the addresses table...")
+		rowsUpdated, err = updateAddressesValidMainchainPatch(pgb.db)
 
 	default:
 		return false, fmt.Errorf(`upgrade "%v" unknown`, tableUpgrade)
@@ -711,6 +735,14 @@ func updateAllTxnsValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
 // rows according to their corresponding transaction.
 func updateAllAddressesValidMainchain(db *sql.DB) (rowsUpdated int64, err error) {
 	return sqlExec(db, internal.UpdateValidMainchainFromTransactions,
+		"failed to update addresses rows valid_mainchain status")
+}
+
+// updateAddressesValidMainchainPatch selectively sets valid_mainchain for
+// addresses table rows that are set incorrectly according to their
+// corresponding transaction.
+func updateAddressesValidMainchainPatch(db *sql.DB) (rowsUpdated int64, err error) {
+	return sqlExec(db, internal.UpdateAddressesGloballyInvalid,
 		"failed to update addresses rows valid_mainchain status")
 }
 


### PR DESCRIPTION
The new block handler neglected to update valid_mainchain=false on the
previous block.  This change adds UpdateLastAddressesValid, which sets
valid_mainchain for the regular transactions in a given block.  Call it
from the "if !lastIsValid" block of (*ChainDB).StoreBlock, where the
previous vins and transactoins were correctly being invalidated.
Modify RetrieveTxnsVinsVoutsByBlock so the caller may specify if only
regular transactions' vins/vouts are needed, or all transaction types.

The rows of the addresses table that should have valid_mainchain=false
are identified with SelectAddressesGloballyInvalid.  The query to
correct the valid_mainchain values is UpdateAddressesGloballyInvalid.
These are called from a table version upgrade (3.5.2 -> 3.5.3).