### PR TITLE
Properly test object validity on null chart data

### DIFF
--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -145,7 +145,7 @@
                 url: '/api/address/' + _this.addr + '/' + graphType +'/'+ interval,
                 beforeSend: function() {},
                 success: function(data) {
-                    if(data.length) {
+                    if(!_.isEmpty(data)) {
                         var newData = []
                         var options = {}
 


### PR DESCRIPTION
Uses LoDash rather than an array length to test for presence of chart data.  Fixes PR #680 