### PR TITLE
show MaximumBlockSizes parameter on the /parameters page

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1155,6 +1155,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 	actualTicketPoolSize := int64(cp.TicketPoolSize * cp.TicketsPerBlock)
 	ecp := ExtendedChainParams{
 		Params:               cp,
+		MaximumBlockSize:     cp.MaximumBlockSizes[0],
 		AddressPrefix:        addrPrefix,
 		ActualTicketPoolSize: actualTicketPoolSize,
 	}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -472,6 +472,7 @@ type NewMempoolTx struct {
 // ExtendedChainParams represents the data of ChainParams
 type ExtendedChainParams struct {
 	Params               *chaincfg.Params
+	MaximumBlockSize     int
 	ActualTicketPoolSize int64
 	AddressPrefix        []AddrPrefix
 }

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -57,7 +57,7 @@
                             <tr>
                                 <td class="mono text-right pr-2 nowrap p03rem0">MaximumBlockSize</td>
                                 <td class="mono">{{.MaximumBlockSize}} bytes</td>
-                                <td>Maximum sizes of a block that can be generated on the network</td>
+                                <td>Maximum size of a block that can be generated on the network</td>
                             </tr>
                             <tr>
                                 <td class="mono text-right pr-2 nowrap p03rem0">MaxTxSize</td>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -55,7 +55,7 @@
                                 <td>Whether or not CPU mining is allowed</td>
                             </tr>
                             <tr>
-                                <td class="mono text-right pr-2 nowrap p03rem0">Maximum block size</td>
+                                <td class="mono text-right pr-2 nowrap p03rem0">MaximumBlockSize</td>
                                 <td class="mono">{{.MaximumBlockSize}} bytes</td>
                                 <td>Maximum sizes of a block that can be generated on the network</td>
                             </tr>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -55,6 +55,11 @@
                                 <td>Whether or not CPU mining is allowed</td>
                             </tr>
                             <tr>
+                                <td class="mono text-right pr-2 nowrap p03rem0">MaximumBlockSizes</td>
+                                <td class="mono">{{.Params.MaximumBlockSizes}}</td>
+                                <td>Maximum sizes of a block that can be generated on the network</td>
+                            </tr>
+                            <tr>
                                 <td class="mono text-right pr-2 nowrap p03rem0">MaxTxSize</td>
                                 <td class="mono">{{.Params.MaxTxSize}} bytes</td>
                                 <td>Largest allowable transaction size</td>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -55,8 +55,8 @@
                                 <td>Whether or not CPU mining is allowed</td>
                             </tr>
                             <tr>
-                                <td class="mono text-right pr-2 nowrap p03rem0">MaximumBlockSizes</td>
-                                <td class="mono">{{.Params.MaximumBlockSizes}}</td>
+                                <td class="mono text-right pr-2 nowrap p03rem0">Maximum block size</td>
+                                <td class="mono">{{.Params.MaximumBlockSize}}</td>
                                 <td>Maximum sizes of a block that can be generated on the network</td>
                             </tr>
                             <tr>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -56,7 +56,7 @@
                             </tr>
                             <tr>
                                 <td class="mono text-right pr-2 nowrap p03rem0">Maximum block size</td>
-                                <td class="mono">{{.MaximumBlockSize}}</td>
+                                <td class="mono">{{.MaximumBlockSize}} bytes</td>
                                 <td>Maximum sizes of a block that can be generated on the network</td>
                             </tr>
                             <tr>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -56,7 +56,7 @@
                             </tr>
                             <tr>
                                 <td class="mono text-right pr-2 nowrap p03rem0">Maximum block size</td>
-                                <td class="mono">{{.Params.MaximumBlockSize}}</td>
+                                <td class="mono">{{.MaximumBlockSize}}</td>
                                 <td>Maximum sizes of a block that can be generated on the network</td>
                             </tr>
                             <tr>


### PR DESCRIPTION
Displayed MaximumBlockSizes in the view to fix https://github.com/decred/dcrdata/issues/678