### PR TITLE
Adds Insight API endpoints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,21 @@ The dcrdata repository is a collection of Go packages and apps for [Decred](http
 ```none
 ../dcrdata              The dcrdata daemon.
 ├── api                 Package blockdata implements dcrdata's own HTTP API.
-│   ├── insight         Package insight implements the Insight API.
-│   └── types           Package types includes the exported structures used by
+│   ├── insight         Package insight implements the Insight API.
+│   └── types           Package types includes the exported structures used by
 |                         the dcrdata and Insight APIs.
 ├── blockdata           Package blockdata is the primary data collection and
 |                         storage hub, and chain monitor.
 ├── cmd
-│   ├── rebuilddb       rebuilddb utility, for SQLite backend. Not required.
-│   ├── rebuilddb2      rebuilddb2 utility, for PostgreSQL backend. Not required.
-│   └── scanblocks      scanblocks utility. Not required.
+│   ├── rebuilddb       rebuilddb utility, for SQLite backend. Not required.
+│   ├── rebuilddb2      rebuilddb2 utility, for PostgreSQL backend. Not required.
+│   └── scanblocks      scanblocks utility. Not required.
 ├── dcrdataapi          Package dcrdataapi for Go API clients.
 ├── db
-│   ├── agendadb        Package agendadb is a basic PoS voting agenda database.
-│   ├── dbtypes         Package dbtypes with common data types.
-│   ├── dcrpg           Package dcrpg providing PostgreSQL backend.
-│   └── dcrsqlite       Package dcrsqlite providing SQLite backend.
+│   ├── agendadb        Package agendadb is a basic PoS voting agenda database.
+│   ├── dbtypes         Package dbtypes with common data types.
+│   ├── dcrpg           Package dcrpg providing PostgreSQL backend.
+│   └── dcrsqlite       Package dcrsqlite providing SQLite backend.
 ├── dev                 Shell scripts for maintenance and deployment.
 ├── explorer            Package explorer, powering the block explorer.
 ├── mempool             Package mempool for monitoring mempool for transactions,
@@ -563,21 +563,48 @@ default in a reduced functionality ("lite") mode that does not require
 PostgreSQL. To enable the PostgreSQL backend (and the expanded functionality),
 dcrdata may be started with the `--pg` switch.
 
+## APIs
+
+The dcrdata block explorer is exposed by two APIs: a Decred implementation of the [Insight API](https://github.com/bitpay/insight-api) (EXPERIMENTAL), and its own JSON HTTP API. The Insight API uses the path prefix `/insight/api`. The dcrdata API uses the path prefix `/api`.
+
 ### Insight API (EXPERIMENTAL)
 
-The [Insight API](https://github.com/bitpay/insight-api) is accessible via HTTP
-at the `/insight/api` URL path prefix, and via WebSocket at the
-`/insight/socket.io` URL path prefix.
+The [Insight API](https://github.com/bitpay/insight-api) is accessible via HTTP via REST or WebSocket. 
+
+To call the REST API, use the `/insight/api` path prefix. To call the Websocket API, use the `/insight/socket.io` path prefix.
 
 The following endpoints are not implemented: `status`, `sync`, `peer`, `email`,
 and `rates`.
 
+#### Endpoint List
+
+| Method           | Path                   | 
+| -------------------- | ---------------------- | 
+| Block              | `/block/{hash}`          |  
+| Block index          | `/block-index/{height}`      |  
+| Raw block (hash)               | `/rawblock/{hash}`   | 
+| Raw block (height)                | `/rawblock/{height}`     |  
+| Raw summaries               | `/blocks (URL query params: limit, blockDate, ...) `   |              
+| Transaction                 | `/tx/{hash}`     |  
+| Raw transaction              | `/rawtx/{hash}`  | 
+| Address         | `/addr/{address}`       | 
+| Address Props   | `/balance, totalReceived, totalSent, /totalSent, unconfirmedBalance` |  
+| UTXOs | `/addr/{address}/utxo`  |  
+| Multi-address UTXOs | `/addrs/{address0, address1, etc}/utxo`  |  
+| POST-variant of multi-address UTXOs | ``  |                     
+| Transactions by block | `/txs/?block={hash}`  |   
+| Transactions by address | `/txs/?address={address}`  |   
+| Transactions for multiple addresses | `/addrs/{addr0, addr1, ...}/txs (params: from, to)`  |   
+| POST-variant for ^^ | `(includes params: noAsm, noScriptSig, noSpent)`  |  
+| Transaction broadcast | `/tx/send (raw tx in POST params) `  | 
+| Sync status (dcrdata) | `/sync`  |  
+| Sync status (dcrd) | `/peer`  |  
+| Decred network status | `/status(with each possible value for the q param)`  |  
+| Estimate fee | `/estimatefee (params: nbBlocks)`  |  
 ### dcrdata API
 
-dcrdata has its own JSON HTTP API in addition to the experimental Insight API
-implementation. **dcrdata's API endpoints are prefixed with `/api`** (e.g.
-`http://localhost:7777/api/stake`). The Insight API endpoints (not described in
-this section) are prefixed with `/insight/api`.
+The dcrdata API is a REST API accessible via HTTP. To call the dcrdata API, use the `/api` path prefix.
+
 
 #### Endpoint List
 

--- a/README.md
+++ b/README.md
@@ -573,8 +573,6 @@ The [Insight API](https://github.com/bitpay/insight-api) is accessible via HTTP 
 
 To call the REST API, use the `/insight/api` path prefix. To call the Websocket API, use the `/insight/socket.io` path prefix.
 
-The following endpoints are not implemented: `status`, `sync`, `peer`, `email`,
-and `rates`.
 
 #### Endpoint List
 


### PR DESCRIPTION
Have listed endpoints for Insight API, as documented [in Issue #400](https://github.com/decred/dcrdata/issues/400) ( Closes #694 ).

Changes:
- Adds table with Insight API endpoints
- Puts 'Insight API' and 'dcrd API' as subheadings under new heading 'APIs'
- Tweaks text introducing APIs

I could have worked on this further, but wanted to put what I have out for review first. Also, here are  a few Qs I had as an imaginary user:

- Do we want to provide guidance on which API to use? Is one being depricated eventually (this is often implied when a new API is added)? Is one API better than another for a particular use case?
- Is the Insight API still experimental? Remove (EXPERIMENTAL) qualifier?
- Do we want to document the datatypes, as is done with dcrdata in the 'Type' column? 
- We say “....the following endpoints are not implemented ‘status, sync, peer, email, and rates.’. Is this still true?
