### PR TITLE
scope table-responsive class to narrow screens in /blocks table

### DIFF
--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -78,10 +78,10 @@
 
         <div class="row">
             <div class="col-md-12">
-                <table class="table striped table-responsive" id="explorertable">
+                <table class="table striped table-responsive-sm" id="explorertable">
                     <thead>
                         <tr>
-                            <th>Ticket Price Window #</th>
+                            <th><span class="nowrap">Ticket Price</span> <span class="nowrap">Window #<span></th>
                             <th>Height</th>
                             <th>
                                 <span class="d-none d-md-inline">Transactions</span>


### PR DESCRIPTION
This fixes /blocks table not expanding to full width after upgrading to latest Bootstrap.

**Before**
<img width="1153" alt="screen shot 2018-11-01 at 11 10 15 am" src="https://user-images.githubusercontent.com/25571523/47870417-c00ada80-ddc6-11e8-847c-3dea39251ccd.png">

**After
<img width="959" alt="screen shot 2018-11-01 at 11 08 23 am" src="https://user-images.githubusercontent.com/25571523/47870440-ce58f680-ddc6-11e8-96ad-f99cd49efdde.png">
**
![image](https://user-images.githubusercontent.com/25571523/47870391-acf80a80-ddc6-11e8-90f5-96d33be5843a.png)
