### PR TITLE
fix chart zoom for uninitialized charts

### DIFF
--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -222,6 +222,9 @@
         }
 
         onZoom(){
+            if (this.graph == undefined) {
+                return
+            }
             $('body').addClass('loading');
             this.graph.resetZoom();
             if (this.zoom > 0 && this.zoom < this.xVal[1]) {


### PR DESCRIPTION
bug in address.js cause the loading animation to hang when chart isn't initialized
