### PR TITLE
'confirms' formatting on websocket update in views/transaction

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -233,7 +233,7 @@
                     $(v).text("0");
                 }
                 $(v).text(
-                    newBlock.block.height - $(v).data('confirmation-block-height')
+                    "(" + newBlock.block.height - $(v).data('confirmation-block-height') + " confirmations)"
                 )
             })
 

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -233,7 +233,7 @@
                     $(v).text("0");
                 }
                 $(v).text(
-                    "(" + newBlock.block.height - $(v).data('confirmation-block-height') + " confirmations)"
+                    "(" + (newBlock.block.height - $(v).data('confirmation-block-height')) + " confirmations)"
                 )
             })
 

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -232,9 +232,8 @@
                 if (isNaN($(v).text())) {
                     $(v).text("0");
                 }
-                $(v).text(
-                    "(" + (newBlock.block.height - $(v).data('confirmation-block-height')) + " confirmations)"
-                )
+                var confirmations = newBlock.block.height - $(v).data('confirmation-block-height');
+                $(v).text("(" + confirmations + (confirmations > 1? " confirmations": " confirmation") + ")")
             })
 
             // block summary data

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -12,9 +12,9 @@
                 Transaction
                 <span class="fs15">
                 {{if eq .Confirmations 0}}
-                    <strong data-confirmation-block-height="{{$.ConfirmHeight}}">( unconfirmed )</strong>
+                    <strong data-confirmation-block-height="{{$.ConfirmHeight}}">(unconfirmed)</strong>
                 {{else}}
-                    (<span data-confirmation-block-height="{{$.ConfirmHeight}}">{{.Confirmations}}</span> confirmations )
+                    <span data-confirmation-block-height="{{$.ConfirmHeight}}">({{.Confirmations}} confirmations)</span>
                 {{end}}
                 </span>
             </h4>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -14,7 +14,9 @@
                 {{if eq .Confirmations 0}}
                     <strong data-confirmation-block-height="{{$.ConfirmHeight}}">(unconfirmed)</strong>
                 {{else}}
-                    <span data-confirmation-block-height="{{$.ConfirmHeight}}">({{.Confirmations}} confirmations)</span>
+                    <strong data-confirmation-block-height="{{$.ConfirmHeight}}">
+                        ({{.Confirmations}} {{if gt .Confirmations 1}}confirmations{{else}}confirmation{{end}})
+                    </strong>
                 {{end}}
                 </span>
             </h4>


### PR DESCRIPTION
This is a fix for https://github.com/decred/dcrdata/issues/637
Modified the `updateBlockData` function in the extras.tmpl file to append the parenthesis and the text 'confirmations' during WebSocket update.
the span with `data-confirmation-block-height` attribute should no longer the wrapped in parenthesis as the function will provide the full content during an update