### PR TITLE
semver/rpcutils: allow multiple compatible dcrd RPC API versions

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -30,6 +30,18 @@ func Compatible(required, actual Semver) bool {
 	}
 }
 
+// AnyCompatible checks if the version is compatible with any versions in a
+// slice of versions.
+func AnyCompatible(compatible []Semver, actual Semver) (isApiCompat bool) {
+	for _, v := range compatible {
+		if Compatible(v, actual) {
+			isApiCompat = true
+			break
+		}
+	}
+	return
+}
+
 func (s Semver) String() string {
 	return fmt.Sprintf("%d.%d.%d", s.major, s.minor, s.patch)
 }

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -1,0 +1,74 @@
+package semver
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	ver := NewSemver(3, 2, 8)
+	if ver.String() != "3.2.8" {
+		t.Errorf("Incorrect semver formatting: %v", ver)
+	}
+}
+
+func TestCompatible(t *testing.T) {
+	required := NewSemver(3, 2, 8)
+
+	// Equal is compatible
+	testver := NewSemver(3, 2, 8)
+	if !Compatible(required, testver) {
+		t.Errorf("Versions %v and %v should be compatible.", required, testver)
+	}
+
+	// Higher patch is compatible
+	testver = NewSemver(3, 2, 9)
+	if !Compatible(required, testver) {
+		t.Errorf("Versions %v and %v should be compatible.", required, testver)
+	}
+
+	// Lower patch is incompatible
+	testver = NewSemver(3, 2, 7)
+	if Compatible(required, testver) {
+		t.Errorf("Versions %v and %v should be incompatible.", required, testver)
+	}
+
+	// Higher minor is compatible
+	testver = NewSemver(3, 3, 0)
+	if !Compatible(required, testver) {
+		t.Errorf("Versions %v and %v should be compatible.", required, testver)
+	}
+
+	// Lower minor is incompatible
+	testver = NewSemver(3, 1, 0)
+	if Compatible(required, testver) {
+		t.Errorf("Versions %v and %v should be incompatible.", required, testver)
+	}
+}
+
+func TestAnyCompatible(t *testing.T) {
+	compatibleVersions := []Semver{
+		NewSemver(3, 2, 0),
+		NewSemver(4, 0, 0),
+	}
+
+	// One equal is compatible
+	testver := NewSemver(3, 2, 0)
+	if !AnyCompatible(compatibleVersions, testver) {
+		t.Errorf("Versions %v and one of %v should be compatible.",
+			testver, compatibleVersions)
+	}
+
+	// Other equal is compatible
+	testver = NewSemver(4, 0, 0)
+	if !AnyCompatible(compatibleVersions, testver) {
+		t.Errorf("Versions %v and one of %v should be compatible.",
+			testver, compatibleVersions)
+	}
+
+	// Neither compatible is incompatible
+	testver = NewSemver(3, 1, 0)
+	if AnyCompatible(compatibleVersions, testver) {
+		t.Errorf("Versions %v and one of %v should not be compatible.",
+			testver, compatibleVersions)
+	}
+}


### PR DESCRIPTION
The dcrd RPC API version was [bumped from 3.3.0 to 4.0.0 because of the removal of the `createrawssgen` RPC](https://github.com/decred/dcrd/pull/1448).  This RPC was not used by dcrdata, so both dcrd RPC API versions 3.x.0 and 4.0.0 are compatible.

This change to dcrdata introduces a slice of compatible versions, instead of just one, and a new function to check that the connected node API version is compatible with at least one of the versions listed in the slice.

semver: Add `semver.AnyCompatible` to check if a `Semver` is compatible with any in a `[]Semver`.  Add tests for `package semver`.
rpcutils: Specify multiple compatible dcrd RPC API versions.  Instead of a single dcrd RPC API version, there is now a slice of `semver.Semver` values.  The `semver.AnyCompatible` function checks the actual dcrd RPC API version against the slice of compatible versions.

This is slated for 3.1, but it may be backported to 3.0.x.