### PR TITLE
Change the API return status code from 202 to 503

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1305,13 +1305,11 @@ func (exp *explorerUI) HandleApiRequestsOnSync(w http.ResponseWriter, r *http.Re
 	})
 
 	str := string(data)
-	statusCode := http.StatusAccepted
 	if err != nil {
-		str = fmt.Sprintf("error occurred while process the API response: %v", err)
-		statusCode = http.StatusServiceUnavailable
+		str = fmt.Sprintf("error occurred while processing the API response: %v", err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
+	w.WriteHeader(http.StatusServiceUnavailable)
 	io.WriteString(w, str)
 }


### PR DESCRIPTION
For the API endpoints the status 503 (Service Temporarily Unavailable)  should be used tell the user to resend the request later when the sync is complete.