### PR TITLE
insight: fix marshal of vout values in the tx message

### DIFF
--- a/api/insight/socket.io_test.go
+++ b/api/insight/socket.io_test.go
@@ -1,0 +1,51 @@
+package insight
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalInsightTx(t *testing.T) {
+	isv := InsightSocketVout{
+		Address: "DsZQaCQES5vh3JmcyyFokJYz3aSw8Sm1dsQ",
+		Value:   13741789,
+	}
+
+	b, err := json.Marshal(isv)
+	if err != nil {
+		t.Errorf("Failed to marshal InsightSocketVout: %v", err)
+	}
+
+	t.Logf("%s", string(b))
+	expectedJSON := `{"Address":"DsZQaCQES5vh3JmcyyFokJYz3aSw8Sm1dsQ","Value":13741789}`
+	if string(b) != expectedJSON {
+		t.Errorf("json.Marshal of InsightSocketVout incorrect. "+
+			"Expected %s, got %s", expectedJSON, string(b))
+	}
+}
+
+func TestMarshalInsightTxSlice(t *testing.T) {
+	isv := []InsightSocketVout{
+		{
+			Address: "DsZQaCQES5vh3JmcyyFokJYz3aSw8Sm1dsQ",
+			Value:   13741789,
+		},
+		{
+			Address: "DsidNx5RnC7jMHdvUSEV54WANwMyKbyGtjh",
+			Value:   1000000,
+		},
+	}
+
+	b, err := json.Marshal(isv)
+	if err != nil {
+		t.Errorf("Failed to marshal InsightSocketVout: %v", err)
+	}
+
+	t.Logf("%s", string(b))
+	expectedJSON := `[{"DsZQaCQES5vh3JmcyyFokJYz3aSw8Sm1dsQ":13741789},` +
+		`{"DsidNx5RnC7jMHdvUSEV54WANwMyKbyGtjh":1000000}]`
+	if string(b) != expectedJSON {
+		t.Errorf("json.Marshal of InsightSocketVout incorrect. "+
+			"Expected %s, got %s", expectedJSON, string(b))
+	}
+}


### PR DESCRIPTION
Define a new type for a vout array element, and implement `json.Marshaler` using a temporay map with one key-value pair.
Clean up socket.io.go, embedding the address mutex into a new type, `roomSubscriptionCounter`.

Resolves issue https://github.com/decred/dcrdata/issues/682