### PR TITLE
dcrpg: major optimization with pool status update

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -119,6 +119,10 @@ const (
 		JOIN block_chain ON this_hash=hash
 		WHERE hash = $1;`
 
+	SelectBlockFlags = `SELECT is_valid, is_mainchain
+		FROM blocks
+		WHERE hash = $1;`
+
 	SelectDisapprovedBlocks = `SELECT is_mainchain, height, previous_hash, hash, block_chain.next_hash
 		FROM blocks
 		JOIN block_chain ON this_hash=hash

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -77,6 +77,7 @@ type explorerDataSource interface {
 	SideChainBlocks() ([]*dbtypes.BlockStatus, error)
 	DisapprovedBlocks() ([]*dbtypes.BlockStatus, error)
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
+	BlockFlags(hash string) (bool, bool, error)
 	GetOldestTxBlockTime(addr string) (int64, error)
 	TicketPoolVisualization(interval dbtypes.ChartGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)


### PR DESCRIPTION
The pool status update for unspent expired and missed tickets updated
rows by matching hash.  However, the row IDs (primary keys) of these
ticket hashes are available in the TicketTxnIDGetter, the
unspentTicketCache of ChainDB.  This change uses the cache (without
expiring the entries since they may be needed if the tickets are
eventually spent via revocation) so the update does not require scanning
on the (unindexed) hash column.

The above optimization is noticable as there is no longer a significant
slowdown of the block processing further in the process.

The other optimization relates to the new check in UpdateLastBlock
that ensures the previous block is on the same chain.  This edit
replaces BlockStatus with the new BlockFlags query that does not involve
a join but only provides isValid and isMainchain.  However, for main
chain blocks, even the call to BlockStatus is skipped as there should
never be a main chain block with a side chain parent.

This is cherry picked from https://github.com/decred/dcrdata/pull/745/commits/2eae4639e000adf5623f252ba64c1e07c2925430.

The optimizations were very effective.  Full-mode block sync (excluding indexing) completed in under an hour, with the processing rate barely dropping from the starting rate:

```
[INF] PSQL: ( 86 blk/s, 1493 tx/s, 3336 vin/sec, 5455 vout/s)
[INF] PSQL: Processing blocks 284001 to 284084...
[INF] SQLT: Scanning blocks 284001 to 284084 (41012 live)...
[INF] SQLT: Rescan finished successfully at height 284084.
[INF] SQLT: resyncDBWithPoolValue completed in 57m6.225612785s  ****
[INF] DATD: SQLite sync ended at height 284084
[INF] PSQL: Avg. speed: 1469 tx/s, 5444 vout/s  ****
```

I'm going to pull this optimization commit out into a separate PR.