### PR TITLE
Elided text, vout/vin index, and table-layout: auto on tx page tables.

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -748,6 +748,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				Type:            txhelpers.TxTypeToString(int(vouts[iv].TxType)),
 				Spent:           spendingTx != "",
 				OP_RETURN:       opReturn,
+				Index:           vouts[iv].TxIndex,
 			})
 		}
 
@@ -809,6 +810,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				},
 				Addresses:       addresses,
 				FormattedAmount: humanize.Commaf(amount),
+				Index:           txIndex,
 			})
 		}
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -994,7 +994,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		} else if vin.Stakebase != "" {
 			vin.DisplayText = "Stakebase: " + vin.Stakebase
 		} else {
-			vin.DisplayText = vin.Txid + ":" + strconv.Itoa(int(vin.Vout))
+			voutStr := strconv.Itoa(int(vin.Vout))
+			vin.DisplayText = vin.Txid + ":" + voutStr
+			vin.Link = "/tx/" + vin.Txid + "/out/" + voutStr
 		}
 	}
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -986,6 +986,18 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		} // tx.IsTicket()
 	} // !exp.liteMode
 
+	// Prepare the string to display for previous outpoint.
+	for idx, _ := range tx.Vin {
+		vin := &tx.Vin[idx]
+		if vin.Coinbase != "" {
+			vin.DisplayText = "Coinbase: " + vin.Coinbase
+		} else if vin.Stakebase != "" {
+			vin.DisplayText = "Stakebase: " + vin.Stakebase
+		} else {
+			vin.DisplayText = vin.Txid + ":" + strconv.Itoa(int(vin.Vout))
+		}
+	}
+
 	pageData := struct {
 		*CommonPageData
 		Data              *TxInfo

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -990,9 +990,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 	for idx, _ := range tx.Vin {
 		vin := &tx.Vin[idx]
 		if vin.Coinbase != "" {
-			vin.DisplayText = "Coinbase: " + vin.Coinbase
+			vin.DisplayText = "Coinbase"
 		} else if vin.Stakebase != "" {
-			vin.DisplayText = "Stakebase: " + vin.Stakebase
+			vin.DisplayText = "Stakebase"
 		} else {
 			voutStr := strconv.Itoa(int(vin.Vout))
 			vin.DisplayText = vin.Txid + ":" + voutStr

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -200,6 +200,7 @@ type Vin struct {
 	Addresses       []string
 	FormattedAmount string
 	Index           uint32
+	DisplayText     string
 }
 
 // Vout models basic data about a tx output for display

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -201,6 +201,7 @@ type Vin struct {
 	FormattedAmount string
 	Index           uint32
 	DisplayText     string
+	Link            string
 }
 
 // Vout models basic data about a tx output for display

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -355,8 +355,13 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"theme": func() string {
 			return netTheme
 		},
-		"now": func() int64 {
-			return time.Now().Unix()
+		"elide": func(a string, maxLen int) string {
+			aLen := len(a)
+			if aLen <= maxLen || maxLen < 3 {
+				return a
+			}
+			endLen := (maxLen - 2) / 2
+			return a[:endLen] + "..." + a[aLen-endLen:aLen]
 		},
 		"uint16toInt64": func(v uint16) int64 {
 			return int64(v)

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -355,14 +355,6 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"theme": func() string {
 			return netTheme
 		},
-		"elide": func(a string, maxLen int) string {
-			aLen := len(a)
-			if aLen <= maxLen || maxLen < 3 {
-				return a
-			}
-			endLen := (maxLen - 2) / 2
-			return a[:endLen] + "..." + a[aLen-endLen:aLen]
-		},
 		"uint16toInt64": func(v uint16) int64 {
 			return int64(v)
 		},
@@ -378,6 +370,17 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			} else {
 				return arr
 			}
+		},
+		"hashlink": func(hash string, link string) [2]string {
+			return [2]string{hash, link}
+		},
+		"hashStart": func(hash string) string {
+			hashLen := len(hash)
+			return hash[0 : hashLen-6]
+		},
+		"hashEnd": func(hash string) string {
+			hashLen := len(hash)
+			return hash[hashLen-6 : hashLen]
 		},
 	}
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -152,6 +152,18 @@ body.darkBG a,
 body.darkBG a:hover {
   color: #94ffca;
 }
+body.darkBG a.elidedhash,  body.darkBG a.elidedhash:hover{
+  color:transparent;
+  text-decoration-color:#94ffca;
+}
+body.darkBG a.elidedhash::before,
+body.darkBG a.elidedhash::after {
+  color: #94ffca;
+}
+body.darkBG div.elidedhash::before,
+body.darkBG div.elidedhash::after {
+  color: #fdfdfd;
+}
 body.darkBG a.grayed,
 body.darkBG a.grayed:hover {
   color: rgba(148, 255, 202, 0.75) !important;
@@ -594,9 +606,11 @@ body.darkBG .progress {
   -moz-user-select: all;
   user-select: all;
   z-index:20;
-  cursor:pointer;
   text-overflow:clip;
   overflow:hidden;
+}
+a.elidedhash {
+  cursor:pointer;
 }
 a.elidedhash:visited {
   color:transparent;
@@ -624,7 +638,6 @@ div.elidedhash:before, div.elidedhash:after {
 }
 .elidedhash:after {
   content:attr(data-tail);
-  color:#2e75ff;
   position:absolute;
   right:0;
   top:0;
@@ -633,7 +646,7 @@ div.elidedhash:before, div.elidedhash:after {
   text-align:right;
   direction:rtl;
 }
-.elidedhash:hover {
+a.elidedhash:hover {
   color:transparent;
   text-decoration: underline;
   text-decoration-color:#2e75ff;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -553,12 +553,6 @@ body.darkBG .progress {
   padding: .1rem .5rem;
   height: 25px;
 }
-.table .tx-type-stub{
-  max-width: 80px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow:hidden;
-}
 .table.flush-left tr td:first-child {
   padding-left: 0px;
 }
@@ -575,35 +569,74 @@ body.darkBG .progress {
 .table-fixed {
   table-layout: fixed;
 }
-.table .hex-elide-wrap {
+.table div.hash-box {
   position:relative;
+  height:1.4rem;
+  min-width:4em;
+  font-size:14px;
+  padding:0.2em 10% 0.2em 0;
+}
+.table div.hash-fill {
+  position:absolute;
+  left:0;
+  top:0;
+  right:0;
   bottom:0;
 }
-.table .hex-elide-wrap:hover > div {
-  text-decoration:underline;
-}
-.table .hex-elide-left, .table .hex-elide-right {
-  padding-top:.1rem;
-  position:absolute;
-  top:0;
-  overflow:hidden;
+.elidedhash {
+  position:relative;
+  display:inline-block;
+  font-family: 'inconsolata-v15-latin-regular', monospace;
+  color:transparent;
+/*   border: 1px solid #aaa; */
+  max-width:100%;
   -webkit-user-select: all;
   -moz-user-select: all;
   user-select: all;
-}
-.table .hex-elide-left {
-  left:5px;
-  right:50%;
-  text-align:right;
-  text-overflow: ellipsis;
-}
-.table .hex-elide-right {
-  right:5px;
-  left:50%;
-  text-align:left;
-  direction:rtl;
+  z-index:20;
+  cursor:pointer;
   text-overflow:clip;
-  text-overflow:'';
+  overflow:hidden;
+}
+a.elidedhash:visited {
+  color:transparent;
+}
+.elidedhash::selection {
+  color:transparent;
+  background-color:#ccc;
+}
+.elidedhash:before {
+  content:attr(data-head);
+  position:absolute;
+  left:0;
+  top:0;
+  right:3em;
+  text-overflow:ellipsis;
+  overflow:hidden;
+  z-index:10;
+  text-align:left;
+}
+a.elidedhash:before, a.elidedhash:after {
+  color:#2e75ff;
+}
+div.elidedhash:before, div.elidedhash:after {
+  color:#212529;
+}
+.elidedhash:after {
+  content:attr(data-tail);
+  color:#2e75ff;
+  position:absolute;
+  right:0;
+  top:0;
+  width:3em;
+  z-index:10;
+  text-align:right;
+  direction:rtl;
+}
+.elidedhash:hover {
+  color:transparent;
+  text-decoration: underline;
+  text-decoration-color:#2e75ff;
 }
 
 /*flexboxtable*/
@@ -624,14 +657,11 @@ body.darkBG .progress {
   width:1%;
   white-space:nowrap;
 }
-
-.addressAndScriptData {
-  overflow: hidden;
-}
 .scriptDataStar {
   z-index: 1;
   text-align: center;
   color: coral;
+  cursor:pointer;
 }
 .scriptData {
   z-index: -1;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -553,11 +553,11 @@ body.darkBG .progress {
   padding: .1rem .5rem;
   height: 25px;
 }
-.tx-col-l{
-  max-width:54%;
-}
-.tx-col-r{
-  max-width:46%;
+.tx-type-stub{
+  max-width: 80px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow:hidden;
 }
 .table.flush-left tr td:first-child {
   padding-left: 0px;
@@ -775,6 +775,16 @@ body.darkBG .keynav-target {
     display:none;
   }
 }
+
+@media only screen and (min-width: 768px)  {
+  .tx-col-l{
+    max-width:52%;
+  }
+  .tx-col-r{
+    max-width:48%;
+  }
+}
+
 @media only screen and (max-width: 576px)  {
   .home-link {
     width: 35px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -584,6 +584,11 @@ body.darkBG .progress {
   border-bottom: 1px solid #e4e4e4;
 }
 
+.shrink-to-fit {
+  width:1%;
+  white-space:nowrap;
+}
+
 .addressAndScriptData {
   overflow: hidden;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -553,7 +553,7 @@ body.darkBG .progress {
   padding: .1rem .5rem;
   height: 25px;
 }
-.tx-type-stub{
+.table .tx-type-stub{
   max-width: 80px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -574,6 +574,36 @@ body.darkBG .progress {
 }
 .table-fixed {
   table-layout: fixed;
+}
+.table .hex-elide-wrap {
+  position:relative;
+  bottom:0;
+}
+.table .hex-elide-wrap:hover > div {
+  text-decoration:underline;
+}
+.table .hex-elide-left, .table .hex-elide-right {
+  padding-top:.1rem;
+  position:absolute;
+  top:0;
+  overflow:hidden;
+  -webkit-user-select: all;
+  -moz-user-select: all;
+  user-select: all;
+}
+.table .hex-elide-left {
+  left:5px;
+  right:50%;
+  text-align:right;
+  text-overflow: ellipsis;
+}
+.table .hex-elide-right {
+  right:5px;
+  left:50%;
+  text-align:left;
+  direction:rtl;
+  text-overflow:clip;
+  text-overflow:'';
 }
 
 /*flexboxtable*/
@@ -773,15 +803,6 @@ body.darkBG .keynav-target {
   }
   .block-msg {
     display:none;
-  }
-}
-
-@media only screen and (min-width: 768px)  {
-  .tx-col-l{
-    max-width:52%;
-  }
-  .tx-col-r{
-    max-width:48%;
   }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -553,6 +553,12 @@ body.darkBG .progress {
   padding: .1rem .5rem;
   height: 25px;
 }
+.tx-col-l{
+  max-width:54%;
+}
+.tx-col-r{
+  max-width:46%;
+}
 .table.flush-left tr td:first-child {
   padding-left: 0px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -588,6 +588,10 @@ body.darkBG .progress {
   font-size:14px;
   padding:0.2em 10% 0.2em 0;
 }
+.table th.addr-hash-column {
+  font-size:14px;
+  width:20em;
+}
 .table div.hash-fill {
   position:absolute;
   left:0;
@@ -628,7 +632,7 @@ a.elidedhash:visited {
   text-overflow:ellipsis;
   overflow:hidden;
   z-index:10;
-  text-align:left;
+  text-align:right;
 }
 a.elidedhash:before, a.elidedhash:after {
   color:#2e75ff;

--- a/public/css/nexthome.css
+++ b/public/css/nexthome.css
@@ -492,7 +492,7 @@ body {
     .top-nav .logo a {
         width: 90px !important;
     }
-    .col-md-6 {
+    .nh-col-md-6 {
         flex: 0 0 50%;
         max-width: 100%;
     }

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -787,3 +787,18 @@
         </select>
     </div>
 {{end}}
+
+{{define "hashElide"}}
+  {{$hash := (index . 0)}}
+  {{$link := (index . 1)}}
+  {{if eq $link ""}}
+    <div
+  {{else}}
+    <a href="{{$link}}"
+  {{end}}
+    data-keynav-priority
+    class="elidedhash mono"
+    data-head="{{hashStart $hash}}"
+    data-tail="{{hashEnd $hash}}"
+    >{{$hash}}{{if eq $link ""}}</div>{{else}}</a>{{end}}
+{{end}}

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -4,13 +4,13 @@
 
 {{ template "html-head" "Decred Block Explorer by dcrdata.org"}}
 
-<body class="{{ theme }}"> 
+<body class="{{ theme }}">
     {{ template "navbar" . }}
     <div class="container main" data-controller="main">
 
         <div class="row" data-controller="homepageMempool">
 
-            <div class="col-md-6">
+            <div class="col-md-6 nh-col-md-6">
 
                 <h3 class="mt-2">{{.NetName}} Chain State</h3>
 
@@ -78,7 +78,7 @@
                             <td class="text-right pr-2 lh1rem pt-1 pb-1 vam">TICKET REWARD</td>
                             <td>
                             <div class="mono vam lh1rem fs24 p03rem0 fs14-decimal">
-                                +<span id="ticket_reward">{{printf "%.2f" .TicketReward}}</span>%&nbsp;<span class="mono lh1rem fs18">per ~{{.RewardPeriod}}</span>  
+                                +<span id="ticket_reward">{{printf "%.2f" .TicketReward}}</span>%&nbsp;<span class="mono lh1rem fs18">per ~{{.RewardPeriod}}</span>
                                 <span class="mono lh1rem fs18" title="Annual Stake Rewards">({{printf "%.2f" .ASR}}% / year)</span>
                             </div>
                             </td>
@@ -87,7 +87,7 @@
                             <td class="text-right pr-2 lh1rem pt-1 pb-1">TICKET POOL SIZE</td>
                             <td>
                                 <div class="mono lh1rem p03rem0 fs14-decimal fs18">
-                                    <span id="pool_size">{{intComma .PoolInfo.Size}}&nbsp;</span> 
+                                    <span id="pool_size">{{intComma .PoolInfo.Size}}&nbsp;</span>
                                     (<span id="target_percent">{{printf "%.2f" .PoolInfo.PercentTarget}}</span>% of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>)
                                 </div>
                             </td>
@@ -187,7 +187,7 @@
 
             </div>
 
-            <div class="col-md-6">
+            <div class="col-md-6 nh-col-md-6">
 
                 <div class="d-flex align-items-center">
                     <h4>Latest Transactions</h4> <a href="/mempool" class="pl-2 keyboard-target" data-keynav-priority><small>see more ...</small></a>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -294,7 +294,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-7 mb-3">
+        <div class="col-md-7 mb-3 tx-col-l">
             <h4>Input</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -308,21 +308,21 @@
                     {{range .Vin}}
                     <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="break-word mono fs13">
+                        <td class="mono fs13">
                             <div>
                             {{if .Coinbase}}
-                                Coinbase: {{elide .Coinbase 32}}
+                                Coinbase: {{elide .Coinbase 20}}
                             {{else if .Stakebase}}
-                                Stakebase: {{elide .Stakebase 32}}
+                                Stakebase: {{elide .Stakebase 20}}
                             {{else}}
-                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{elide .Txid 32}}:{{.Vout}}</a>
+                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{elide .Txid 20}}:{{.Vout}}</a>
                             {{end}}
                             </div>
                         </td>
-                        <td><div class="break-word mono fs13">
+                        <td><div class="mono fs13">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
-                                    <div><a href="/address/{{.}}">{{elide . 32}}</a></div>
+                                    <div><a href="/address/{{.}}">{{.}}</a></div>
                                 {{end}}
                             {{else}}
                                 N/A
@@ -358,7 +358,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-5 mb-3">
+        <div class="col-md-5 mb-3 tx-col-r">
             <h4>Output</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -372,9 +372,9 @@
                     {{range $i, $v := .Vout}}
                     <tr {{if and (eq $.HighlightInOut "out") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="break-word mono fs13 addressAndScriptData">
+                        <td class="mono fs13 addressAndScriptData">
                             {{range .Addresses}}
-                                <div class="sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{elide . 32}}</a></div>
+                                <div class="sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
                             {{end}}
                             {{if .OP_RETURN}}
                                 {{if .Addresses}}
@@ -385,7 +385,7 @@
                                 {{else}}
                                 <div>
                                 {{end}}
-                                    <span>{{.OP_RETURN}}</span>
+                                    <span class="break-work">{{.OP_RETURN}}</span>
                                 </div>
                             {{end}}
                         </td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -308,7 +308,7 @@
                     {{range .Vin}}
                     <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="mono fs13">
+                        <td class="mono fs13 break-word">
                             <div>
                             {{if .Coinbase}}
                                 Coinbase: {{elide .Coinbase 20}}
@@ -319,7 +319,7 @@
                             {{end}}
                             </div>
                         </td>
-                        <td><div class="mono fs13">
+                        <td><div class="mono fs13 break-word">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
                                     <div><a href="/address/{{.}}">{{.}}</a></div>
@@ -374,7 +374,7 @@
                         <td class="shrink-to-fit">{{.Index}}</td>
                         <td class="mono fs13 addressAndScriptData">
                             {{range .Addresses}}
-                                <div class="sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
+                                <div class="sm-fullwidth break-word"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
                             {{end}}
                             {{if .OP_RETURN}}
                                 {{if .Addresses}}
@@ -385,12 +385,12 @@
                                 {{else}}
                                 <div>
                                 {{end}}
-                                    <span class="break-work">{{.OP_RETURN}}</span>
+                                    <span class="break-word">{{.OP_RETURN}}</span> 
                                 </div>
                             {{end}}
                         </td>
-                        <td class="fs13 break-word shrink-to-fit">
-                            {{.Type}}
+                        <td class="fs13">
+                            <div class="tx-type-stub">{{.Type}}</div>
                         </td>
                         <td class="text-left fs13 shrink-to-fit">{{with $spending := (index $.Data.SpendingTxns $i) }}
                             {{if $spending.Hash}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -294,7 +294,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-7 mb-3 tx-col-l">
+        <div class="col-md-6 mb-3">
             <h4>Input</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -308,16 +308,15 @@
                     {{range .Vin}}
                     <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="mono fs13 break-word">
-                            <div>
-                            {{if .Coinbase}}
-                                Coinbase: {{elide .Coinbase 20}}
-                            {{else if .Stakebase}}
-                                Stakebase: {{elide .Stakebase 20}}
-                            {{else}}
-                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{elide .Txid 20}}:{{.Vout}}</a>
-                            {{end}}
-                            </div>
+                        <td class="mono fs13">
+                            {{if or .Coinbase .Stakebase}}<div{{else}}<a href="/tx/{{.Txid}}/out/{{.Vout}}"{{end}} class="d-block hex-elide-wrap h-100 position-relative" data-keynav-priority>
+                              <div class="hex-elide-left">
+                                {{.DisplayText}}
+                              </div>
+                              <div class="hex-elide-right">
+                                {{.DisplayText}}
+                              </div>
+                            {{if or .Coinbase .Stakebase}}</div>{{else}}</a>{{end}}
                         </td>
                         <td><div class="mono fs13 break-word">
                             {{if gt (len .Addresses) 0}}
@@ -358,7 +357,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-5 mb-3 tx-col-r">
+        <div class="col-md-6 mb-3">
             <h4>Output</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -385,7 +384,7 @@
                                 {{else}}
                                 <div>
                                 {{end}}
-                                    <span class="break-word">{{.OP_RETURN}}</span> 
+                                    <span class="break-word">{{.OP_RETURN}}</span>
                                 </div>
                             {{end}}
                         </td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -294,13 +294,13 @@
     </div>
 
     <div class="row">
-        <div class="col-md-7 mb-3">
+        <div class="col-md-6 mb-3">
             <h4>Input</h4>
             <table class="table table-sm striped">
                 <thead>
                     <th class="shrink-to-fit">#</th>
-                    <th>Previous Outpoint</th>
-                    <th>Addresses</th>
+                    <th class="text-nowrap">Previous Outpoint</th>
+                    <th class="addr-hash-column">Addresses</th>
                     <th class="text-center shrink-to-fit">Block</th>
                     <th class="text-center shrink-to-fit">DCR</th>
                 </thead>
@@ -353,12 +353,12 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-5 mb-3">
+        <div class="col-md-6 mb-3">
             <h4>Output</h4>
             <table class="table table-sm striped">
                 <thead>
                     <th class="shrink-to-fit">#</th>
-                    <th>Address</th>
+                    <th class="addr-hash-column">Address</th>
                     <th class="text-left shrink-to-fit">Type</th>
                     <th class="text-left shrink-to-fit">Spent</th>
                     <th class="text-center shrink-to-fit">DCR</th>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -294,7 +294,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-6 mb-3">
+        <div class="col-md-7 mb-3">
             <h4>Input</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -308,25 +308,26 @@
                     {{range .Vin}}
                     <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="mono fs13">
-                            {{if or .Coinbase .Stakebase}}<div{{else}}<a href="/tx/{{.Txid}}/out/{{.Vout}}"{{end}} class="d-block hex-elide-wrap h-100 position-relative" data-keynav-priority>
-                              <div class="hex-elide-left">
-                                {{.DisplayText}}
-                              </div>
-                              <div class="hex-elide-right">
-                                {{.DisplayText}}
-                              </div>
-                            {{if or .Coinbase .Stakebase}}</div>{{else}}</a>{{end}}
+                        <td class="position-relative">
+                          <div class="hash-box">
+                            <div class="hash-fill">
+                              {{template "hashElide" (hashlink .DisplayText .Link)}}
+                            </div>
+                          </div>
                         </td>
-                        <td><div class="mono fs13 break-word">
+                        <td class="position-relative">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
-                                    <div><a href="/address/{{.}}">{{.}}</a></div>
+                                <div class="hash-box">
+                                  <div class="hash-fill">
+                                    {{template "hashElide" (hashlink . (print "/address/" .))}}
+                                  </div>
+                                </div>
                                 {{end}}
                             {{else}}
                                 N/A
                             {{end}}
-                        </div></td>
+                        </td>
                         <td class="shrink-to-fit">
                         {{if or .Coinbase .Stakebase}}
                             created
@@ -336,13 +337,8 @@
                             <a href="/block/{{.BlockHeight}}">{{.BlockHeight}}</a>
                         {{end}}
                         </td>
-<<<<<<< 826a6489fc114c7f5343067813d68165b9859510
-                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}}
-                        <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}} {{end}}</span>
-=======
                         <td class="mono fs13 text-right shrink-to-fit">{{if lt .AmountIn 0.0}} N/A {{else}}
                         <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .AmountIn 6 false)}} {{end}}</span>
->>>>>>> Elided text, vout/vin index, and table-layout: auto on tx page tables.
                         </td>
                     </tr>
                     {{end}}
@@ -357,7 +353,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-6 mb-3">
+        <div class="col-md-5 mb-3">
             <h4>Output</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -371,9 +367,13 @@
                     {{range $i, $v := .Vout}}
                     <tr {{if and (eq $.HighlightInOut "out") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
                         <td class="shrink-to-fit">{{.Index}}</td>
-                        <td class="mono fs13 addressAndScriptData">
+                        <td class="position-relative">
                             {{range .Addresses}}
-                                <div class="sm-fullwidth break-word"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
+                              <div class="hash-box">
+                                <div class="hash-fill">
+                                  {{template "hashElide" (hashlink . (print "/address/" .))}}
+                                </div>
+                              </div>
                             {{end}}
                             {{if .OP_RETURN}}
                                 {{if .Addresses}}
@@ -388,8 +388,8 @@
                                 </div>
                             {{end}}
                         </td>
-                        <td class="fs13">
-                            <div class="tx-type-stub">{{.Type}}</div>
+                        <td class="fs13 break-word shrink-to-fit">
+                            {{.Type}}
                         </td>
                         <td class="text-left fs13 shrink-to-fit">{{with $spending := (index $.Data.SpendingTxns $i) }}
                             {{if $spending.Hash}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -296,37 +296,39 @@
     <div class="row">
         <div class="col-md-7 mb-3">
             <h4>Input</h4>
-            <table class="table table-sm table-fixed striped">
+            <table class="table table-sm striped">
                 <thead>
+                    <th class="shrink-to-fit">#</th>
                     <th>Previous Outpoint</th>
                     <th>Addresses</th>
-                    <th class="text-center" width="60">Block</th>
-                    <th class="text-center" width="100">DCR</th>
+                    <th class="text-center shrink-to-fit">Block</th>
+                    <th class="text-center shrink-to-fit">DCR</th>
                 </thead>
                 <tbody>
                     {{range .Vin}}
                     <tr {{if and (eq $.HighlightInOut "in") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
+                        <td class="shrink-to-fit">{{.Index}}</td>
                         <td class="break-word mono fs13">
-                            <div class="outpoint">
+                            <div>
                             {{if .Coinbase}}
-                                Coinbase: {{ .Coinbase }}
+                                Coinbase: {{elide .Coinbase 32}}
                             {{else if .Stakebase}}
-                                Stakebase: {{ .Stakebase }}
+                                Stakebase: {{elide .Stakebase 32}}
                             {{else}}
-                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{.Txid}}:{{.Vout}}</a>
+                                <a data-keynav-priority href="/tx/{{.Txid}}/out/{{.Vout}}">{{elide .Txid 32}}:{{.Vout}}</a>
                             {{end}}
                             </div>
                         </td>
-                        <td><div class="break-word address mono fs13">
+                        <td><div class="break-word mono fs13">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
-                                    <div><a href="/address/{{.}}">{{.}}</a></div>
+                                    <div><a href="/address/{{.}}">{{elide . 32}}</a></div>
                                 {{end}}
                             {{else}}
                                 N/A
                             {{end}}
                         </div></td>
-                        <td>
+                        <td class="shrink-to-fit">
                         {{if or .Coinbase .Stakebase}}
                             created
                         {{else if eq .BlockHeight 0}}
@@ -335,8 +337,13 @@
                             <a href="/block/{{.BlockHeight}}">{{.BlockHeight}}</a>
                         {{end}}
                         </td>
+<<<<<<< 826a6489fc114c7f5343067813d68165b9859510
                         <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}}
                         <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}} {{end}}</span>
+=======
+                        <td class="mono fs13 text-right shrink-to-fit">{{if lt .AmountIn 0.0}} N/A {{else}}
+                        <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .AmountIn 6 false)}} {{end}}</span>
+>>>>>>> Elided text, vout/vin index, and table-layout: auto on tx page tables.
                         </td>
                     </tr>
                     {{end}}
@@ -345,7 +352,7 @@
                             <td class="mono fs13">(Transaction Fees Collected)</td>
                             <td></td>
                             <td></td>
-                            <td class="mono fs13 text-right">{{template "decimalParts" (amountAsDecimalParts .BlockMiningFee false)}}</td>
+                            <td class="mono fs13 text-right">{{template "decimalParts" (float64AsDecimalParts .BlockMiningFee 6 false)}}</td>
                         </tr>
                     {{end}}
                 </tbody>
@@ -353,19 +360,21 @@
         </div>
         <div class="col-md-5 mb-3">
             <h4>Output</h4>
-            <table class="table table-sm table-fixed striped">
+            <table class="table table-sm striped">
                 <thead>
+                    <th class="shrink-to-fit">#</th>
                     <th>Address</th>
-                    <th class="text-left">Type</th>
-                    <th class="text-left" width="50">Spent</th>
-                    <th class="text-right" width="100">DCR</th>
+                    <th class="text-left shrink-to-fit">Type</th>
+                    <th class="text-left shrink-to-fit">Spent</th>
+                    <th class="text-center shrink-to-fit">DCR</th>
                 </thead>
                 <tbody>
                     {{range $i, $v := .Vout}}
                     <tr {{if and (eq $.HighlightInOut "out") (eq $.HighlightInOutID .Index)}} class="matching-hash" {{end}}>
+                        <td class="shrink-to-fit">{{.Index}}</td>
                         <td class="break-word mono fs13 addressAndScriptData">
                             {{range .Addresses}}
-                                <div class="address sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{.}}</a></div>
+                                <div class="sm-fullwidth"><a href="/address/{{.}}" data-keynav-priority>{{elide . 32}}</a></div>
                             {{end}}
                             {{if .OP_RETURN}}
                                 {{if .Addresses}}
@@ -380,10 +389,10 @@
                                 </div>
                             {{end}}
                         </td>
-                        <td class="fs13 break-word">
+                        <td class="fs13 break-word shrink-to-fit">
                             {{.Type}}
                         </td>
-                        <td class="text-left fs13">{{with $spending := (index $.Data.SpendingTxns $i) }}
+                        <td class="text-left fs13 shrink-to-fit">{{with $spending := (index $.Data.SpendingTxns $i) }}
                             {{if $spending.Hash}}
                                 <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
                             {{else}}
@@ -396,7 +405,7 @@
                             {{end}}
                         </td>
 			            <td class="text-right mono fs13">
-                            <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .Amount 8 false)}}</span>
+                            <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .Amount 6 false)}}</span>
                         </td>
                     </tr>
                     {{end}}


### PR DESCRIPTION
See #241

This makes some changes to the table layout on the transactions page. The abridged/elided text is created using the `template.FuncMap`, so it can be used on any other page as well. 

![image](https://user-images.githubusercontent.com/6109680/47714375-af156a00-dc0a-11e8-9607-c6a2b1f0c531.png)
