### PR TITLE
Show address page for address with ONLY unconfirmed Tx

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -607,6 +607,17 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			addrData.Balance = &AddressBalance{}
 		}
 
+		// If there are confirmed transactions, check the oldest transaction's time.
+		if len(addrData.Transactions) > 0 {
+			oldestTxBlockTime, err = exp.explorerSource.GetOldestTxBlockTime(address)
+			if err != nil {
+				log.Errorf("Unable to fetch oldest transactions block time %s: %v", address, err)
+				exp.StatusPage(w, defaultErrorCode, "oldest block time not found",
+					NotFoundStatusType)
+				return
+			}
+		}
+
 		// Check for unconfirmed transactions
 		addressOuts, numUnconfirmed, err := exp.blockData.UnconfirmedTxnsForAddress(address)
 		if err != nil {
@@ -710,16 +721,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// If there are transactions, check the oldest transaction's time.
-		if len(addrData.Transactions) > 0 {
-			oldestTxBlockTime, err = exp.explorerSource.GetOldestTxBlockTime(address)
-			if err != nil {
-				log.Errorf("Unable to fetch oldest transactions block time %s: %v", address, err)
-				exp.StatusPage(w, defaultErrorCode, "oldest block time not found",
-					NotFoundStatusType)
-				return
-			}
-		}
+
 	}
 
 	// Set page parameters

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -53,7 +53,7 @@
         });
         return html;
     }
-   
+
     function plotGraph(processedData, otherOptions){
         var commonOptions = {
             digitsAfterDecimal: 8,
@@ -145,37 +145,43 @@
                 url: '/api/address/' + _this.addr + '/' + graphType +'/'+ interval,
                 beforeSend: function() {},
                 success: function(data) {
-                    var newData = []
-                    var options = {}
+                    if(data.length) {
+                        var newData = []
+                        var options = {}
 
-                    switch(graphType){
-                        case 'types':
-                            newData = txTypesFunc(data)
-                            options = _this.typesGraphOptions
-                            break
+                        switch(graphType){
+                            case 'types':
+                                newData = txTypesFunc(data)
+                                options = _this.typesGraphOptions
+                                break
 
-                        case 'amountflow':
-                            newData = amountFlowFunc(data)
-                            options = _this.amountFlowGraphOptions
-                            $('#toggle-charts').removeClass('d-hide');
-                            break
+                            case 'amountflow':
+                                newData = amountFlowFunc(data)
+                                options = _this.amountFlowGraphOptions
+                                $('#toggle-charts').removeClass('d-hide');
+                                break
 
-                        case 'unspent':
-                            newData = unspentAmountFunc(data)
-                            options = _this.unspentGraphOptions
-                            break
+                            case 'unspent':
+                                newData = unspentAmountFunc(data)
+                                options = _this.unspentGraphOptions
+                                break
+                        }
+
+                        if (_this.graph == undefined) {
+                            _this.graph = plotGraph(newData, options)
+                        } else {
+                            _this.graph.updateOptions({
+                                ...{'file': newData},
+                                ...options})
+                            _this.graph.resetZoom()
+                        }
+                        _this.updateFlow()
+                        _this.xVal = _this.graph.xAxisExtremes()
+                    }else{
+                        $('#no-bal').removeClass('d-hide');
+                        $('#history-chart').addClass('d-hide');
+                        $('#toggle-charts').removeClass('d-hide');
                     }
-
-                    if (_this.graph == undefined) {
-                        _this.graph = plotGraph(newData, options)
-                    } else {
-                        _this.graph.updateOptions({
-                            ...{'file': newData},
-                            ...options})
-                        _this.graph.resetZoom()
-                    }
-                    _this.updateFlow()
-                    _this.xVal = _this.graph.xAxisExtremes()
 
                     $('body').removeClass('loading');
                 }

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -33,15 +33,15 @@
                   This a is dummy address, typically used for unspendable ticket change outputs.<br/>
                   <br/>
                 {{end}}
-                <div class="btn-group mr-auto mb-0 align-bottom address-btn" 
-                    data-toggle="buttons" 
-                    data-target="address.btns" 
+                <div class="btn-group mr-auto mb-0 align-bottom address-btn"
+                    data-toggle="buttons"
+                    data-target="address.btns"
                     data-action="click->address#changeView"
                 >
                     <input id="addr-btn" type="button" class="btn btn_sm btn-active" value="List" name="list">
                     <input id="addr-btn" type="button" class="btn btn_sm" value="Charts"
                     name="chart" {{if $.IsLiteMode}}disabled{{end}}>
-                </div> 
+                </div>
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">
                 <table>
@@ -295,7 +295,7 @@
                     <div
                         id="txntype-wrapper"
                         class="d-flex align-items-center justify-content-end"
-                    > 
+                    >
                         <label class="mb-0 mr-1" for="txntype">Type</label>
                         <select
                             name="txntype"
@@ -338,12 +338,12 @@
                 </div>
                 <div class="chart-display d-hide">
                     <div id="history-chart" style="width:100%; height:500px; margin-top:20 auto;"></div>
-                    <h5 id="no-bal" class="mt-2 bal-d" style="margin:7% auto 0 auto;">There are no transactions to display.</h5>
+                    <h5 id="no-bal" class="mt-2 bal-d" style="margin:7% auto 0 auto;">There are no confirmed transactions to display.</h5>
                 </div>
             </div>
         </div>
     </div>
-    
+
     <script>
         $(".jsonly").show()
         $('#list-display').hide()


### PR DESCRIPTION
This PR will allow the address page to be visible for an address with only unconfirmed transactions.  It will also insure the charts do not stall on loading and display a message that there are no CONFIRMED transactions to display (and thus no charts).

I could not find any open issues related to this.

![image](https://user-images.githubusercontent.com/11194546/45431413-80dcca80-b65c-11e8-91a2-ac3bbe801c9d.png)

![image](https://user-images.githubusercontent.com/11194546/45431438-8afec900-b65c-11e8-98bb-1ea03f92b355.png)

