### PR TITLE
fix stakedb rewind error on startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -442,7 +442,7 @@ func loadConfig() (*config, error) {
 		// value greater than 5000. 5000 is the max value that can be set by the user
 		// in dcrdata.conf file.
 		if cfg.SyncStatusLimit < 2 || cfg.SyncStatusLimit > 5000 {
-			return nil, fmt.Errorf("sync-status-limit should not be set to a value "+
+			return nil, fmt.Errorf("sync-status-limit should not be set to a value " +
 				"less than 2 or more than 5000")
 		}
 	}

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -176,7 +176,7 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 		}
 		return startHeight, nil
 	}
-	
+
 	if barLoad != nil && db.updateStatusSync {
 		barLoad <- &dbtypes.ProgressBarLoad{
 			Msg:   InitialLoadSyncStatusMsg,

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -95,13 +96,13 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 	// pace rather than waiting on other consumers to get done with the stakedb.
 	master := blockGetter == nil || blockGetter.(*rpcutils.BlockGate) == nil
 
-	// Get chain servers's best block
+	// Get chain servers's best block.
 	_, height, err := db.client.GetBestBlock()
 	if err != nil {
 		return -1, fmt.Errorf("GetBestBlock failed: %v", err)
 	}
 
-	// Time this function
+	// Time this function.
 	defer func(start time.Time, perr *error) {
 		if *perr == nil {
 			log.Infof("resyncDBWithPoolValue completed in %v", time.Since(start))
@@ -110,7 +111,8 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 		log.Errorf("resyncDBWithPoolValue failed: %v", err)
 	}(time.Now(), &err)
 
-	// Check and report heights of the DBs
+	// Check and report heights of the DBs. startHeight is the lowest of the
+	// heights, and may be -1 with an empty SQLite DB.
 	startHeight, summaryHeight, stakeInfoHeight, stakeDBHeight, err := db.DBHeights()
 	if err != nil {
 		return -1, fmt.Errorf("DBHeights failed: %v", err)
@@ -127,7 +129,8 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 	}
 	log.Info("Current best block (stakedb):         ", stakeDBHeight)
 
-	// Attempt to rewind stake database, if needed
+	// Attempt to rewind stake database, if needed, forcing it to the lowest DB
+	// height (or 0 if the lowest DB height is -1).
 	if stakeDBHeight > startHeight && stakeDBHeight > 0 {
 		if startHeight < 0 || stakeDBHeight > 2*startHeight {
 			return -1, fmt.Errorf("delete stake db (ffldb_stake) and try again")
@@ -140,8 +143,29 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 		}
 	}
 
-	if fetchToHeight < stakeDBHeight && !master {
-		return startHeight, fmt.Errorf("fetchToHeight may not be less than stakedb height")
+	// When coordinating with an external MasterBlockGetter, do not start beyond
+	// fetchToHeight, which is intended to indicate where the MasterBlockGetter
+	// will be relaying blocks, and potentially relying on stakedb block
+	// connection notifications that are triggered in this function.
+	if !master {
+		// stakedb height may not be larger than fetchToHeight if there is an
+		// external MasterBlockGetter since it is likely to require notification
+		// of block connection in stakedb starting at height fetchToHeight.
+		if fetchToHeight < stakeDBHeight {
+			return startHeight, fmt.Errorf("fetchToHeight may not be less than stakedb height")
+		}
+
+		// Start at the next block we don't have in both SQLite and stakedb, but
+		// do not start beyond fetchToHeight if there is an external
+		// MasterBlockGetter, the owner of which should already be configured to
+		// send the block at fetchToHeight over the waitChan (e.g. the call to
+		// UpdateToBlock in (*ChainDB).SyncChainDB).
+		if fetchToHeight > startHeight {
+			startHeight++
+		}
+	} else {
+		// Begin at the next block not in all DBs.
+		startHeight++
 	}
 
 	// At least this many blocks to check (another may come in before finishing)
@@ -152,16 +176,13 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 		}
 		return startHeight, nil
 	}
-
+	
 	if barLoad != nil && db.updateStatusSync {
 		barLoad <- &dbtypes.ProgressBarLoad{
 			Msg:   InitialLoadSyncStatusMsg,
 			BarID: dbtypes.InitialDBLoad,
 		}
 	}
-
-	// Start at next block we don't have in every DB
-	startHeight++
 
 	timeStart := time.Now()
 	for i := startHeight; i <= height; i++ {
@@ -201,6 +222,8 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 			db.waitChan = blockGetter.WaitForHeight(i + 1)
 		}
 
+		// Advance stakedb height, which should always be less than or equal to
+		// SQLite height, as enforced by the rewinding code in this function.
 		if i > stakeDBHeight {
 			if i != int64(db.sDB.Height()+1) {
 				panic(fmt.Sprintf("about to connect the wrong block: %d, %d", i, db.sDB.Height()))
@@ -209,11 +232,6 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 				return i - 1, err
 			}
 		}
-
-		numLive := db.sDB.PoolSize()
-		//liveTickets := db.sDB.BestNode.LiveTickets()
-		// TODO: winning tickets
-		//winningTickets := db.sDB.BestNode.Winners()
 
 		if (i-1)%rescanLogBlockChunk == 0 && i-1 != startHeight || i == startHeight {
 			if i == 0 {
@@ -224,7 +242,7 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 					endRangeBlock = height
 				}
 				log.Infof("Scanning blocks %d to %d (%d live)...",
-					i, endRangeBlock, numLive)
+					i, endRangeBlock, db.sDB.PoolSize())
 
 				// If updateStatusSync is set to true then this is the only way that sync progress will be updated.
 				if barLoad != nil && db.updateStatusSync {
@@ -241,6 +259,15 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 					timeStart = time.Now()
 				}
 			}
+		}
+
+		// If SQLite is ahead, go to next block (stakedb may be catching up).
+		if i <= summaryHeight && i <= stakeInfoHeight {
+			// update height, the end condition for the loop
+			if _, height, err = db.client.GetBestBlock(); err != nil {
+				return i - 1, fmt.Errorf("GetBestBlock failed: %v", err)
+			}
+			continue
 		}
 
 		var tpi *apitypes.TicketPoolInfo
@@ -269,6 +296,8 @@ func (db *wiredDB) resyncDB(quit chan struct{}, blockGetter rpcutils.BlockGetter
 			PoolInfo:   *tpi,
 		}
 
+		// Allow different summaryHeight and stakeInfoHeight values to be
+		// handled, although this should never happen.
 		if i > summaryHeight {
 			if err = db.StoreBlockSummary(&blockSummary); err != nil {
 				return i - 1, fmt.Errorf("Unable to store block summary in database: %v", err)

--- a/main.go
+++ b/main.go
@@ -558,10 +558,12 @@ func mainCore() error {
 		baseDB.SyncDBAsync(sqliteSyncRes, quit, smartClient, fetchHeightInBaseDB,
 			latestBlockHash, barLoad)
 
-		// Now that stakedb is either catching up or waiting for a block, start the
-		// auxDB sync, which is the master block getter, retrieving and making
-		// available blocks to the baseDB. In return, baseDB maintains a
-		// StakeDatabase at the best block's height.
+		// Now that stakedb is either catching up or waiting for a block, start
+		// the auxDB sync, which is the master block getter, retrieving and
+		// making available blocks to the baseDB. In return, baseDB maintains a
+		// StakeDatabase at the best block's height. For a detailed description
+		// on how the DBs' synchronization is coordinated, see the documents in
+		// db/dcrpg/sync.go.
 		go auxDB.SyncChainDBAsync(pgSyncRes, smartClient, quit,
 			updateAddys, updateVotes, newPGInds, latestBlockHash, barLoad)
 

--- a/main.go
+++ b/main.go
@@ -231,7 +231,8 @@ func mainCore() error {
 		}
 
 		// Allow wiredDB/stakedb to catch up to the auxDB, but after
-		// fetchToHeight, stakedb must receive block signals from auxDB.
+		// fetchToHeight, wiredDB must receive block signals from auxDB, and
+		// stakedb must send connect signals to auxDB.
 		fetchToHeight = lastBlockPG + 1
 
 		// Aux DB height and stakedb height must be equal. StakeDatabase will


### PR DESCRIPTION
Fix 1: Rewinding of stakedb never goes below 0, do not use `lastBlockPG`,
which will be -1 when auxDB is empty. This addresses:
`"failed to rewind stakedb: got 0, expecting -1"`

Fix 2: Prevent the startHeight of the block scan in `(*wiredDB).resyncDB`
from beginning beyond `fetchToHeight`, as this is the height at which the
`MasterBlockGetter` in `(*ChainDB).SyncChainDB` begins notifying of new
blocks it fetches via RPC, and begins waiting for blocks to be connected
in stakedb in `(*wiredDB).resyncDB`.

Note that the stakedb rewind in main ensures stakedb is not beyond the
height of `auxDB` (a `ChainDB`).

Thoroughly document semantics of `fetchToHeight` and the relationship of
`BlockGetter` in `baseDB` and `MasterBlockGetter` in `auxDB`.

Add an early loop continue in `(*wiredDB).resyncDB` when that iteration's
only purpose was to advance the stakedb (catching up).