### PR TITLE
rename revocations to revokes

### DIFF
--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -145,7 +145,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="text-right pr-2 lh1rem p03rem0 xs-w117">{{if gt .Revocations  0 }}<a href="#revocations" data-keynav-skip>REVOCATIONS</a>{{else}}REVOCATIONS{{end}}</td>
+                        <td class="text-right pr-2 lh1rem p03rem0 xs-w117">{{if gt .Revocations  0 }}<a href="#revokes" data-keynav-skip>REVOKES</a>{{else}}REVOKES{{end}}</td>
                         <td class="lh1rem">
                             {{.Revocations}}
                         </td>
@@ -332,9 +332,9 @@
 
         {{if .Revocations}}
         <div class="row">
-            <span class="achor" id="revocations"></span>
+            <span class="anchor" id="revokes"></span>
             <div class="col-md-12">
-                <h4><span>Revocations</span></h4>
+                <h4><span>Revokes</span></h4>
                 <table class="table table-sm striped">
                     <thead>
                         <th>Transaction ID</th>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -90,8 +90,7 @@
                             <th>Vote<span class="d-none d-md-inline">s</span></th>
                             <th>Ticket<span class="d-none d-md-inline">s</span></th>
                             <th>
-                                <span class="d-none d-md-inline">Revocations</span>
-                                <span class="d-md-none">Revoke</span>
+                                <span>Revokes</span>
                             </th>
                             <th>Size</th>
                             <th>Age</th>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -231,7 +231,7 @@
                             <th>Vote<span class="d-none d-lg-inline">s</span></th>
                             <th>Ticket<span class="d-none d-lg-inline">s</span></th>
                             <th>
-                                <span class="d-none d-lg-inline">Revocations</span>
+                                <span class="d-none d-lg-inline">Revokes</span>
                                 <span class="d-lg-none">Revoke</span>
                             </th>
                             <th>Size</th>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -52,7 +52,7 @@
                             <td data-target="mempool.mempoolSize" class="lh1rem" >{{.FormattedTotalSize}}</td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem nowrap p03rem0">REVOCATIONS</td>
+                            <td class="text-right pr-2 lh1rem nowrap p03rem0">REVOKES</td>
                             <td data-target="mempool.numRevoke" class="lh1rem">{{.NumRevokes}}</td>
                         </tr>
                         <tr>
@@ -140,7 +140,7 @@
 
             <div class="row">
                 <div class="col-sm-12">
-                <h4><span>Revocations</span></h4>
+                <h4><span>Revokes</span></h4>
                     <table class="table table-sm striped">
                         <thead>
                             <th>Transaction ID</th>
@@ -166,7 +166,7 @@
                             {{end}}
                             {{else}}
                                 <tr>
-                                    <td colspan="4">No revocations in mempool.</td>
+                                    <td colspan="4">No revokes in mempool.</td>
                                 </tr>
                             {{end}}
                         </tbody>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -86,7 +86,7 @@
                             <th class="text-right">Transactions</th>
                             <th class="text-right">Votes</th>
                             <th class="text-right">Tickets</th>
-                            <th class="text-right">Revocations</th>
+                            <th class="text-right">Revokes</th>
                             <th>Total Size</th>
                             <th class="text-right">Difficulty</th>
                             <th class="text-right">Ticket Price (DCR)</th>


### PR DESCRIPTION
Minor change that renames revocations to revokes in the front end.

Since our tables can have a lot of columns and space can be at a premium, we should always choose the shorter version of a word if it's just as clear as the longer version. This helps with using that horizontal space efficiently.

I think it's best to be consistent with the choice of words so I've renamed it in all places exposed to the end user.