### PR TITLE
Mempool transactions on /tx update (mostly) correctly now

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -823,7 +823,8 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				}
 				tx.TicketInfo.SpendStatus = spendStatus.String()
 
-				// Ticket luck and probability of voting
+				// Ticket luck and probability of voting.
+				// blockLive < 0 for immature tickets
 				blocksLive := tx.Confirmations - int64(exp.ChainParams.TicketMaturity)
 				if tx.TicketInfo.SpendStatus == "Voted" {
 					// Blocks from eligible until voted (actual luck)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -897,7 +897,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		BlockInds:         blockInds,
 		HasValidMainchain: hasValidMainchain,
 		// ConfirmHeight is now the same as tx.BlockHeight here.
-		ConfirmHeight:    exp.Height() - tx.Confirmations + 1,
+		ConfirmHeight:    exp.Height() - tx.Confirmations,
 		NetName:          exp.NetName,
 		HighlightInOut:   inout,
 		HighlightInOutID: inoutid,

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -896,10 +896,11 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		Blocks:            blocks,
 		BlockInds:         blockInds,
 		HasValidMainchain: hasValidMainchain,
-		ConfirmHeight:     exp.Height() - tx.Confirmations,
-		NetName:           exp.NetName,
-		HighlightInOut:    inout,
-		HighlightInOutID:  inoutid,
+		// ConfirmHeight is now the same as tx.BlockHeight here.
+		ConfirmHeight:    exp.Height() - tx.Confirmations + 1,
+		NetName:          exp.NetName,
+		HighlightInOut:   inout,
+		HighlightInOutID: inoutid,
 	}
 
 	str, err := exp.templates.execTemplateToString("tx", pageData)

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -349,5 +349,8 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"now": func() int64 {
 			return time.Now().Unix()
 		},
+		"uint16toInt64": func(v uint16) int64 {
+			return int64(v)
+		},
 	}
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -842,18 +842,17 @@ body.darkBG .keynav-target {
   padding: 1px 5px;
 }
 
-.progress-bar {
-  background: #74e06b;
-  color: #333;
-  height: 20px;
-  line-height: 20px;
-  text-shadow: 1px 1px 0px #00000012;
-}
-
 /*bootstrap overrides*/
 .progress {
   background-color: #dddddd;
   border-radius: 2px;
+  height: 1.5rem;
+}
+.progress-bar {
+  background: #74e06b;
+  color: #333;
+  line-height: 1.5rem;
+  text-shadow: 1px 1px 0px #00000012;
 }
 .btn-primary {
   background-color: #2970ff;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -843,8 +843,8 @@ body.darkBG .keynav-target {
 }
 
 .progress-bar {
-  background: #41BF53;
-  color: #fff;
+  background: #74e06b;
+  color: #333;
   height: 20px;
   line-height: 20px;
   text-shadow: 1px 1px 0px #00000012;
@@ -852,7 +852,7 @@ body.darkBG .keynav-target {
 
 /*bootstrap overrides*/
 .progress {
-  background-color: #c5c4c4;
+  background-color: #dddddd;
   border-radius: 2px;
 }
 .btn-primary {

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -188,6 +188,14 @@
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    // `formatTxDate`: Format a string to match the format `(UTC) YYYY-MM-DD HH:MM:SS` used by explorer.TxPage and tx.tmpl
+    function formatTxDate(stamp) {
+        var d = new Date(stamp*1000);
+        var zone = d.toLocaleTimeString('en-us',{timeZoneName:'short'}).split(' ')[2];
+        return "("+zone+") "+String(d.getFullYear())+"-"+String(d.getMonth()+1).padStart(2, "0")+"-"+String(d.getDate()).padStart(2, "0")+" "
+            +String(d.getHours()).padStart(2, "0")+":"+String(d.getMinutes()).padStart(2, "0")+":"+String(d.getSeconds()).padStart(2, "0");
+    }
+
     var ws; // websocket global
     async function createWebSocket(loc) {
         // wait a bit to prevent websocket churn from drive by page loads
@@ -244,9 +252,30 @@
             var b = newBlock.block;
             desktopNotifyNewBlock(b);
 
+
             // Update the blocktime counter.
             DCRThings.counter.data("main-lastblocktime", b.time).removeClass("text-danger")
             DCRThings.counter.html(humanize.timeSince(b.time))
+
+            // This is triggered on a transaction (/tx) page for an unconfirmed mempool transaction
+            var needsConfirmation = $("[data-txid-mempool-display]")
+            if(needsConfirmation.length && needsConfirmation.text() == "mempool"){
+                var txid = needsConfirmation.data("txid-mempool-display");
+                var k, txs, idx;
+                $.each([b.Tx, b.Tickets, b.Revs, b.Votes], function(k, txs){
+                    for(idx in txs){
+                        if(txs[idx].TxID ==  txid){
+                            needsConfirmation.remove();
+                            $("[data-confirmation-block-height]").data("confirmation-block-height", b.height).html("(1 confirmation)");
+                            $("#txMempoolLink").html(b.height).attr("href", "/block/"+b.hash);
+                            $("#txFmtTime").html(formatTxDate(b.time));
+                            $("#txAge").html(humanize.timeSince(b.time)).before("(").after(" ago)").attr("data-age",b.time);
+                            $("#txMaturityProgress").css({"width":"0.4%"}).attr("aria-valuenow","1").children("span").html("Immature, eligible to vote in 255 blocks (20.8 hours remaining)")
+                            return false
+                        }
+                    }
+                })
+            }
 
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -110,6 +110,7 @@
 
     var DCRThings = {}
     DCRThings.targetBlockTime = {{$.BlockTimeUnix}}
+    DCRThings.ticketPoolSize = {{$.ChainParams.TicketPoolSize}}
 
     var sunIcon = document.getElementById("sun-icon")
     var darkBGCookieName = 'dcrdataDarkBG';
@@ -257,26 +258,6 @@
             DCRThings.counter.data("main-lastblocktime", b.time).removeClass("text-danger")
             DCRThings.counter.html(humanize.timeSince(b.time))
 
-            // This is triggered on a transaction (/tx) page for an unconfirmed mempool transaction
-            var needsConfirmation = $("[data-txid-mempool-display]")
-            if(needsConfirmation.length && needsConfirmation.text() == "mempool"){
-                var txid = needsConfirmation.data("txid-mempool-display");
-                var k, txs, idx;
-                $.each([b.Tx, b.Tickets, b.Revs, b.Votes], function(k, txs){
-                    for(idx in txs){
-                        if(txs[idx].TxID ==  txid){
-                            needsConfirmation.remove();
-                            $("[data-confirmation-block-height]").data("confirmation-block-height", b.height).html("(1 confirmation)");
-                            $("#txMempoolLink").html(b.height).attr("href", "/block/"+b.hash);
-                            $("#txFmtTime").html(formatTxDate(b.time));
-                            $("#txAge").html(humanize.timeSince(b.time)).before("(").after(" ago)").attr("data-age",b.time);
-                            $("#txMaturityProgress").css({"width":"0.4%"}).attr("aria-valuenow","1"
-                          ).children("span").html("Immature, eligible to vote in 255 blocks (21.3 hours remaining)")
-                            return false
-                        }
-                    }
-                })
-            }
             advanceTicketProgress(b)
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());
@@ -418,6 +399,30 @@
 
     // Advance various progress bars on /tx.
     function advanceTicketProgress(block){
+        // Check for confirmations on mempool transactions.
+        var needsConfirmation = $("[data-txid-mempool-display]")
+        if(needsConfirmation.length && needsConfirmation.text() == "mempool"){
+            var txid = needsConfirmation.data("txid-mempool-display");
+            var k, txs, idx;
+            $.each([block.Tx, block.Tickets, block.Revs, block.Votes], function(k, txs){
+                for(idx in txs){
+                    if(txs[idx].TxID ==  txid){
+                        needsConfirmation.remove();
+                        $("[data-confirmation-block-height]").data("confirmation-block-height", block.height).html("(1 confirmation)");
+                        $("#txMempoolLink").html(block.height).attr("href", "/block/"+block.hash);
+                        $("#txFmtTime").html(formatTxDate(block.time));
+                        $("#txAge").html(humanize.timeSince(block.time)).before("(").after(" ago)").attr("data-age",block.time);
+                        var progressBar = $("#txMaturityProgress")
+                        var remainingBlocks = parseInt(progressBar.attr("aria-valuemax")) - 1
+                        var remainingTime = remainingBlocks*DCRThings.targetBlockTime
+                        progressBar.css({"width":"0.4%"}).attr("aria-valuenow","1"
+                      ).children("span").html("Immature, eligible to vote in "+remainingBlocks+" blocks ("+remainingTime.toFixed(1)+" hours remaining)")
+                        return false
+                    }
+                }
+            })
+        }
+        // Advance the progress bars.
         var ticketProgress = $("#txMaturityProgress");
         if(!ticketProgress.length){
             return;
@@ -442,9 +447,9 @@
             var blocksLeft = complete+1-confirmations;
             if(txType == "LiveTicket"){
                 ticketProgress.children("span").html("block "+confirmations+" of "+complete+" ("+((1-ratio)*142.2).toFixed(1)+" days remaining)");
-                // Chance of expiring is (1-P)^N where P: single-block probability of being picked, N: blocks remaining.
+                // Chance of expiring is (1-P)^N where P := single-block probability of being picked, N := blocks remaining.
                 // This probability is using the network parameter rather than the calculated value. So far, the ticket pool size seems stable enough to do that.
-                var pctChance = Math.pow(1 - 1/8192, blocksLeft)*100;
+                var pctChance = Math.pow(1 - 1/DCRThings.ticketPoolSize, blocksLeft)*100;
                 $("#ticketExpiryChance").children("span").html(pctChance.toFixed(2)+"% chance of expiry");
             }
             else{

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -408,7 +408,7 @@
                 for(idx in txs){
                     if(txs[idx].TxID ==  txid){
                         needsConfirmation.remove();
-                        $("[data-confirmation-block-height]").data("confirmation-block-height", block.height).html("(1 confirmation)");
+                        $("[data-confirmation-block-height]").data("confirmation-block-height", block.height - 1).html("(1 confirmation)");
                         $("#txMempoolLink").html(block.height).attr("href", "/block/"+block.hash);
                         $("#txFmtTime").html(formatTxDate(block.time));
                         $("#txAge").html(humanize.timeSince(block.time)).before("(").after(" ago)").attr("data-age",block.time);

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -270,11 +270,25 @@
                             $("#txMempoolLink").html(b.height).attr("href", "/block/"+b.hash);
                             $("#txFmtTime").html(formatTxDate(b.time));
                             $("#txAge").html(humanize.timeSince(b.time)).before("(").after(" ago)").attr("data-age",b.time);
-                            $("#txMaturityProgress").css({"width":"0.4%"}).attr("aria-valuenow","1").children("span").html("Immature, eligible to vote in 255 blocks (20.8 hours remaining)")
+                            $("#txMaturityProgress").css({"width":"0.4%"}).attr("aria-valuenow","1"
+                          ).children("span").html("Immature, eligible to vote in 255 blocks (21.3 hours remaining)")
                             return false
                         }
                     }
                 })
+            }
+            var ticketProgress = $("#txMaturityProgress");
+            if(ticketProgress.length){
+                var progress = ticketProgress.attr("aria-valuenow");
+                if(progress == 255){
+                    oldProgress.closest(".row").replaceWith("Mature");
+                }
+                else{
+                    progress++
+                    var ratio = progress/256
+                    ticketProgress.attr("aria-valuenow", progress).css({"width":(ratio*100).toString()+"%"})
+                    ticketProgress.children("span").html("Immature, eligible to vote in "+(256-progress).toString()+" blocks ("+((1-ratio)*21.3).toFixed(1)+" hours remaining)");
+                }
             }
 
             var expTableRows = $('#explorertable tbody tr');

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -277,20 +277,7 @@
                     }
                 })
             }
-            var ticketProgress = $("#txMaturityProgress");
-            if(ticketProgress.length){
-                var progress = ticketProgress.attr("aria-valuenow");
-                if(progress == 255){
-                    oldProgress.closest(".row").replaceWith("Mature");
-                }
-                else{
-                    progress++
-                    var ratio = progress/256
-                    ticketProgress.attr("aria-valuenow", progress).css({"width":(ratio*100).toString()+"%"})
-                    ticketProgress.children("span").html("Immature, eligible to vote in "+(256-progress).toString()+" blocks ("+((1-ratio)*21.3).toFixed(1)+" hours remaining)");
-                }
-            }
-
+            advanceTicketProgress(b)
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());
             if (expTableRows){
@@ -428,6 +415,46 @@
             doNotification(block);
         }
     }
+
+    // Advance various progress bars on /tx.
+    function advanceTicketProgress(block){
+        var ticketProgress = $("#txMaturityProgress");
+        if(!ticketProgress.length){
+            return;
+        }
+        var confirmations = block.height - ticketProgress.data("confirm-height") + 1;
+        var txType = ticketProgress.data("tx-type");
+        var complete = parseInt(ticketProgress.attr("aria-valuemax"));
+        if(confirmations == complete + 1){
+            ticketProgress.closest(".row").replaceWith(txType == "LiveTicket" ? "Expired" : "Mature");
+            return;
+        }
+        var ratio = confirmations/complete;
+        if(confirmations == complete){
+            ticketProgress.children("span").html(txType == "Ticket" ? "Mature. Eligible to vote on next block." :
+            txType == "LiveTicket" ? "Ticket has expired" : "Mature. Ready to spend.");
+            var status = $("#txPoolStatus");
+            if(status.length){
+                status.html("live / unspent");
+            }
+        }
+        else{
+            var blocksLeft = complete+1-confirmations;
+            if(txType == "LiveTicket"){
+                ticketProgress.children("span").html("block "+confirmations+" of "+complete+" ("+((1-ratio)*142.2).toFixed(1)+" days remaining)");
+                // Chance of expiring is (1-P)^N where P: single-block probability of being picked, N: blocks remaining.
+                // This probability is using the network parameter rather than the calculated value. So far, the ticket pool size seems stable enough to do that.
+                var pctChance = Math.pow(1 - 1/8192, blocksLeft)*100;
+                $("#ticketExpiryChance").children("span").html(pctChance.toFixed(2)+"% chance of expiry");
+            }
+            else{
+                var typeStub = txType == "Ticket" ? "eligible to vote" : "spendable";
+                ticketProgress.children("span").html("Immature, "+typeStub+" in "+blocksLeft+" blocks ("+((1-ratio)*21.3).toFixed(1)+" hours remaining)");
+            }
+            ticketProgress.attr("aria-valuenow", confirmations).css({"width":(ratio*100).toString()+"%"});
+        }
+    }
+
 </script>
 
 <script>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -107,7 +107,7 @@
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="{{.TicketInfo.TicketMaturity}}"
-                                            data-confirm-height="{{$.ConfirmHeight}}"
+                                            data-confirm-height="{{add $.ConfirmHeight 1}}"
                                             data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
@@ -153,7 +153,7 @@
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="{{.Maturity}}"
-                                            data-confirm-height="{{$.ConfirmHeight}}"
+                                            data-confirm-height="{{add $.ConfirmHeight 1}}"
                                             data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
@@ -218,7 +218,7 @@
                                                     aria-valuenow="{{.Confirmations}}"
                                                     aria-valuemin="0"
                                                     aria-valuemax="{{.TicketInfo.TicketExpiry}}"
-                                                    data-confirm-height="{{add $.ConfirmHeight (uint16toInt64 $.ChainParams.TicketMaturity)}}"
+                                                    data-confirm-height="{{add (add $.ConfirmHeight 1) (uint16toInt64 $.ChainParams.TicketMaturity)}}"
                                                     data-tx-type="LiveTicket"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -79,7 +79,7 @@
                     </tr>
                 {{end}}
                 {{if eq .Mature "True"}}
-                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURITY</td><td>Fully Mature</td></tr>
+                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURITY</td><td>Mature</td></tr>
                 {{end}}
                 {{if and (eq .Mature "False") (eq .Type "Ticket")}}
                     <tr>
@@ -99,7 +99,7 @@
                                         >
                                             <span class="nowrap pl-1 pr-1">
                                               {{if gt .Confirmations 0}}
-                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining){{end}}
+                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract .TicketInfo.TicketMaturity .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining){{end}}
                                               {{else}}
                                                 Awaiting confirmation
                                               {{end}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -29,28 +29,30 @@
                 </span>
             </div>
             <table class="table no-border table-centered-1rem">
-                {{if gt .BlockHeight 0}}
-                    <tr>
-                        <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">INCLUDED IN BLOCK</td>
-                        <td>
-                        {{range $i, $b := $.Blocks}}
-                        {{$blockInd := index $.BlockInds $i}}
-                        {{$validMainchain := and $b.IsValid $b.IsMainchain}}
-                            <a href="/block/{{$b.Hash}}?ind={{$blockInd}}"
-                                {{if not $validMainchain}}
-                                class="fs18 grayed" title="Mainchain: {{$b.IsMainchain}}&#xA;Valid: {{$b.IsValid}}"
-                                {{else}}
-                                class="fs18"
-                                {{end}}>
-                                {{$b.Height}}</a>{{if lt (add (int64 $i) 1) (len $.Blocks)}}, {{end}}
-                        {{end}}
-                        </td>
-                    </tr>
-                    {{if not $.HasValidMainchain}}
-                    <tr>
-                        <span class="attention">This transaction is not included in a stakeholder-approved mainchain block.</span>
-                    </tr>
+                <tr>
+                    <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">INCLUDED IN BLOCK</td>
+                    {{if eq .BlockHeight 0}}
+                        <td><span data-txid-mempool-display="{{.TxID}}">mempool</span><a id="txMempoolLink" href="" class="fs18"></a></td>
+                    {{else}}
+                      <td>
+                      {{range $i, $b := $.Blocks}}
+                      {{$blockInd := index $.BlockInds $i}}
+                      {{$validMainchain := and $b.IsValid $b.IsMainchain}}
+                          <a href="/block/{{$b.Hash}}?ind={{$blockInd}}"
+                              {{if not $validMainchain}}
+                              class="fs18 grayed" title="Mainchain: {{$b.IsMainchain}}&#xA;Valid: {{$b.IsValid}}"
+                              {{else}}
+                              class="fs18"
+                              {{end}}>
+                              {{$b.Height}}</a>{{if lt (add (int64 $i) 1) (len $.Blocks)}}, {{end}}
+                      {{end}}
+                      </td>
                     {{end}}
+                </tr>
+                {{if and (ne .BlockHeight 0) (not $.HasValidMainchain)}}
+                <tr>
+                    <span class="attention">This transaction is not included in a stakeholder-approved mainchain block.</span>
+                </tr>
                 {{end}}
                 {{if or (eq .Type "Vote") (eq .Type "Revocation")}}
                     {{range .Vin}}
@@ -77,13 +79,9 @@
                     </tr>
                 {{end}}
                 {{if eq .Mature "True"}}
-                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td></tr>
-                {{else}}
-                {{if and (eq .Confirmations 0) (or (eq .Type "Ticket") (eq .Type "Vote")) }}
-                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>N/A</td></tr>
+                    <tr><td class="text-right pr-2 h1rem p03rem0">MATURITY</td><td>Fully Mature</td></tr>
                 {{end}}
-                {{end}}
-                {{if and (gt .Confirmations 0) (and (eq .Mature "False") (eq .Type "Ticket"))}}
+                {{if and (eq .Mature "False") (eq .Type "Ticket")}}
                     <tr>
                         <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                         <td>
@@ -92,14 +90,19 @@
                                     <div class="progress" style="max-width: 330px">
                                         <div
                                             class="progress-bar"
+                                            id="txMaturityProgress"
                                             role="progressbar"
-                                            style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%;"
+                                            style="width:{{if eq .Confirmations 0}}0{{else}}{{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%{{end}};"
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="256"
                                         >
                                             <span class="nowrap pl-1 pr-1">
+                                              {{if gt .Confirmations 0}}
                                                 Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining){{end}}
+                                              {{else}}
+                                                Awaiting confirmation
+                                              {{end}}
                                             </span>
                                         </div>
                                     </div>
@@ -227,9 +230,9 @@
                     <td class="text-right pr-2">TIME</td>
                     <td class="lh1rem">
                         {{if eq .Time 0}}
-                            N/A
+                            <span id="txFmtTime">N/A</span> <span class="op60 fs12 nowrap"><span id="txAge" data-target="main.age" data-age=""></span></span>
                         {{else}}
-                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.Time}}"></span> ago)</span>
+                            <span>({{timezone}}) {{.FormattedTime}}</span> <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.Time}}"></span> ago)</span>
                         {{end}}
                     </td>
                 </tr>
@@ -300,7 +303,7 @@
                             <a href="/block/{{.BlockHeight}}">{{.BlockHeight}}</a>
                         {{end}}
                         </td>
-                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} 
+                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}}
                         <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}} {{end}}</span>
                         </td>
                     </tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -73,8 +73,19 @@
                 {{if and (ne .TicketInfo.PoolStatus "") (and (eq .Type "Ticket") (gt .Confirmations 0))}}
                     <tr>
                         <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
-                        <td>
-                            {{if ne .TicketInfo.SpendStatus "Voted"}} {{.TicketInfo.PoolStatus}}  / {{end}} {{if (index .SpendingTxns 0).Hash}}<a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{.TicketInfo.SpendStatus}}</a>{{else}}{{.TicketInfo.SpendStatus}}{{end}}
+                        <td id="txPoolStatus">
+                            {{if ne .TicketInfo.SpendStatus "Voted"}}
+                              {{if eq .Confirmations 256}}
+                                live /
+                              {{else}}
+                                {{.TicketInfo.PoolStatus}}  /
+                              {{end}}
+                            {{end}}
+                            {{if (index .SpendingTxns 0).Hash}}
+                              <a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{.TicketInfo.SpendStatus}}</a>
+                            {{else}}
+                              {{.TicketInfo.SpendStatus}}
+                            {{end}}
                         </td>
                     </tr>
                 {{end}}
@@ -96,10 +107,26 @@
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="256"
+                                            data-confirm-height="{{$.ConfirmHeight}}"
+                                            data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
                                               {{if gt .Confirmations 0}}
-                                                Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract .TicketInfo.TicketMaturity .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining){{end}}
+                                                {{if eq .Confirmations 256}}
+                                                  Mature,
+                                                {{else}}
+                                                  Immature,
+                                                {{end}}
+                                                {{ if eq .Type "Ticket"}}
+                                                  eligible to vote
+                                                {{else}}
+                                                  spendable
+                                                {{end}} in
+                                                {{ if eq .Confirmations .TicketInfo.TicketMaturity }}
+                                                  next block
+                                                {{else}}
+                                                  {{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks ({{printf "%.1f" .TicketInfo.TimeTillMaturity}} hours remaining)
+                                                {{end}}
                                               {{else}}
                                                 Awaiting confirmation
                                               {{end}}
@@ -120,11 +147,14 @@
                                     <div class="progress" style="max-width: 330px">
                                         <div
                                             class="progress-bar"
+                                            id="txMaturityProgress"
                                             role="progressbar"
                                             style="width: {{percentage  .Confirmations .Maturity}}%;"
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="256"
+                                            data-confirm-height="{{$.ConfirmHeight}}"
+                                            data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
                                                 Immature, spendable in {{ if eq (add .Confirmations 1) .Maturity }}next block{{else}}{{subtract .Maturity .Confirmations}} blocks ({{printf "%.1f" .MaturityTimeTill}} hours remaining){{end}}
@@ -158,6 +188,7 @@
                                             <div class="progress" style="max-width: 330px">
                                                 <div
                                                     class="progress-bar"
+                                                    id="ticketExpiryChance"
                                                     role="progressbar"
                                                     style="width: {{.TicketInfo.Probability}}%;"
                                                     aria-valuenow="{{.TicketInfo.Probability}}"
@@ -173,8 +204,6 @@
                                     </div>
                                 </td>
                             </tr>
-                        {{end}}
-                        {{if ge .TicketInfo.TicketExpiry .TicketInfo.TicketLiveBlocks}}
                             <tr>
                                 <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
                                 <td>
@@ -183,11 +212,14 @@
                                             <div class="progress" style="max-width: 330px">
                                                 <div
                                                     class="progress-bar"
+                                                    id="txMaturityProgress"
                                                     role="progressbar"
                                                     style="width: {{percentage (subtract .TicketInfo.TicketLiveBlocks 1) .TicketInfo.TicketExpiry}}%;"
                                                     aria-valuenow="{{.Confirmations}}"
                                                     aria-valuemin="0"
-                                                    aria-valuemax="256"
+                                                    aria-valuemax="40960"
+                                                    data-confirm-height="{{add $.ConfirmHeight 256}}"
+                                                    data-tx-type="LiveTicket"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">
                                                         block {{.TicketInfo.TicketLiveBlocks}} of {{.TicketInfo.TicketExpiry}} ({{printf "%.1f" .TicketInfo.TicketExpiryDaysLeft}} days remaining)

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -75,7 +75,7 @@
                         <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
                         <td id="txPoolStatus">
                             {{if ne .TicketInfo.SpendStatus "Voted"}}
-                              {{if eq .Confirmations 256}}
+                              {{if eq .Confirmations .TicketInfo.TicketMaturity}}
                                 live /
                               {{else}}
                                 {{.TicketInfo.PoolStatus}}  /
@@ -106,13 +106,13 @@
                                             style="width:{{if eq .Confirmations 0}}0{{else}}{{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%{{end}};"
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
-                                            aria-valuemax="256"
+                                            aria-valuemax="{{.TicketInfo.TicketMaturity}}"
                                             data-confirm-height="{{$.ConfirmHeight}}"
                                             data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
                                               {{if gt .Confirmations 0}}
-                                                {{if eq .Confirmations 256}}
+                                                {{if eq .Confirmations .TicketInfo.TicketMaturity}}
                                                   Mature,
                                                 {{else}}
                                                   Immature,
@@ -152,7 +152,7 @@
                                             style="width: {{percentage  .Confirmations .Maturity}}%;"
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
-                                            aria-valuemax="256"
+                                            aria-valuemax="{{.Maturity}}"
                                             data-confirm-height="{{$.ConfirmHeight}}"
                                             data-tx-type="{{.Type}}"
                                         >
@@ -217,8 +217,8 @@
                                                     style="width: {{percentage (subtract .TicketInfo.TicketLiveBlocks 1) .TicketInfo.TicketExpiry}}%;"
                                                     aria-valuenow="{{.Confirmations}}"
                                                     aria-valuemin="0"
-                                                    aria-valuemax="40960"
-                                                    data-confirm-height="{{add $.ConfirmHeight 256}}"
+                                                    aria-valuemax="{{.TicketInfo.TicketExpiry}}"
+                                                    data-confirm-height="{{add $.ConfirmHeight (uint16toInt64 $.ChainParams.TicketMaturity)}}"
                                                     data-tx-type="LiveTicket"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">


### PR DESCRIPTION
Resolves #309

There is a related issue with the confirmations counter at the top that I didn't touch because is looks like it's being worked on. see https://github.com/decred/dcrdata/pull/766#issuecomment-433546786

The only difference between a confirmed transaction's /tx page and a mempool /tx page which is confirmed after page/turbolinks load is that the "Pool Status"  is not displayed after a mempool tx is confirmed. 

@gozart1 I put  the JS in the `updateBlockData` websocket callback. I wonder if we could build a little signal system for block data callbacks, ala

```
var blockCallbacks = {}
function registerBlockCallback(key, f){
    blockCallbacks[key] = f;
}
function signalBlock(block){
    for(key in blockCallbacks){
        blockCallbacks[key](block);
    }
}

...

// In createWebSocket()
var updateBlockData = function (event) {
    var newBlock = JSON.parse(event);

    ...

    signalBlock(newBlock.block);
}
 ...

function doBlockStuff(block){
    ...
}
registerBlockCallback("doblockstuff", doBlockStuff)
```

Edit: I see now that you have `desktopNotifyNewBlock` which might serve a similar purpose.
