### PR TITLE
Full side chain import from dcrd on startup

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -285,8 +285,15 @@ type BlockDataBasic struct {
 	StakeDiff  float64 `json:"sdiff,omitemtpy"`
 	Time       int64   `json:"time,omitemtpy"`
 	NumTx      uint32  `json:"txlength,omitempty"`
-	//TicketPoolInfo
-	PoolInfo TicketPoolInfo `json:"ticket_pool,omitempty"`
+	// TicketPoolInfo may be nil for side chain blocks.
+	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`
+}
+
+// NewBlockDataBasic constructs a *BlockDataBasic with pointer fields allocated.
+func NewBlockDataBasic() *BlockDataBasic {
+	return &BlockDataBasic{
+		PoolInfo: new(TicketPoolInfo),
+	}
 }
 
 // BlockExplorerBasic models primary information about block at height Height
@@ -346,7 +353,15 @@ type StakeInfoExtended struct {
 	StakeDiff        float64              `json:"stakediff"`
 	PriceWindowNum   int                  `json:"window_number"`
 	IdxBlockInWindow int                  `json:"window_block_index"`
-	PoolInfo         TicketPoolInfo       `json:"ticket_pool"`
+	PoolInfo         *TicketPoolInfo      `json:"ticket_pool"`
+}
+
+// NewStakeInfoExtended constructs a *StakeInfoExtended with pointer fields
+// allocated.
+func NewStakeInfoExtended() *StakeInfoExtended {
+	return &StakeInfoExtended{
+		PoolInfo: new(TicketPoolInfo),
+	}
 }
 
 // StakeInfoExtendedEstimates is similar to StakeInfoExtended but includes stake
@@ -356,7 +371,7 @@ type StakeInfoExtendedEstimates struct {
 	StakeDiff        StakeDiff            `json:"stakediff"`
 	PriceWindowNum   int                  `json:"window_number"`
 	IdxBlockInWindow int                  `json:"window_block_index"`
-	PoolInfo         TicketPoolInfo       `json:"ticket_pool"`
+	PoolInfo         *TicketPoolInfo      `json:"ticket_pool"`
 }
 
 // MempoolTicketFeeInfo models statistical ticket fee info at block height

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -27,7 +27,7 @@ type BlockData struct {
 	FeeInfo          dcrjson.FeeInfoBlock
 	CurrentStakeDiff dcrjson.GetStakeDifficultyResult
 	EstStakeDiff     dcrjson.EstimateStakeDiffResult
-	PoolInfo         apitypes.TicketPoolInfo
+	PoolInfo         *apitypes.TicketPoolInfo
 	ExtraInfo        apitypes.BlockExplorerExtraInfo
 	PriceWindowNum   int
 	IdxBlockInWindow int
@@ -97,7 +97,7 @@ func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 
 // Collector models a structure for the source of the blockdata
 type Collector struct {
-	mtx          sync.Mutex
+	sync.Mutex
 	dcrdChainSvr *rpcclient.Client
 	netParams    *chaincfg.Params
 	stakeDB      *stakedb.StakeDatabase
@@ -107,7 +107,6 @@ type Collector struct {
 func NewCollector(dcrdChainSvr *rpcclient.Client, params *chaincfg.Params,
 	stakeDB *stakedb.StakeDatabase) *Collector {
 	return &Collector{
-		mtx:          sync.Mutex{},
 		dcrdChainSvr: dcrdChainSvr,
 		netParams:    params,
 		stakeDB:      stakeDB,
@@ -142,6 +141,7 @@ func (t *Collector) CollectAPITypes(hash *chainhash.Hash) (*apitypes.BlockDataBa
 func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataBasic,
 	*dcrjson.FeeInfoBlock, *dcrjson.GetBlockHeaderVerboseResult,
 	*apitypes.BlockExplorerExtraInfo, *wire.MsgBlock, error) {
+	// Retrieve block from dcrd.
 	msgBlock, err := t.dcrdChainSvr.GetBlock(hash)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -149,6 +149,9 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	height := msgBlock.Header.Height
 	block := dcrutil.NewBlock(msgBlock)
 	txLen := len(block.Transactions())
+
+	// Coin supply and block subsidy. If either RPC fails, do not immediately
+	// return. Attempt acquisition of other data for this block.
 	coinSupply, err := t.dcrdChainSvr.GetCoinSupply()
 	if err != nil {
 		log.Error("GetCoinSupply failed: ", err)
@@ -157,16 +160,20 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	if err != nil {
 		log.Errorf("GetBlockSubsidy for %d failed: %v", msgBlock.Header.Height, err)
 	}
+
 	// Ticket pool info (value, size, avg)
 	var ticketPoolInfo *apitypes.TicketPoolInfo
 	var found bool
 	if ticketPoolInfo, found = t.stakeDB.PoolInfo(*hash); !found {
-		log.Infof("Unable to find block (%s) in pool info cache, trying best block.", hash.String())
+		log.Infof("Unable to find block (%v) in pool info cache, trying best block.", hash)
 		ticketPoolInfo = t.stakeDB.PoolInfoBest()
 		if ticketPoolInfo.Height != height {
-			log.Warnf("Collected block height %d != stake db height %d. Pool "+
-				"info will not match the rest of this block's data.",
-				height, ticketPoolInfo.Height)
+			// If unable to get ticket pool info for this block, stakedb does
+			// not have it. This may be the case for side chain blocks. Warn but
+			// do not error so that these blocks may be recorded without ticket
+			// pool information.
+			log.Warnf("Ticket pool info not available for block %v.", hash)
+			ticketPoolInfo = nil
 		}
 	}
 
@@ -177,10 +184,11 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	}
 
 	// Work/Stake difficulty
-	header := block.MsgBlock().Header
+	header := msgBlock.Header
 	diff := txhelpers.GetDifficultyRatio(header.Bits, t.netParams)
 	sdiff := dcrutil.Amount(header.SBits).ToCoin()
 
+	// Block header
 	blockHeaderResults, err := t.dcrdChainSvr.GetBlockHeaderVerbose(hash)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -194,7 +202,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		Difficulty: diff,
 		StakeDiff:  sdiff,
 		Time:       header.Timestamp.Unix(),
-		PoolInfo:   *ticketPoolInfo,
+		PoolInfo:   ticketPoolInfo,
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{
 		TxLen:            txLen,
@@ -208,8 +216,8 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 func (t *Collector) CollectHash(hash *chainhash.Hash) (*BlockData, *wire.MsgBlock, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.Lock()
+	defer t.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {
@@ -250,8 +258,8 @@ func (t *Collector) CollectHash(hash *chainhash.Hash) (*BlockData, *wire.MsgBloc
 func (t *Collector) Collect() (*BlockData, *wire.MsgBlock, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.Lock()
+	defer t.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {

--- a/blockdata/datasaver.go
+++ b/blockdata/datasaver.go
@@ -152,7 +152,7 @@ func (s *BlockDataToSummaryStdOut) Store(data *BlockData, _ *wire.MsgBlock) erro
 		data.FeeInfo.Mean, data.FeeInfo.Median, data.FeeInfo.StdDev,
 		data.FeeInfo.Number)
 
-	if data.PoolInfo.Value >= 0 {
+	if data.PoolInfo != nil && data.PoolInfo.Value >= 0 {
 		fmt.Printf("  Ticket pool:  %v (size), %.3f (avg. price), %.2f (total DCR locked)\n",
 			data.PoolInfo.Size, data.PoolInfo.ValAvg, data.PoolInfo.Value)
 	}

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -95,7 +95,7 @@ func mainCore() int {
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
 			Time:       header.Timestamp.Unix(),
-			PoolInfo: apitypes.TicketPoolInfo{
+			PoolInfo: &apitypes.TicketPoolInfo{
 				Size: header.PoolSize,
 			},
 		}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -575,3 +575,9 @@ type BlockStatus struct {
 	Hash        string `json:"hash"`
 	NextHash    string `json:"next_hash"`
 }
+
+// SideChain represents blocks of a side chain, in ascending height order.
+type SideChain struct {
+	Hashes  []string
+	Heights []int64
+}

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -113,15 +113,13 @@ func (pgb *ChainDBRPC) GetTransactionHex(txid string) string {
 // GetBlockVerboseByHash returns a *dcrjson.GetBlockVerboseResult for the
 // specified block hash, optionally with transaction details.
 func (pgb *ChainDBRPC) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult {
-	return rpcutils.GetBlockVerboseByHash(pgb.Client, pgb.chainParams,
-		hash, verboseTx)
+	return rpcutils.GetBlockVerboseByHash(pgb.Client, hash, verboseTx)
 }
 
 // GetTransactionsForBlockByHash returns a *apitypes.BlockTransactions for the
 // block with the specified hash.
 func (pgb *ChainDBRPC) GetTransactionsForBlockByHash(hash string) *apitypes.BlockTransactions {
-	blockVerbose := rpcutils.GetBlockVerboseByHash(
-		pgb.Client, pgb.chainParams, hash, false)
+	blockVerbose := rpcutils.GetBlockVerboseByHash(pgb.Client, hash, false)
 
 	return makeBlockTransactions(blockVerbose)
 }

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -240,7 +240,9 @@ func (db *wiredDB) GetChainParams() *chaincfg.Params {
 func (db *wiredDB) GetBlockHash(idx int64) (string, error) {
 	hash, err := db.RetrieveBlockHash(idx)
 	if err != nil {
-		log.Errorf("Unable to get block hash for block number %d: %v", idx, err)
+		if err != sql.ErrNoRows {
+			log.Errorf("Unable to get block hash for block number %d: %v", idx, err)
+		}
 		return "", err
 	}
 	return hash, nil
@@ -249,22 +251,24 @@ func (db *wiredDB) GetBlockHash(idx int64) (string, error) {
 func (db *wiredDB) GetBlockHeight(hash string) (int64, error) {
 	height, err := db.RetrieveBlockHeight(hash)
 	if err != nil {
-		log.Errorf("Unable to get block height for hash %s: %v", hash, err)
+		if err != sql.ErrNoRows {
+			log.Errorf("Unable to get block height for hash %s: %v", hash, err)
+		}
 		return -1, err
 	}
 	return height, nil
 }
 
 func (db *wiredDB) GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult {
-	return rpcutils.GetBlockHeaderVerbose(db.client, db.params, int64(idx))
+	return rpcutils.GetBlockHeaderVerbose(db.client, int64(idx))
 }
 
 func (db *wiredDB) GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult {
-	return rpcutils.GetBlockVerbose(db.client, db.params, int64(idx), verboseTx)
+	return rpcutils.GetBlockVerbose(db.client, int64(idx), verboseTx)
 }
 
 func (db *wiredDB) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult {
-	return rpcutils.GetBlockVerboseByHash(db.client, db.params, hash, verboseTx)
+	return rpcutils.GetBlockVerboseByHash(db.client, hash, verboseTx)
 }
 
 func (db *wiredDB) CoinSupply() (supply *apitypes.CoinSupply) {
@@ -297,13 +301,13 @@ func (db *wiredDB) BlockSubsidy(height int64, voters uint16) *dcrjson.GetBlockSu
 }
 
 func (db *wiredDB) GetTransactionsForBlock(idx int64) *apitypes.BlockTransactions {
-	blockVerbose := rpcutils.GetBlockVerbose(db.client, db.params, idx, false)
+	blockVerbose := rpcutils.GetBlockVerbose(db.client, idx, false)
 
 	return makeBlockTransactions(blockVerbose)
 }
 
 func (db *wiredDB) GetTransactionsForBlockByHash(hash string) *apitypes.BlockTransactions {
-	blockVerbose := rpcutils.GetBlockVerboseByHash(db.client, db.params, hash, false)
+	blockVerbose := rpcutils.GetBlockVerboseByHash(db.client, hash, false)
 
 	return makeBlockTransactions(blockVerbose)
 }

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -225,13 +225,14 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 	return dataBase, err
 }
 
-// DBDataSaver models a DB with a channel to communicate new block height to the web interface
+// DBDataSaver models a DB with a channel to communicate new block height to the
+// web interface.
 type DBDataSaver struct {
 	*DB
 	updateStatusChan chan uint32
 }
 
-// Store satisfies the blockdata.BlockDataSaver interface
+// Store satisfies the blockdata.BlockDataSaver interface.
 func (db *DBDataSaver) Store(data *blockdata.BlockData, _ *wire.MsgBlock) error {
 	summary := data.ToBlockSummary()
 	err := db.DB.StoreBlockSummary(&summary)
@@ -248,8 +249,8 @@ func (db *DBDataSaver) Store(data *blockdata.BlockData, _ *wire.MsgBlock) error 
 	return db.DB.StoreStakeInfoExtended(&stakeInfoExtended)
 }
 
-// StoreBlockSummary attempts to stores the block data in the database and
-// returns an error on failure
+// StoreBlockSummary attempts to store the block data in the database, and
+// returns an error on failure.
 func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	stmt, err := db.Prepare(db.insertBlockSQL)
 	if err != nil {
@@ -257,6 +258,13 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	}
 	defer stmt.Close()
 
+	// If input block data lacks non-nil PoolInfo, set to a zero-value
+	// TicketPoolInfo.
+	if bd.PoolInfo == nil {
+		bd.PoolInfo = new(apitypes.TicketPoolInfo)
+	}
+
+	// Insert the block.
 	winners := strings.Join(bd.PoolInfo.Winners, ";")
 
 	res, err := stmt.Exec(&bd.Height, &bd.Size, &bd.Hash,
@@ -267,11 +275,11 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 		return err
 	}
 
+	// Update the DB block summary height.
 	db.Lock()
 	defer db.Unlock()
 	if err = logDBResult(res); err == nil {
 		// TODO: atomic with CAS
-		//log.Debugf("Store height: %v", bd.Height)
 		height := int64(bd.Height)
 		if height > db.dbSummaryHeight {
 			db.dbSummaryHeight = height
@@ -641,13 +649,13 @@ func (db *DB) RetrieveBlockSummaryByTimeRange(minTime, maxTime int64, limit int)
 	defer rows.Close()
 
 	for rows.Next() {
-		var bd apitypes.BlockDataBasic
+		bd := apitypes.NewBlockDataBasic()
 		if err = rows.Scan(&bd.Height, &bd.Size, &bd.Hash,
 			&bd.Difficulty, &bd.StakeDiff, &bd.Time,
 			&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg); err != nil {
 			log.Errorf("Unable to scan for block fields")
 		}
-		blocks = append(blocks, bd)
+		blocks = append(blocks, *bd)
 	}
 	if err = rows.Err(); err != nil {
 		log.Error(err)
@@ -671,7 +679,7 @@ func (db *DB) RetrieveSDiff(ind int64) (float64, error) {
 
 // RetrieveLatestBlockSummary returns the block summary for the best block
 func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
-	bd := new(apitypes.BlockDataBasic)
+	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
 	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Height, &bd.Size,
@@ -715,7 +723,7 @@ func (db *DB) RetrieveBestBlockHeight() (int64, error) {
 
 // RetrieveBlockSummaryByHash returns basic block data for a block given its hash
 func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic, error) {
-	bd := new(apitypes.BlockDataBasic)
+	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
 	err := db.QueryRow(db.getBlockByHashSQL, hash).Scan(&bd.Height, &bd.Size, &bd.Hash,
@@ -731,7 +739,7 @@ func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic,
 
 // RetrieveBlockSummary returns basic block data for block ind
 func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) {
-	bd := new(apitypes.BlockDataBasic)
+	bd := apitypes.NewBlockDataBasic()
 
 	// Three different ways
 
@@ -828,13 +836,19 @@ func (db *DB) RetrieveBlockSizeRange(ind0, ind1 int64) ([]int32, error) {
 	return blockSizes, nil
 }
 
-// StoreStakeInfoExtended stores the extended stake info in the database
+// StoreStakeInfoExtended stores the extended stake info in the database.
 func (db *DB) StoreStakeInfoExtended(si *apitypes.StakeInfoExtended) error {
 	stmt, err := db.Prepare(db.insertStakeInfoExtendedSQL)
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
+
+	// If input block data lacks non-nil PoolInfo, set to a zero-value
+	// TicketPoolInfo.
+	if si.PoolInfo == nil {
+		si.PoolInfo = new(apitypes.TicketPoolInfo)
+	}
 
 	winners := strings.Join(si.PoolInfo.Winners, ";")
 
@@ -859,9 +873,10 @@ func (db *DB) StoreStakeInfoExtended(si *apitypes.StakeInfoExtended) error {
 	return err
 }
 
-// RetrieveLatestStakeInfoExtended returns the extended stake info for the best block
+// RetrieveLatestStakeInfoExtended returns the extended stake info for the best
+// block.
 func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, error) {
-	si := new(apitypes.StakeInfoExtended)
+	si := apitypes.NewStakeInfoExtended()
 
 	var winners string
 	err := db.QueryRow(db.getLatestStakeInfoExtendedSQL).Scan(
@@ -878,9 +893,10 @@ func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, er
 	return si, nil
 }
 
-// RetrieveStakeInfoExtended returns the extended stake info for block ind
+// RetrieveStakeInfoExtended returns the extended stake info for the block at
+// height ind.
 func (db *DB) RetrieveStakeInfoExtended(ind int64) (*apitypes.StakeInfoExtended, error) {
-	si := new(apitypes.StakeInfoExtended)
+	si := apitypes.NewStakeInfoExtended()
 
 	var winners string
 	err := db.QueryRow(db.getStakeInfoExtendedSQL, ind).Scan(&si.Feeinfo.Height,
@@ -915,11 +931,12 @@ func logDBResult(res sql.Result) error {
 	return nil
 }
 
-// splitToArray is utility function, correctly splits given string into array of strings
+// splitToArray splits a string into array of strings using the ";" character as
+// the separator.
 func splitToArray(str string) []string {
 	if str == "" {
-		// this case returns an empty array
-		return make([]string, 0)
+		// Return a non-nil empty slice.
+		return []string{}
 	} else {
 		return strings.Split(str, ";")
 	}

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -270,16 +270,15 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 			continue
 		}
 
-		var tpi *apitypes.TicketPoolInfo
-		var found bool
-		if tpi, found = db.sDB.PoolInfo(blockhash); !found {
+		tpi, found := db.sDB.PoolInfo(blockhash)
+		if !found {
 			if i != 0 {
-				log.Warnf("Unable to find block (%s) in pool info cache. Resync is malfunctioning!", blockhash.String())
+				log.Warnf("Unable to find block (%v) in pool info cache. Resync is malfunctioning!", blockhash)
 			}
 			tpi = db.sDB.PoolInfoBest()
 			if int64(tpi.Height) != i {
-				log.Errorf("Collected block height %d != stake db height %d. Pool info "+
-					"will not match the rest of this block's data.", tpi.Height, i)
+				log.Errorf("Ticket pool info not available for block %v.", blockhash)
+				tpi = nil
 			}
 		}
 
@@ -293,7 +292,7 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
 			Time:       header.Timestamp.Unix(),
-			PoolInfo:   *tpi,
+			PoolInfo:   tpi,
 		}
 
 		// Allow different summaryHeight and stakeInfoHeight values to be

--- a/main.go
+++ b/main.go
@@ -68,18 +68,18 @@ func mainCore() error {
 	}
 
 	if cfg.UseGops {
-		// Start gops diagnostic agent, without shutdown cleanup
+		// Start gops diagnostic agent, with shutdown cleanup.
 		if err = agent.Listen(agent.Options{}); err != nil {
 			return err
 		}
 		defer agent.Close()
 	}
 
-	// Start with version info
+	// Display app version.
 	log.Infof("%s version %v (Go version %s)", version.AppName,
 		version.Version(), runtime.Version())
 
-	// PostgreSQL
+	// PostgreSQL backend is enabled via FullMode config option (--pg switch).
 	usePG := cfg.FullMode
 	if usePG {
 		log.Info(`Running in full-functionality mode with PostgreSQL backend enabled.`)
@@ -87,12 +87,10 @@ func mainCore() error {
 		log.Info(`Running in "Lite" mode with only SQLite backend and limited functionality.`)
 	}
 
-	// Connect to dcrd RPC server using websockets
-
-	// Set up the notification handler to deliver blocks through a channel.
+	// Setup the notification handlers.
 	notify.MakeNtfnChans(cfg.MonitorMempool, usePG)
 
-	// Daemon client connection
+	// Connect to dcrd RPC server using a websocket.
 	ntfnHandlers, collectionQueue := notify.MakeNodeNtfnHandlers()
 	dcrdClient, nodeVer, err := connectNodeRPC(cfg, ntfnHandlers)
 	if err != nil || dcrdClient == nil {
@@ -100,7 +98,8 @@ func mainCore() error {
 	}
 
 	defer func() {
-		// Closing these channels should be unnecessary if quit was handled right
+		// The individial hander's loops should close the notifications channels
+		// on quit, but do it here too to be sure.
 		notify.CloseNtfnChans()
 
 		if dcrdClient != nil {
@@ -112,7 +111,7 @@ func mainCore() error {
 		time.Sleep(250 * time.Millisecond)
 	}()
 
-	// Display connected network
+	// Display connected network (e.g. mainnet, testnet, simnet).
 	curnet, err := dcrdClient.GetCurrentNet()
 	if err != nil {
 		return fmt.Errorf("Unable to get current network from dcrd: %v", err)
@@ -159,7 +158,7 @@ func mainCore() error {
 	log.Infof("SQLite DB successfully opened: %s", cfg.DBFileName)
 	defer baseDB.Close()
 
-	// PostgreSQL
+	// Auxiliary DB (currently PostgreSQL)
 	var auxDB *dcrpg.ChainDBRPC
 	var newPGIndexes, updateAllAddresses, updateAllVotes bool
 	if usePG {
@@ -218,7 +217,7 @@ func mainCore() error {
 	// with auxDB. Setting fetchToHeight to a large number allows this.
 	var fetchToHeight = int64(math.MaxInt32)
 	if usePG {
-		// Get the last block added to the aux DB
+		// Get the last block added to the aux DB.
 		var heightDB uint64
 		heightDB, err = auxDB.HeightDB()
 		lastBlockPG := int64(heightDB)
@@ -243,7 +242,7 @@ func mainCore() error {
 		stakedbHeight := int64(baseDB.GetStakeDB().Height())
 		fromHeight := stakedbHeight
 		if uint64(stakedbHeight) > heightDB {
-			// rewind stakedb and log at intervals of 200
+			// Rewind stakedb and log at intervals of 200 blocks.
 			if stakedbHeight == fromHeight || stakedbHeight%200 == 0 {
 				log.Infof("Rewinding StakeDatabase from %d to %d.", stakedbHeight, heightDB)
 			}
@@ -304,7 +303,7 @@ func mainCore() error {
 		}
 	}
 
-	// SetAgendaDB Path
+	// Set the path to the AgendaDB file.
 	agendadb.SetDbPath(filepath.Join(cfg.DataDir, cfg.AgendaDBFileName))
 
 	// AgendaDB upgrade check
@@ -318,7 +317,7 @@ func mainCore() error {
 		return fmt.Errorf("Failed to create block data collector")
 	}
 
-	// Build a slice of each required saver type for each data source
+	// Build a slice of each required saver type for each data source.
 	var blockDataSavers []blockdata.BlockDataSaver
 	var mempoolSavers []mempool.MempoolDataSaver
 	if usePG {
@@ -335,14 +334,14 @@ func mainCore() error {
 	blockDataSavers = append(blockDataSavers, &baseDB)
 	mempoolSavers = append(mempoolSavers, baseDB.MPC)
 
-	// Allow Ctrl-C to halt startup
+	// Allow Ctrl-C to halt startup here.
 	select {
 	case <-quit:
 		return nil
 	default:
 	}
 
-	// Create the explorer system
+	// Create the explorer system.
 	explore := explorer.New(&baseDB, auxDB, cfg.UseRealIP, version.Version(), !cfg.NoDevPrefetch)
 	if explore == nil {
 		return fmt.Errorf("failed to create new explorer (templates missing?)")
@@ -450,9 +449,10 @@ func mainCore() error {
 
 	blockDataSavers = append(blockDataSavers, explore)
 
-	// Create the insight socket server and add it to block savers if in pg mode.
-	// Since insightSocketServer is added into the url before even the sync starts,
-	// this implementation cannot be moved to initiateHandlersAndCollectBlocks function.
+	// Create the Insight socket.io server, and add it to block savers if in
+	// full/pg mode. Since insightSocketServer is added into the url before even
+	// the sync starts, this implementation cannot be moved to
+	// initiateHandlersAndCollectBlocks function.
 	var insightSocketServer *insight.SocketServer
 	if usePG {
 		insightSocketServer, err = insight.NewSocketServer(notify.NtfnChans.InsightNewTxChan, activeChain)
@@ -466,16 +466,17 @@ func mainCore() error {
 	// WaitGroup for the monitor goroutines
 	var wg sync.WaitGroup
 
-	// Start web API
+	// Start dcrdata's JSON web API.
 	app := api.NewContext(dcrdClient, activeChain, &baseDB, auxDB, cfg.IndentJSON)
-	// Start notification hander to keep /status up-to-date
+	// Start the notification hander for keeping /status up-to-date.
 	wg.Add(1)
 	go app.StatusNtfnHandler(&wg, quit)
-	// Initial setting of db_height. Subsequently, Store() will send this.
+	// Initial setting of DBHeight. Subsequently, Store() will send this.
 	notify.NtfnChans.UpdateStatusDBHeight <- uint32(wireDBheight)
 
+	// Configure the URL path to http handler router for the API.
 	apiMux := api.NewAPIRouter(app, cfg.UseRealIP)
-
+	// Configure the explorer web pages router.
 	webMux := chi.NewRouter()
 	webMux.With(explore.SyncStatusPageActivation).Group(func(r chi.Router) {
 		r.Get("/", explore.Home)
@@ -493,7 +494,9 @@ func mainCore() error {
 
 	// SyncStatusApiResponse returns a json response when the sync status page is running.
 	webMux.With(explore.SyncStatusApiResponse).Group(func(r chi.Router) {
+		// Mount the dcrdata's REST API.
 		r.Mount("/api", apiMux.Mux)
+		// Setup and mount the Insight API.
 		if usePG {
 			insightApp := insight.NewInsightContext(dcrdClient, auxDB, activeChain, &baseDB, cfg.IndentJSON)
 			insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP)
@@ -534,6 +537,7 @@ func mainCore() error {
 		}
 	})
 
+	// Start the web server.
 	if err = listenAndServeProto(cfg.APIListen, cfg.APIProto, webMux); err != nil {
 		log.Criticalf("listenAndServeProto: %v", err)
 		close(quit)
@@ -541,20 +545,21 @@ func mainCore() error {
 
 	log.Infof("Starting blockchain sync...")
 
-	// Sync up with the blockchain after the web server has loaded.
+	// Coordinate the sync of both sqlite and auxiliary DBs with the network.
+	// This closure captures the RPC client and the quit channel.
 	getSyncd := func(updateAddys, updateVotes, newPGInds bool,
 		fetchHeightInBaseDB int64) (int64, int64, error) {
-		// Simultaneously synchronize the ChainDB (PostgreSQL) and the block/stake
-		// info DB (sqlite). Results are returned over channels:
+		// Simultaneously synchronize the ChainDB (PostgreSQL) and the
+		// block/stake info DB (sqlite). Results are returned over channels:
 		sqliteSyncRes := make(chan dbtypes.SyncResult)
 		pgSyncRes := make(chan dbtypes.SyncResult)
 
 		// Synchronization between DBs via rpcutils.BlockGate
 		smartClient := rpcutils.NewBlockGate(dcrdClient, 10)
 
-		// stakedb (in baseDB) connects blocks *after* ChainDB retrieves them, but
-		// it has to get a notification channel first to receive them. The BlockGate
-		// will provide this for blocks after fetchHeightInBaseDB.
+		// stakedb (in baseDB) connects blocks *after* ChainDB retrieves them,
+		// but it has to get a notification channel first to receive them. The
+		// BlockGate will provide this for blocks after fetchHeightInBaseDB.
 		baseDB.SyncDBAsync(sqliteSyncRes, quit, smartClient, fetchHeightInBaseDB,
 			latestBlockHash, barLoad)
 
@@ -567,7 +572,7 @@ func mainCore() error {
 		go auxDB.SyncChainDBAsync(pgSyncRes, smartClient, quit,
 			updateAddys, updateVotes, newPGInds, latestBlockHash, barLoad)
 
-		// Wait for the results
+		// Wait for the results from both of these DBs.
 		return waitForSync(sqliteSyncRes, pgSyncRes, usePG, quit)
 	}
 
@@ -579,8 +584,8 @@ func mainCore() error {
 
 	if usePG {
 		// After sync and indexing, must use upsert statement, which checks for
-		// duplicate entries and updates instead of erroring. SyncChainDB should set
-		// this on successful sync, but do it again anyway.
+		// duplicate entries and updates instead of erroring. SyncChainDB should
+		// set this on successful sync, but do it again anyway.
 		auxDB.EnableDuplicateCheckOnInsert(true)
 	}
 
@@ -612,6 +617,69 @@ func mainCore() error {
 	// because all we needed then was the blockchain sync be completed successfully.
 	if cfg.SyncAndQuit {
 		return nil
+	}
+
+	// Ensure all side chains known by dcrd are also present in the auxiliary DB
+	// and import them if they are not already there.
+	if usePG {
+		// First identify the side chain blocks that are missing from the DB.
+		log.Infof("Retrieving side chain blocks from dcrd.")
+		sideChainBlocksToStore, nSideChainBlocks, err := auxDB.MissingSideChainBlocks()
+		if err != nil {
+			return fmt.Errorf("unable to determine missing side chain blocks: %v", err)
+		}
+		nSideChains := len(sideChainBlocksToStore)
+
+		// Importing side chain blocks involves only the aux (postgres) DBs
+		// since dcrsqlite does not track side chain blocks, and stakedb only
+		// supports mainchain. TODO: Get stakedb to work with side chain blocks
+		// to get ticket pool info.
+
+		// Collect and store data for each side chain.
+		log.Infof("Importing %d blocks from %d side chains...",
+			nSideChainBlocks, nSideChains)
+		var sideChainsStored, sideChainBlocksStored int
+		for _, sideChain := range sideChainBlocksToStore {
+			// Process this side chain only if there are block in it that need
+			// to be stored.
+			if len(sideChain.Hashes) == 0 {
+				continue
+			}
+			sideChainsStored++
+
+			// Collect and store data for each block in this side chain.
+			for _, hash := range sideChain.Hashes {
+				// Validate the block hash.
+				blockHash, err := chainhash.NewHashFromStr(hash)
+				if err != nil {
+					log.Errorf("Invalid block hash %s: %v.", hash, err)
+					continue
+				}
+
+				// Collect block data.
+				blockData, msgBlock, err := collector.CollectHash(blockHash)
+				if err != nil {
+					// Do not quit if unable to collect side chain block data.
+					log.Errorf("Unable to collect data for side chain block %s: %v.",
+						hash, err)
+					continue
+				}
+
+				// Store data in the aux (dcrpg) DB.
+				isValid, isMainchain := true, false // invalidation handled by subsequent block
+				_, _, err = auxDB.StoreBlock(msgBlock, blockData.WinningTickets,
+					isValid, isMainchain, true, true)
+				if err != nil {
+					// If data collection succeeded, but storage fails, bail out
+					// to diagnose the DB trouble.
+					return fmt.Errorf("ChainDBRPC.Store failed: %v", err)
+				}
+
+				sideChainBlocksStored++
+			}
+		}
+		log.Infof("Successfully added %d blocks from %d side chains into dcrpg DB.",
+			sideChainBlocksStored, sideChainsStored)
 	}
 
 	// Collect the data now it was not collected earlier. Set up the monitors too.
@@ -679,11 +747,11 @@ func mainCore() error {
 			sdbChainMonitor.BlockConnectedSync,     // 1. Stake DB for pool info
 			wsChainMonitor.BlockConnectedSync,      // 2. blockdata for regular block data collection and storage
 			wiredDBChainMonitor.BlockConnectedSync, // 3. dcrsqlite for sqlite DB reorg handling
-			auxDBBlockConnectedSync,
+			auxDBBlockConnectedSync,                // 4. dcrpg for postgres DB reorg handling
 		})
 
 		// Initial data summary for web ui. stakedb must be at the same height, so
-		// we get do this before starting the monitors.
+		// we do this before starting the monitors.
 		blockData, msgBlock, err := collector.Collect()
 		if err != nil {
 			return fmt.Errorf("Block data collection for initial summary failed: %v",
@@ -696,7 +764,7 @@ func mainCore() error {
 
 		explore.StartMempoolMonitor(notify.NtfnChans.ExpNewTxChan)
 
-		// blockdata collector
+		// blockdata collector handlers
 		wg.Add(2)
 		go wsChainMonitor.BlockConnectedHandler()
 		// The blockdata reorg handler disables collection during reorg, leaving
@@ -709,37 +777,40 @@ func mainCore() error {
 		go sdbChainMonitor.BlockConnectedHandler()
 		go sdbChainMonitor.ReorgHandler()
 
-		// dcrsqlite does not handle new blocks except during reorg
+		// dcrsqlite does not handle new blocks except during reorg.
 		wg.Add(2)
 		go wiredDBChainMonitor.BlockConnectedHandler()
 		go wiredDBChainMonitor.ReorgHandler()
 
 		if usePG {
-			// dcrsqlite does not handle new blocks except during reorg
+			// dcrpg also does not handle new blocks except during reorg.
 			wg.Add(2)
 			go auxDBChainMonitor.BlockConnectedHandler()
 			go auxDBChainMonitor.ReorgHandler()
 		}
 
 		if cfg.MonitorMempool {
+			// Create the mempool data collector.
 			mpoolCollector := mempool.NewMempoolDataCollector(dcrdClient, activeChain)
 			if mpoolCollector == nil {
 				return fmt.Errorf("Failed to create mempool data collector")
 			}
 
+			// Collect and store initial mempool data.
 			mpData, err := mpoolCollector.Collect()
 			if err != nil {
 				return fmt.Errorf("Mempool info collection failed while gathering"+
 					" initial data: %v", err.Error())
 			}
 
-			// Store initial MP data
+			// Store initial MP data.
 			if err = baseDB.MPC.StoreMPData(mpData, time.Now()); err != nil {
 				return fmt.Errorf("Failed to store initial mempool data (wiredDB): %v",
 					err.Error())
 			}
 
-			// Setup monitor
+			// Setup the mempool monitor, which handles notifications of new
+			// transactions.
 			mpi := &mempool.MempoolInfo{
 				CurrentHeight:               mpData.GetHeight(),
 				NumTicketPurchasesInMempool: mpData.GetNumTickets(),
@@ -747,6 +818,7 @@ func mainCore() error {
 				LastCollectTime:             time.Now(),
 			}
 
+			// Parameters for triggering data collection. See config.go.
 			newTicketLimit := int32(cfg.MPTriggerTickets)
 			mini := time.Duration(cfg.MempoolMinInterval) * time.Second
 			maxi := time.Duration(cfg.MempoolMaxInterval) * time.Second
@@ -757,7 +829,8 @@ func mainCore() error {
 			go mpm.TxHandler(dcrdClient)
 		}
 
-		// Wait for notification handlers to quit
+		// Wait for notification handlers to quit.
+
 		wg.Wait()
 	}
 
@@ -767,7 +840,7 @@ func mainCore() error {
 		return fmt.Errorf("RPC client error: %v (%v)", cerr.Error(), cerr.Cause())
 	}
 
-	return nil
+	return err
 }
 
 func main() {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -302,7 +302,7 @@ func (m *MempoolData) GetNumTickets() uint32 {
 }
 
 type mempoolDataCollector struct {
-	mtx          sync.Mutex
+	sync.Mutex
 	dcrdChainSvr *rpcclient.Client
 	activeChain  *chaincfg.Params
 }
@@ -310,7 +310,6 @@ type mempoolDataCollector struct {
 // NewMempoolDataCollector creates a new mempoolDataCollector.
 func NewMempoolDataCollector(dcrdChainSvr *rpcclient.Client, params *chaincfg.Params) *mempoolDataCollector {
 	return &mempoolDataCollector{
-		mtx:          sync.Mutex{},
 		dcrdChainSvr: dcrdChainSvr,
 		activeChain:  params,
 	}
@@ -320,8 +319,8 @@ func NewMempoolDataCollector(dcrdChainSvr *rpcclient.Client, params *chaincfg.Pa
 func (t *mempoolDataCollector) Collect() (*MempoolData, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
+	t.Lock()
+	defer t.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 )
 
+const (
+	nodeUser = "dcrd"
+	nodePass = "dcrd"
+)
+
 func TestSideChains(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", "dcrd", "dcrd", "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -16,4 +21,25 @@ func TestSideChains(t *testing.T) {
 		t.Errorf("SideChains failed: %v", err)
 	}
 	t.Logf("Tips: %v", tips)
+}
+
+func TestSideChainFull(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to get side chain for a main chain block
+	sideChain, err := SideChainFull(client, "00000000aab245a5b4c5cd4c3318310c45edcc1aa016305820602e76551daf87")
+	if err == nil {
+		t.Errorf("SideChainFull should have failed for a mainchain block")
+	}
+	t.Logf("Main chain block is not on sidechain, as expected: %v", err)
+
+	// Try to get side chain for a block that was recorded on one node as a side chain tip.
+	sideChain, err = SideChainFull(client, "00000000cef7d921ccbb78282509c6a693d67c74d1bc046f0154ef89f082c231")
+	if err != nil {
+		t.Errorf("SideChainFull failed: %v", err)
+	}
+	t.Logf("Side chain: %v", sideChain)
 }

--- a/rpcutils/rpcclient_test.go
+++ b/rpcutils/rpcclient_test.go
@@ -86,3 +86,31 @@ func TestSideChainTips(t *testing.T) {
 		t.Errorf("Incorrect side chain tips.\nGot:\n\t%v\nExpected:\n\t%v", tips, sideTips)
 	}
 }
+
+func TestReverseStringSlice(t *testing.T) {
+	// Even length slice
+	s0 := []string{"a", "b", "c", "d"}
+	ref0 := []string{"d", "c", "b", "a"}
+
+	reverseStringSlice(s0)
+	if !reflect.DeepEqual(s0, ref0) {
+		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s0, ref0)
+	}
+
+	// Odd length slice
+	s1 := []string{"a", "b", "c", "d", "e"}
+	ref1 := []string{"e", "d", "c", "b", "a"}
+
+	reverseStringSlice(s1)
+	if !reflect.DeepEqual(s1, ref1) {
+		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s1, ref1)
+	}
+
+	// nil slice
+	var s2, ref2 []string
+
+	reverseStringSlice(s2)
+	if !reflect.DeepEqual(s2, ref2) {
+		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s2, ref2)
+	}
+}


### PR DESCRIPTION
This adds the ability to get all known side chains from dcrd and import all side chain blocks into the aux (dcrpg) database.

- [x] dcrd/rpcclient: add `GetChainTips` to RPC client (https://github.com/decred/dcrd/pull/1469)
- [x] rpcutils: add SideChainFull to get all blocks in a side chain
- [x] dcrpg: Modify StoreBlock and storeTxns to work correctly with side chain blocks.
- [x] dcrsqlite and dcrpg: Check for preexistence of side chain blocks in the DBs.
- [x] Capability to import all side chain blocks into dcrsqlite and dcrpg on start up.
- [x] Update/verify `/side` page for imported blocks, as currently it only shows side chain blocks from reorgs.

This resolves issue https://github.com/decred/dcrdata/issues/338.

For a follow-up PR:  Do the check and import periodically *while running* so that new forks that were not reorganized may be added without having to restart dcrdata.