### PR TITLE
side chain import fixes and block sync/store refactoring

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -79,7 +79,7 @@ type DataSourceLite interface {
 	GetAddressTransactionsWithSkip(addr string, count, skip int) *apitypes.Address
 	GetAddressTransactionsRawWithSkip(addr string, count, skip int) []*apitypes.AddressTxRaw
 	SendRawTransaction(txhex string) (string, error)
-	GetExplorerAddress(address string, count, offset int64) *explorer.AddressInfo
+	GetExplorerAddress(address string, count, offset int64) (*explorer.AddressInfo, error)
 }
 
 // DataSourceAux specifies an interface for advanced data collection using the

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -336,9 +336,10 @@ func mainCore() error {
 		}
 
 		var numVins, numVouts int64
-		isValid, isMainchain := true, true
+		isValid, isMainchain, updateExistingRecords := true, true, true
 		numVins, numVouts, err = db.StoreBlock(block.MsgBlock(), winners,
-			isValid, isMainchain, cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch)
+			isValid, isMainchain, updateExistingRecords,
+			cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch)
 		if err != nil {
 			return fmt.Errorf("StoreBlock failed: %v", err)
 		}

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -225,8 +225,9 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 		// New blocks stored this way are considered part of mainchain. They are
 		// also considered valid unless invalidated by the next block
 		// (invalidation of previous handled inside StoreBlock).
-		isValid, isMainChain := true, true
-		_, _, err := p.db.StoreBlock(msgBlock, winners, isValid, isMainChain, true, true)
+		isValid, isMainChain, updateExisting := true, true, true
+		_, _, err := p.db.StoreBlock(msgBlock, winners, isValid, isMainChain,
+			updateExisting, true, true)
 		if err != nil {
 			return int32(p.db.Height()), p.db.Hash(),
 				fmt.Errorf("error connecting block %v", p.sideChain[i])

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -1,32 +1,6 @@
 package internal
 
 const (
-	insertAddressRow0 = `INSERT INTO addresses (address, matching_tx_hash, tx_hash,
-		tx_vin_vout_index, tx_vin_vout_row_id, value, block_time, is_funding, valid_mainchain, tx_type)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) `
-
-	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
-
-	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE
-		SET matching_tx_hash = $2, tx_hash = $3, tx_vin_vout_index = $4,
-		block_time = $7, valid_mainchain = $9 RETURNING id;`
-	InsertAddressRowReturnID = `WITH inserting AS (` +
-		insertAddressRow0 +
-		`ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE
-			SET address = NULL WHERE FALSE
-			RETURNING id
-		)
-		SELECT id FROM inserting
-		UNION  ALL
-		SELECT id FROM addresses
-		WHERE  address = $1 AND is_funding = $8 AND tx_vin_vout_row_id = $5
-		LIMIT  1;`
-
-	// SelectSpendingTxsByPrevTx = `SELECT id, tx_hash, tx_index, prev_tx_index FROM vins WHERE prev_tx_hash=$1;`
-	// SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins WHERE prev_tx_hash=$1 AND prev_tx_index=$2;`
-	// SelectFundingTxsByTx      = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1;`
-	// SelectFundingTxByTxIn     = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
-
 	CreateAddressTable = `CREATE TABLE IF NOT EXISTS addresses (
 		id SERIAL8 PRIMARY KEY,
 		address TEXT,
@@ -39,7 +13,69 @@ const (
 		tx_vin_vout_index INT4,
 		tx_vin_vout_row_id INT8,
 		tx_type INT4
-		);`
+	);`
+
+	// insertAddressRow is the basis for several address insert/upsert
+	// statements.
+	insertAddressRow = `INSERT INTO addresses (address, matching_tx_hash, tx_hash,
+		tx_vin_vout_index, tx_vin_vout_row_id, value, block_time, is_funding, valid_mainchain, tx_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) `
+
+	// InsertAddressRow inserts a address block row without checking for unique
+	// index conflicts. This should only be used before the unique indexes are
+	// created or there may be constraint violations (errors).
+	InsertAddressRow = insertAddressRow + `RETURNING id;`
+
+	// UpsertAddressRow is an upsert (insert or update on conflict), returning
+	// the inserted/updated address row id.
+	UpsertAddressRow = insertAddressRow + `ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO UPDATE
+		SET matching_tx_hash = $2, tx_hash = $3, tx_vin_vout_index = $4,
+		block_time = $7, valid_mainchain = $9 RETURNING id;`
+
+	// InsertAddressRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
+	// conflict with addresses' unique tx index, while returning the row id of
+	// either the inserted row or the existing row that causes the conflict. The
+	// complexity of this statement is necessary to avoid an unnecessary UPSERT,
+	// which would have performance consequences. The row is not locked.
+	InsertAddressRowOnConflictDoNothing = `WITH inserting AS (` +
+		insertAddressRow +
+		`	ON CONFLICT (tx_vin_vout_row_id, address, is_funding) DO NOTHING -- no lock on row
+			RETURNING id
+		)
+		SELECT id FROM inserting
+		UNION  ALL
+		SELECT id FROM addresses
+		WHERE  address = $1 AND is_funding = $8 AND tx_vin_vout_row_id = $5 -- only executed if no INSERT
+		LIMIT  1;`
+
+	// IndexAddressTableOnVoutID creates the unique index uix_addresses_vout_id
+	// on (tx_vin_vout_row_id, address, is_funding).
+	IndexAddressTableOnVoutID = `CREATE UNIQUE INDEX uix_addresses_vout_id
+		ON addresses(tx_vin_vout_row_id, address, is_funding);`
+	DeindexAddressTableOnVoutID = `DROP INDEX uix_addresses_vout_id;`
+
+	// IndexBlockTimeOnTableAddress creates a sorted index on block_time, which
+	// accelerates queries with ORDER BY block_time LIMIT n OFFSET m.
+	IndexBlockTimeOnTableAddress = `CREATE INDEX block_time_index
+		ON addresses(block_time DESC NULLS LAST);`
+	DeindexBlockTimeOnTableAddress = `DROP INDEX block_time_index;`
+
+	IndexMatchingTxHashOnTableAddress = `CREATE INDEX matching_tx_hash_index
+	    ON addresses(matching_tx_hash);`
+	DeindexMatchingTxHashOnTableAddress = `DROP INDEX matching_tx_hash_index;`
+
+	IndexAddressTableOnAddress = `CREATE INDEX uix_addresses_address
+		ON addresses(address);`
+	DeindexAddressTableOnAddress = `DROP INDEX uix_addresses_address;`
+
+	IndexAddressTableOnTxHash = `CREATE INDEX uix_addresses_funding_tx
+		ON addresses(tx_hash);`
+	DeindexAddressTableOnTxHash = `DROP INDEX uix_addresses_funding_tx;`
+
+	// SelectSpendingTxsByPrevTx = `SELECT id, tx_hash, tx_index, prev_tx_index FROM vins WHERE prev_tx_hash=$1;`
+	// SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins WHERE prev_tx_hash=$1 AND prev_tx_index=$2;`
+	// SelectFundingTxsByTx      = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1;`
+	// SelectFundingTxByTxIn     = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
 
 	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, valid_mainchain,
 		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
@@ -148,15 +184,6 @@ const (
 	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses WHERE address=$1 AND
 	    tx_vin_vout_row_id=$2 AND is_funding = TRUE;`
 
-	SetAddressFundingForMatchingTxHash = `UPDATE addresses SET matching_tx_hash=$1
-		WHERE tx_hash=$2 AND is_funding = TRUE AND tx_vin_vout_index=$3;`
-
-	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1
-		WHERE is_funding = TRUE AND tx_vin_vout_row_id=$2;`
-
-	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1
-		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2;`
-
 	SelectAddressOldestTxBlockTime = `SELECT block_time FROM addresses WHERE
 		address=$1 ORDER BY block_time DESC LIMIT 1;`
 
@@ -180,6 +207,30 @@ const (
 	SelectAddressUnspentAmountByAddress = `SELECT (block_time/$1)*$1 as timestamp,
 		SUM(value) as unspent FROM addresses WHERE address=$2 AND is_funding=TRUE
 		AND matching_tx_hash ='' GROUP BY timestamp ORDER BY timestamp;`
+
+	// UPDATEs/SETs
+
+	// SetAddressMatchingTxHashForOutpoint sets the matching tx hash (a spending
+	// transaction) for the addresses rows corresponding to the specified
+	// outpoint (tx_hash:tx_vin_vout_index), a funding tx row.
+	SetAddressMatchingTxHashForOutpoint = `UPDATE addresses SET matching_tx_hash=$1
+		WHERE tx_hash=$2 AND is_funding = TRUE AND tx_vin_vout_index=$3`  // not terminated with ;
+
+	// AssignMatchingTxHashForOutpoint is like
+	// SetAddressMatchingTxHashForOutpoint except that it only updates rows
+	// where matching_tx_hash is not already set.
+	AssignMatchingTxHashForOutpoint = SetAddressMatchingTxHashForOutpoint + ` AND matching_tx_hash='';`
+
+	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1
+		WHERE is_funding = TRUE AND tx_vin_vout_row_id=$2;`
+
+	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1
+		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2;`
+
+	SetTxTypeOnAddressesByVinAndVoutIDs = `UPDATE addresses SET tx_type=$1 WHERE
+		tx_vin_vout_row_id=$2 AND is_funding=$3;`
+
+	// Patches/upgrades
 
 	// The SelectAddressesGloballyInvalid and UpdateAddressesGloballyInvalid
 	// queries are used to patch a bug in new block handling that neglected to
@@ -240,34 +291,23 @@ const (
 		SET valid_mainchain = (tr.is_mainchain::int * tr.is_valid::int)::boolean
 		FROM transactions AS tr
 		WHERE addresses.tx_hash = tr.tx_hash;`
-
-	SetTxTypeOnAddressesByVinAndVoutIDs = `UPDATE addresses SET tx_type=$1 WHERE
-		tx_vin_vout_row_id=$2 AND is_funding=$3;`
-
-	IndexBlockTimeOnTableAddress = `CREATE INDEX block_time_index
-		ON addresses (block_time DESC NULLS LAST);`
-	DeindexBlockTimeOnTableAddress = `DROP INDEX block_time_index;`
-
-	IndexMatchingTxHashOnTableAddress = `CREATE INDEX matching_tx_hash_index
-	    ON addresses (matching_tx_hash);`
-	DeindexMatchingTxHashOnTableAddress = `DROP INDEX matching_tx_hash_index;`
-
-	IndexAddressTableOnAddress = `CREATE INDEX uix_addresses_address
-		ON addresses(address);`
-	DeindexAddressTableOnAddress = `DROP INDEX uix_addresses_address;`
-
-	IndexAddressTableOnVoutID = `CREATE UNIQUE INDEX uix_addresses_vout_id
-		ON addresses(tx_vin_vout_row_id, address, is_funding);`
-	DeindexAddressTableOnVoutID = `DROP INDEX uix_addresses_vout_id;`
-
-	IndexAddressTableOnTxHash = `CREATE INDEX uix_addresses_funding_tx
-		ON addresses(tx_hash);`
-	DeindexAddressTableOnTxHash = `DROP INDEX uix_addresses_funding_tx;`
 )
 
-func MakeAddressRowInsertStatement(checked bool) string {
-	if checked {
+// MakeAddressRowInsertStatement returns the appropriate addresses insert statement for
+// the desired conflict checking and handling behavior. For checked=false, no ON
+// CONFLICT checks will be performed, and the value of updateOnConflict is
+// ignored. This should only be used prior to creating the unique indexes as
+// these constraints will cause an errors if an inserted row violates a
+// constraint. For updateOnConflict=true, an upsert statement will be provided
+// that UPDATEs the conflicting row. For updateOnConflict=false, the statement
+// will either insert or do nothing, and return the inserted (new) or
+// conflicting (unmodified) row id.
+func MakeAddressRowInsertStatement(checked, updateOnConflict bool) string {
+	if !checked {
+		return InsertAddressRow
+	}
+	if updateOnConflict {
 		return UpsertAddressRow
 	}
-	return InsertAddressRow
+	return InsertAddressRowOnConflictDoNothing
 }

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -7,47 +7,6 @@ import (
 )
 
 const (
-	// Block insert. is_valid refers to blocks that have been validated by
-	// stakeholders (voting on the previous block), while is_mainchain
-	// distinguishes blocks that are on the main chain from those that are
-	// on side chains and/or orphaned.
-
-	insertBlockRow0 = `INSERT INTO blocks (
-		hash, height, size, is_valid, is_mainchain, version, merkle_root, stake_root,
-		numtx, num_rtx, tx, txDbIDs, num_stx, stx, stxDbIDs,
-		time, nonce, vote_bits, final_state, voters,
-		fresh_stake, revocations, pool_size, bits, sbits, 
-		difficulty, extra_data, stake_version, previous_hash)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
-		$9, $10, %s, %s, $11, %s, %s,
-		$12, $13, $14, $15, $16, 
-		$17, $18, $19, $20, $21,
-		$22, $23, $24, $25) `
-	insertBlockRow = insertBlockRow0 + `RETURNING id;`
-	// insertBlockRowChecked  = insertBlockRow0 + `ON CONFLICT (hash) DO NOTHING RETURNING id;`
-	upsertBlockRow = insertBlockRow0 + `ON CONFLICT (hash) DO UPDATE 
-		SET is_valid = $4, is_mainchain = $5 RETURNING id;`
-	insertBlockRowReturnId = `WITH ins AS (` +
-		insertBlockRow0 +
-		`ON CONFLICT (hash) DO UPDATE
-		SET hash = NULL WHERE FALSE
-		RETURNING id
-		)
-	SELECT id FROM ins
-	UNION  ALL
-	SELECT id FROM blocks
-	WHERE  hash = $1
-	LIMIT  1;`
-
-	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
-
-	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
-		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
-	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx
-		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC;`
-	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
-	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
-
 	CreateBlockTable = `CREATE TABLE IF NOT EXISTS blocks (  
 		id SERIAL PRIMARY KEY,
 		hash TEXT NOT NULL, -- UNIQUE
@@ -81,15 +40,74 @@ const (
 		previous_hash TEXT
 	);`
 
-	IndexBlockTableOnHash = `CREATE UNIQUE INDEX uix_block_hash
-		ON blocks(hash);`
+	// Block inserts. is_valid refers to blocks that have been validated by
+	// stakeholders (voting on the previous block), while is_mainchain
+	// distinguishes blocks that are on the main chain from those that are on
+	// side chains and/or orphaned.
+
+	// insertBlockRow is the basis for several block insert/upsert statements.
+	insertBlockRow = `INSERT INTO blocks (
+		hash, height, size, is_valid, is_mainchain, version, merkle_root, stake_root,
+		numtx, num_rtx, tx, txDbIDs, num_stx, stx, stxDbIDs,
+		time, nonce, vote_bits, final_state, voters,
+		fresh_stake, revocations, pool_size, bits, sbits, 
+		difficulty, extra_data, stake_version, previous_hash)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+		$9, $10, %s, %s, $11, %s, %s,
+		$12, $13, $14, $15, $16, 
+		$17, $18, $19, $20, $21,
+		$22, $23, $24, $25) `
+
+	// InsertBlockRow inserts a new block row without checking for unique index
+	// conflicts. This should only be used before the unique indexes are created
+	// or there may be constraint violations (errors).
+	InsertBlockRow = insertBlockRow + `RETURNING id;`
+
+	// UpsertBlockRow is an upsert (insert or update on conflict), returning
+	// the inserted/updated block row id.
+	UpsertBlockRow = insertBlockRow + `ON CONFLICT (hash) DO UPDATE 
+		SET is_valid = $4, is_mainchain = $5 RETURNING id;`
+
+	// InsertBlockRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
+	// conflict with blocks' unique tx index, while returning the row id of
+	// either the inserted row or the existing row that causes the conflict. The
+	// complexity of this statement is necessary to avoid an unnecessary UPSERT,
+	// which would have performance consequences. The row is not locked.
+	InsertBlockRowOnConflictDoNothing = `WITH ins AS (` +
+		insertBlockRow +
+		`	ON CONFLICT (hash) DO NOTHING -- no lock on row
+			RETURNING id
+		)
+		SELECT id FROM ins
+		UNION  ALL
+		SELECT id FROM blocks
+		WHERE  hash = $1 -- only executed if no INSERT
+		LIMIT  1;`
+
+	// IndexBlockTableOnHash creates the unique index uix_block_hash on (hash).
+	IndexBlockTableOnHash   = `CREATE UNIQUE INDEX uix_block_hash ON blocks(hash);`
 	DeindexBlockTableOnHash = `DROP INDEX uix_block_hash;`
 
-	RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
-	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks ORDER BY height DESC LIMIT 1;`
-	RetrieveBestBlockHeight    = `SELECT id, hash, height FROM blocks WHERE is_mainchain = true ORDER BY height DESC LIMIT 1;`
+	// IndexBlocksTableOnHeight creates the index uix_block_height on (height).
+	// This is not unique because of side chains.
+	IndexBlocksTableOnHeight   = `CREATE INDEX uix_block_height ON blocks(height);`
+	DeindexBlocksTableOnHeight = `DROP INDEX uix_block_height;`
 
-	// SelectBlocksTicketsPrice selects the ticket price and difficulty for the first block in a stake difficulty window.
+	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
+	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx
+		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC;`
+	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
+	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
+
+	RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
+	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks
+		ORDER BY height DESC LIMIT 1;`
+	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks
+		WHERE is_mainchain = true ORDER BY height DESC LIMIT 1;`
+
+	// SelectBlocksTicketsPrice selects the ticket price and difficulty for the
+	// first block in a stake difficulty window.
 	SelectBlocksTicketsPrice = `SELECT sbits, time, difficulty FROM blocks WHERE height % $1 = 0 ORDER BY time;`
 
 	SelectBlocksBlockSize = `SELECT time, size, numtx, height FROM blocks ORDER BY time;`
@@ -99,8 +117,6 @@ const (
 	SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`
 
 	SelectBlockVoteCount = `SELECT voters FROM blocks WHERE hash = $1;`
-
-	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = $2 WHERE hash = $1 RETURNING previous_hash;`
 
 	SelectSideChainBlocks = `SELECT is_valid, height, previous_hash, hash, block_chain.next_hash
 		FROM blocks
@@ -129,11 +145,13 @@ const (
 		WHERE is_valid = FALSE
 		ORDER BY height DESC;`
 
-	IndexBlocksTableOnHeight = `CREATE INDEX uix_block_height ON blocks(height);`
+	// blocks table updates
 
-	DeindexBlocksTableOnHeight = `DROP INDEX uix_block_height;`
+	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
+	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = $2 WHERE hash = $1 RETURNING previous_hash;`
 
-	// block_chain, with primary key that is not a SERIAL
+	// block_chain table. The primary key is not a SERIAL, but rather the row ID
+	// of the block in the blocks table.
 	CreateBlockPrevNextTable = `CREATE TABLE IF NOT EXISTS block_chain (
 		block_db_id INT8 PRIMARY KEY,
 		prev_hash TEXT NOT NULL,
@@ -141,16 +159,18 @@ const (
 		next_hash TEXT
 	);`
 
-	// Insert includes the primary key, which should be from the blocks table
-	InsertBlockPrevNext = `INSERT INTO block_chain (
-		block_db_id, prev_hash, this_hash, next_hash)
-	VALUES ($1, $2, $3, $4)
-	ON CONFLICT (this_hash) DO NOTHING;`
+	// InsertBlockPrevNext includes the primary key, which should be the row ID
+	// of the corresponding block in the blocks table.
+	InsertBlockPrevNext = `INSERT INTO block_chain (block_db_id, prev_hash, this_hash, next_hash)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (this_hash) DO NOTHING;`
 
 	SelectBlockChainRowIDByHash = `SELECT block_db_id FROM block_chain WHERE this_hash = $1;`
 
 	UpdateBlockNext       = `UPDATE block_chain SET next_hash = $2 WHERE block_db_id = $1;`
 	UpdateBlockNextByHash = `UPDATE block_chain SET next_hash = $2 WHERE this_hash = $1;`
+
+	// TODO: index block_chain where needed
 )
 
 func MakeBlockInsertStatement(block *dbtypes.Block, checked bool) string {
@@ -165,9 +185,9 @@ func makeBlockInsertStatement(txDbIDs, stxDbIDs []uint64, rtxs, stxs []string, c
 	stxTEXTARRAY := makeARRAYOfTEXT(stxs)
 	var insert string
 	if checked {
-		insert = upsertBlockRow
+		insert = UpsertBlockRow
 	} else {
-		insert = insertBlockRow
+		insert = InsertBlockRow
 	}
 	return fmt.Sprintf(insert, rtxTEXTARRAY, rtxDbIDsARRAY,
 		stxTEXTARRAY, stxDbIDsARRAY)

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -26,16 +26,40 @@ const (
 		tx_type INT4
 	);`
 
-	InsertVinRow0 = `INSERT INTO vins (tx_hash, tx_index, tx_tree, prev_tx_hash, prev_tx_index, prev_tx_tree,
+	// insertVinRow is the basis for several vinvs insert/upsert statements.
+	insertVinRow = `INSERT INTO vins (tx_hash, tx_index, tx_tree, prev_tx_hash, prev_tx_index, prev_tx_tree,
 		value_in, is_valid, is_mainchain, block_time, tx_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) `
-	InsertVinRow = InsertVinRow0 + `RETURNING id;`
-	// InsertVinRowChecked = InsertVinRow0 +
-	// 	`ON CONFLICT (tx_hash, tx_index, tx_tree) DO NOTHING RETURNING id;`
-	UpsertVinRow = InsertVinRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE
+
+	// InsertVinRow inserts a new vin row without checking for unique index
+	// conflicts. This should only be used before the unique indexes are created
+	// or there may be constraint violations (errors).
+	InsertVinRow = insertVinRow + `RETURNING id;`
+
+	// UpsertVinRow is an upsert (insert or update on conflict), returning the
+	// inserted/updated vin row id.
+	UpsertVinRow = insertVinRow + `ON CONFLICT ON CONSTRAINT uix_vin DO UPDATE
 		SET is_valid = $8, is_mainchain = $9, block_time = $10,
 			prev_tx_hash = $4, prev_tx_index = $5, prev_tx_tree = $6
 		RETURNING id;`
 
+	// InsertVinRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
+	// conflict with vins' unique tx index, while returning the row id of either
+	// the inserted row or the existing row that causes the conflict. The
+	// complexity of this statement is necessary to avoid an unnecessary UPSERT,
+	// which would have performance consequences. The row is not locked.
+	InsertVinRowOnConflictDoNothing = `WITH inserting AS (` +
+		insertVinRow +
+		`	ON CONFLICT ON CONSTRAINT uix_vin DO NOTHING -- no lock on row
+			RETURNING id
+		)
+		SELECT id FROM inserting
+		UNION  ALL
+		SELECT id FROM vins
+		WHERE  tx_hash = $1 AND tx_index = $2 AND tx_tree = $3 -- only executed if no INSERT
+		LIMIT  1;`
+
+	// DeleteVinsDuplicateRows removes rows that would violate the unique index
+	// uix_vin. This should be run prior to creating the index.
 	DeleteVinsDuplicateRows = `DELETE FROM vins
 		WHERE id IN (SELECT id FROM (
 				SELECT id, ROW_NUMBER()
@@ -126,25 +150,40 @@ const (
 		script_addresses TEXT[]
 	);`
 
-	insertVoutRow0 = `INSERT INTO vouts (tx_hash, tx_index, tx_tree, value,
+	// insertVinRow is the basis for several vout insert/upsert statements.
+	insertVoutRow = `INSERT INTO vouts (tx_hash, tx_index, tx_tree, value,
 		version, pkscript, script_req_sigs, script_type, script_addresses)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) `
-	insertVoutRow = insertVoutRow0 + `RETURNING id;`
-	//insertVoutRowChecked  = insertVoutRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO NOTHING RETURNING id;`
-	upsertVoutRow = insertVoutRow0 + `ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE
-		SET version = $5 RETURNING id;`
-	insertVoutRowReturnId = `WITH inserting AS (` +
-		insertVoutRow0 +
-		`ON CONFLICT (tx_hash, tx_index, tx_tree) DO UPDATE
-		SET tx_hash = NULL WHERE FALSE
-		RETURNING id
-		)
-	 SELECT id FROM inserting
-	 UNION  ALL
-	 SELECT id FROM vouts
-	 WHERE  tx_hash = $1 AND tx_index = $2 AND tx_tree = $3
-	 LIMIT  1;`
 
+	// InsertVoutRow inserts a new vout row without checking for unique index
+	// conflicts. This should only be used before the unique indexes are created
+	// or there may be constraint violations (errors).
+	InsertVoutRow = insertVoutRow + `RETURNING id;`
+
+	// UpsertVoutRow is an upsert (insert or update on conflict), returning the
+	// inserted/updated vout row id.
+	UpsertVoutRow = insertVoutRow + `ON CONFLICT ON CONSTRAINT uix_vout_txhash_ind DO UPDATE
+		SET version = $5 RETURNING id;`
+
+	// InsertVoutRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
+	// conflict with vouts' unique tx index, while returning the row id of
+	// either the inserted row or the existing row that causes the conflict. The
+	// complexity of this statement is necessary to avoid an unnecessary UPSERT,
+	// which would have performance consequences. The row is not locked.
+	InsertVoutRowOnConflictDoNothing = `WITH inserting AS (` +
+		insertVoutRow +
+		`	ON CONFLICT ON CONSTRAINT uix_vout_txhash_ind DO UPDATE
+			SET tx_hash = NULL WHERE FALSE
+			RETURNING id
+		)
+		SELECT id FROM inserting
+		UNION  ALL
+		SELECT id FROM vouts
+		WHERE  tx_hash = $1 AND tx_index = $2 AND tx_tree = $3
+		LIMIT  1;`
+
+	// DeleteVoutDuplicateRows removes rows that would violate the unique index
+	// uix_vout_txhash_ind. This should be run prior to creating the index.
 	DeleteVoutDuplicateRows = `DELETE FROM vouts
 		WHERE id IN (SELECT id FROM (
 				SELECT id, ROW_NUMBER()
@@ -177,11 +216,23 @@ const (
 	);`
 )
 
-func MakeVinInsertStatement(checked bool) string {
-	if checked {
+// MakeVinInsertStatement returns the appropriate vins insert statement for the
+// desired conflict checking and handling behavior. For checked=false, no ON
+// CONFLICT checks will be performed, and the value of updateOnConflict is
+// ignored. This should only be used prior to creating the unique indexes as
+// these constraints will cause an errors if an inserted row violates a
+// constraint. For updateOnConflict=true, an upsert statement will be provided
+// that UPDATEs the conflicting row. For updateOnConflict=false, the statement
+// will either insert or do nothing, and return the inserted (new) or
+// conflicting (unmodified) row id.
+func MakeVinInsertStatement(checked, updateOnConflict bool) string {
+	if !checked {
+		return InsertVinRow
+	}
+	if updateOnConflict {
 		return UpsertVinRow
 	}
-	return InsertVinRow
+	return InsertVinRowOnConflictDoNothing
 }
 
 var (
@@ -200,11 +251,23 @@ func MakeVinCopyInStatement() string {
 	return vinCopyStmt
 }
 
-func MakeVoutInsertStatement(checked bool) string {
-	if checked {
-		return upsertVoutRow
+// MakeVoutInsertStatement returns the appropriate vouts insert statement for
+// the desired conflict checking and handling behavior. For checked=false, no ON
+// CONFLICT checks will be performed, and the value of updateOnConflict is
+// ignored. This should only be used prior to creating the unique indexes as
+// these constraints will cause an errors if an inserted row violates a
+// constraint. For updateOnConflict=true, an upsert statement will be provided
+// that UPDATEs the conflicting row. For updateOnConflict=false, the statement
+// will either insert or do nothing, and return the inserted (new) or
+// conflicting (unmodified) row id.
+func MakeVoutInsertStatement(checked, updateOnConflict bool) string {
+	if !checked {
+		return InsertVoutRow
 	}
-	return insertVoutRow
+	if updateOnConflict {
+		return UpsertVoutRow
+	}
+	return InsertVoutRowOnConflictDoNothing
 }
 
 func makeARRAYOfVouts(vouts []*dbtypes.Vout) string {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -199,7 +199,7 @@ func (db *ChainDBRPC) MissingSideChainBlocks() ([]dbtypes.SideChain, int, error)
 	var nSideChainBlocks int
 	for it := range tips {
 		sideHeight := tips[it].Height
-		log.Debugf("Getting full side chain with tip %s at %d.", tips[it].Hash, sideHeight)
+		log.Tracef("Getting full side chain with tip %s at %d.", tips[it].Hash, sideHeight)
 
 		sideChain, err := rpcutils.SideChainFull(db.Client, tips[it].Hash)
 		if err != nil {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -203,13 +203,15 @@ func DeleteDuplicateMisses(db *sql.DB) (int64, error) {
 // transactions, extracts the tickets, and inserts the tickets into the
 // database. Outputs are a slice of DB row IDs of the inserted tickets, and an
 // error.
-func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked bool) ([]uint64, []*dbtypes.Tx, error) {
+func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked, updateExistingRecords bool) ([]uint64, []*dbtypes.Tx, error) {
 	dbtx, err := db.Begin()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.MakeTicketInsertStatement(checked))
+	// Prepare ticket insert statement, optionally updating a row if it conflicts
+	// with the unique index on (tx_hash, block_hash).
+	stmt, err := dbtx.Prepare(internal.MakeTicketInsertStatement(checked, updateExistingRecords))
 	if err != nil {
 		log.Errorf("Ticket INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
@@ -287,8 +289,8 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 // subsequent cache lookups by other consumers will succeed.
 //
 // Outputs are slices of DB row IDs for the votes and misses, and an error.
-func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
-	fTx *TicketTxnIDGetter, msgBlock *MsgBlockPG, checked bool, params *chaincfg.Params) ([]uint64,
+func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64, fTx *TicketTxnIDGetter,
+	msgBlock *MsgBlockPG, checked, updateExistingRecords bool, params *chaincfg.Params) ([]uint64,
 	[]*dbtypes.Tx, []string, []uint64, map[string]uint64, error) {
 	// Choose only SSGen txns
 	msgTxs := msgBlock.STransactions
@@ -310,13 +312,15 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		return nil, nil, nil, nil, nil, nil
 	}
 
-	// Start DB transaction and prepare vote insert statement
+	// Start DB transaction.
 	dbtx, err := db.Begin()
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	voteInsert := internal.MakeVoteInsertStatement(checked)
+	// Prepare vote insert statement, optionally updating a row if it conflicts
+	// with the unique index on (tx_hash, block_hash).
+	voteInsert := internal.MakeVoteInsertStatement(checked, updateExistingRecords)
 	voteStmt, err := dbtx.Prepare(voteInsert)
 	if err != nil {
 		log.Errorf("Votes INSERT prepare: %v", err)
@@ -324,11 +328,22 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		return nil, nil, nil, nil, nil, err
 	}
 
-	prep, err := dbtx.Prepare(internal.MakeAgendaInsertStatement(checked))
+	// Prepare agenda status insert statement.
+	agendaStmt, err := dbtx.Prepare(internal.MakeAgendaInsertStatement(checked))
 	if err != nil {
 		log.Errorf("Agendas INSERT prepare: %v", err)
+		_ = voteStmt.Close()
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
 		return nil, nil, nil, nil, nil, err
+	}
+
+	bail := func() {
+		// Already up a creek. Just log any Rollback error.
+		_ = voteStmt.Close()
+		_ = agendaStmt.Close()
+		if errRoll := dbtx.Rollback(); errRoll != nil {
+			log.Errorf("Rollback failed: %v", errRoll)
+		}
 	}
 
 	// Insert each vote, and build list of missed votes equal to
@@ -344,30 +359,27 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		voteVersion := stake.SSGenVersion(msgTx)
 		validBlock, voteBits, err := txhelpers.SSGenVoteBlockValid(msgTx)
 		if err != nil {
+			bail()
 			return nil, nil, nil, nil, nil, err
 		}
 
+		voteReward := dcrutil.Amount(msgTx.TxIn[0].ValueIn).ToCoin()
 		stakeSubmissionAmount := dcrutil.Amount(msgTx.TxIn[1].ValueIn).ToCoin()
 		stakeSubmissionTxHash := msgTx.TxIn[1].PreviousOutPoint.Hash.String()
 		spentTicketHashes = append(spentTicketHashes, stakeSubmissionTxHash)
 
-		var ticketTxDbID sql.NullInt64
+		// Lookup the row ID in the transactions table for the ticket purchase.
+		var ticketTxDbID uint64
 		if fTx != nil {
-			t, err := fTx.TxnDbID(stakeSubmissionTxHash, false)
+			ticketTxDbID, err = fTx.TxnDbID(stakeSubmissionTxHash, false)
 			if err != nil {
-				_ = voteStmt.Close() // try, but we want the QueryRow error back
-				if errRoll := dbtx.Rollback(); errRoll != nil {
-					log.Errorf("Rollback failed: %v", errRoll)
-				}
+				bail()
 				return nil, nil, nil, nil, nil, err
 			}
-			ticketTxDbID.Int64 = int64(t)
 		}
-		spentTicketDbIDs = append(spentTicketDbIDs, uint64(ticketTxDbID.Int64))
+		spentTicketDbIDs = append(spentTicketDbIDs, ticketTxDbID)
 
-		voteReward := dcrutil.Amount(msgTx.TxIn[0].ValueIn).ToCoin()
-
-		// delete spent ticket from missed list
+		// Remove the spent ticket from missed list.
 		for im := range misses {
 			if misses[im] == stakeSubmissionTxHash {
 				misses[im] = misses[len(misses)-1]
@@ -376,16 +388,38 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 			}
 		}
 
+		// votes table insert
+		var id uint64
+		err = voteStmt.QueryRow(
+			tx.BlockHeight, tx.TxID, tx.BlockHash, candidateBlockHash,
+			voteVersion, voteBits, validBlock.Validity,
+			stakeSubmissionTxHash, ticketTxDbID, stakeSubmissionAmount,
+			voteReward, tx.IsMainchainBlock).Scan(&id)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				continue
+			}
+			bail()
+			return nil, nil, nil, nil, nil, err
+		}
+		ids = append(ids, id)
+
+		// agendas table, not modified if not updating existing records.
+		if checked && !updateExistingRecords {
+			continue // rest of loop deals with agendas table
+		}
+
 		_, _, _, choices, err := txhelpers.SSGenVoteChoices(msgTx, params)
 		if err != nil {
+			bail()
 			return nil, nil, nil, nil, nil, err
 		}
 
-		// agendas
 		var rowID uint64
 		for _, val := range choices {
 			index, err := dbtypes.ChoiceIndexFromStr(val.Choice.Id)
 			if err != nil {
+				bail()
 				return nil, nil, nil, nil, nil, err
 			}
 
@@ -400,34 +434,18 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 				hardForked = (progress.HardForked == tx.BlockHeight)
 			}
 
-			err = prep.QueryRow(val.ID, index, tx.TxID, tx.BlockHeight,
+			err = agendaStmt.QueryRow(val.ID, index, tx.TxID, tx.BlockHeight,
 				tx.BlockTime, lockedIn, activated, hardForked).Scan(&rowID)
 			if err != nil {
+				bail()
 				return nil, nil, nil, nil, nil, err
 			}
 		}
-
-		var id uint64
-		err = voteStmt.QueryRow(
-			tx.BlockHeight, tx.TxID, tx.BlockHash, candidateBlockHash,
-			voteVersion, voteBits, validBlock.Validity,
-			stakeSubmissionTxHash, ticketTxDbID, stakeSubmissionAmount,
-			voteReward, tx.IsMainchainBlock).Scan(&id)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				continue
-			}
-			_ = voteStmt.Close() // try, but we want the QueryRow error back
-			if errRoll := dbtx.Rollback(); errRoll != nil {
-				log.Errorf("Rollback failed: %v", errRoll)
-			}
-			return nil, nil, nil, nil, nil, err
-		}
-		ids = append(ids, id)
 	}
 
-	// Close prepared statement. Ignore errors as we'll Commit regardless.
+	// Close prepared statements. Ignore errors as we'll Commit regardless.
 	_ = voteStmt.Close()
+	_ = agendaStmt.Close()
 
 	// If the validators are available, miss accounting should be accurate.
 	if len(msgBlock.Validators) > 0 && len(ids)+len(misses) != 5 {
@@ -437,16 +455,20 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, _ /*txDbIDs*/ []uint64,
 		panic(fmt.Sprintf("votes (%d) + misses (%d) != 5", len(ids), len(misses)))
 	}
 
-	// Store missed tickets
+	// Store missed tickets.
 	missHashMap := make(map[string]uint64)
 	if len(misses) > 0 {
-		stmtMissed, err := dbtx.Prepare(internal.MakeMissInsertStatement(checked))
+		// Insert misses, optionally updating a row if it conflicts with the
+		// unique index on (ticket_hash, block_hash).
+		stmtMissed, err := dbtx.Prepare(internal.MakeMissInsertStatement(checked, updateExistingRecords))
 		if err != nil {
 			log.Errorf("Miss INSERT prepare: %v", err)
 			_ = dbtx.Rollback() // try, but we want the Prepare error back
 			return nil, nil, nil, nil, nil, err
 		}
 
+		// Insert the miss in the misses table, and store the row ID of the
+		// new/existing/updated miss.
 		blockHash := msgBlock.BlockHash().String()
 		for i := range misses {
 			var id uint64
@@ -896,8 +918,8 @@ func setSpendingForTickets(dbtx *sql.Tx, ticketDbIDs, spendDbIDs []uint64,
 
 // InsertAddressRow inserts an AddressRow (input or output), returning the row
 // ID in the addresses table of the inserted data.
-func InsertAddressRow(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck bool) (uint64, error) {
-	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
+func InsertAddressRow(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck, updateExistingRecords bool) (uint64, error) {
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck, updateExistingRecords)
 	var id uint64
 	err := db.QueryRow(sqlStmt, dbA.Address, dbA.MatchingTxHash, dbA.TxHash,
 		dbA.TxVinVoutIndex, dbA.VinVoutDbID, dbA.Value, dbA.TxBlockTime,
@@ -907,7 +929,7 @@ func InsertAddressRow(db *sql.DB, dbA *dbtypes.AddressRow, dupCheck bool) (uint6
 
 // InsertAddressRows inserts multiple transaction inputs or outputs for certain
 // addresses ([]AddressRow). The row IDs of the inserted data are returned.
-func InsertAddressRows(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck bool) ([]uint64, error) {
+func InsertAddressRows(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck, updateExistingRecords bool) ([]uint64, error) {
 	// Create the address table if it does not exist
 	tableName := "addresses"
 	if haveTable, _ := TableExists(db, tableName); !haveTable {
@@ -921,7 +943,7 @@ func InsertAddressRows(db *sql.DB, dbAs []*dbtypes.AddressRow, dupCheck bool) ([
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck)
+	sqlStmt := internal.MakeAddressRowInsertStatement(dupCheck, updateExistingRecords)
 
 	stmt, err := dbtx.Prepare(sqlStmt)
 	if err != nil {
@@ -1758,9 +1780,16 @@ func RetrieveVoutsByIDs(db *sql.DB, voutDbIDs []uint64) ([]dbtypes.Vout, error) 
 	return vouts, nil
 }
 
-// SetSpendingForVinDbIDs updates rows of the addresses table with spending
-// information from the rows of the vins table specified by vinDbIDs.
-func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, error) {
+// SetSpendingForVinDbIDs updates the addresses table with spending information
+// from the rows of the vins table specified by vinDbIDs. This includes
+// inserting the spending transaction information into the addresses table, and
+// setting the matched tx info for corresponding funding tx rows of the
+// addresses table. If checked=true, the unique index constraints are checked on
+// insert, with updateExisting indicating if conflicting rows should be updated
+// (or left alone). When setting the corresponding funding tx rows,
+// updateExisting=false also prevents modifications to the matching tx hash
+// unless it was not set previously (empty string).
+func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64, checked, updateExisting bool) ([]int64, int64, error) {
 	// Get funding details for vin and set them in the address table.
 	dbtx, err := db.Begin()
 	if err != nil {
@@ -1807,11 +1836,11 @@ func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, erro
 		}
 
 		// Set the spending tx info (addresses table) for the vin DB ID
-		addressRowsUpdated[iv], err = insertSpendingTxByPrptStmt(dbtx,
-			prevOutHash, prevOutVoutInd, prevOutTree,
-			txHash, txVinInd, vinDbID, false, isValid && isMainchain, txType)
+		addressRowsUpdated[iv], err = insertAddrSpendingTxUpdateMatchedFunding(dbtx,
+			prevOutHash, prevOutVoutInd, prevOutTree, txHash, txVinInd, vinDbID,
+			checked, updateExisting, isValid && isMainchain, txType)
 		if err != nil {
-			return addressRowsUpdated, 0, fmt.Errorf(`insertSpendingTxByPrptStmt: `+
+			return addressRowsUpdated, 0, fmt.Errorf(`insertAddrSpendingTxUpdateMatchedFunding: `+
 				`%v + %v (rollback)`, err, bail())
 		}
 
@@ -1824,9 +1853,16 @@ func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, erro
 	return addressRowsUpdated, totalUpdated, dbtx.Commit()
 }
 
-// SetSpendingForVinDbID updates a row of the addresses table with spending
-// information from a rows of the vins table specified by vinDbID.
-func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
+// SetSpendingForVinDbID updates the addresses table with spending information
+// from a rows of the vins table specified by vinDbID. This includes inserting
+// the spending transaction information into the addresses table, and setting
+// the matched tx info for corresponding funding tx rows of the addresses table.
+// If checked=true, the unique index constraints are checked on insert, with
+// updateExisting indicating if conflicted rows should be updated (or left
+// alone). When setting the corresponding funding tx rows, updateExisting=false
+// also prevents modifications to the matching tx hash unless it was not set
+// previously (empty string).
+func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64, checked, updateExisting bool) (int64, error) {
 	// get funding details for vin and set them in the address table
 	dbtx, err := db.Begin()
 	if err != nil {
@@ -1854,8 +1890,9 @@ func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
 	}
 
 	// Insert the spending tx info (addresses table) for the vin DB ID
-	N, err := insertSpendingTxByPrptStmt(dbtx, prevOutHash, prevOutVoutInd,
-		prevOutTree, txHash, txVinInd, vinDbID, false, isValid && isMainchain, txType)
+	N, err := insertAddrSpendingTxUpdateMatchedFunding(dbtx,
+		prevOutHash, prevOutVoutInd, prevOutTree, txHash, txVinInd, vinDbID,
+		checked, updateExisting, isValid && isMainchain, txType)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -1869,7 +1906,7 @@ func SetSpendingForVinDbID(db *sql.DB, vinDbID uint64) (int64, error) {
 func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 	fundingTxVoutIndex uint32, fundingTxTree int8, spendingTxHash string,
 	spendingTxVinIndex uint32, spendingTXBlockTime, vinDbID uint64,
-	checked, isValidMainchain bool, txType int16) (int64, error) {
+	checked, updateExisting, isValidMainchain bool, txType int16) (int64, error) {
 
 	// Only allow atomic transactions to happen
 	dbtx, err := db.Begin()
@@ -1877,9 +1914,10 @@ func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 		return 0, fmt.Errorf(`unable to begin database transaction: %v`, err)
 	}
 
-	c, err := insertSpendingTxByPrptStmt(dbtx, fundingTxHash, fundingTxVoutIndex,
-		fundingTxTree, spendingTxHash, spendingTxVinIndex, vinDbID, checked,
-		isValidMainchain, txType, spendingTXBlockTime)
+	c, err := insertAddrSpendingTxUpdateMatchedFunding(dbtx,
+		fundingTxHash, fundingTxVoutIndex, fundingTxTree,
+		spendingTxHash, spendingTxVinIndex, vinDbID,
+		checked, updateExisting, isValidMainchain, txType, spendingTXBlockTime)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -1888,13 +1926,19 @@ func SetSpendingForFundingOP(db *sql.DB, fundingTxHash string,
 	return c, dbtx.Commit()
 }
 
-// insertSpendingTxByPrptStmt inserts into the addresses table a new spending
-// transaction corresponding to a vin specified by the row ID vinDbID, and
-// updates the spending information for the corresponding funding row in the
-// addresses table.
-func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutIndex uint32,
-	fundingTxTree int8, spendingTxHash string, spendingTxVinIndex uint32,
-	vinDbID uint64, checked, validMainchain bool, txType int16, blockT ...uint64) (int64, error) {
+// insertAddrSpendingTxUpdateMatchedFunding inserts into the addresses table a
+// new spending transaction corresponding to a vin specified by the row ID
+// vinDbID, and updates the spending information for the corresponding funding
+// row in the addresses table. When checked=true, the column constraints on the
+// addresses are checked for conflicts, with updateExisting further indicating
+// if a conflict should be handled by an upsert (or do nothing). Further,
+// updateExisting=false also indicates that the matching tx hash for the funding
+// tx outpoint should only be set if the matching tx was not previously set (is
+// the empty string), while updateExisting=true indicates that the matching tx
+// hash should be set/updated unconditionally.
+func insertAddrSpendingTxUpdateMatchedFunding(tx *sql.Tx, fundingTxHash string, fundingTxVoutIndex uint32,
+	fundingTxTree int8, spendingTxHash string, spendingTxVinIndex uint32, vinDbID uint64,
+	checked, updateExisting, validMainchain bool, txType int16, blockT ...uint64) (int64, error) {
 	var addr string
 	var value, rowID, blockTime uint64
 
@@ -1904,7 +1948,7 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 		fundingTxHash, fundingTxVoutIndex, fundingTxTree).Scan(&addr, &value)
 	switch err {
 	case sql.ErrNoRows, nil:
-		// If no row found or error is nil, continue
+		// If no row found or error is nil, continue.
 	default:
 		return 0, fmt.Errorf("SelectAddressByTxHash: %v", err)
 	}
@@ -1914,20 +1958,20 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 	addr = replacer.Replace(addr)
 	newAddr := strings.Split(addr, ",")[0]
 
-	// Check if the block time was passed
+	// Check if the block time is provided.
 	if len(blockT) > 0 {
 		blockTime = blockT[0]
 	} else {
-		// fetch the block time from the tx table
+		// Fetch the block time from the tx table.
 		err = tx.QueryRow(internal.SelectTxBlockTimeByHash, spendingTxHash).Scan(&blockTime)
 		if err != nil {
 			return 0, fmt.Errorf("SelectTxBlockTimeByHash: %v", err)
 		}
 	}
 
-	// Insert the new spending tx
+	// Insert/update the new spending tx, or retrieve ID of existing row.
 	var isFunding bool
-	sqlStmt := internal.MakeAddressRowInsertStatement(checked)
+	sqlStmt := internal.MakeAddressRowInsertStatement(checked, updateExisting)
 	err = tx.QueryRow(sqlStmt, newAddr, fundingTxHash, spendingTxHash,
 		spendingTxVinIndex, vinDbID, value, blockTime, isFunding,
 		validMainchain, txType).Scan(&rowID)
@@ -1935,12 +1979,18 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 		return 0, fmt.Errorf("InsertAddressRow: %v", err)
 	}
 
-	// Update the matchingTxHash for the funding tx output. matchingTxHash here
-	// is the hash of the funding tx.
-	res, err := tx.Exec(internal.SetAddressFundingForMatchingTxHash,
-		spendingTxHash, fundingTxHash, fundingTxVoutIndex)
+	// Update the matching tx hash for the funding tx outpoint (funding
+	// hash:index). The matching tx hash is the spending transaction.
+	// Unless updateExisting=true, only assign matching tx hash if it is still
+	// unassigned (empty string).
+	matchingStmt := internal.AssignMatchingTxHashForOutpoint
+	if updateExisting {
+		// Update matching tx hash even if it was already set.
+		matchingStmt = internal.SetAddressMatchingTxHashForOutpoint
+	}
+	res, err := tx.Exec(matchingStmt, spendingTxHash, fundingTxHash, fundingTxVoutIndex)
 	if err != nil || res == nil {
-		return 0, fmt.Errorf("SetAddressFundingForMatchingTxHash: %v", err)
+		return 0, fmt.Errorf("SetAddressMatchingTxHashForFundingTx: %v", err)
 	}
 
 	return res.RowsAffected()
@@ -1950,7 +2000,7 @@ func insertSpendingTxByPrptStmt(tx *sql.Tx, fundingTxHash string, fundingTxVoutI
 // need to get the funding (previous output) tx info, and then update the
 // corresponding row in the addresses table with the spending tx info.
 func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
-	spendingTxHash string, spendingTxVinIndex uint32, checked, isValidMainchain bool,
+	spendingTxHash string, spendingTxVinIndex uint32, checked, updateExisting, isValidMainchain bool,
 	txType int16) (int64, error) {
 	// get funding details for vin and set them in the address table
 	dbtx, err := db.Begin()
@@ -1975,8 +2025,9 @@ func SetSpendingByVinID(db *sql.DB, vinDbID uint64, spendingTxDbID uint64,
 	}
 
 	// Insert the spending tx info (addresses table) for the vin DB ID
-	N, err := insertSpendingTxByPrptStmt(dbtx, fundingTxHash, fundingTxVoutIndex,
-		tree, spendingTxHash, spendingTxVinIndex, vinDbID, checked, isValidMainchain, txType)
+	N, err := insertAddrSpendingTxUpdateMatchedFunding(dbtx, fundingTxHash, fundingTxVoutIndex,
+		tree, spendingTxHash, spendingTxVinIndex, vinDbID, checked,
+		updateExisting, isValidMainchain, txType)
 	if err != nil {
 		return 0, fmt.Errorf(`RowsAffected: %v + %v (rollback)`,
 			err, dbtx.Rollback())
@@ -2073,8 +2124,8 @@ func retrieveAgendaVoteChoices(db *sql.DB, agendaID string, byType int) (*dbtype
 
 // --- transactions table ---
 
-func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked bool) (uint64, error) {
-	insertStatement := internal.MakeTxInsertStatement(checked)
+func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked, updateExistingRecords bool) (uint64, error) {
+	insertStatement := internal.MakeTxInsertStatement(checked, updateExistingRecords)
 	var id uint64
 	err := db.QueryRow(insertStatement,
 		dbTx.BlockHash, dbTx.BlockHeight, dbTx.BlockTime, dbTx.Time,
@@ -2086,13 +2137,13 @@ func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked bool) (uint64, error) {
 	return id, err
 }
 
-func InsertTxns(db *sql.DB, dbTxns []*dbtypes.Tx, checked bool) ([]uint64, error) {
+func InsertTxns(db *sql.DB, dbTxns []*dbtypes.Tx, checked, updateExistingRecords bool) ([]uint64, error) {
 	dbtx, err := db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
-	stmt, err := dbtx.Prepare(internal.MakeTxInsertStatement(checked))
+	stmt, err := dbtx.Prepare(internal.MakeTxInsertStatement(checked, updateExistingRecords))
 	if err != nil {
 		log.Errorf("Transaction INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -46,7 +46,7 @@ type explorerDataSourceLite interface {
 	GetBlockHeight(hash string) (int64, error)
 	GetBlockHash(idx int64) (string, error)
 	GetExplorerTx(txid string) *TxInfo
-	GetExplorerAddress(address string, count, offset int64) *AddressInfo
+	GetExplorerAddress(address string, count, offset int64) (*AddressInfo, error)
 	DecodeRawTransaction(txhex string) (*dcrjson.TxRawResult, error)
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -25,6 +25,7 @@ const (
 	NotFoundStatusType       statusType = "Not Found"
 	NotSupportedStatusType   statusType = "Not Supported"
 	NotImplementedStatusType statusType = "Not Implemented"
+	WrongNetworkStatusType   statusType = "Wrong Network"
 	DeprecatedStatusType     statusType = "Deprecated"
 	BlockchainSyncingType    statusType = "Blocks Syncing"
 )

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -92,7 +92,7 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 		case "Ticket":
 			if _, found := exp.MempoolData.InvStake[tx.Hash]; found {
 				exp.MempoolData.Unlock()
-				log.Debugf("Not broadcasting duplicate ticket notification: %s", hash)
+				log.Tracef("Not broadcasting duplicate ticket notification: %s", hash)
 				continue // back to waiting for new tx signal
 			}
 			exp.MempoolData.InvStake[tx.Hash] = struct{}{}
@@ -105,7 +105,7 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			// included in that update.
 			if tx.VoteInfo.Validation.Height > lastBlockHeight {
 				exp.MempoolData.Unlock()
-				log.Debug("Got a vote for a future block. Waiting to pull it "+
+				log.Trace("Got a vote for a future block. Waiting to pull it "+
 					"out of mempool with new block signal. Vote: ", tx.Hash)
 				continue
 			}
@@ -113,7 +113,7 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			// Maintain the list of unique stake txns encountered.
 			if _, found := exp.MempoolData.InvStake[tx.Hash]; found {
 				exp.MempoolData.Unlock()
-				log.Debugf("Not broadcasting duplicate vote notification: %s", hash)
+				log.Tracef("Not broadcasting duplicate vote notification: %s", hash)
 				continue // back to waiting for new tx signal
 			}
 			exp.MempoolData.InvStake[tx.Hash] = struct{}{}
@@ -133,7 +133,7 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			// Maintain the list of unique regular txns encountered.
 			if _, found := exp.MempoolData.InvRegular[tx.Hash]; found {
 				exp.MempoolData.Unlock()
-				log.Debugf("Not broadcasting duplicate txns notification: %s", hash)
+				log.Tracef("Not broadcasting duplicate txns notification: %s", hash)
 				continue // back to waiting for new tx signal
 			}
 			exp.MempoolData.InvRegular[tx.Hash] = struct{}{}
@@ -143,7 +143,7 @@ func (exp *explorerUI) mempoolMonitor(txChan chan *NewMempoolTx) {
 			// Maintain the list of unique stake txns encountered.
 			if _, found := exp.MempoolData.InvStake[tx.Hash]; found {
 				exp.MempoolData.Unlock()
-				log.Debugf("Not broadcasting duplicate revocation notification: %s", hash)
+				log.Tracef("Not broadcasting duplicate revocation notification: %s", hash)
 				continue // back to waiting for new tx signal
 			}
 			exp.MempoolData.InvStake[tx.Hash] = struct{}{}

--- a/main.go
+++ b/main.go
@@ -640,8 +640,11 @@ func mainCore() error {
 		// to get ticket pool info.
 
 		// Collect and store data for each side chain.
-		log.Infof("Importing %d blocks from %d side chains...",
+		log.Infof("Importing %d new block(s) from %d known side chains...",
 			nSideChainBlocks, nSideChains)
+		// Disable recomputing project fund balance, and clearing address
+		// balance and counts cache.
+		auxDB.InBatchSync = true
 		var sideChainsStored, sideChainBlocksStored int
 		for _, sideChain := range sideChainBlocksToStore {
 			// Process this side chain only if there are blocks in it that need
@@ -711,6 +714,7 @@ func mainCore() error {
 				sideChainBlocksStored++
 			}
 		}
+		auxDB.InBatchSync = false
 		log.Infof("Successfully added %d blocks from %d side chains into dcrpg DB.",
 			sideChainBlocksStored, sideChainsStored)
 	}

--- a/main.go
+++ b/main.go
@@ -679,20 +679,22 @@ func mainCore() error {
 				}
 
 				// SQLite / base DB
-				log.Debugf("Importing block %s (height %d) into base DB.",
-					blockHash, msgBlock.Header.Height)
+				// TODO: Make hash the primary key instead of height, otherwise
+				// the main chain block will be overwritten.
+				// log.Debugf("Importing block %s (height %d) into base DB.",
+				// 	blockHash, msgBlock.Header.Height)
 
-				blockDataSummary, stakeInfoSummaryExtended := collector.CollectAPITypes(blockHash)
-				if blockDataSummary == nil || stakeInfoSummaryExtended == nil {
-					log.Error("Failed to collect data for reorg.")
-					continue
-				}
-				if err = baseDB.StoreBlockSummary(blockDataSummary); err != nil {
-					log.Errorf("Failed to store block summary data: %v", err)
-				}
-				if err = baseDB.StoreStakeInfoExtended(stakeInfoSummaryExtended); err != nil {
-					log.Errorf("Failed to store stake info data: %v", err)
-				}
+				// blockDataSummary, stakeInfoSummaryExtended := collector.CollectAPITypes(blockHash)
+				// if blockDataSummary == nil || stakeInfoSummaryExtended == nil {
+				// 	log.Error("Failed to collect data for reorg.")
+				// 	continue
+				// }
+				// if err = baseDB.StoreBlockSummary(blockDataSummary); err != nil {
+				// 	log.Errorf("Failed to store block summary data: %v", err)
+				// }
+				// if err = baseDB.StoreStakeInfoExtended(stakeInfoSummaryExtended); err != nil {
+				// 	log.Errorf("Failed to store stake info data: %v", err)
+				// }
 
 				// PostgreSQL / aux DB
 				log.Debugf("Importing block %s (height %d) into aux DB.",

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -277,7 +277,10 @@ func sideChainTips(allTips []dcrjson.GetChainTipsResult) (sideTips []dcrjson.Get
 }
 
 // SideChainFull gets all of the blocks in the side chain with the specified tip
-// block hash. The last block is not mainchain, but it's previous block is.
+// block hash. The first block in the slice is the lowest height block in the
+// side chain, and its previous block is the main/side common ancestor, which is
+// not included in the slice since it is main chain. The last block in the slice
+// is thus the side chain tip.
 func SideChainFull(client *rpcclient.Client, tipHash string) ([]string, error) {
 	// Do not assume specified tip hash is even side chain.
 	var sideChain []string


### PR DESCRIPTION
These changes focus on dcrpg and correcting the side chain import process.  However, there is a considerable amount of added documentation, and tangential refactoring that supports these changes.

An key change is support for 3 different insert statements in several tables:
1. Insert without checking for constraint conflicts.  This can result in a constraint violation error, and is intended to be used during initial sync (before creation of the unique indexes).
2. Upsert (insert or update existing).  If there is a constraint conflict, this is considered an existing record, which will be updated with the upsert statement.  The updates columns are generally sidechain/valid flags, or other data that may change for side chains.
3. Insert or do nothing on conflict.  If there is no constraint conflict, the new record is inserted, otherwise there is no insert or update.  This statement will still return the row id of the conflicting record.

To support the 3 insert strategies where appropriate, the `MakeXInsertStatement` functions (e.g. `MakeAddressRowInsertStatement`) are modified with a flag to indicate how to handle conflicts (upsert or do nothing).

`ChainDB`'s `StoreBlock` and `storeTxns` functions will take one of the strategies depending on where and how they are called:
a. Initial start-up sync (before index creation): The insert without checks strategy (1) is used.
b. Start-up sync (with existing indexes): The upsert strategy (2) is used.
c. Regular block storage in response to new block notifications from dcrd: The upsert strategy (2) is used.
d. Side chain block insertion: The insert or do nothing strategy (3) is used.
e. Reorganization, when side chain is moved to main chain (switchToSideChain): The upsert strategy (2) is used since these are changing to main chain blocks.  Moving the old main chain to side chain (TipToSideChain) does not use StoreBlock, instead updating flags without performing insertions.

The **insert or do nothing strategy** (3) is necessary for side chain block insertion because when side chain blocks are imported and stored, dcrdata has synchronized with dcrd's best block, and the imported blocks may already have main chain entries.  These main chain entries should not be modified (e.g. vins and addresses table rows have is_mainchain flags that indicate if the record exists in a main chain block).

A major fixed issue for the import side chain operation is that after side chain import, which can take a few minutes, there was not a final check for new blocks prior to starting notification monitors. This resulted in missed blocks, and inconsistencies in the ticket pool. The introduction of the `ensureSync` closure, and calling it after indexing and again after importing side blocks (right before staring ntfn handlers) ensures dcrdata is in sync with the node before beginning normal operation.

Other related fixes:
- Fix MissingSideChainBlocks to start at lowest block in side chain, and count up to the tip. Document the expected order in rpcutils.SideChainFull.
- Fix InsertVotes to always close both prepared statements and rollback on an error.
- Return an error from GetExplorerAddress so errors can be handled according to context (e.g. when called from Search, it is not appropriate to log most errors and failures to find addresses since the search string can be garbage from the user).
- Only after storing a block received in response to a notification will the project fund update be run asynchronously.  In SyncChainDB, run the project fund update after the last block is stored, but do it
synchronously so it does not interfere with subsequent start-up operations such as importing side chain blocks.

NOTE: Blocks from imported side chains are not added to SQLite since the tables use height as primary key (should be hash) and they do not even have flags for is_mainchain or is_valid.  This should be addressed in a future release.