### PR TITLE
Format the ticketprice windows view

### DIFF
--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -256,6 +256,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			result = dateTime.Format("2006-01-02 15:04:05 MST")
 			return
 		},
+		"toLowerCase": func(a string) string {
+			return strings.ToLower(a)
+		},
 		"theme": func() string {
 			return netTheme
 		},

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -35,7 +35,7 @@
                     </select>
                 </span>
                 <span class="fs12 nowrap text-right">
-                    {{intComma (add $Offset 1)}} &mdash; {{intComma (add $Offset .Rows)}} of {{intComma (add .BestBlock 1) }} rows
+                    {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .Rows)}} of {{intComma (add .BestBlock 1) }} rows
                 </span>
                 <nav aria-label="blocks navigation" data-limit="{{.Rows}}" class="ml-2">
                     <ul class="pagination mb-0 pagination-sm">

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -81,8 +81,8 @@
                 <table class="table striped table-responsive">
                     <thead>
                         <tr>
-                            <th>Ticket Price Window #</th>
-                            <th>End Block</th>
+                            <th class="text-right">Ticket Price Window #</th>
+                            <th class="text-right">End Block</th>
                             <th class="text-right">Transactions</th>
                             <th class="text-right">Votes</th>
                             <th class="text-right">Tickets</th>
@@ -97,12 +97,12 @@
                     <tbody>
                     {{range .Data}}
                         <tr id="{{.EndBlock}}">
-                            <td>
-                                <span>{{.WindowIndx}}</span>
+                            <td class="text-right">
                                 {{$blocksCount := (.BlocksCount)}}
                                 {{if lt .BlocksCount $.WindowSize}}{{$blocksCount = (subtract .BlocksCount 1)}} <span>({{$blocksCount}}/{{$.WindowSize}}) </span>{{end}}
+                                <span>{{.WindowIndx}}</span>
                             </td>
-                            <td>
+                            <td class="text-right">
                                 <a class="fs16 height" href="/blocks?height={{.EndBlock}}&rows=20">{{.EndBlock}}</a>
                             </td>
                             <td class="text-right">{{intComma .Transactions}}</td>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -6,7 +6,7 @@
 <body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="main">
-        <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks or on {{.NetName}} (~12 hours).</h6>
+        <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>
         {{$pendingWindows := 0}}
         {{if gt (int64 (len .Data)) 0}}{{$pendingWindows = (int64 (index .Data 0).WindowIndx)}}{{end}}
 
@@ -35,7 +35,7 @@
                     </select>
                 </span>
                 <span class="fs12 nowrap text-right">
-                    {{intComma (add .OffsetWindow 1)}} &mdash; {{intComma $oldest}} of {{ intComma $lastWindow }} rows
+                    {{intComma (add .OffsetWindow 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastWindow }} rows
                 </span>
                 <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="ml-2">
                     <ul class="pagination mb-0 pagination-sm">
@@ -83,14 +83,14 @@
                         <tr>
                             <th>Ticket Price Window #</th>
                             <th>End Block</th>
-                            <th>Transactions</th>
-                            <th>Votes</th>
-                            <th>Tickets</th>
-                            <th>Revocations</th>
+                            <th class="text-right">Transactions</th>
+                            <th class="text-right">Votes</th>
+                            <th class="text-right">Tickets</th>
+                            <th class="text-right">Revocations</th>
                             <th>Total Size</th>
-                            <th>Difficulty</th>
-                            <th>Ticket Price (DCR)</th>
-                            <th>Age</th>
+                            <th class="text-right">Difficulty</th>
+                            <th class="text-right">Ticket Price (DCR)</th>
+                            <th class="text-right">Age</th>
                             <th>Start Time ({{timezone}})</th>
                         </tr>
                     </thead>
@@ -105,14 +105,18 @@
                             <td>
                                 <a class="fs16 height" href="/blocks?height={{.EndBlock}}&rows=20">{{.EndBlock}}</a>
                             </td>
-                            <td>{{.Transactions}}</td>
-                            <td>{{.Voters}}</td>
-                            <td>{{.FreshStake}}</td>
-                            <td>{{.Revocations}}</td>
+                            <td class="text-right">{{intComma .Transactions}}</td>
+                            <td class="text-right">{{intComma .Voters}}</td>
+                            <td class="text-right">{{intComma .FreshStake}}</td>
+                            <td class="text-right">{{intComma .Revocations}}</td>
                             <td>{{.FormattedSize}}</td>
-                            <td>{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
-                            <td>{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .TicketPrice) 2 false)}}</td>
-                            <td data-target="main.age" data-age="{{.StartTime}}"></td>
+                            <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
+                            <td class="text-right">
+                                <span class="rm-spacing-tb lh15rem">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .TicketPrice) 2 false)}}
+                                </span>
+                            </td>
+                            <td class="text-right" data-target="main.age" data-age="{{.StartTime}}"></td>
                             <td>{{.FormattedTime}}</td>
                         </tr>
                     {{end}}


### PR DESCRIPTION
Formats the Tickets Price Windows list view to have:
- All columns with numerals and Age to be right aligned
- Fixes typo in the ticket price windows description.
- Add a thousand comma seperator on all aggregate values

#763 

![screenshot from 2018-10-26 19-23-16](https://user-images.githubusercontent.com/22055953/47579744-857fe880-d955-11e8-8bc6-31d607b2e833.png)
