### PR TITLE
agendas page: redundant time spec #652

### DIFF
--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -251,8 +251,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			result = int(a) * b
 			return
 		},
-		"TimeConversion": func(a uint64) (result time.Time) {
-			result = time.Unix(int64(a), 0)
+		"TimeConversion": func(a uint64) (result string) {
+			dateTime := time.Unix(int64(a), 0)
+			result = dateTime.Format("2006-01-02 15:04:05 MST")
 			return
 		},
 		"theme": func() string {

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -252,7 +252,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			return
 		},
 		"TimeConversion": func(a uint64) (result string) {
-			dateTime := time.Unix(int64(a), 0)
+			dateTime := time.Unix(int64(a), 0).UTC()
 			result = dateTime.Format("2006-01-02 15:04:05 MST")
 			return
 		},


### PR DESCRIPTION
removed redundant time spec in agenda page by updating the `TimeConversion` template function to return a string with the format, `2006-01-02 15:04:05 MST`
https://github.com/decred/dcrdata/issues/652