### PR TITLE
Block time counter in the footer

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -268,7 +268,6 @@ func (db *wiredDB) GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVer
 func (db *wiredDB) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult {
 	return rpcutils.GetBlockVerboseByHash(db.client, hash, verboseTx)
 }
-
 func (db *wiredDB) CoinSupply() (supply *apitypes.CoinSupply) {
 	coinSupply, err := db.client.GetCoinSupply()
 	if err != nil {
@@ -1579,4 +1578,26 @@ func (db *wiredDB) Difficulty() (float64, error) {
 		return diff, err
 	}
 	return diff, nil
+}
+
+// GetTip grabs the highest block stored in the database.
+func (db *wiredDB) GetTip() (*explorer.WebBasicBlock, error) {
+	tip, err := db.DB.getTip()
+	if err != nil {
+		return nil, err
+	}
+	blockdata := explorer.WebBasicBlock{
+		Height:      tip.Height,
+		Size:        tip.Size,
+		Hash:        tip.Hash,
+		Difficulty:  tip.Difficulty,
+		StakeDiff:   tip.StakeDiff,
+		Time:        tip.Time,
+		NumTx:       tip.NumTx,
+		PoolSize:    tip.PoolInfo.Size,
+		PoolValue:   tip.PoolInfo.Value,
+		PoolValAvg:  tip.PoolInfo.ValAvg,
+		PoolWinners: tip.PoolInfo.Winners,
+	}
+	return &blockdata, nil
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -48,6 +48,7 @@ type explorerDataSourceLite interface {
 	GetBlockHash(idx int64) (string, error)
 	GetExplorerTx(txid string) *TxInfo
 	GetExplorerAddress(address string, count, offset int64) (*AddressInfo, error)
+	GetTip() (*WebBasicBlock, error)
 	DecodeRawTransaction(txhex string) (*dcrjson.TxRawResult, error)
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -55,17 +55,17 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 	exp.pageData.RLock()
 
 	str, err := exp.templates.execTemplateToString("home", struct {
+		*CommonPageData
 		Info    *HomeInfo
 		Mempool *MempoolInfo
 		Blocks  []*BlockBasic
-		Version string
 		NetName string
 	}{
-		exp.pageData.HomeInfo,
-		exp.MempoolData,
-		blocks,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Info:           exp.pageData.HomeInfo,
+		Mempool:        exp.MempoolData,
+		Blocks:         blocks,
+		NetName:        exp.NetName,
 	})
 
 	exp.MempoolData.RUnlock()
@@ -91,13 +91,13 @@ func (exp *explorerUI) SideChains(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("sidechains", struct {
+		*CommonPageData
 		Data    []*dbtypes.BlockStatus
-		Version string
 		NetName string
 	}{
-		sideBlocks,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Data:           sideBlocks,
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -121,13 +121,13 @@ func (exp *explorerUI) DisapprovedBlocks(w http.ResponseWriter, r *http.Request)
 	}
 
 	str, err := exp.templates.execTemplateToString("rejects", struct {
+		*CommonPageData
 		Data    []*dbtypes.BlockStatus
-		Version string
 		NetName string
 	}{
-		disapprovedBlocks,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Data:           disapprovedBlocks,
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -150,17 +150,17 @@ func (exp *explorerUI) NextHome(w http.ResponseWriter, r *http.Request) {
 	exp.MempoolData.RLock()
 
 	str, err := exp.templates.execTemplateToString("nexthome", struct {
+		*CommonPageData
 		Info    *HomeInfo
 		Mempool *MempoolInfo
 		Blocks  []*BlockInfo
-		Version string
 		NetName string
 	}{
-		exp.pageData.HomeInfo,
-		exp.MempoolData,
-		blocks,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Info:           exp.pageData.HomeInfo,
+		Mempool:        exp.MempoolData,
+		Blocks:         blocks,
+		NetName:        exp.NetName,
 	})
 	exp.pageData.RUnlock()
 	exp.MempoolData.RUnlock()
@@ -209,21 +209,21 @@ func (exp *explorerUI) StakeDiffWindows(w http.ResponseWriter, r *http.Request) 
 	}
 
 	str, err := exp.templates.execTemplateToString("windows", struct {
+		*CommonPageData
 		Data         []*dbtypes.BlocksGroupedInfo
 		WindowSize   int64
 		BestWindow   int64
 		OffsetWindow int64
 		Limit        int64
-		Version      string
 		NetName      string
 	}{
-		windows,
-		exp.ChainParams.StakeDiffWindowSize,
-		int64(bestWindow),
-		int64(offsetWindow),
-		int64(rows),
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Data:           windows,
+		WindowSize:     exp.ChainParams.StakeDiffWindowSize,
+		BestWindow:     int64(bestWindow),
+		OffsetWindow:   int64(offsetWindow),
+		Limit:          int64(rows),
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -375,19 +375,19 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("explorer", struct {
+		*CommonPageData
 		Data       []*BlockBasic
 		BestBlock  int64
 		Rows       int64
-		Version    string
 		NetName    string
 		WindowSize int64
 	}{
-		summaries,
-		int64(bestBlockHeight),
-		int64(rows),
-		exp.Version,
-		exp.NetName,
-		exp.ChainParams.StakeDiffWindowSize,
+		CommonPageData: exp.commonData(),
+		Data:           summaries,
+		BestBlock:      int64(bestBlockHeight),
+		Rows:           int64(rows),
+		NetName:        exp.NetName,
+		WindowSize:     exp.ChainParams.StakeDiffWindowSize,
 	})
 
 	if err != nil {
@@ -441,18 +441,18 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 		data.MainChain = blockStatus.IsMainchain
 	}
 
-	str, err := exp.templates.execTemplateToString("block", struct {
+	pageData := struct {
+		*CommonPageData
 		Data          *BlockInfo
 		ConfirmHeight int64
-		Version       string
 		NetName       string
 	}{
-		data,
-		exp.Height() - data.Confirmations,
-		exp.Version,
-		exp.NetName,
-	})
-
+		CommonPageData: exp.commonData(),
+		Data:           data,
+		ConfirmHeight:  exp.Height() - data.Confirmations,
+		NetName:        exp.NetName,
+	}
+	str, err := exp.templates.execTemplateToString("block", pageData)
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
 		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, ErrorStatusType)
@@ -468,13 +468,13 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 func (exp *explorerUI) Mempool(w http.ResponseWriter, r *http.Request) {
 	exp.MempoolData.RLock()
 	str, err := exp.templates.execTemplateToString("mempool", struct {
+		*CommonPageData
 		Mempool *MempoolInfo
-		Version string
 		NetName string
 	}{
-		exp.MempoolData,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Mempool:        exp.MempoolData,
+		NetName:        exp.NetName,
 	})
 	exp.MempoolData.RUnlock()
 
@@ -516,19 +516,19 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 	exp.MempoolData.RUnlock()
 
 	str, err := exp.templates.execTemplateToString("ticketpool", struct {
-		Version      string
+		*CommonPageData
 		NetName      string
 		ChartsHeight uint64
 		ChartData    []*dbtypes.PoolTicketsData
 		GroupedData  *dbtypes.PoolTicketsData
 		Mempool      *dbtypes.PoolTicketsData
 	}{
-		exp.Version,
-		exp.NetName,
-		height,
-		barGraphs,
-		donutChart,
-		&mp,
+		CommonPageData: exp.commonData(),
+		NetName:        exp.NetName,
+		ChartsHeight:   height,
+		ChartData:      barGraphs,
+		GroupedData:    donutChart,
+		Mempool:        &mp,
 	})
 
 	if err != nil {
@@ -880,25 +880,25 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 	} // !exp.liteMode
 
 	pageData := struct {
+		*CommonPageData
 		Data              *TxInfo
 		Blocks            []*dbtypes.BlockStatus
 		BlockInds         []uint32
 		HasValidMainchain bool
 		ConfirmHeight     int64
-		Version           string
 		NetName           string
 		HighlightInOut    string
 		HighlightInOutID  int64
 	}{
-		tx,
-		blocks,
-		blockInds,
-		hasValidMainchain,
-		exp.Height() - tx.Confirmations,
-		exp.Version,
-		exp.NetName,
-		inout,
-		inoutid,
+		CommonPageData:    exp.commonData(),
+		Data:              tx,
+		Blocks:            blocks,
+		BlockInds:         blockInds,
+		HasValidMainchain: hasValidMainchain,
+		ConfirmHeight:     exp.Height() - tx.Confirmations,
+		NetName:           exp.NetName,
+		HighlightInOut:    inout,
+		HighlightInOutID:  inoutid,
 	}
 
 	str, err := exp.templates.execTemplateToString("tx", pageData)
@@ -917,9 +917,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	// AddressPageData is the data structure passed to the HTML template
 	type AddressPageData struct {
+		*CommonPageData
 		Data          *AddressInfo
 		ConfirmHeight []int64
-		Version       string
 		NetName       string
 		OldestTxTime  int64
 		IsLiteMode    bool
@@ -1194,12 +1194,12 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pageData := AddressPageData{
-		Data:          addrData,
-		ConfirmHeight: confirmHeights,
-		IsLiteMode:    exp.liteMode,
-		OldestTxTime:  oldestTxBlockTime,
-		Version:       exp.Version,
-		NetName:       exp.NetName,
+		CommonPageData: exp.commonData(),
+		Data:           addrData,
+		ConfirmHeight:  confirmHeights,
+		IsLiteMode:     exp.liteMode,
+		OldestTxTime:   oldestTxBlockTime,
+		NetName:        exp.NetName,
 	}
 	str, err := exp.templates.execTemplateToString("address", pageData)
 	if err != nil {
@@ -1217,11 +1217,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 // decoding or broadcasting is handled by the websocket hub.
 func (exp *explorerUI) DecodeTxPage(w http.ResponseWriter, r *http.Request) {
 	str, err := exp.templates.execTemplateToString("rawtx", struct {
-		Version string
+		*CommonPageData
 		NetName string
 	}{
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		NetName:        exp.NetName,
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1248,13 +1248,13 @@ func (exp *explorerUI) Charts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("charts", struct {
-		Version string
+		*CommonPageData
 		NetName string
 		Data    *dbtypes.ChartsData
 	}{
-		exp.Version,
-		exp.NetName,
-		tickets,
+		CommonPageData: exp.commonData(),
+		NetName:        exp.NetName,
+		Data:           tickets,
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1327,17 +1327,17 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 // handling without redirecting.
 func (exp *explorerUI) StatusPage(w http.ResponseWriter, code, message string, sType statusType) {
 	str, err := exp.templates.execTemplateToString("status", struct {
+		*CommonPageData
 		StatusType statusType
 		Code       string
 		Message    string
-		Version    string
 		NetName    string
 	}{
-		sType,
-		code,
-		message,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		StatusType:     sType,
+		Code:           code,
+		Message:        message,
+		NetName:        exp.NetName,
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1383,13 +1383,13 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("parameters", struct {
+		*CommonPageData
 		Cp      ExtendedChainParams
-		Version string
 		NetName string
 	}{
-		ecp,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Cp:             ecp,
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -1436,17 +1436,17 @@ func (exp *explorerUI) AgendaPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("agenda", struct {
+		*CommonPageData
 		Ai               *agendadb.AgendaTagged
-		Version          string
 		NetName          string
 		ChartDataByTime  *dbtypes.AgendaVoteChoices
 		ChartDataByBlock *dbtypes.AgendaVoteChoices
 	}{
-		agendaInfo,
-		exp.Version,
-		exp.NetName,
-		chartDataByTime,
-		chartDataByHeight,
+		CommonPageData:   exp.commonData(),
+		Ai:               agendaInfo,
+		NetName:          exp.NetName,
+		ChartDataByTime:  chartDataByTime,
+		ChartDataByBlock: chartDataByHeight,
 	})
 
 	if err != nil {
@@ -1469,13 +1469,13 @@ func (exp *explorerUI) AgendasPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	str, err := exp.templates.execTemplateToString("agendas", struct {
+		*CommonPageData
 		Agendas []*agendadb.AgendaTagged
-		Version string
 		NetName string
 	}{
-		agendas,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Agendas:        agendas,
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -1580,13 +1580,13 @@ func (exp *explorerUI) StatsPage(w http.ResponseWriter, r *http.Request) {
 	exp.pageData.RUnlock()
 
 	str, err := exp.templates.execTemplateToString("statistics", struct {
+		*CommonPageData
 		Stats   StatsInfo
-		Version string
 		NetName string
 	}{
-		stats,
-		exp.Version,
-		exp.NetName,
+		CommonPageData: exp.commonData(),
+		Stats:          stats,
+		NetName:        exp.NetName,
 	})
 
 	if err != nil {
@@ -1597,4 +1597,20 @@ func (exp *explorerUI) StatsPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, str)
+}
+
+// commonData grabs the common page data that is available to every page.
+// This is particularly useful for extras.tmpl, parts of which
+// are used on every page
+func (exp *explorerUI) commonData() *CommonPageData {
+	var cd CommonPageData
+	cd.Version = exp.Version
+	cd.ChainParams = exp.ChainParams
+	cd.BlockTimeUnix = int64(exp.ChainParams.TargetTimePerBlock.Seconds())
+	var err error
+	cd.Tip, err = exp.blockData.GetTip()
+	if err != nil {
+		log.Errorf("Failed to get retreive the chain tip from the database.: %v", err)
+	}
+	return &cd
 }

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1610,7 +1610,7 @@ func (exp *explorerUI) commonData() *CommonPageData {
 	var err error
 	cd.Tip, err = exp.blockData.GetTip()
 	if err != nil {
-		log.Errorf("Failed to get retreive the chain tip from the database.: %v", err)
+		log.Errorf("Failed to get the chain tip from the database.: %v", err)
 	}
 	return &cd
 }

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -593,6 +593,9 @@ type StatsInfo struct {
 	RewardWindowSize           int64
 }
 
+// CommonPageData is the basis for dasta structs used for HTML templates.
+// explorerUI.commonData returns an initialized instance or CommonPageData,
+// which itself should be used to initialize page data template structs.
 type CommonPageData struct {
 	Tip           *WebBasicBlock
 	Version       string

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -52,6 +52,21 @@ type BlockBasic struct {
 	FormattedBytes string `json:"formatted_bytes"`
 }
 
+// WebBasicBlock is used for quick DB data without rpc calls
+type WebBasicBlock struct {
+	Height      uint32   `json:"height"`
+	Size        uint32   `json:"size"`
+	Hash        string   `json:"hash"`
+	Difficulty  float64  `json:"diff"`
+	StakeDiff   float64  `json:"sdiff"`
+	Time        int64    `json:"time"`
+	NumTx       uint32   `json:"txlength"`
+	PoolSize    uint32   `json:"poolsize"`
+	PoolValue   float64  `json:"poolvalue"`
+	PoolValAvg  float64  `json:"poolvalavg"`
+	PoolWinners []string `json:"winners"`
+}
+
 // TxBasic models data for transactions on the block page
 type TxBasic struct {
 	TxID          string
@@ -576,6 +591,13 @@ type StatsInfo struct {
 	BlockTime                  int64
 	IdxInRewardWindow          int
 	RewardWindowSize           int64
+}
+
+type CommonPageData struct {
+	Tip           *WebBasicBlock
+	Version       string
+	ChainParams   *chaincfg.Params
+	BlockTimeUnix int64
 }
 
 // isSyncExplorerUpdate helps determine when the explorer should be updated

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -593,7 +593,7 @@ type StatsInfo struct {
 	RewardWindowSize           int64
 }
 
-// CommonPageData is the basis for dasta structs used for HTML templates.
+// CommonPageData is the basis for data structs used for HTML templates.
 // explorerUI.commonData returns an initialized instance or CommonPageData,
 // which itself should be used to initialize page data template structs.
 type CommonPageData struct {

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -346,5 +346,8 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"theme": func() string {
 			return netTheme
 		},
+		"now": func() int64 {
+			return time.Now().Unix()
+		},
 	}
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -498,6 +498,11 @@ body.darkBG .progress {
   position: relative;
 }
 
+.navbar-fixed-bottom .blockcounter {
+  width:20%;
+  overflow:visible;
+}
+
 #watermark
 {
   left: 50%;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -499,8 +499,7 @@ body.darkBG .progress {
 }
 
 .navbar-fixed-bottom .blockcounter {
-  width:20%;
-  overflow:visible;
+  width:100px;
 }
 
 #watermark
@@ -763,6 +762,9 @@ body.darkBG .keynav-target {
   }
   .sm-w151 {
     width: 151px;
+  }
+  .block-msg {
+    display:none;
   }
 }
 @media only screen and (max-width: 576px)  {

--- a/public/js/controllers/main.js
+++ b/public/js/controllers/main.js
@@ -31,12 +31,7 @@
 
         setAges() {
             if(this.data.has("lastblocktime")){
-              // This next line is apparently wrong :
-              // var lbt = this.data.get("lastblocktime")
-              // console.log("-- stimulus lastblocktime: "+lbt)
-              // It doesn't give the correct value if the data attribute has
-              // been updated elsewhere. Using jQuery until I can figure it out
-              var lbt = $("[data-main-lastblocktime]").data("main-lastblocktime")
+              var lbt = DCRThings.counter.data("main-lastblocktime")
               this.element.textContent = humanize.timeSince(lbt)
               if((new Date()).getTime()/1000 - lbt > 8*DCRThings.targetBlockTime){ // 8*blocktime = 40minutes = 12000 seconds
                 this.element.classList.add("text-danger")

--- a/public/js/controllers/main.js
+++ b/public/js/controllers/main.js
@@ -30,6 +30,14 @@
         }
 
         setAges() {
+            if(this.data.has("lastblocktime")){
+              var lbt = this.data.get("lastblocktime")
+              this.element.textContent = humanize.timeSince(lbt)
+              if((new Date()).getTime()/1000 - lbt > 12000){ // 8*blocktime = 40minutes = 12000 seconds
+                this.element.classList.add("text-danger")
+              }
+              return
+            }
             this.ageTargets.forEach((el,i) => {
                 if (el.dataset.age > 0) {
                     el.textContent = humanize.timeSince(el.dataset.age, el.id)

--- a/public/js/controllers/main.js
+++ b/public/js/controllers/main.js
@@ -31,9 +31,14 @@
 
         setAges() {
             if(this.data.has("lastblocktime")){
-              var lbt = this.data.get("lastblocktime")
+              // This next line is apparently wrong :
+              // var lbt = this.data.get("lastblocktime")
+              // console.log("-- stimulus lastblocktime: "+lbt)
+              // It doesn't give the correct value if the data attribute has
+              // been updated elsewhere. Using jQuery until I can figure it out
+              var lbt = $("[data-main-lastblocktime]").data("main-lastblocktime")
               this.element.textContent = humanize.timeSince(lbt)
-              if((new Date()).getTime()/1000 - lbt > 12000){ // 8*blocktime = 40minutes = 12000 seconds
+              if((new Date()).getTime()/1000 - lbt > 8*DCRThings.targetBlockTime){ // 8*blocktime = 40minutes = 12000 seconds
                 this.element.classList.add("text-danger")
               }
               return

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -245,7 +245,7 @@
             desktopNotifyNewBlock(b);
 
             // Update the blocktime counter.
-            $("[data-main-lastblocktime]").data("main-lastblocktime", b.time).removeClass("text-danger")
+            DCRThings.counter.data("main-lastblocktime", b.time).removeClass("text-danger")
 
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());
@@ -398,9 +398,11 @@
 
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
-    <div class="container d-flex">
-        <ul class="nav align-items-center nowrap blockcounter">
-          <span class="nav-item"><span data-controller="main" data-target="main.age" data-main-lastblocktime="{{$.Tip.Time}}"></span> since last block</span>
+    <div class="container d-flex justify-content-between align-items-center">
+        <ul class="nav justify-contents-left nowrap blockcounter">
+          <li class="nav-item text-left">
+            <span data-controller="main" data-target="main.age" data-main-lastblocktime="{{$.Tip.Time}}"></span> <span class="block-msg">since last block</span>
+          </li>
         </ul>
         <ul class="nav justify-content-center col">
             <li class="nav-item">
@@ -622,12 +624,12 @@
             Notify.requestPermission(onPermissionGranted, onPermissionDenied);
         }
     })
-
     $("#listing-view").change(function(ev) {
         Turbolinks.visit( "/"+
             $("#listing-view option:selected").val()
         )
     })
+    DCRThings.counter = $("[data-main-lastblocktime]")
 </script>
 
 <script data-turbolinks-eval="false">

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -107,6 +107,10 @@
         var expires = "expires="+d.toUTCString();
         document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
     }
+
+    var DCRThings = {}
+    DCRThings.targetBlockTime = {{$.BlockTimeUnix}}
+
     var sunIcon = document.getElementById("sun-icon")
     var darkBGCookieName = 'dcrdataDarkBG';
     function darkEnabled() {
@@ -240,7 +244,11 @@
             var b = newBlock.block;
             desktopNotifyNewBlock(b);
 
+<<<<<<< 578926bf19314216786a4a73ae1443a4faa26ca4
             // Update the blocktime counter.
+=======
+            // update the blocktime counter
+>>>>>>> base CommonPageData structure for explorer templates
             $("[data-main-lastblocktime]").data("main-lastblocktime", b.time).removeClass("text-danger")
 
             var expTableRows = $('#explorertable tbody tr');

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -246,6 +246,7 @@
 
             // Update the blocktime counter.
             DCRThings.counter.data("main-lastblocktime", b.time).removeClass("text-danger")
+            DCRThings.counter.html(humanize.timeSince(b.time))
 
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -244,11 +244,7 @@
             var b = newBlock.block;
             desktopNotifyNewBlock(b);
 
-<<<<<<< 578926bf19314216786a4a73ae1443a4faa26ca4
             // Update the blocktime counter.
-=======
-            // update the blocktime counter
->>>>>>> base CommonPageData structure for explorer templates
             $("[data-main-lastblocktime]").data("main-lastblocktime", b.time).removeClass("text-danger")
 
             var expTableRows = $('#explorertable tbody tr');
@@ -403,8 +399,8 @@
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
     <div class="container d-flex">
-        <ul class="nav justify-content-left align-items-center nowrap">
-          <div class="float-left"><span data-controller="main" data-target="main.age" data-main-lastblocktime="{{$.Tip.Time}}"></span> since last block</div>
+        <ul class="nav align-items-center nowrap blockcounter">
+          <span class="nav-item"><span data-controller="main" data-target="main.age" data-main-lastblocktime="{{$.Tip.Time}}"></span> since last block</span>
         </ul>
         <ul class="nav justify-content-center col">
             <li class="nav-item">

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -240,6 +240,9 @@
             var b = newBlock.block;
             desktopNotifyNewBlock(b);
 
+            // Update the blocktime counter.
+            $("[data-main-lastblocktime]").data("main-lastblocktime", b.time).removeClass("text-danger")
+
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());
             if (expTableRows){
@@ -392,6 +395,9 @@
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
     <div class="container d-flex">
+        <ul class="nav justify-content-left align-items-center nowrap">
+          <div class="float-left"><span data-controller="main" data-target="main.age" data-main-lastblocktime="{{$.Tip.Time}}"></span> since last block</div>
+        </ul>
         <ul class="nav justify-content-center col">
             <li class="nav-item">
                 <a


### PR DESCRIPTION
Possible solution for #399. This is a persistent block time counter in the footer. The text comes red when the time is longer than my somewhat arbitrarily defined 8*blocktime = 40 minutes. 

It is not ready, but I need some advice. Right now, I don't see a straightforward way of getting basic block information into the footer on every page, but I might be missing something. There is no welcome message from the websocket with basic block info. And the page data struct used by `templates` is different for every page, so if I wanted to grab it there, I would have to add it to every page's handler in `explorerroutes`, I think. Is that the right approach? Is the basic best block information available somewhere that I'm not seeing?