### PR TITLE
dcrpg: expire ticket db id cache entries in the right place

### DIFF
--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -282,6 +282,10 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 // previous block (msgBlock.WinningTickets are the lottery winners to be mined
 // in the next block).
 //
+// The TicketTxnIDGetter is used to get the spent tickets' row IDs. The get
+// function, TxnDbID, is called with the expire argument set to false, so that
+// subsequent cache lookups by other consumers will succeed.
+//
 // Outputs are slices of DB row IDs for the votes and misses, and an error.
 func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 	fTx *TicketTxnIDGetter, msgBlock *MsgBlockPG, checked bool, params *chaincfg.Params) ([]uint64,
@@ -349,7 +353,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 
 		var ticketTxDbID sql.NullInt64
 		if fTx != nil {
-			t, err := fTx.TxnDbID(stakeSubmissionTxHash, true)
+			t, err := fTx.TxnDbID(stakeSubmissionTxHash, false)
 			if err != nil {
 				_ = voteStmt.Close() // try, but we want the QueryRow error back
 				if errRoll := dbtx.Rollback(); errRoll != nil {


### PR DESCRIPTION
A performance regression snuck in with https://github.com/decred/dcrdata/commit/b7d213317d9aa251cb926b78d0d4264e6a377c9c, which caused cache misses when looking up the row ids of spent tickets.

This change expires entries in the correct place, `CollectTicketSpendDBInfo`, not in `InsertVotes`.  This is now correct because `CollectTicketSpendDBInfo` is now called after `InsertVotes`.
