### PR TITLE
update addresses entries on stake-invalidation

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -8,7 +8,8 @@ const (
 	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
 
 	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE
-		SET block_time = $7, valid_mainchain = $9 RETURNING id;`
+		SET matching_tx_hash = $2 tx_hash = $3, tx_vin_vout_index = $4,
+		block_time = $7, valid_mainchain = $9 RETURNING id;`
 	InsertAddressRowReturnID = `WITH inserting AS (` +
 		insertAddressRow0 +
 		`ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE
@@ -212,6 +213,18 @@ const (
 			WHERE invalid_ids.valid_mainchain=true
 		) AS incorrectly_valid
 		WHERE incorrectly_valid.id=addresses.id;`
+
+	// UpdateAddressesFundingMatchingHash sets matching_tx_hash as per the vins
+	// table. This is needed to fix partially updated addresses table entries
+	// that were affected by stake invalidation.
+	UpdateAddressesFundingMatchingHash = `UPDATE addresses
+		SET matching_tx_hash=vins.tx_hash -- this patch is before matching_tx_index
+		FROM vins
+		WHERE addresses.tx_hash=vins.prev_tx_hash
+		AND addresses.tx_vin_vout_index=vins.prev_tx_index
+		AND is_funding=TRUE
+		AND is_valid=TRUE
+		AND matching_tx_hash!=vins.tx_hash;`
 
 	// UpdateValidMainchainFromTransactions sets valid_mainchain in all rows of
 	// the addresses table according to the transactions table, unlike

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -217,14 +217,13 @@ const (
 	// UpdateAddressesFundingMatchingHash sets matching_tx_hash as per the vins
 	// table. This is needed to fix partially updated addresses table entries
 	// that were affected by stake invalidation.
-	UpdateAddressesFundingMatchingHash = `UPDATE addresses
-		SET matching_tx_hash=vins.tx_hash -- this patch is before matching_tx_index
+	UpdateAddressesFundingMatchingHash = `UPDATE addresses SET matching_tx_hash=vins.tx_hash, matching_tx_index=vins.tx_index
 		FROM vins
 		WHERE addresses.tx_hash=vins.prev_tx_hash
 		AND addresses.tx_vin_vout_index=vins.prev_tx_index
 		AND is_funding=TRUE
 		AND is_valid=TRUE
-		AND matching_tx_hash!=vins.tx_hash;`
+		AND (matching_tx_hash!=vins.tx_hash OR matching_tx_index!=vins.tx_index);`
 
 	// UpdateValidMainchainFromTransactions sets valid_mainchain in all rows of
 	// the addresses table according to the transactions table, unlike

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -217,13 +217,14 @@ const (
 	// UpdateAddressesFundingMatchingHash sets matching_tx_hash as per the vins
 	// table. This is needed to fix partially updated addresses table entries
 	// that were affected by stake invalidation.
-	UpdateAddressesFundingMatchingHash = `UPDATE addresses SET matching_tx_hash=vins.tx_hash, matching_tx_index=vins.tx_index
+	UpdateAddressesFundingMatchingHash = `UPDATE addresses SET matching_tx_hash=vins.tx_hash -- , matching_tx_index=vins.tx_index
 		FROM vins
 		WHERE addresses.tx_hash=vins.prev_tx_hash
 		AND addresses.tx_vin_vout_index=vins.prev_tx_index
 		AND is_funding=TRUE
 		AND is_valid=TRUE
-		AND (matching_tx_hash!=vins.tx_hash OR matching_tx_index!=vins.tx_index);`
+		AND matching_tx_hash!=vins.tx_hash;`
+	// AND (matching_tx_hash!=vins.tx_hash OR matching_tx_index!=vins.tx_index);`
 
 	// UpdateValidMainchainFromTransactions sets valid_mainchain in all rows of
 	// the addresses table according to the transactions table, unlike

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
@@ -40,7 +41,7 @@ var createTypeStatements = map[string]string{
 const (
 	tableMajor = 3
 	tableMinor = 5
-	tablePatch = 3
+	tablePatch = 4
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.


### PR DESCRIPTION
This patches matching_tx_hash and updates the column during stake invalidation.

NOTE: This bumps dcrpg tables from 3.5.3 to 3.5.4, and a short automatic upgrade
is required.

The addresses table upsert must update in/out data. Each of matching_tx_hash,
tx_hash, and tx_vin_vout_index need to be updated when performing an upsert
in the addresses table.  When a block is invalidated, the transactions are able to
be mined in a different block, in which case it is possible that the matching_tx_hash
entry may be change for funding addresses rows.

Due to the incorrect upsert statements, matching_tx_hash in the addresses table
may be incorrect if an invalidate transaction was later re-mined and then validated.
This adds and upgrade (3.5.4 -> 3.5.5) that patches the matching_tx_hash column
via the vins table. This also avoids early return from an upgrade when the upgrade
query returns sql.ErrNoRows, as this is not necessarily an error.