### PR TITLE
reduce messages for expected events on side chain block import

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1609,10 +1609,14 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 				lastBlockHash, errB)
 			return // do not return an error, but this should not happen
 		}
+		// Do not update previous block data if it is not the blockchain branch.
 		if blockStatus.IsMainchain != isMainchain {
-			log.Debugf("Previous block %v on a different branch (main=%v)"+
-				" from current block (main=%v). Not updating previous block's data.",
-				lastBlockHash, blockStatus.IsMainchain, isMainchain)
+			// A main chain block should never have a side chain parent.
+			if isMainchain {
+				log.Errorf("Previous block %v on a different branch (main=%v)"+
+					" from current block (main=%v). Not updating previous block's data.",
+					lastBlockHash, blockStatus.IsMainchain, isMainchain)
+			}
 			return
 		}
 

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -652,12 +652,22 @@ func (db *wiredDB) GetSummaryByHash(hash string) *apitypes.BlockDataBasic {
 	return blockSummary
 }
 
+// GetBestBlockSummary retrieves data for teh best block in the DB. If there are
+// no blocks in the table (yet), a nil pointer is returned.
 func (db *wiredDB) GetBestBlockSummary() *apitypes.BlockDataBasic {
+	// Attempt to retrieve height of best block in DB.
 	dbBlkHeight, err := db.GetBlockSummaryHeight()
 	if err != nil {
 		log.Errorf("GetBlockSummaryHeight failed: %v", err)
 		return nil
 	}
+
+	// Empty table is not an error.
+	if dbBlkHeight == -1 {
+		return nil
+	}
+
+	// Retrieve the block data.
 	blockSummary, err := db.RetrieveBlockSummary(dbBlkHeight)
 	if err != nil {
 		log.Errorf("Unable to retrieve block %d summary: %v", dbBlkHeight, err)


### PR DESCRIPTION
Certain conditions are presently expected when importing a side chain
block.  Namely, there will be no ticket pool info, and the parent of the
side chain root block will be main chain.  Do not log these cases.

This also silences an expected condition in a wiredDB query:
With empty block tables, the best block height will be returned as -1.
In this case, return from GetBestBlockSummary early before trying
and failing to get the block summary for this non-existent block. This
change is meant to further clean up log messages when there is no
real error.