### PR TITLE
api: transaction output spent status

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -43,8 +43,7 @@ type TxShort struct {
 	Vout     []Vout        `json:"vout"`
 }
 
-// TrimmedTx models data to resemble to result of the decoderawtransaction
-// call
+// TrimmedTx models data to resemble to result of the decoderawtransaction RPC.
 type TrimmedTx struct {
 	TxID     string        `json:"txid"`
 	Version  int32         `json:"version"`
@@ -98,6 +97,13 @@ type Vout struct {
 	N                   uint32       `json:"n"`
 	Version             uint16       `json:"version"`
 	ScriptPubKeyDecoded ScriptPubKey `json:"scriptPubKey"`
+	Spend               *TxInputID   `json:"spend,omitempty"`
+}
+
+// TxInputID specifies a transaction input as hash:vin_index.
+type TxInputID struct {
+	Hash  string `json:"hash"`
+	Index uint32 `json:"vin_index"`
 }
 
 // ScriptPubKey is the result of decodescript(ScriptPubKeyHex)


### PR DESCRIPTION
This resolves issue https://github.com/decred/dcrdata/issues/441.

This PR modifies the following API endpoints to set output spend info
when the URL query ?spends=true is provided: /api/tx, /api/tx/decoded,
and /api/txs.

Add `(*c.appContext).setOutputSpends` to retrieve any known spending
transaction information for the outputs of a transaction.
Add wrappers `setTxSpends` and `setTrimmedTxSpends` to perform
lookup of spending info for `apitypes.Tx` and `apitypes.TrimmedTx`.
Update /api/tx, /api/tx/decoded, and /api/txs HTTP handlers to get
the spending info if requested on with the URL query param, spends.
Note: This lookup only functions in full mode, not lite mode.

Add `Spend` field to `apitypes.Vout` type.
The `Vout.Spend` field is of type `*TxInputID`, a new type that specifies a
transaction input by hash and input index.
`Vout.Spend` is tagged as `json:"spend,omitempty"`.

For example, http://127.0.0.1:7777/api/tx/decoded/80fab1571621d577e44f517071622e4b18fa127d2f729027bed1f42a0f656ef9?indent=true&spends=true

```json
{
   "txid": "80fab1571621d577e44f517071622e4b18fa127d2f729027bed1f42a0f656ef9",
   "version": 1,
   "locktime": 0,
   "expiry": 0,
   "vin": [
      {
         "txid": "fde9faa1cc84b54c08b49783737685f5d71bc06a1e0752d1a5abfc015ef2be06",
         "vout": 2,
         "tree": 1,
         "sequence": 4294967295,
         "amountin": 99.34190707,
         "blockheight": 277301,
         "blockindex": 2,
         "scriptSig": {
            "asm": "30450221008e8af0e6275a80636d1b2855af17992ba75a327a353406746107db4611d7f5c2022070beae39d9991a53df87862f60ccc1a9dd68990f0530b168d99b929fb785883101 0368fc57831335cb3ed05c956a60745a743db4f66f31e27c8fa66cf8499ac16931",
            "hex": "4830450221008e8af0e6275a80636d1b2855af17992ba75a327a353406746107db4611d7f5c2022070beae39d9991a53df87862f60ccc1a9dd68990f0530b168d99b929fb785883101210368fc57831335cb3ed05c956a60745a743db4f66f31e27c8fa66cf8499ac16931"
         }
      }
   ],
   "vout": [
      {
         "value": 98.54689821,
         "n": 0,
         "version": 0,
         "scriptPubKey": {
            "asm": "OP_DUP OP_HASH160 7be756a0b6f2ed20d1a02cdd8f9ae685c9322993 OP_EQUALVERIFY OP_CHECKSIG",
            "reqSigs": 1,
            "type": "pubkeyhash",
            "addresses": [
               "DscG3jhUr3eC26u1TdB1Q63ioyS4QsXTcYW"
            ]
         },
         "spend": {      <-- this output is SPENT
            "hash": "fdb25767960209eb607578bce17716ceaf678d7c1974d8ba1dbc3a115f50a216",
            "vin_index": 0
         }
      },
      {
         "value": 0.79475586,
         "n": 1,
         "version": 0,
         "scriptPubKey": {
            "asm": "OP_DUP OP_HASH160 78f546b89eafb1e00dda039ee6e0f8289b696340 OP_EQUALVERIFY OP_CHECKSIG",
            "reqSigs": 1,
            "type": "pubkeyhash",
            "addresses": [
               "DsbzUQYTAzGJMeuRrMD77M6PmpGgL7Pi2SD"
            ]
         }
      }     <-- this output is UNSPENT
   ]
}
```