### PR TITLE
dcrpg: addresses table query optimization with block_time_index sorting

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -118,11 +118,13 @@ const (
 		ORDER BY addresses.block_time DESC;`
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
-	    WHERE address=$1 AND valid_mainchain = TRUE ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		WHERE address=$1 AND valid_mainchain = TRUE
+		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressLimitNByAddressSubQry = `WITH these AS (SELECT ` + addrsColumnNames +
 		` FROM addresses WHERE address=$1 AND valid_mainchain = TRUE)
-		SELECT * FROM these ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		SELECT * FROM these
+		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressMergedDebitView = `SELECT tx_hash, valid_mainchain, block_time, sum(value), COUNT(*)
 		FROM addresses
@@ -238,7 +240,8 @@ const (
 	SetTxTypeOnAddressesByVinAndVoutIDs = `UPDATE addresses SET tx_type=$1 WHERE
 		tx_vin_vout_row_id=$2 AND is_funding=$3;`
 
-	IndexBlockTimeOnTableAddress   = `CREATE INDEX block_time_index ON addresses (block_time);`
+	IndexBlockTimeOnTableAddress = `CREATE INDEX block_time_index
+		ON addresses (block_time DESC NULLS LAST);`
 	DeindexBlockTimeOnTableAddress = `DROP INDEX block_time_index;`
 
 	IndexMatchingTxHashOnTableAddress = `CREATE INDEX matching_tx_hash_index

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -121,10 +121,12 @@ const (
 		WHERE address=$1 AND valid_mainchain = TRUE
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
-	SelectAddressLimitNByAddressSubQry = `WITH these AS (SELECT ` + addrsColumnNames +
-		` FROM addresses WHERE address=$1 AND valid_mainchain = TRUE)
-		SELECT * FROM these
-		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+	// SelectAddressLimitNByAddressSubQry was used in certain cases prior to
+	// sorting the block_time_index.
+	// SelectAddressLimitNByAddressSubQry = `WITH these AS (SELECT ` + addrsColumnNames +
+	// 	` FROM addresses WHERE address=$1 AND valid_mainchain = TRUE)
+	// 	SELECT * FROM these
+	// 	ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
 	SelectAddressMergedDebitView = `SELECT tx_hash, valid_mainchain, block_time, sum(value), COUNT(*)
 		FROM addresses

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -594,13 +594,7 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 	case dbtypes.AddrTxnCredit:
 		addrFunc = RetrieveAddressCreditTxns
 	case dbtypes.AddrTxnAll:
-		// The organization address occurs very frequently, so use the regular
-		// (non sub-query) select as it is much more efficient.
-		if address == pgb.devAddress {
-			addrFunc = RetrieveAddressTxnsAlt
-		} else {
-			addrFunc = RetrieveAddressTxns
-		}
+		addrFunc = RetrieveAddressTxns
 	case dbtypes.AddrTxnDebit:
 		addrFunc = RetrieveAddressDebitTxns
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1586,10 +1586,25 @@ func (pgb *ChainDB) DeindexTicketsTable() error {
 	return errAny
 }
 
+func errIsNotExist(err error) bool {
+	return strings.Contains(err.Error(), "does not exist")
+}
+
 func warnUnlessNotExists(err error) {
-	if !strings.Contains(err.Error(), "does not exist") {
+	if !errIsNotExist(err) {
 		log.Warn(err)
 	}
+}
+
+// ReindexAddressesBlockTime rebuilds the addresses(block_time) index.
+func (pgb *ChainDB) ReindexAddressesBlockTime() error {
+	log.Infof("Reindexing addresses table on block time...")
+	err := DeindexBlockTimeOnTableAddress(pgb.db)
+	if err != nil && !errIsNotExist(err) {
+		log.Errorf("Failed to drop index addresses index on block_time: %v", err)
+		return err
+	}
+	return IndexBlockTimeOnTableAddress(pgb.db)
 }
 
 // IndexAddressTable creates the indexes on the address table on the vout ID,

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1126,11 +1126,6 @@ func RetrieveAllAddressTxns(db *sql.DB, address string) ([]uint64, []*dbtypes.Ad
 
 func RetrieveAddressTxns(db *sql.DB, address string, N, offset int64) ([]uint64, []*dbtypes.AddressRow, error) {
 	return retrieveAddressTxns(db, address, N, offset,
-		internal.SelectAddressLimitNByAddressSubQry, false)
-}
-
-func RetrieveAddressTxnsAlt(db *sql.DB, address string, N, offset int64) ([]uint64, []*dbtypes.AddressRow, error) {
-	return retrieveAddressTxns(db, address, N, offset,
 		internal.SelectAddressLimitNByAddress, false)
 }
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -41,7 +41,7 @@ var createTypeStatements = map[string]string{
 const (
 	tableMajor = 3
 	tableMinor = 5
-	tablePatch = 4
+	tablePatch = 5
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.


### PR DESCRIPTION
This creates the addresses' table block_time_index *with sorting* on the
`block_time` column in order to avoid a sort when querying for rows by a
particular address.
Add `ReindexAddressesBlockTime`, to simplify dropping and re-creating the
block_time_index with this sorting.  Implement the upgrade from dcrpg
3.5.4 to 3.5.5 for this block_time reindexing.

This is motivated in part by the slowness of such queries with large numbers
of rows in the addresses table, such as
DshMNsvETDWpVoCe1re9NTAChiJagzsFV7J, which has over 116,746
transactions some of which have hundreds of inputs.
@papacarp Proposed the index sorting solution implemented here.

The reindexing is fairly quick:
```
15:01:38.196 [INF] PSQL: Reindex the addresses table on block_time
15:01:38.196 [INF] PSQL: Reindexing addresses table on block time.
15:01:51.213 [INF] PSQL: Modified the vouts table version to 3.5.5
```