### PR TITLE
config: add import-side-chains flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,13 +98,14 @@ type config struct {
 	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)."`
 	AgendaDBFileName   string `long:"agendadbfile" description:"Agenda DB file name (default is agendas.db)."`
 
-	FullMode      bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support"`
-	PGDBName      string `long:"pgdbname" description:"PostgreSQL DB name."`
-	PGUser        string `long:"pguser" description:"PostgreSQL DB user."`
-	PGPass        string `long:"pgpass" description:"PostgreSQL DB password."`
-	PGHost        string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
-	NoDevPrefetch bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
-	SyncAndQuit   bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API."`
+	FullMode         bool   `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support"`
+	PGDBName         string `long:"pgdbname" description:"PostgreSQL DB name."`
+	PGUser           string `long:"pguser" description:"PostgreSQL DB user."`
+	PGPass           string `long:"pgpass" description:"PostgreSQL DB password."`
+	PGHost           string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
+	NoDevPrefetch    bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
+	SyncAndQuit      bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API."`
+	ImportSideChains bool   `long:"import-side-chains" description:"Enable startup import of side chains retrieved from dcrd via getchaintips."`
 
 	SyncStatusLimit int64 `long:"sync-status-limit" description:"Sets the number of blocks behind the current best height past which only the syncing status page can be served on the running web server. Value should be greater than 2 but less than 5000."`
 
@@ -468,6 +469,12 @@ func loadConfig() (*config, error) {
 
 	log.Infof("Log folder:  %s", cfg.LogDir)
 	log.Infof("Config file: %s", configFile)
+
+	// If import-sidechains is true, but not running in full mode, warn the user
+	// that side chain import cannot be performed.
+	if !cfg.FullMode && cfg.ImportSideChains {
+		log.Warn("Unable to import side chains in lite mode!")
+	}
 
 	// Disable dev balance prefetch if network has invalid script.
 	_, err = dbtypes.DevSubsidyAddress(activeChain)

--- a/config.go
+++ b/config.go
@@ -105,7 +105,7 @@ type config struct {
 	PGHost           string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
 	NoDevPrefetch    bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected."`
 	SyncAndQuit      bool   `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API."`
-	ImportSideChains bool   `long:"import-side-chains" description:"Enable startup import of side chains retrieved from dcrd via getchaintips."`
+	ImportSideChains bool   `long:"import-side-chains" description:"(experimental) Enable startup import of side chains retrieved from dcrd via getchaintips."`
 
 	SyncStatusLimit int64 `long:"sync-status-limit" description:"Sets the number of blocks behind the current best height past which only the syncing status page can be served on the running web server. Value should be greater than 2 but less than 5000."`
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -189,7 +189,7 @@ const (
 	// SelectAddressesGloballyInvalid selects the row ids of the addresses table
 	// corresponding to transactions that should have valid_mainchain set to
 	// false according to the transactions table. Should is defined as any
-	// occurence of a given transaction (hash) being flagged as is_valid AND
+	// occurrence of a given transaction (hash) being flagged as is_valid AND
 	// is_mainchain.
 	SelectAddressesGloballyInvalid = `SELECT id, valid_mainchain
 		FROM addresses

--- a/main.go
+++ b/main.go
@@ -625,7 +625,7 @@ func mainCore() error {
 
 	// Ensure all side chains known by dcrd are also present in the auxiliary DB
 	// and import them if they are not already there.
-	if usePG {
+	if usePG && cfg.ImportSideChains {
 		// First identify the side chain blocks that are missing from the DB.
 		log.Infof("Retrieving side chain blocks from dcrd.")
 		sideChainBlocksToStore, nSideChainBlocks, err := auxDB.MissingSideChainBlocks()


### PR DESCRIPTION
The import of side chains from dcrd into dcrdata's dcrpg
backend has known issues, and it should be optional
functionality until it is more well tested. This adds a switch
to explicitly enable side chain imports.  The default is to
not import side chains (--import-side-chains=false).