### PR TITLE
Show future block page 372

### DIFF
--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -5,9 +5,10 @@ package explorer
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
-        "fmt"
+	"time"
 
 	"github.com/go-chi/chi"
 )
@@ -36,18 +37,15 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 				return
 			}
 		} else {
-                        //Handle blocks which are in future time
-                        maxHeight := exp.blockData.GetHeight()
-                        if height > int64(maxHeight) {
-                        maturityTime := int(float64(height - int64(maxHeight) ) * exp.ChainParams.TargetTimePerBlock.Minutes())
-                        days := maturityTime / 1440
-                        hours := (maturityTime % 1440  ) / 60
-                        minutes := maturityTime % 60
-                        message := fmt.Sprintf("This block will arrive in approximately %d days, %d hour, %d min.",days,hours,minutes)
-                        log.Errorf("Block with height %d will arrive in future.", height)
-                        exp.StatusPage(w, defaultErrorCode, message, ErrorStatusType)
-                        return
-                        }
+			//Handle future blocks
+			maxHeight := int64(exp.blockData.GetHeight())
+			if height > maxHeight {
+				expectedTime := time.Duration(height-maxHeight) * exp.ChainParams.TargetTimePerBlock
+				message := fmt.Sprintf("This block is expected to arrive in approximately in %v. ", expectedTime)
+				log.Errorf("Block with height %d will arrive in future.", height)
+				exp.StatusPage(w, defaultErrorCode, message, NotFoundStatusType)
+				return
+			}
 
 			hash, err = exp.blockData.GetBlockHash(height)
 			if err != nil {

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -42,7 +42,6 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 			if height > maxHeight {
 				expectedTime := time.Duration(height-maxHeight) * exp.ChainParams.TargetTimePerBlock
 				message := fmt.Sprintf("This block is expected to arrive in approximately in %v. ", expectedTime)
-				log.Errorf("Block with height %d will arrive in future.", height)
 				exp.StatusPage(w, defaultErrorCode, message, NotFoundStatusType)
 				return
 			}

--- a/views/status.tmpl
+++ b/views/status.tmpl
@@ -9,7 +9,8 @@
         <br/>
         <div class="alert alert-info">
             {{if eq .StatusType "Not Found"}}
-                <h5>No matching page, block, address or transaction that could be found</h3>
+                <h5>No matching page, block, address or transaction that could be found</h5>
+                <h5>{{.Message}}</h5>
             {{else}}
                 <h5>{{.Message}}</h5>
             {{end}}


### PR DESCRIPTION
I have implemented, update of status page of a block which is in future . 
Functionality: Once a newblock event happens in websocket , the page will reload . If requested block is still in future then it will update the expected time , else it will show the block page .