### PR TITLE
Initial ctrl-c fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,13 +159,6 @@ func mainCore() error {
 	log.Infof("SQLite DB successfully opened: %s", cfg.DBFileName)
 	defer baseDB.Close()
 
-	// Allow Ctrl-C to halt startup
-	select {
-	case <-quit:
-		return nil
-	default:
-	}
-
 	// PostgreSQL
 	var auxDB *dcrpg.ChainDBRPC
 	var newPGIndexes, updateAllAddresses, updateAllVotes bool
@@ -212,13 +205,6 @@ func mainCore() error {
 		if !idxExists || err != nil {
 			updateAllAddresses = true
 		}
-	}
-
-	// Allow Ctrl-C to halt startup
-	select {
-	case <-quit:
-		return nil
-	default:
 	}
 
 	_, height, err := dcrdClient.GetBestBlock()
@@ -299,13 +285,6 @@ func mainCore() error {
 		}
 	}
 
-	// Allow Ctrl-C to halt startup
-	select {
-	case <-quit:
-		return nil
-	default:
-	}
-
 	// SetAgendaDB Path
 	agendadb.SetDbPath(filepath.Join(cfg.DataDir, cfg.AgendaDBFileName))
 
@@ -380,13 +359,6 @@ func mainCore() error {
 
 		// Wait for the results
 		return waitForSync(sqliteSyncRes, pgSyncRes, usePG, quit)
-	}
-
-	// Allow Ctrl-C to halt startup
-	select {
-	case <-quit:
-		return nil
-	default:
 	}
 
 	baseDBHeight, auxDBHeight, err := getSyncd(updateAllAddresses,
@@ -499,6 +471,13 @@ func mainCore() error {
 		return fmt.Errorf("Failed to store initial block data for explorer pages: %v", err.Error())
 	}
 
+	// Allow Ctrl-C to halt startup
+	select {
+	case <-quit:
+		return nil
+	default:
+	}
+
 	explore.StartMempoolMonitor(notify.NtfnChans.ExpNewTxChan)
 
 	// blockdata collector
@@ -560,12 +539,6 @@ func mainCore() error {
 			notify.NtfnChans.NewTxChan, quit, &wg, newTicketLimit, mini, maxi, mpi)
 		wg.Add(1)
 		go mpm.TxHandler(dcrdClient)
-	}
-
-	select {
-	case <-quit:
-		return nil
-	default:
 	}
 
 	// Start web API


### PR DESCRIPTION
This PR addresses startup issues notably on windows that will corrupt the badger db.  Addresses issue #645 

1.  Ctrl-C handler is moved earlier in main.go to insure its operational during stakedb load
2.  Sprinkles in additional channel selects to allow exiting startup at safe times.
3.  Modifies Ctrl-C handling to insure additional Ctrl-C's after the first one do not force an abrupt exit.

Testing shows this eliminates corruption due to Ctrl-C on startup that I saw previously.  Examples of shutdown are shown below (4 ctrl-c's pressed in each case):

```
2018-09-21 12:24:03.281 [INF] RPCC: Established connection to RPC server localhost:9109
2018-09-21 12:24:03.283 [INF] DATD: Connected to dcrd (JSON-RPC API v3.3.0) on MainNet
2018-09-21 12:24:03.300 [INF] SKDB: Loading ticket pool DB. This may take a minute...
2018-09-21 12:24:03.399 [INF] SKDB: Loading all ticket pool diffs...
2018-09-21 12:24:07.018 [INF] DATD: CTRL+C hit.  Closing goroutines.
2018-09-21 12:24:08.602 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:24:08.770 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:24:08.915 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:24:42.657 [DBG] SKDB: len(poolDiffs)=276412
2018-09-21 12:24:42.657 [DBG] SKDB: poolDiffs[0].Height=1, poolDiffs[end].Height=276412
2018-09-21 12:24:43.073 [DBG] SKDB: Opened existing stake db.
2018-09-21 12:24:43.073 [INF] SKDB: Advancing ticket pool DB to tip via diffs...
2018-09-21 12:24:43.970 [INF] SKDB: Pre-populating live ticket cache and computing pool value...
2018-09-21 12:24:50.821 [INF] DATD: SQLite DB successfully opened: dcrdata.sqlt.db
2018-09-21 12:24:50.913 [INF] DATD: Closing connection to dcrd.
2018-09-21 12:24:50.914 [INF] DATD: Bye!
```

```
2018-09-21 12:24:54.550 [INF] RPCC: Established connection to RPC server localhost:9109
2018-09-21 12:24:54.553 [INF] DATD: Connected to dcrd (JSON-RPC API v3.3.0) on MainNet
2018-09-21 12:24:54.559 [INF] SKDB: Loading ticket pool DB. This may take a minute...
2018-09-21 12:24:54.674 [INF] SKDB: Loading all ticket pool diffs...
2018-09-21 12:25:35.150 [DBG] SKDB: len(poolDiffs)=276412
2018-09-21 12:25:35.150 [DBG] SKDB: poolDiffs[0].Height=1, poolDiffs[end].Height=276412
2018-09-21 12:25:35.509 [DBG] SKDB: Opened existing stake db.
2018-09-21 12:25:35.509 [INF] SKDB: Advancing ticket pool DB to tip via diffs...
2018-09-21 12:25:36.498 [INF] SKDB: Pre-populating live ticket cache and computing pool value...
2018-09-21 12:25:42.495 [INF] DATD: SQLite DB successfully opened: dcrdata.sqlt.db
2018-09-21 12:25:42.664 [INF] PSQL: Pre-loading unspent ticket info for InsertVote optimization.
2018-09-21 12:25:48.752 [INF] PSQL: Storing data for 43224 unspent tickets in cache.
2018-09-21 12:25:48.806 [DBG] PSQL: Table vins: v3.5.3
2018-09-21 12:25:48.807 [DBG] PSQL: Table agendas: v3.5.3
2018-09-21 12:25:48.810 [DBG] PSQL: Table transactions: v3.5.3
2018-09-21 12:25:48.812 [DBG] PSQL: Table misses: v3.5.3
2018-09-21 12:25:48.813 [DBG] PSQL: Table addresses: v3.5.3
2018-09-21 12:25:48.814 [DBG] PSQL: Table votes: v3.5.3
2018-09-21 12:25:48.816 [DBG] PSQL: Table blocks: v3.5.3
2018-09-21 12:25:48.817 [DBG] PSQL: Table tickets: v3.5.3
2018-09-21 12:25:48.818 [DBG] PSQL: Table vouts: v3.5.3
2018-09-21 12:25:48.823 [DBG] PSQL: Table block_chain: v3.5.3
2018-09-21 12:25:48.824 [DBG] PSQL: All tables at correct version (3.5.3)
2018-09-21 12:25:48.834 [DBG] DATD: Setting ticket pool cache capacity to 28 blocks
2018-09-21 12:25:48.835 [DBG] SQLT: No pool info to load into cache
2018-09-21 12:25:48.876 [DBG] EXPR: Organization address: Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx
2018-09-21 12:25:48.883 [INF] EXPR: Mean Voting Blocks calculated: 7860
2018-09-21 12:25:48.933 [INF] EXPR: Pre-populating the charts data. This may take a minute...
2018-09-21 12:25:51.218 [INF] DATD: CTRL+C hit.  Closing goroutines.
2018-09-21 12:25:53.490 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:25:53.659 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:25:53.786 [INF] DATD: Shutdown signaled.  Already shutting down...
2018-09-21 12:27:32.305 [INF] EXPR: Done Pre-populating the charts data
2018-09-21 12:27:32.309 [INF] EXPR: Signals unsupported on windows
2018-09-21 12:27:32.309 [INF] EXPR: Starting WebsocketHub run loop.
2018-09-21 12:27:32.310 [INF] EXPR: Stopping mempool monitor
2018-09-21 12:27:32.310 [INF] EXPR: Stopping websocket hub.
2018-09-21 12:27:32.310 [ERR] EXPR: Do not send on stopPing channel, only close it.
2018-09-21 12:27:32.494 [INF] DATD: Closing connection to dcrd.
2018-09-21 12:27:32.495 [INF] DATD: Bye!
```

Eventually I would like to see the ability to exit mid way through the stakedb loading and the chart data loading as these are each the longest events during startup.  However those should probably be a separate PR.