### PR TITLE
issue 372, enhancing the block page for the future block

### DIFF
--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -48,7 +48,7 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 			if height > maxHeight {
 				expectedTime := time.Duration(height-maxHeight) * exp.ChainParams.TargetTimePerBlock
 				message := fmt.Sprintf("This block is expected to arrive in approximately in %v. ", expectedTime)
-				exp.StatusPage(w, defaultErrorCode, message, NotFoundStatusType)
+				exp.StatusPage(w, defaultErrorCode, message, FutureBlockStatusType)
 				return
 			}
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1190,6 +1190,8 @@ func (exp *explorerUI) StatusPage(w http.ResponseWriter, code, message string, s
 		w.WriteHeader(http.StatusAccepted)
 	case NotSupportedStatusType:
 		w.WriteHeader(http.StatusUnprocessableEntity)
+	case FutureBlockStatusType:
+		w.WriteHeader(http.StatusOK)
 	default:
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -28,6 +28,7 @@ const (
 	WrongNetworkStatusType   statusType = "Wrong Network"
 	DeprecatedStatusType     statusType = "Deprecated"
 	BlockchainSyncingType    statusType = "Blocks Syncing"
+	FutureBlockStatusType    statusType = "Future Block"
 )
 
 // blockchainSyncStatus defines the status update displayed on the syncing status page

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -306,6 +306,10 @@
                 $("#target_percent").html(parseFloat(ex.pool_info.percent_target).toFixed(2))
                 $("#pool_size_percentage").html(parseFloat(ex.pool_info.percent).toFixed(2))
             }
+            //handling statuspage for future block
+            if($("#futureblock").length ){
+                Turbolinks.visit(window.location);
+            }
         };
         ws.registerEvtHandler("newblock", updateBlockData);
 

--- a/views/status.tmpl
+++ b/views/status.tmpl
@@ -10,9 +10,12 @@
         <div class="alert alert-info">
             {{if eq .StatusType "Not Found"}}
                 <h5>No matching page, block, address or transaction that could be found</h5>
-                <h5>{{.Message}}</h5>
             {{else}}
-                <h5>{{.Message}}</h5>
+                {{if eq .StatusType "Future Block"}}
+                    <h5 id="futureblock">{{.Message}}</h5>
+                {{else}}
+                    <h5>{{.Message}}</h5>
+                {{end}}
             {{end}}
         </div>
         <div id="initial-load" class="sync-progress">


### PR DESCRIPTION
Resubmitting the pr for issue 372. I have modified the dcrdata block page to show the waiting time for future block, it updates the time using websockets,  and also using websockets I am getting the block page when it is mined .