### PR TITLE
[3.0]  dcrpg: backported bugfixes

### DIFF
--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -63,7 +63,7 @@ const (
 			transactions.is_valid=TRUE AND
 			transactions.is_mainchain=TRUE
 		WHERE prev_tx_hash=$1 AND vins.is_valid=TRUE AND vins.is_mainchain=TRUE;`
-	SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins
+	SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index, tx_tree FROM vins
 		WHERE prev_tx_hash=$1 AND prev_tx_index=$2;`
 	SelectFundingTxsByTx        = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1;`
 	SelectFundingTxByTxIn       = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
@@ -154,7 +154,7 @@ const (
 	SelectAddressByTxHash = `SELECT script_addresses, value FROM vouts
 		WHERE tx_hash = $1 AND tx_index = $2 AND tx_tree = $3;`
 
-	SelectPkScriptByID     = `SELECT pkscript FROM vouts WHERE id=$1;`
+	SelectPkScriptByID     = `SELECT version, pkscript FROM vouts WHERE id=$1;`
 	SelectVoutIDByOutpoint = `SELECT id FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
 	SelectVoutByID         = `SELECT * FROM vouts WHERE id=$1;`
 

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -25,7 +25,7 @@ func openDB() (func() error, error) {
 		DBName: "dcrdata",
 	}
 	var err error
-	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams)
+	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true)
 	cleanUp := func() error { return nil }
 	if db != nil {
 		cleanUp = db.Close
@@ -62,7 +62,7 @@ func TestStuff(t *testing.T) {
 	testTxBlockTree := wire.TxTreeRegular
 
 	// Test number of spent outputs / spending transactions
-	spendingTxns, err := db.SpendingTransactions(testTx)
+	spendingTxns, _, _, err := db.SpendingTransactions(testTx)
 	if err != nil {
 		t.Error("SpendingTransactions", err)
 	}
@@ -74,7 +74,7 @@ func TestStuff(t *testing.T) {
 	}
 
 	// Test a certain spending transaction is as expected
-	spendingTx, err := db.SpendingTransaction(testTx, voutInd)
+	spendingTx, _, _, err := db.SpendingTransaction(testTx, voutInd)
 	if err != nil {
 		t.Error("SpendingTransaction", err)
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -47,8 +47,8 @@ func IsUniqueIndex(db *sql.DB, indexName string) (isUnique bool, err error) {
 	return
 }
 
-func RetrievePkScriptByID(db *sql.DB, id uint64) (pkScript []byte, err error) {
-	err = db.QueryRow(internal.SelectPkScriptByID, id).Scan(&pkScript)
+func RetrievePkScriptByID(db *sql.DB, id uint64) (pkScript []byte, ver uint16, err error) {
+	err = db.QueryRow(internal.SelectPkScriptByID, id).Scan(&ver, &pkScript)
 	return
 }
 
@@ -936,9 +936,10 @@ func RetrieveVinByID(db *sql.DB, vinDbID uint64) (prevOutHash string, prevOutVou
 	prevOutTree int8, txHash string, txVinInd uint32, txTree int8, valueIn int64, err error) {
 	var blockTime uint64
 	var isValid, isMainchain bool
+	var txType uint32
 	err = db.QueryRow(internal.SelectAllVinInfoByID, vinDbID).
 		Scan(&txHash, &txVinInd, &txTree, &isValid, &isMainchain, &blockTime,
-			&prevOutHash, &prevOutVoutInd, &prevOutTree, &valueIn)
+			&prevOutHash, &prevOutVoutInd, &prevOutTree, &valueIn, &txType)
 	return
 }
 


### PR DESCRIPTION
This fixes the tests in pgblockchain_test.go (started with `-tags mainnettest`, and using a live postgres server.
`SelectSpendingTxByPrevOut` should have been returning `tx_tree` also.
`SelectPkScriptByID` should also scan `version` with the `pkScript`.
`RetrieveVinByID` needed to scan `txType`.