### PR TITLE
Show Tx Type in the address page's tx table

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -77,7 +77,7 @@ const (
 	// SelectFundingTxsByTx      = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1;`
 	// SelectFundingTxByTxIn     = `SELECT id, prev_tx_hash FROM vins WHERE tx_hash=$1 AND tx_index=$2;`
 
-	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, valid_mainchain,
+	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, tx_type, valid_mainchain,
 		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
 
 	SelectAddressAllByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses WHERE address=$1 ORDER BY block_time DESC;`

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1255,7 +1255,7 @@ func scanAddressQueryRows(rows *sql.Rows) (ids []uint64, addressRows []*dbtypes.
 		var txHash sql.NullString
 		var blockTime, txVinIndex, vinDbID sql.NullInt64
 		// Scan values in order of columns listed in internal.addrsColumnNames
-		err = rows.Scan(&id, &addr.Address, &addr.MatchingTxHash, &txHash,
+		err = rows.Scan(&id, &addr.Address, &addr.MatchingTxHash, &txHash, &addr.TxType,
 			&addr.ValidMainChain, &txVinIndex, &blockTime, &vinDbID,
 			&addr.Value, &addr.IsFunding)
 		if err != nil {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1025,6 +1025,13 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	tx.FormattedTime = t.Format("2006-01-02 15:04:05")
 	tx.Confirmations = data.Confirmations
 
+	msgTx, err := txhelpers.MsgTxFromHex(data.Hex)
+	if err == nil {
+		tx.TxType = txhelpers.DetermineTxTypeString(msgTx)
+	}else{
+		log.Trace("makeExplorerAddressTx cannot get tx type", err)
+	}
+
 	for i := range data.Vin {
 		if data.Vin[i].PrevOut != nil && len(data.Vin[i].PrevOut.Addresses) > 0 {
 			if data.Vin[i].PrevOut.Addresses[0] == address {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1028,7 +1028,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	msgTx, err := txhelpers.MsgTxFromHex(data.Hex)
 	if err == nil {
 		tx.TxType = txhelpers.DetermineTxTypeString(msgTx)
-	}else{
+	} else {
 		log.Trace("makeExplorerAddressTx cannot get tx type", err)
 	}
 

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1029,7 +1029,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	if err == nil {
 		tx.TxType = txhelpers.DetermineTxTypeString(msgTx)
 	} else {
-		log.Trace("makeExplorerAddressTx cannot get tx type", err)
+		log.Warn("makeExplorerAddressTx cannot get tx type", err)
 	}
 
 	for i := range data.Vin {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -65,6 +65,7 @@ type TxBasic struct {
 // AddressTx models data for transactions on the address page
 type AddressTx struct {
 	TxID           string
+	TxType         string
 	InOutID        uint32
 	Size           uint32
 	FormattedSize  string
@@ -412,6 +413,13 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 			TxID:      addrOut.TxHash,
 			MatchedTx: addrOut.MatchingTxHash,
 			IsFunding: addrOut.IsFunding,
+		}
+
+		if tx.TxType == "" {
+			msgTx, err := txhelpers.MsgTxFromHex(addrOut.TxHash)
+			if err == nil {
+				tx.TxType = txhelpers.DetermineTxTypeString(msgTx)
+			}
 		}
 
 		if addrOut.IsFunding {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -411,15 +411,9 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 			BlockTime: addrOut.TxBlockTime,
 			InOutID:   addrOut.TxVinVoutIndex,
 			TxID:      addrOut.TxHash,
+			TxType:    txhelpers.TxTypeToString(int(addrOut.TxType)),
 			MatchedTx: addrOut.MatchingTxHash,
 			IsFunding: addrOut.IsFunding,
-		}
-
-		if tx.TxType == "" {
-			msgTx, err := txhelpers.MsgTxFromHex(addrOut.TxHash)
-			if err == nil {
-				tx.TxType = txhelpers.DetermineTxTypeString(msgTx)
-			}
 		}
 
 		if addrOut.IsFunding {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -207,6 +207,7 @@
                     {{if .Transactions}}
                     <table class="table table-mono-cells table-sm striped" style="width: 100%;">
                         <thead>
+                            <th>Tx Type</th>
                             <th>Input/Output ID</th>
                             {{if eq $txType "merged_debit"}}
                                 <th># of Input(s)</th>
@@ -227,6 +228,7 @@
                             {{range $i, $v := .Transactions}}
                             <tr>
                                 {{with $v}}
+                                <td>{{.TxType}}</td>
                                 <td><a href="/tx/{{.TxID}}/{{if .IsFunding}}out{{else}}in{{end}}/{{.InOutID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
                                 {{if eq $txType "merged_debit"}}
                                     <td class="text-right">{{.MergedTxnCount}}</td>


### PR DESCRIPTION
Resolution of issue https://github.com/decred/dcrdata/issues/741

Added `TxType` to the `AddressTx` struct, set it for both lite and full mode and displayed it in the on the tx table in the address page.