### PR TITLE
SQLite structure and routines updated for orphaned blocks

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -48,7 +48,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
-			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
 				rt.Get("/count", app.getBlockTransactionsCount)
@@ -63,7 +63,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
-			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Get("/pos", app.getBlockStakeInfoExtendedByHash)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
 				rt.Get("/count", app.getBlockTransactionsCount)
@@ -78,7 +78,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
-			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
 				rt.Get("/count", app.getBlockTransactionsCount)
@@ -96,7 +96,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 				rs.Get("/size", app.getBlockRangeSteppedSize)
 			})
 			// rd.Get("/header", app.getBlockHeader)
-			// rd.Get("/pos", app.getBlockStakeInfoExtended)
+			// rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 		})
 
 		//r.With(middleware.DefaultCompress).Get("/raw", app.someLargeResponse)

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -56,7 +56,7 @@ type DataSourceLite interface {
 	GetFeeInfo(idx int) *dcrjson.FeeInfoBlock
 	//GetStakeDiffEstimate(idx int) *dcrjson.EstimateStakeDiffResult
 	GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended
-	//needs db update: GetStakeInfoExtendedByHash(hash string) *apitypes.StakeInfoExtended
+	GetStakeInfoExtendedByHash(hash string) *apitypes.StakeInfoExtended
 	GetStakeDiffEstimates() *apitypes.StakeDiff
 	//GetBestBlock() *blockdata.BlockData
 	GetSummary(idx int) *apitypes.BlockDataBasic
@@ -731,15 +731,21 @@ func (c *appContext) getBlockFeeInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *appContext) getBlockStakeInfoExtended(w http.ResponseWriter, r *http.Request) {
-	idx := c.getBlockHeightCtx(r)
-	if idx < 0 {
+	hash := c.getBlockHashCtx(r)
+	if hash == "" {
 		http.Error(w, http.StatusText(422), 422)
 		return
 	}
 
-	stakeinfo := c.BlockData.GetStakeInfoExtended(int(idx))
+	// idx := c.getBlockHeightCtx(r)
+	// if idx < 0 {
+	// 	http.Error(w, http.StatusText(422), 422)
+	// 	return
+	// }
+
+	stakeinfo := c.BlockData.GetStakeInfoExtendedByHash(hash)
 	if stakeinfo == nil {
-		apiLog.Errorf("Unable to get block %d fee info", idx)
+		apiLog.Errorf("Unable to get block fee info for %s", hash)
 		http.Error(w, http.StatusText(422), 422)
 		return
 	}

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -369,6 +369,7 @@ type StakeDiff struct {
 
 // StakeInfoExtended models data about the fee, pool and stake difficulty
 type StakeInfoExtended struct {
+	Hash             string               `json:"hash"`
 	Feeinfo          dcrjson.FeeInfoBlock `json:"feeinfo"`
 	StakeDiff        float64              `json:"stakediff"`
 	PriceWindowNum   int                  `json:"window_number"`
@@ -387,6 +388,7 @@ func NewStakeInfoExtended() *StakeInfoExtended {
 // StakeInfoExtendedEstimates is similar to StakeInfoExtended but includes stake
 // difficulty estimates with the stake difficulty
 type StakeInfoExtendedEstimates struct {
+	Hash             string               `json:"hash"`
 	Feeinfo          dcrjson.FeeInfoBlock `json:"feeinfo"`
 	StakeDiff        StakeDiff            `json:"stakediff"`
 	PriceWindowNum   int                  `json:"window_number"`

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -39,6 +39,7 @@ type BlockData struct {
 // blockdata
 func (b *BlockData) ToStakeInfoExtended() apitypes.StakeInfoExtended {
 	return apitypes.StakeInfoExtended{
+		Hash:             b.Header.Hash,
 		Feeinfo:          b.FeeInfo,
 		StakeDiff:        b.CurrentStakeDiff.CurrentStakeDifficulty,
 		PriceWindowNum:   b.PriceWindowNum,
@@ -51,6 +52,7 @@ func (b *BlockData) ToStakeInfoExtended() apitypes.StakeInfoExtended {
 // object from the blockdata
 func (b *BlockData) ToStakeInfoExtendedEstimates() apitypes.StakeInfoExtendedEstimates {
 	return apitypes.StakeInfoExtendedEstimates{
+		Hash:    b.Header.Hash,
 		Feeinfo: b.FeeInfo,
 		StakeDiff: apitypes.StakeDiff{
 			GetStakeDifficultyResult: b.CurrentStakeDiff,
@@ -125,6 +127,7 @@ func (t *Collector) CollectAPITypes(hash *chainhash.Hash) (*apitypes.BlockDataBa
 	winSize := t.netParams.StakeDiffWindowSize
 
 	stakeInfoExtended := &apitypes.StakeInfoExtended{
+		Hash:             blockDataBasic.Hash,
 		Feeinfo:          *feeInfoBlock,
 		StakeDiff:        blockDataBasic.StakeDiff,
 		PriceWindowNum:   int(height / winSize),

--- a/blockmemdb.go
+++ b/blockmemdb.go
@@ -121,8 +121,8 @@ func (s *BlockDataToMemdb) GetStakeDiffEstimate(idx int) *dcrjson.EstimateStakeD
 	return &blockdata.EstStakeDiff
 }
 
-// GetStakeInfoExtended returns the stake info for block idx
-func (s *BlockDataToMemdb) GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended {
+// GetStakeInfoExtendedByHeight returns the stake info for block idx
+func (s *BlockDataToMemdb) GetStakeInfoExtendedByHeight(idx int) *apitypes.StakeInfoExtended {
 	if idx < 0 {
 		return nil
 	}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -631,7 +631,7 @@ func (db *wiredDB) GetFeeInfo(idx int) *dcrjson.FeeInfoBlock {
 	return &stakeInfo.Feeinfo
 }
 
-func (db *wiredDB) GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended {
+func (db *wiredDB) GetStakeInfoExtendedByHeight(idx int) *apitypes.StakeInfoExtended {
 	stakeInfo, err := db.RetrieveStakeInfoExtended(int64(idx))
 	if err != nil {
 		log.Errorf("Unable to retrieve stake info: %v", err)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -641,6 +641,16 @@ func (db *wiredDB) GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended {
 	return stakeInfo
 }
 
+func (db *wiredDB) GetStakeInfoExtendedByHash(blockhash string) *apitypes.StakeInfoExtended {
+	stakeInfo, err := db.RetrieveStakeInfoExtendedByHash(blockhash)
+	if err != nil {
+		log.Errorf("Unable to retrieve stake info: %v", err)
+		return nil
+	}
+
+	return stakeInfo
+}
+
 func (db *wiredDB) GetSummary(idx int) *apitypes.BlockDataBasic {
 	blockSummary, err := db.RetrieveBlockSummary(int64(idx))
 	if err != nil {

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -1180,7 +1180,7 @@ func (db *DB) JustifyTableStructures(dbInfo *DBInfo) error {
 	}
 
 	// Clean up the file a little bit
-	_, err = db.Query("VACUUM;")
+	_, err = db.Exec("VACUUM;")
 	if err != nil {
 		log.Error("Failed to VACUUM SQLite database.")
 	}

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/v3/api/types"
 	"github.com/decred/dcrdata/v3/blockdata"
@@ -42,6 +43,9 @@ const (
 	TableNameSummaries = "dcrdata_block_summary"
 	// TableNameStakeInfo is name of the table used to store extended stake info
 	TableNameStakeInfo = "dcrdata_stakeinfo_extended"
+	// A couple database queries that are called before NewWiredDB
+	SetCacheSizeSQL       = "PRAGMA cache_size = 32768;"
+	SetSynchrounousOffSQL = "pragma synchronous = OFF;"
 )
 
 // DB is a wrapper around sql.DB that adds methods for storing and retrieving
@@ -63,11 +67,16 @@ type DB struct {
 	getBlockHashSQL, getBlockHeightSQL                           string
 	getBlockSizeRangeSQL                                         string
 	getBestBlockHashSQL, getBestBlockHeightSQL                   string
-	getLatestStakeInfoExtendedSQL                                string
+	getLatestStakeInfoExtendedSQL, getHighestStakeHeight         string
 	getStakeInfoExtendedSQL, insertStakeInfoExtendedSQL          string
-	getStakeInfoWinnersSQL                                       string
+	getStakeInfoExtendedByHashSQL                                string
+	getStakeInfoWinnersSQL, getStakeInfoWinnersByHashSQL         string
 	getAllPoolValSize                                            string
 	getAllFeeInfoPerBlock                                        string
+	rawCreateBlockSummaryStmt, rawCreateStakeInfoExtendedStmt    string
+	getBlockSummaryTableInfo, getStakeInfoExtendedTableInfo      string
+	getMainchainStatusSQL, invalidateBlockSQL                    string
+	setHeightToSideChainSQL                                      string
 	// returns difficulty in 24hrs or immediately after 24hrs.
 	getDifficulty string
 }
@@ -84,21 +93,21 @@ func NewDB(db *sql.DB) (*DB, error) {
 
 	// Ticket pool queries
 	d.getPoolSQL = fmt.Sprintf(`SELECT hash, poolsize, poolval, poolavg, winners`+
-		` FROM %s WHERE height = ?`, TableNameSummaries)
+		` FROM %s WHERE height = ? AND is_mainchain = 1`, TableNameSummaries)
 	d.getPoolByHashSQL = fmt.Sprintf(`SELECT height, poolsize, poolval, poolavg, winners`+
 		` FROM %s WHERE hash = ?`, TableNameSummaries)
 	d.getPoolRangeSQL = fmt.Sprintf(`SELECT height, hash, poolsize, poolval, poolavg, winners `+
-		`FROM %s WHERE height BETWEEN ? AND ?`, TableNameSummaries)
+		`FROM %s WHERE height BETWEEN ? AND ? AND is_mainchain = 1`, TableNameSummaries)
 	d.getPoolValSizeRangeSQL = fmt.Sprintf(`SELECT poolsize, poolval `+
-		`FROM %s WHERE height BETWEEN ? AND ?`, TableNameSummaries)
+		`FROM %s WHERE height BETWEEN ? AND ? AND is_mainchain = 1`, TableNameSummaries)
 	d.getAllPoolValSize = fmt.Sprintf(`SELECT distinct poolsize, poolval, time `+
-		`FROM %s ORDER BY time`, TableNameSummaries)
-	d.getWinnersSQL = fmt.Sprintf(`SELECT hash, winners FROM %s WHERE height = ?`,
+		`FROM %s WHERE is_mainchain = 1 ORDER BY time`, TableNameSummaries)
+	d.getWinnersSQL = fmt.Sprintf(`SELECT hash, winners FROM %s WHERE height = ? AND is_mainchain = 1`,
 		TableNameSummaries)
 	d.getWinnersByHashSQL = fmt.Sprintf(`SELECT height, winners FROM %s WHERE hash = ?`,
 		TableNameSummaries)
 
-	d.getSDiffSQL = fmt.Sprintf(`SELECT sdiff FROM %s WHERE height = ?`,
+	d.getSDiffSQL = fmt.Sprintf(`SELECT sdiff FROM %s WHERE height = ? AND is_mainchain = 1`,
 		TableNameSummaries)
 	d.getDifficulty = fmt.Sprintf(`SELECT diff FROM %s WHERE time >= ? ORDER BY time LIMIT 1`,
 		TableNameSummaries)
@@ -106,44 +115,64 @@ func NewDB(db *sql.DB) (*DB, error) {
 		TableNameSummaries)
 
 	// Block queries
-	d.getBlockSQL = fmt.Sprintf(`SELECT * FROM %s WHERE height = ?`, TableNameSummaries)
+	d.getBlockSQL = fmt.Sprintf(`SELECT * FROM %s WHERE height = ? AND is_mainchain = 1`, TableNameSummaries)
 	d.getBlockByHashSQL = fmt.Sprintf(`SELECT * FROM %s WHERE hash = ?`, TableNameSummaries)
 	d.getLatestBlockSQL = fmt.Sprintf(`SELECT * FROM %s ORDER BY height DESC LIMIT 0, 1`,
 		TableNameSummaries)
 	d.insertBlockSQL = fmt.Sprintf(`
         INSERT OR REPLACE INTO %s(
-            height, size, hash, diff, sdiff, time, poolsize, poolval, poolavg, winners
-        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            hash, height, size, diff, sdiff, time, poolsize, poolval, poolavg, winners, is_mainchain, is_valid
+        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, TableNameSummaries)
 
-	d.getBlockSizeRangeSQL = fmt.Sprintf(`SELECT size FROM %s WHERE height BETWEEN ? AND ?`,
+	d.getBlockSizeRangeSQL = fmt.Sprintf(`SELECT size FROM %s WHERE is_mainchain = 1 AND height BETWEEN ? AND ?`,
 		TableNameSummaries)
-	d.getBlockByTimeRangeSQL = fmt.Sprintf(`SELECT * FROM %s WHERE time BETWEEN ? AND ? ORDER BY time LIMIT ?`,
+	d.getBlockByTimeRangeSQL = fmt.Sprintf(`SELECT * FROM %s WHERE is_mainchain = 1 AND time BETWEEN ? AND ? ORDER BY time LIMIT ?`,
 		TableNameSummaries)
 	d.getBlockByTimeSQL = fmt.Sprintf(`SELECT * FROM %s WHERE time = ?`,
 		TableNameSummaries)
 
-	d.getBestBlockHashSQL = fmt.Sprintf(`SELECT hash FROM %s ORDER BY height DESC LIMIT 0, 1`, TableNameSummaries)
+	d.getBestBlockHashSQL = fmt.Sprintf(`SELECT hash FROM %s WHERE is_mainchain = 1 ORDER BY height DESC LIMIT 0, 1`, TableNameSummaries)
 	d.getBestBlockHeightSQL = fmt.Sprintf(`SELECT height FROM %s ORDER BY height DESC LIMIT 0, 1`, TableNameSummaries)
 
-	d.getBlockHashSQL = fmt.Sprintf(`SELECT hash FROM %s WHERE height = ?`, TableNameSummaries)
-	d.getBlockHeightSQL = fmt.Sprintf(`SELECT height FROM %s WHERE hash = ?`, TableNameSummaries)
+	d.getBlockHashSQL = fmt.Sprintf(`SELECT hash FROM %s WHERE height = ? AND is_mainchain = 1`, TableNameSummaries)
+	d.getBlockHeightSQL = fmt.Sprintf(`SELECT height FROM %s WHERE hash = ? AND is_mainchain = 1`, TableNameSummaries)
+	d.getMainchainStatusSQL = fmt.Sprintf(`SELECT is_mainchain FROM %s WHERE hash = ?`, TableNameSummaries)
+	d.invalidateBlockSQL = fmt.Sprintf(`UPDATE %s SET is_valid = 0 WHERE hash = ?`, TableNameSummaries)
+	d.setHeightToSideChainSQL = fmt.Sprintf(`UPDATE %s SET is_mainchain = 0 where height = ?`, TableNameSummaries)
 
 	// Stake info queries
-	d.getStakeInfoExtendedSQL = fmt.Sprintf(`SELECT * FROM %s WHERE height = ?`,
+	d.getStakeInfoExtendedSQL = fmt.Sprintf(`SELECT %[1]s.* FROM %[1]s JOIN %[2]s ON %[1]s.hash = %[2]s.hash WHERE %[2]s.is_mainchain = 1 AND %[1]s.height = ?`,
+		TableNameStakeInfo, TableNameSummaries)
+	d.getStakeInfoExtendedByHashSQL = fmt.Sprintf(`SELECT * FROM %s WHERE hash = ?`,
 		TableNameStakeInfo)
-	d.getStakeInfoWinnersSQL = fmt.Sprintf(`SELECT winners FROM %s WHERE height = ?`,
-		TableNameStakeInfo)
+	d.getStakeInfoWinnersSQL = fmt.Sprintf(`SELECT %[1]s.winners FROM %[1]s JOIN %[2]s ON %[1]s.hash = %[2]s.hash WHERE %[1]s.height = ?`,
+		TableNameStakeInfo, TableNameSummaries)
+	d.getStakeInfoWinnersByHashSQL = fmt.Sprintf(`SELECT %[1]s.winners FROM %[1]s JOIN %[2]s ON %[1]s.hash = %[2]s.hash WHERE %[1]s.hash = ?`,
+		TableNameStakeInfo, TableNameSummaries)
+
+	// &si.Feeinfo.Height, &si.Feeinfo.Number, &si.Feeinfo.Min,
+	// &si.Feeinfo.Max, &si.Feeinfo.Mean,
+	// &si.Feeinfo.Median, &si.Feeinfo.StdDev,
+	// &si.StakeDiff, // no next or estimates
+	// &si.PriceWindowNum, &si.IdxBlockInWindow, &si.PoolInfo.Size,
+	// &si.PoolInfo.Value, &si.PoolInfo.ValAvg, &winners
+
 	d.getLatestStakeInfoExtendedSQL = fmt.Sprintf(
-		`SELECT * FROM %s ORDER BY height DESC LIMIT 0, 1`, TableNameStakeInfo)
+		`SELECT %[1]s.* FROM %[1]s JOIN %[2]s ON %[1]s.hash = %[2]s.hash WHERE %[2]s.is_mainchain = 1 ORDER BY %[1]s.height DESC LIMIT 0, 1`, TableNameStakeInfo, TableNameSummaries)
+	d.getHighestStakeHeight = fmt.Sprintf(
+		`SELECT height FROM %s ORDER BY height DESC LIMIT 0, 1`, TableNameStakeInfo)
 	d.insertStakeInfoExtendedSQL = fmt.Sprintf(`
         INSERT OR REPLACE INTO %s(
-            height, num_tickets, fee_min, fee_max, fee_mean, fee_med, fee_std,
+            hash, height, num_tickets, fee_min, fee_max, fee_mean, fee_med, fee_std,
 			sdiff, window_num, window_ind, pool_size, pool_val, pool_valavg, winners
-        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, TableNameStakeInfo)
 
-	d.getAllFeeInfoPerBlock = fmt.Sprintf(`SELECT distinct height, fee_med FROM %s ORDER BY height;`, TableNameStakeInfo)
+	d.getAllFeeInfoPerBlock = fmt.Sprintf(`SELECT distinct %[1]s.height, fee_med FROM %[1]s JOIN %[2]s ON %[1]s.hash = %[2]s.hash ORDER BY %[1]s.height;`, TableNameStakeInfo, TableNameSummaries)
+
+	d.getBlockSummaryTableInfo = fmt.Sprintf(`PRAGMA table_info(%s);`, TableNameSummaries)
+	d.getStakeInfoExtendedTableInfo = fmt.Sprintf(`PRAGMA table_info(%s);`, TableNameStakeInfo)
 
 	var err error
 	if d.dbSummaryHeight, err = d.GetBlockSummaryHeight(); err != nil {
@@ -176,22 +205,36 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 		return nil, err
 	}
 
-	createBlockSummaryStmt := fmt.Sprintf(`
-        PRAGMA cache_size = 32768;
-        pragma synchronous = OFF;
+	// These are db-wide settings
+	_, err = db.Exec(SetCacheSizeSQL)
+	if err != nil {
+		log.Error("Error setting SQLite Cache size")
+		return nil, err
+	}
+	_, err = db.Exec(SetSynchrounousOffSQL)
+	if err != nil {
+		log.Error("Error setting SQLite synchrounous off")
+		return nil, err
+	}
+
+	rawCreateBlockSummaryStmt := `
         create table if not exists %s(
-            height INTEGER PRIMARY KEY,
+						hash TEXT PRIMARY KEY,
+            height INTEGER,
             size INTEGER,
-            hash TEXT,
             diff FLOAT,
             sdiff FLOAT,
             time INTEGER,
             poolsize INTEGER,
             poolval FLOAT,
 			poolavg FLOAT,
-			winners TEXT
+			winners TEXT,
+			is_mainchain BOOL,
+			is_valid BOOL
         );
-        `, TableNameSummaries)
+        `
+
+	createBlockSummaryStmt := fmt.Sprintf(rawCreateBlockSummaryStmt, TableNameSummaries)
 
 	_, err = db.Exec(createBlockSummaryStmt)
 	if err != nil {
@@ -199,11 +242,10 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 		return nil, err
 	}
 
-	createStakeInfoExtendedStmt := fmt.Sprintf(`
-        PRAGMA cache_size = 32768;
-        pragma synchronous = OFF;
+	rawCreateStakeInfoExtendedStmt := `
         create table if not exists %s(
-            height INTEGER PRIMARY KEY,
+						hash TEXT PRIMARY KEY,
+            height INTEGER,
             num_tickets INTEGER,
             fee_min FLOAT, fee_max FLOAT, fee_mean FLOAT,
 			fee_med FLOAT, fee_std FLOAT,
@@ -211,7 +253,9 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 			pool_size INTEGER, pool_val FLOAT, pool_valavg FLOAT,
 			winners TEXT
         );
-        `, TableNameStakeInfo)
+        `
+
+	createStakeInfoExtendedStmt := fmt.Sprintf(rawCreateStakeInfoExtendedStmt, TableNameStakeInfo)
 
 	_, err = db.Exec(createStakeInfoExtendedStmt)
 	if err != nil {
@@ -224,6 +268,18 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 	}
 
 	dataBase, err := NewDB(db)
+	if err != nil {
+		return nil, err
+	}
+
+	// Table creation string are used in JustifyTableStructures
+	// Eventually won't be needed.
+	dataBase.rawCreateBlockSummaryStmt = rawCreateBlockSummaryStmt
+	dataBase.rawCreateStakeInfoExtendedStmt = rawCreateStakeInfoExtendedStmt
+	if err = dataBase.JustifyTableStructures(); err != nil {
+		return nil, err
+	}
+
 	return dataBase, err
 }
 
@@ -235,9 +291,45 @@ type DBDataSaver struct {
 }
 
 // Store satisfies the blockdata.BlockDataSaver interface.
-func (db *DBDataSaver) Store(data *blockdata.BlockData, _ *wire.MsgBlock) error {
+func (db *DBDataSaver) Store(data *blockdata.BlockData, msgBlock *wire.MsgBlock) error {
 	summary := data.ToBlockSummary()
-	err := db.DB.StoreBlockSummary(&summary)
+	var err error
+
+	// Store is assumed to be called with a mainchain block
+	lastIsValid := msgBlock.Header.VoteBits&1 != 0
+	if !lastIsValid {
+		// Update the is_valid flag in the blocks table.
+		// Need to check whether to invalidate previous block
+		lastBlockHash := msgBlock.Header.PrevBlock
+		log.Infof("Setting last block %s as INVALID", lastBlockHash)
+
+		// Check for genesis block
+		isSecondBlock := lastBlockHash != chainhash.Hash{}
+		if isSecondBlock {
+			var lastIsMain bool
+			lastIsMain, err = db.DB.getMainchainStatus(lastBlockHash.String())
+			if err != nil {
+				return err
+			}
+			if lastIsMain {
+				lastIsValid := msgBlock.Header.VoteBits&1 != 0
+				if !lastIsValid {
+					err = db.DB.invalidateBlock(lastBlockHash.String())
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// Set is_mainchain false for every block at this height
+	err = db.DB.setHeightToSideChain(int64(msgBlock.Header.Height))
+	if err != nil {
+		return err
+	}
+
+	err = db.DB.StoreBlockSummary(&summary)
 	if err != nil {
 		return err
 	}
@@ -251,9 +343,28 @@ func (db *DBDataSaver) Store(data *blockdata.BlockData, _ *wire.MsgBlock) error 
 	return db.DB.StoreStakeInfoExtended(&stakeInfoExtended)
 }
 
-// StoreBlockSummary attempts to store the block data in the database, and
+// Invalidate block at given hash
+func (db *DB) invalidateBlock(blockhash string) error {
+	_, err := db.Exec(db.invalidateBlockSQL, blockhash)
+	return err
+}
+
+// Sets the is_mainchain field to false for the given block in the database.
+func (db *DB) setHeightToSideChain(height int64) error {
+	_, err := db.Exec(db.setHeightToSideChainSQL, height)
+	return err
+}
+
+// Returns the is_mainchain value from the database for the given hash.
+func (db *DB) getMainchainStatus(blockhash string) (bool, error) {
+	var isMainchain bool
+	err := db.QueryRow(db.getMainchainStatusSQL, blockhash).Scan(&isMainchain)
+	return isMainchain, err
+}
+
+// StoreBlock attempts to store the block data in the database, and
 // returns an error on failure.
-func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
+func (db *DB) StoreBlock(bd *apitypes.BlockDataBasic, isMainchain bool, isValid bool) error {
 	stmt, err := db.Prepare(db.insertBlockSQL)
 	if err != nil {
 		return err
@@ -271,7 +382,7 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	res, err := stmt.Exec(&bd.Height, &bd.Size, &bd.Hash,
 		&bd.Difficulty, &bd.StakeDiff, bd.Time.S.T.Unix(),
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
-		&winners)
+		&winners, &isMainchain, &isValid)
 	if err != nil {
 		return err
 	}
@@ -293,7 +404,17 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	return err
 }
 
-// GetBestBlockHash returns the hash of the best block
+// StoreBlockSummary is called with new mainchain blocks.
+func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
+	return db.StoreBlock(bd, true, true)
+}
+
+// StoreSideBlockSummary is for storing side chain.
+func (db *DB) StoreSideBlockSummary(bd *apitypes.BlockDataBasic) error {
+	return db.StoreBlock(bd, false, true)
+}
+
+// GetBestBlockHash returns the hash of the best block.
 func (db *DB) GetBestBlockHash() string {
 	hash, err := db.RetrieveBestBlockHash()
 	if err != nil {
@@ -335,16 +456,15 @@ func (db *DB) GetStakeInfoHeight() (int64, error) {
 	db.RLock()
 	defer db.RUnlock()
 	if db.dbStakeInfoHeight < 0 {
-		si, err := db.RetrieveLatestStakeInfoExtended()
-		// No rows returned is not considered an error
-		if err != nil && err != sql.ErrNoRows {
-			return -1, fmt.Errorf("RetrieveLatestStakeInfoExtended failed: %v", err)
-		}
-		if err == sql.ErrNoRows {
+		height, err := db.RetrieveBestStakeHeight()
+		if err != nil {
+			if err != sql.ErrNoRows {
+				return -1, fmt.Errorf("RetrieveBestStakeHeight failed: %v", err)
+			}
 			log.Warn("Stake info DB is empty.")
 			return -1, nil
 		}
-		db.dbStakeInfoHeight = int64(si.Feeinfo.Height)
+		db.dbStakeInfoHeight = height
 	}
 	return db.dbStakeInfoHeight, nil
 }
@@ -659,10 +779,13 @@ func (db *DB) RetrieveBlockSummaryByTimeRange(minTime, maxTime int64, limit int)
 
 	for rows.Next() {
 		bd := apitypes.NewBlockDataBasic()
+		var winners string
+		var isMainchain, isValid bool
 		var timestamp int64
-		if err = rows.Scan(&bd.Height, &bd.Size, &bd.Hash,
+		if err = rows.Scan(&bd.Hash, &bd.Height, &bd.Size,
 			&bd.Difficulty, &bd.StakeDiff, &timestamp,
-			&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg); err != nil {
+			&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
+			&winners, &isMainchain, &isValid); err != nil {
 			log.Errorf("Unable to scan for block fields")
 		}
 		bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
@@ -693,11 +816,13 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
+=======
 	var timestamp int64
-	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Height, &bd.Size,
-		&bd.Hash, &bd.Difficulty, &bd.StakeDiff, &timestamp,
+	var isMainchain, isValid bool
+	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Hash, &bd.Height, &bd.Size,
+		&bd.Difficulty, &bd.StakeDiff, &timestamp,
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
-		&winners)
+		&winners, &isMainchain, &isValid)
 	if err != nil {
 		return nil, err
 	}
@@ -739,11 +864,12 @@ func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic,
 	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
+	var isMainchain, isValid bool
 	var timestamp int64
-	err := db.QueryRow(db.getBlockByHashSQL, hash).Scan(&bd.Height, &bd.Size, &bd.Hash,
+	err := db.QueryRow(db.getBlockByHashSQL, hash).Scan(&bd.Hash, &bd.Height, &bd.Size,
 		&bd.Difficulty, &bd.StakeDiff, &timestamp,
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
-		&winners)
+		&winners, &isMainchain, &isValid)
 	if err != nil {
 		return nil, err
 	}
@@ -760,11 +886,12 @@ func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) 
 
 	// 1. chained QueryRow/Scan only
 	var winners string
+	var isMainchain, isValid bool
 	var timestamp int64
-	err := db.QueryRow(db.getBlockSQL, ind).Scan(&bd.Height, &bd.Size, &bd.Hash,
+	err := db.QueryRow(db.getBlockSQL, ind).Scan(&bd.Hash, &bd.Height, &bd.Size,
 		&bd.Difficulty, &bd.StakeDiff, &timestamp,
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
-		&winners)
+		&winners, &isMainchain, &isValid)
 	if err != nil {
 		return nil, err
 	}
@@ -869,7 +996,7 @@ func (db *DB) StoreStakeInfoExtended(si *apitypes.StakeInfoExtended) error {
 
 	winners := strings.Join(si.PoolInfo.Winners, ";")
 
-	res, err := stmt.Exec(&si.Feeinfo.Height,
+	res, err := stmt.Exec(&si.Hash, &si.Feeinfo.Height,
 		&si.Feeinfo.Number, &si.Feeinfo.Min, &si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
@@ -897,7 +1024,7 @@ func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, er
 
 	var winners string
 	err := db.QueryRow(db.getLatestStakeInfoExtendedSQL).Scan(
-		&si.Feeinfo.Height, &si.Feeinfo.Number, &si.Feeinfo.Min,
+		&si.Hash, &si.Feeinfo.Height, &si.Feeinfo.Number, &si.Feeinfo.Min,
 		&si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
@@ -910,13 +1037,23 @@ func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, er
 	return si, nil
 }
 
+// Retreives the height of the highest block in the stake table.
+func (db *DB) RetrieveBestStakeHeight() (int64, error) {
+	var height int64
+	err := db.QueryRow(db.getHighestStakeHeight).Scan(&height)
+	if err != nil {
+		return -1, err
+	}
+	return height, nil
+}
+
 // RetrieveStakeInfoExtended returns the extended stake info for the block at
 // height ind.
 func (db *DB) RetrieveStakeInfoExtended(ind int64) (*apitypes.StakeInfoExtended, error) {
 	si := apitypes.NewStakeInfoExtended()
 
 	var winners string
-	err := db.QueryRow(db.getStakeInfoExtendedSQL, ind).Scan(&si.Feeinfo.Height,
+	err := db.QueryRow(db.getStakeInfoExtendedSQL, ind).Scan(&si.Hash, &si.Feeinfo.Height,
 		&si.Feeinfo.Number, &si.Feeinfo.Min, &si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
@@ -927,6 +1064,99 @@ func (db *DB) RetrieveStakeInfoExtended(ind int64) (*apitypes.StakeInfoExtended,
 	}
 	si.PoolInfo.Winners = splitToArray(winners)
 	return si, nil
+}
+
+func (db *DB) RetrieveStakeInfoExtendedByHash(blockhash string) (*apitypes.StakeInfoExtended, error) {
+	si := apitypes.NewStakeInfoExtended()
+
+	var winners string
+	err := db.QueryRow(db.getStakeInfoExtendedByHashSQL, blockhash).Scan(&si.Hash, &si.Feeinfo.Height,
+		&si.Feeinfo.Number, &si.Feeinfo.Min, &si.Feeinfo.Max, &si.Feeinfo.Mean,
+		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
+		&si.StakeDiff, // no next or estimates
+		&si.PriceWindowNum, &si.IdxBlockInWindow, &si.PoolInfo.Size,
+		&si.PoolInfo.Value, &si.PoolInfo.ValAvg, &winners)
+	if err != nil {
+		return nil, err
+	}
+	si.PoolInfo.Winners = splitToArray(winners)
+	return si, nil
+}
+
+// JustifyTableStructure updates an old structure that wasn't indexing
+// sidechains. It could and should be removed in a future version. The block
+// summary table got two new boolean columns, `is_mainchain` and `is_valid`,
+// and the Primary key was changed from height to hash.
+// The stake info table got a `hash` column and the primary key was switched from height to hash
+func (db *DB) JustifyTableStructures() error {
+
+	// Grab the column info. Right now, just counting them, but could be looked at more closely
+	// Each tuple is a row with columns [cid, name, type, notnull, dflt_value, pk]
+	rows, err := db.Query(db.getBlockSummaryTableInfo)
+	if err != nil {
+		log.Errorf("Query failed: %v", err)
+		return err
+	}
+	defer rows.Close()
+	rowCounter := 0
+	for rows.Next() {
+		rowCounter += 1
+	}
+
+	// It simply checks whether there are enough columns for the current structure
+	if rowCounter >= 12 {
+		return nil
+	}
+
+	log.Info("Detected old SQLite table structure. Updating.")
+
+	tmpSummaryTableName := TableNameSummaries + "_temp"
+	tmpStakeTableName := TableNameStakeInfo + "_temp"
+
+	queries := make([]string, 0, 8)
+	queries = append(queries, fmt.Sprintf(db.rawCreateBlockSummaryStmt, tmpSummaryTableName))
+	queries = append(queries, fmt.Sprintf(`INSERT INTO %s SELECT hash, height, size, diff,
+		sdiff, time, poolsize, poolval, poolavg, winners, 1, 1 FROM %s;`,
+		tmpSummaryTableName, TableNameSummaries))
+	queries = append(queries, fmt.Sprintf("DROP TABLE %s;", TableNameSummaries))
+	queries = append(queries, fmt.Sprintf("ALTER TABLE %s RENAME TO %s;",
+		tmpSummaryTableName, TableNameSummaries))
+	queries = append(queries, fmt.Sprintf(db.rawCreateStakeInfoExtendedStmt, tmpStakeTableName))
+	queries = append(queries, fmt.Sprintf(`INSERT INTO %[1]s SELECT %[2]s.hash, %[3]s.height, num_tickets,
+		fee_min, fee_max, fee_mean, fee_med, fee_std, %[3]s.sdiff, window_num, window_ind, pool_size,
+		pool_val,pool_valavg, %[3]s.winners FROM %[3]s JOIN %[2]s ON
+		%[3]s.height = %[2]s.height`,
+		tmpStakeTableName, TableNameSummaries, TableNameStakeInfo))
+	queries = append(queries, fmt.Sprintf("DROP TABLE %s;", TableNameStakeInfo))
+	queries = append(queries, fmt.Sprintf("ALTER TABLE %s RENAME TO %s;", tmpStakeTableName, TableNameStakeInfo))
+
+	transaction, err := db.Begin()
+	if err != nil {
+		log.Errorf("Failed to start a transaction: \n", err)
+		return err
+	}
+	for _, query := range queries {
+		_, err = transaction.Exec(query)
+		if err != nil {
+			log.Errorf("Failed updating SQLite table structure: \n", err)
+			transaction.Rollback()
+			return err
+		}
+	}
+
+	err = transaction.Commit()
+	if err != nil {
+		log.Error("Failed to commit SQL transaction after table reorg.")
+		return err
+	}
+
+	// Clean up the file a little bit
+	_, err = db.Query("VACUUM;")
+	if err != nil {
+		log.Error("Failed to VACUUM SQLite database.")
+	}
+
+	return nil
 }
 
 func logDBResult(res sql.Result) error {

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -807,6 +807,7 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
+=======
 	var timestamp int64
 	var isMainchain, isValid bool
 	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Hash, &bd.Height, &bd.Size,

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1127,7 +1128,11 @@ func (db *DB) JustifyTableStructures(dbInfo *DBInfo) error {
 	_, err = os.Stat(bkpPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			copyFile(dbInfo.FileName, bkpPath)
+			err = copyFile(dbInfo.FileName, bkpPath)
+			if err != nil {
+				log.Errorf("Failed to backup %s: %v", dbInfo.FileName, err)
+				return err
+			}
 		} else {
 			log.Errorf("Error retrieving FileInfo for %s: %v", dbInfo.FileName, err)
 			return err

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -807,7 +807,6 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	bd := apitypes.NewBlockDataBasic()
 
 	var winners string
-=======
 	var timestamp int64
 	var isMainchain, isValid bool
 	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Hash, &bd.Height, &bd.Size,
@@ -1134,8 +1133,6 @@ func (db *DB) JustifyTableStructures(dbInfo *DBInfo) error {
 			return err
 		}
 	}
-
-	copyFile(dbInfo.FileName, bkpPath)
 
 	tmpSummaryTableName := TableNameSummaries + "_temp"
 	tmpStakeTableName := TableNameStakeInfo + "_temp"

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -6,12 +6,14 @@ package dcrsqlite
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
 	apitypes "github.com/decred/dcrdata/v3/api/types"
+	"github.com/decred/dcrdata/v3/blockdata"
 	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/explorer"
 	"github.com/decred/dcrdata/v3/rpcutils"
@@ -325,7 +327,9 @@ func (db *wiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 		}
 
 		// Stake info
-		si := apitypes.StakeInfoExtended{}
+		si := apitypes.StakeInfoExtended{
+			Hash: blockSummary.Hash,
+		}
 
 		// Ticket fee info
 		fib := txhelpers.FeeRateInfoBlock(block)
@@ -404,4 +408,55 @@ func (db *wiredDB) getBlock(ind int64) (*dcrutil.Block, *chainhash.Hash, error) 
 	block := dcrutil.NewBlock(msgBlock)
 
 	return block, blockhash, nil
+}
+
+// ImportSideChains imports all side chains. Similar to pgblockchain.MissingSideChainBlocks
+// plus the rest from main.go
+func (db *wiredDB) ImportSideChains(collector *blockdata.Collector) error {
+	tips, err := rpcutils.SideChains(db.client)
+	if err != nil {
+		return err
+	}
+	hashlist := make([]*chainhash.Hash, 0)
+	for it := range tips {
+		sideHeight := tips[it].Height
+		log.Tracef("Primary DB -> Getting base DB side chain with tip %s at %d.", tips[it].Hash, sideHeight)
+		sideChain, err := rpcutils.SideChainFull(db.client, tips[it].Hash)
+		if err != nil {
+			log.Errorf("Primary DB -> Unable to get side chain blocks for chain tip %s: %v", tips[it].Hash, err)
+			return err
+		}
+		sideHeight -= int64(len(sideChain)) - 1
+
+		// For each block in the side chain, check if it already stored.
+		for is := range sideChain {
+			// Check for the block hash in the DB.
+			isMainchainNow, err := db.getMainchainStatus(sideChain[is])
+			if isMainchainNow || err == sql.ErrNoRows {
+				blockhash, err := chainhash.NewHashFromStr(sideChain[is])
+				if err != nil {
+					log.Errorf("Primary DB -> Invalid block hash %s: %v.", blockhash, err)
+					continue
+				}
+				hashlist = append(hashlist, blockhash)
+			}
+		}
+	}
+	log.Infof("Primary DB -> %d new sidechain block(s) to import", len(hashlist))
+	for _, blockhash := range hashlist {
+		// Collect block data.
+		blockDataBasic, _ := collector.CollectAPITypes(blockhash)
+		log.Debugf("Primary DB -> Importing block %s (height %d) into primary DB.",
+			blockhash.String(), blockDataBasic.Height)
+		if blockDataBasic == nil {
+			// Do not quit if unable to collect side chain block data.
+			log.Error("Primary DB -> Unable to collect data for side chain block %s", blockhash.String())
+			continue
+		}
+		err := db.StoreSideBlockSummary(blockDataBasic)
+		if err != nil {
+			log.Errorf("Primary DB -> Failed to store block %s", blockhash.String())
+		}
+	}
+	return nil
 }

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -417,16 +417,14 @@ func (db *wiredDB) ImportSideChains(collector *blockdata.Collector) error {
 	if err != nil {
 		return err
 	}
-	hashlist := make([]*chainhash.Hash, 0)
+	var hashlist []*chainhash.Hash
 	for it := range tips {
-		sideHeight := tips[it].Height
-		log.Tracef("Primary DB -> Getting base DB side chain with tip %s at %d.", tips[it].Hash, sideHeight)
+		log.Tracef("Primary DB -> Getting base DB side chain with tip %s at %d.", tips[it].Hash, tips[it].Height)
 		sideChain, err := rpcutils.SideChainFull(db.client, tips[it].Hash)
 		if err != nil {
 			log.Errorf("Primary DB -> Unable to get side chain blocks for chain tip %s: %v", tips[it].Hash, err)
 			return err
 		}
-		sideHeight -= int64(len(sideChain)) - 1
 
 		// For each block in the side chain, check if it already stored.
 		for is := range sideChain {

--- a/main.go
+++ b/main.go
@@ -566,9 +566,6 @@ func _main(ctx context.Context) error {
 		// Synchronization between DBs via rpcutils.BlockGate
 		smartClient := rpcutils.NewBlockGate(dcrdClient, 10)
 
-		// Update older sqlite table to index side ChainSize if Needed
-		// Needs auxDB
-
 		// stakedb (in baseDB) connects blocks *after* ChainDB retrieves them,
 		// but it has to get a notification channel first to receive them. The
 		// BlockGate will provide this for blocks after fetchHeightInBaseDB. In

--- a/main.go
+++ b/main.go
@@ -566,6 +566,9 @@ func _main(ctx context.Context) error {
 		// Synchronization between DBs via rpcutils.BlockGate
 		smartClient := rpcutils.NewBlockGate(dcrdClient, 10)
 
+		// Update older sqlite table to index side ChainSize if Needed
+		// Needs auxDB
+
 		// stakedb (in baseDB) connects blocks *after* ChainDB retrieves them,
 		// but it has to get a notification channel first to receive them. The
 		// BlockGate will provide this for blocks after fetchHeightInBaseDB. In


### PR DESCRIPTION
For #747
The solution got a little bigger than I expected. Let me know if you want anything changed. The database went from 250 to 430 MB, which is more than I would have expected for essentially adding 3 columns in total. Maybe there's some optimization I'm missing. 

I did not duplicate the `is_mainchain` and `is_valid` columns on the stake table, but that means that a few queries required some `JOIN`s with the block summary table. 