### PR TITLE
dcrpg: fix panic while importing side chain block with missed vote

### DIFF
--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -429,7 +429,8 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 	// Close prepared statement. Ignore errors as we'll Commit regardless.
 	_ = voteStmt.Close()
 
-	if len(ids)+len(misses) != 5 {
+	// If the validators are available, miss accounting should be accurate.
+	if len(msgBlock.Validators) > 0 && len(ids)+len(misses) != 5 {
 		fmt.Println(misses)
 		fmt.Println(voteTxs)
 		_ = dbtx.Rollback()


### PR DESCRIPTION
When importing side chain blocks, we do not have the "validators" list,
which indicates which votes are expected in the block, so no
missed votes are identified.  However, InsertVotes was checking to
ensure that the number of misses + votes is 5.  Disable this check
when the validators slice is empty (importing side chain block).