### PR TITLE
Set block time datatype to timestamp.

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -187,7 +187,7 @@ out:
 
 			c.statusMtx.Lock()
 			c.Status.DBHeight = height
-			c.Status.DBLastBlockTime = summary.Time
+			c.Status.DBLastBlockTime = summary.Time.T.Unix()
 
 			bdHeight := c.BlockData.GetHeight()
 			if bdHeight >= 0 && summary.Height == uint32(bdHeight) &&

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -187,7 +187,7 @@ out:
 
 			c.statusMtx.Lock()
 			c.Status.DBHeight = height
-			c.Status.DBLastBlockTime = summary.Time.T.Unix()
+			c.Status.DBLastBlockTime = summary.Time.S.T.Unix()
 
 			bdHeight := c.BlockData.GetHeight()
 			if bdHeight >= 0 && summary.Height == uint32(bdHeight) &&

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -823,8 +823,9 @@ func (c *insightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http
 				break
 			}
 			outputBlockSummary = append(outputBlockSummary, block)
-			if block.Time < summaryOutput.Pagination.MoreTs {
-				summaryOutput.Pagination.MoreTs = block.Time
+			blockTime := block.Time.Unix()
+			if blockTime < summaryOutput.Pagination.MoreTs {
+				summaryOutput.Pagination.MoreTs = blockTime
 			}
 		}
 		summaryOutput.Blocks = outputBlockSummary

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -823,7 +823,7 @@ func (c *insightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http
 				break
 			}
 			outputBlockSummary = append(outputBlockSummary, block)
-			blockTime := block.Time.Unix()
+			blockTime := block.Time.T.Unix()
 			if blockTime < summaryOutput.Pagination.MoreTs {
 				summaryOutput.Pagination.MoreTs = blockTime
 			}

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -286,7 +286,7 @@ type BlockDataBasic struct {
 	Hash       string          `json:"hash,omitemtpy"`
 	Difficulty float64         `json:"diff,omitemtpy"`
 	StakeDiff  float64         `json:"sdiff,omitemtpy"`
-	Time       dbtypes.TimeDef `json:"time,omitemtpy"`
+	Time       dbtypes.TimeAPI `json:"time,omitemtpy"`
 	NumTx      uint32          `json:"txlength,omitempty"`
 	// TicketPoolInfo may be nil for side chain blocks.
 	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -4,9 +4,8 @@
 package types
 
 import (
-	"time"
-
 	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
 
@@ -163,18 +162,18 @@ type AddressTxRaw struct {
 	Vout          []Vout               `json:"vout"`
 	Confirmations int64                `json:"confirmations"`
 	BlockHash     string               `json:"blockhash"`
-	Time          time.Time            `json:"time,omitempty"`
-	Blocktime     time.Time            `json:"blocktime,omitempty"`
+	Time          dbtypes.TimeAPI      `json:"time,omitempty"`
+	Blocktime     dbtypes.TimeAPI      `json:"blocktime,omitempty"`
 }
 
 // AddressTxShort is a subset of AddressTxRaw with just the basic tx details
 // pertaining the particular address
 type AddressTxShort struct {
-	TxID          string    `json:"txid"`
-	Size          int32     `json:"size"`
-	Time          time.Time `json:"time"`
-	Value         float64   `json:"value"`
-	Confirmations int64     `json:"confirmations"`
+	TxID          string          `json:"txid"`
+	Size          int32           `json:"size"`
+	Time          dbtypes.TimeAPI `json:"time"`
+	Value         float64         `json:"value"`
+	Confirmations int64           `json:"confirmations"`
 }
 
 // AddressTotals represents the number and value of spent and unspent outputs
@@ -282,13 +281,13 @@ type TicketPoolValsAndSizes struct {
 
 // BlockDataBasic models primary information about block at height Height
 type BlockDataBasic struct {
-	Height     uint32  `json:"height,omitemtpy"`
-	Size       uint32  `json:"size,omitemtpy"`
-	Hash       string  `json:"hash,omitemtpy"`
-	Difficulty float64 `json:"diff,omitemtpy"`
-	StakeDiff  float64 `json:"sdiff,omitemtpy"`
-	Time       int64   `json:"time,omitemtpy"`
-	NumTx      uint32  `json:"txlength,omitempty"`
+	Height     uint32          `json:"height,omitemtpy"`
+	Size       uint32          `json:"size,omitemtpy"`
+	Hash       string          `json:"hash,omitemtpy"`
+	Difficulty float64         `json:"diff,omitemtpy"`
+	StakeDiff  float64         `json:"sdiff,omitemtpy"`
+	Time       dbtypes.TimeDef `json:"time,omitemtpy"`
+	NumTx      uint32          `json:"txlength,omitempty"`
 	// TicketPoolInfo may be nil for side chain blocks.
 	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`
 }
@@ -303,13 +302,13 @@ func NewBlockDataBasic() *BlockDataBasic {
 // BlockExplorerBasic models primary information about block at height Height
 // for the block explorer.
 type BlockExplorerBasic struct {
-	Height      uint32  `json:"height"`
-	Size        uint32  `json:"size"`
-	Voters      uint16  `json:"votes"`
-	FreshStake  uint8   `json:"tickets"`
-	Revocations uint8   `json:"revocations"`
-	StakeDiff   float64 `json:"sdiff"`
-	Time        int64   `json:"time"`
+	Height      uint32          `json:"height"`
+	Size        uint32          `json:"size"`
+	Voters      uint16          `json:"votes"`
+	FreshStake  uint8           `json:"tickets"`
+	Revocations uint8           `json:"revocations"`
+	StakeDiff   float64         `json:"sdiff"`
+	Time        dbtypes.TimeDef `json:"time"`
 	BlockExplorerExtraInfo
 }
 
@@ -317,7 +316,6 @@ type BlockExplorerBasic struct {
 // explorer.
 type BlockExplorerExtraInfo struct {
 	TxLen            int                            `json:"tx"`
-	FormattedTime    string                         `json:"formatted_time"`
 	CoinSupply       int64                          `json:"coin_supply"`
 	NextBlockSubsidy *dcrjson.GetBlockSubsidyResult `json:"next_block_subsidy"`
 }

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
@@ -161,18 +163,18 @@ type AddressTxRaw struct {
 	Vout          []Vout               `json:"vout"`
 	Confirmations int64                `json:"confirmations"`
 	BlockHash     string               `json:"blockhash"`
-	Time          int64                `json:"time,omitempty"`
-	Blocktime     int64                `json:"blocktime,omitempty"`
+	Time          time.Time            `json:"time,omitempty"`
+	Blocktime     time.Time            `json:"blocktime,omitempty"`
 }
 
 // AddressTxShort is a subset of AddressTxRaw with just the basic tx details
 // pertaining the particular address
 type AddressTxShort struct {
-	TxID          string  `json:"txid"`
-	Size          int32   `json:"size"`
-	Time          int64   `json:"time"`
-	Value         float64 `json:"value"`
-	Confirmations int64   `json:"confirmations"`
+	TxID          string    `json:"txid"`
+	Size          int32     `json:"size"`
+	Time          time.Time `json:"time"`
+	Value         float64   `json:"value"`
+	Confirmations int64     `json:"confirmations"`
 }
 
 // AddressTotals represents the number and value of spent and unspent outputs

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -4,10 +4,28 @@
 package types
 
 import (
+	"encoding/json"
+
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
+
+// TimeAPI is a fall back dbtypes.TimeDef wrapper that allows API endpoints that
+// previously returned a timestamp instead of a formatted string time to continue
+// working.
+type TimeAPI struct {
+	S dbtypes.TimeDef
+}
+
+func (t TimeAPI) String() string {
+	return t.S.String()
+}
+
+// MarshalJSON is set as the default marshalling function for TimeAPI struct.
+func (t *TimeAPI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.S.T.Unix())
+}
 
 // much of the time, dcrdata will be using the types in dcrjson, but others are
 // defined here
@@ -162,18 +180,18 @@ type AddressTxRaw struct {
 	Vout          []Vout               `json:"vout"`
 	Confirmations int64                `json:"confirmations"`
 	BlockHash     string               `json:"blockhash"`
-	Time          dbtypes.TimeAPI      `json:"time,omitempty"`
-	Blocktime     dbtypes.TimeAPI      `json:"blocktime,omitempty"`
+	Time          TimeAPI              `json:"time,omitempty"`
+	Blocktime     TimeAPI              `json:"blocktime,omitempty"`
 }
 
 // AddressTxShort is a subset of AddressTxRaw with just the basic tx details
 // pertaining the particular address
 type AddressTxShort struct {
-	TxID          string          `json:"txid"`
-	Size          int32           `json:"size"`
-	Time          dbtypes.TimeAPI `json:"time"`
-	Value         float64         `json:"value"`
-	Confirmations int64           `json:"confirmations"`
+	TxID          string  `json:"txid"`
+	Size          int32   `json:"size"`
+	Time          TimeAPI `json:"time"`
+	Value         float64 `json:"value"`
+	Confirmations int64   `json:"confirmations"`
 }
 
 // AddressTotals represents the number and value of spent and unspent outputs
@@ -281,13 +299,13 @@ type TicketPoolValsAndSizes struct {
 
 // BlockDataBasic models primary information about block at height Height
 type BlockDataBasic struct {
-	Height     uint32          `json:"height,omitemtpy"`
-	Size       uint32          `json:"size,omitemtpy"`
-	Hash       string          `json:"hash,omitemtpy"`
-	Difficulty float64         `json:"diff,omitemtpy"`
-	StakeDiff  float64         `json:"sdiff,omitemtpy"`
-	Time       dbtypes.TimeAPI `json:"time,omitemtpy"`
-	NumTx      uint32          `json:"txlength,omitempty"`
+	Height     uint32  `json:"height,omitemtpy"`
+	Size       uint32  `json:"size,omitemtpy"`
+	Hash       string  `json:"hash,omitemtpy"`
+	Difficulty float64 `json:"diff,omitemtpy"`
+	StakeDiff  float64 `json:"sdiff,omitemtpy"`
+	Time       TimeAPI `json:"time,omitemtpy"`
+	NumTx      uint32  `json:"txlength,omitempty"`
 	// TicketPoolInfo may be nil for side chain blocks.
 	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/rpcclient"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/v3/api/types"
+	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/stakedb"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
@@ -66,23 +67,22 @@ func (b *BlockData) ToStakeInfoExtendedEstimates() apitypes.StakeInfoExtendedEst
 
 // ToBlockSummary returns an apitypes.BlockDataBasic object from the blockdata
 func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
+	t := dbtypes.TimeDef{T:time.Unix(b.Header.Time, 0)}
 	return apitypes.BlockDataBasic{
 		Height:     b.Header.Height,
 		Size:       b.Header.Size,
 		Hash:       b.Header.Hash,
 		Difficulty: b.Header.Difficulty,
 		StakeDiff:  b.Header.SBits,
-		Time:       b.Header.Time,
+		Time:       t,
 		PoolInfo:   b.PoolInfo,
 	}
 }
 
 // ToBlockExplorerSummary returns a BlockExplorerBasic
 func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
-	t := time.Unix(b.Header.Time, 0)
-	ftime := t.Format("2006-01-02 15:04:05")
 	extra := b.ExtraInfo
-	extra.FormattedTime = ftime
+	t := dbtypes.TimeDef{T:time.Unix(b.Header.Time, 0)}
 	return apitypes.BlockExplorerBasic{
 		Height:                 b.Header.Height,
 		Size:                   b.Header.Size,
@@ -91,7 +91,7 @@ func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 		FreshStake:             b.Header.FreshStake,
 		StakeDiff:              b.Header.SBits,
 		BlockExplorerExtraInfo: extra,
-		Time:                   b.Header.Time,
+		Time:                   t,
 	}
 }
 
@@ -205,7 +205,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		Hash:       hash.String(),
 		Difficulty: diff,
 		StakeDiff:  sdiff,
-		Time:       header.Timestamp.Unix(),
+		Time:       dbtypes.TimeDef{T:header.Timestamp},
 		PoolInfo:   ticketPoolInfo,
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -67,14 +67,14 @@ func (b *BlockData) ToStakeInfoExtendedEstimates() apitypes.StakeInfoExtendedEst
 
 // ToBlockSummary returns an apitypes.BlockDataBasic object from the blockdata
 func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
-	t := dbtypes.TimeDef{T:time.Unix(b.Header.Time, 0)}
+	t := dbtypes.TimeDef{T: time.Unix(b.Header.Time, 0)}
 	return apitypes.BlockDataBasic{
 		Height:     b.Header.Height,
 		Size:       b.Header.Size,
 		Hash:       b.Header.Hash,
 		Difficulty: b.Header.Difficulty,
 		StakeDiff:  b.Header.SBits,
-		Time:       t,
+		Time:       dbtypes.TimeAPI{t},
 		PoolInfo:   b.PoolInfo,
 	}
 }
@@ -82,7 +82,7 @@ func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
 // ToBlockExplorerSummary returns a BlockExplorerBasic
 func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 	extra := b.ExtraInfo
-	t := dbtypes.TimeDef{T:time.Unix(b.Header.Time, 0)}
+	t := dbtypes.TimeDef{T: time.Unix(b.Header.Time, 0)}
 	return apitypes.BlockExplorerBasic{
 		Height:                 b.Header.Height,
 		Size:                   b.Header.Size,
@@ -205,7 +205,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		Hash:       hash.String(),
 		Difficulty: diff,
 		StakeDiff:  sdiff,
-		Time:       dbtypes.TimeDef{T:header.Timestamp},
+		Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 		PoolInfo:   ticketPoolInfo,
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -74,7 +74,7 @@ func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
 		Hash:       b.Header.Hash,
 		Difficulty: b.Header.Difficulty,
 		StakeDiff:  b.Header.SBits,
-		Time:       dbtypes.TimeAPI{t},
+		Time:       apitypes.TimeAPI{S: t},
 		PoolInfo:   b.PoolInfo,
 	}
 }
@@ -205,7 +205,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		Hash:       hash.String(),
 		Difficulty: diff,
 		StakeDiff:  sdiff,
-		Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+		Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 		PoolInfo:   ticketPoolInfo,
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -13,6 +13,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/rpcclient"
 	apitypes "github.com/decred/dcrdata/v3/api/types"
+	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/rpcutils"
 	"github.com/decred/dcrdata/v3/txhelpers"
 	"github.com/decred/slog"
@@ -94,7 +95,7 @@ func mainCore() int {
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       header.Timestamp.Unix(),
+			Time:       dbtypes.TimeDef{T:header.Timestamp},
 			PoolInfo: &apitypes.TicketPoolInfo{
 				Size: header.PoolSize,
 			},

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -95,7 +95,7 @@ func mainCore() int {
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       dbtypes.TimeDef{T:header.Timestamp},
+			Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 			PoolInfo: &apitypes.TicketPoolInfo{
 				Size: header.PoolSize,
 			},

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -95,7 +95,7 @@ func mainCore() int {
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+			Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 			PoolInfo: &apitypes.TicketPoolInfo{
 				Size: header.PoolSize,
 			},

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -41,7 +41,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params) *B
 		Tx:           txHashStrs,
 		NumStakeTx:   uint32(len(msgBlock.STransactions)),
 		STx:          stxHashStrs,
-		Time:         uint64(blockHeader.Timestamp.Unix()),
+		Time:         blockHeader.Timestamp,
 		Nonce:        uint64(blockHeader.Nonce),
 		VoteBits:     blockHeader.VoteBits,
 		FinalState:   blockHeader.FinalState[:],
@@ -106,7 +106,7 @@ func CalculateWindowIndex(height, stakeDiffWindowSize int64) int64 {
 	windowVal := float64(height) / float64(stakeDiffWindowSize)
 	index := int64(windowVal)
 	if windowVal != math.Floor(windowVal) || windowVal == 0 {
-		index += 1
+		index++
 	}
 	return index
 }

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -41,7 +41,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params) *B
 		Tx:           txHashStrs,
 		NumStakeTx:   uint32(len(msgBlock.STransactions)),
 		STx:          stxHashStrs,
-		Time:         blockHeader.Timestamp,
+		Time:         TimeDef{blockHeader.Timestamp},
 		Nonce:        uint64(blockHeader.Nonce),
 		VoteBits:     blockHeader.VoteBits,
 		FinalState:   blockHeader.FinalState[:],

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -41,7 +41,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params) *B
 		Tx:           txHashStrs,
 		NumStakeTx:   uint32(len(msgBlock.STransactions)),
 		STx:          stxHashStrs,
-		Time:         TimeDef{blockHeader.Timestamp},
+		Time:         TimeDef{T: blockHeader.Timestamp},
 		Nonce:        uint64(blockHeader.Nonce),
 		VoteBits:     blockHeader.VoteBits,
 		FinalState:   blockHeader.FinalState[:],

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -62,7 +62,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 
 	blockHeight := msgBlock.Header.Height
 	blockHash := msgBlock.BlockHash()
-	blockTime := TimeDef{msgBlock.Header.Timestamp}
+	blockTime := TimeDef{T: msgBlock.Header.Timestamp}
 
 	dbTransactions := make([]*Tx, 0, len(txs))
 	dbTxVouts := make([][]*Vout, len(txs))

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -62,7 +62,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 
 	blockHeight := msgBlock.Header.Height
 	blockHash := msgBlock.BlockHash()
-	blockTime := msgBlock.Header.Timestamp.Unix()
+	blockTime := msgBlock.Header.Timestamp
 
 	dbTransactions := make([]*Tx, 0, len(txs))
 	dbTxVouts := make([][]*Vout, len(txs))

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -62,7 +62,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 
 	blockHeight := msgBlock.Header.Height
 	blockHash := msgBlock.BlockHash()
-	blockTime := msgBlock.Header.Timestamp
+	blockTime := TimeDef{msgBlock.Header.Timestamp}
 
 	dbTransactions := make([]*Tx, 0, len(txs))
 	dbTxVouts := make([][]*Vout, len(txs))

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -14,6 +14,28 @@ import (
 	"github.com/decred/dcrdata/v3/db/dbtypes/internal"
 )
 
+// TimeDef is time.Time wrapper that formats time by default as a string without
+// a timezone. The time Stringer interface formats the time into a string
+// with a timezone.
+type TimeDef struct {
+	T time.Time
+}
+
+func (t *TimeDef) String() string {
+	return t.T.Format("2006-01-02 15:04:05")
+}
+
+// TimeAPI is a fall back dbtypes.TimeDef wrapper that allows API endpoint that
+// previously accepted timestamp instead of a formatted string time to continue
+// working.
+type TimeAPI struct {
+	S TimeDef
+}
+
+func (t *TimeAPI) String() int64 {
+	return t.S.T.Unix()
+}
+
 // Tickets have 6 states, 5 possible fates:
 // Live -...---> Voted
 //           \-> Missed (unspent) [--> Revoked]
@@ -129,9 +151,9 @@ type BlocksGroupedInfo struct {
 	EndBlock           int64
 	Difficulty         float64
 	TicketPrice        int64
-	StartTime          time.Time
+	StartTime          TimeDef
 	FormattedStartTime string
-	EndTime            time.Time
+	EndTime            TimeDef
 	FormattedEndTime   string
 	Size               int64
 	FormattedSize      string
@@ -410,7 +432,7 @@ type AddressRow struct {
 	// funding tx outputs.
 	MatchingTxHash   string
 	IsFunding        bool
-	TxBlockTime      time.Time
+	TxBlockTime      TimeDef
 	TxHash           string
 	TxVinVoutIndex   uint32
 	Value            uint64
@@ -433,28 +455,28 @@ type AddressMetrics struct {
 // ChartsData defines the fields that store the values needed to plot the charts
 // on the frontend.
 type ChartsData struct {
-	Difficulty  []float64   `json:"difficulty,omitempty"`
-	Time        []time.Time `json:"time,omitempty"`
-	Value       []uint64    `json:"value,omitempty"`
-	Size        []uint64    `json:"size,omitempty"`
-	ChainSize   []uint64    `json:"chainsize,omitempty"`
-	Count       []uint64    `json:"count,omitempty"`
-	SizeF       []float64   `json:"sizef,omitempty"`
-	ValueF      []float64   `json:"valuef,omitempty"`
-	Unspent     []uint64    `json:"unspent,omitempty"`
-	Revoked     []uint64    `json:"revoked,omitempty"`
-	Height      []uint64    `json:"height,omitempty"`
-	Pooled      []uint64    `json:"pooled,omitempty"`
-	Solo        []uint64    `json:"solo,omitempty"`
-	SentRtx     []uint64    `json:"sentRtx,omitempty"`
-	ReceivedRtx []uint64    `json:"receivedRtx,omitempty"`
-	Tickets     []uint64    `json:"tickets,omitempty"`
-	Votes       []uint64    `json:"votes,omitempty"`
-	RevokeTx    []uint64    `json:"revokeTx,omitempty"`
-	Amount      []float64   `json:"amount,omitempty"`
-	Received    []float64   `json:"received,omitempty"`
-	Sent        []float64   `json:"sent,omitempty"`
-	Net         []float64   `json:"net,omitempty"`
+	Difficulty  []float64 `json:"difficulty,omitempty"`
+	Time        []TimeDef `json:"time,omitempty"`
+	Value       []uint64  `json:"value,omitempty"`
+	Size        []uint64  `json:"size,omitempty"`
+	ChainSize   []uint64  `json:"chainsize,omitempty"`
+	Count       []uint64  `json:"count,omitempty"`
+	SizeF       []float64 `json:"sizef,omitempty"`
+	ValueF      []float64 `json:"valuef,omitempty"`
+	Unspent     []uint64  `json:"unspent,omitempty"`
+	Revoked     []uint64  `json:"revoked,omitempty"`
+	Height      []uint64  `json:"height,omitempty"`
+	Pooled      []uint64  `json:"pooled,omitempty"`
+	Solo        []uint64  `json:"solo,omitempty"`
+	SentRtx     []uint64  `json:"sentRtx,omitempty"`
+	ReceivedRtx []uint64  `json:"receivedRtx,omitempty"`
+	Tickets     []uint64  `json:"tickets,omitempty"`
+	Votes       []uint64  `json:"votes,omitempty"`
+	RevokeTx    []uint64  `json:"revokeTx,omitempty"`
+	Amount      []float64 `json:"amount,omitempty"`
+	Received    []float64 `json:"received,omitempty"`
+	Sent        []float64 `json:"sent,omitempty"`
+	Net         []float64 `json:"net,omitempty"`
 }
 
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)
@@ -466,35 +488,35 @@ type ScriptPubKeyData struct {
 
 // VinTxProperty models a transaction input with previous outpoint information.
 type VinTxProperty struct {
-	PrevOut     string    `json:"prevout"`
-	PrevTxHash  string    `json:"prevtxhash"`
-	PrevTxIndex uint32    `json:"prevvoutidx"`
-	PrevTxTree  uint16    `json:"tree"`
-	Sequence    uint32    `json:"sequence"`
-	ValueIn     int64     `json:"amountin"`
-	TxID        string    `json:"tx_hash"`
-	TxIndex     uint32    `json:"tx_index"`
-	TxTree      uint16    `json:"tx_tree"`
-	TxType      int16     `json:"tx_type"`
-	BlockHeight uint32    `json:"blockheight"`
-	BlockIndex  uint32    `json:"blockindex"`
-	ScriptHex   []byte    `json:"scripthex"`
-	IsValid     bool      `json:"is_valid"`
-	IsMainchain bool      `json:"is_mainchain"`
-	Time        time.Time `json:"time"`
+	PrevOut     string  `json:"prevout"`
+	PrevTxHash  string  `json:"prevtxhash"`
+	PrevTxIndex uint32  `json:"prevvoutidx"`
+	PrevTxTree  uint16  `json:"tree"`
+	Sequence    uint32  `json:"sequence"`
+	ValueIn     int64   `json:"amountin"`
+	TxID        string  `json:"tx_hash"`
+	TxIndex     uint32  `json:"tx_index"`
+	TxTree      uint16  `json:"tx_tree"`
+	TxType      int16   `json:"tx_type"`
+	BlockHeight uint32  `json:"blockheight"`
+	BlockIndex  uint32  `json:"blockindex"`
+	ScriptHex   []byte  `json:"scripthex"`
+	IsValid     bool    `json:"is_valid"`
+	IsMainchain bool    `json:"is_mainchain"`
+	Time        TimeDef `json:"time"`
 }
 
 // PoolTicketsData defines the real time data
 // needed for ticket pool visualization charts.
 type PoolTicketsData struct {
-	Time     []time.Time `json:"time,omitempty"`
-	Price    []float64   `json:"price,omitempty"`
-	Mempool  []uint64    `json:"mempool,omitempty"`
-	Immature []uint64    `json:"immature,omitempty"`
-	Live     []uint64    `json:"live,omitempty"`
-	Solo     uint64      `json:"solo,omitempty"`
-	Pooled   uint64      `json:"pooled,omitempty"`
-	TxSplit  uint64      `json:"txsplit,omitempty"`
+	Time     []TimeDef `json:"time,omitempty"`
+	Price    []float64 `json:"price,omitempty"`
+	Mempool  []uint64  `json:"mempool,omitempty"`
+	Immature []uint64  `json:"immature,omitempty"`
+	Live     []uint64  `json:"live,omitempty"`
+	Solo     uint64    `json:"solo,omitempty"`
+	Pooled   uint64    `json:"pooled,omitempty"`
+	TxSplit  uint64    `json:"txsplit,omitempty"`
 }
 
 // Vin models a transaction input.
@@ -523,33 +545,33 @@ type ScriptSig struct {
 // the block heights, or a day, in which case Time contains the time stamps of
 // each interval. Total is always the sum of Yes, No, and Abstain.
 type AgendaVoteChoices struct {
-	Abstain []uint64    `json:"abstain"`
-	Yes     []uint64    `json:"yes"`
-	No      []uint64    `json:"no"`
-	Total   []uint64    `json:"total"`
-	Height  []uint64    `json:"height,omitempty"`
-	Time    []time.Time `json:"time,omitempty"`
+	Abstain []uint64  `json:"abstain"`
+	Yes     []uint64  `json:"yes"`
+	No      []uint64  `json:"no"`
+	Total   []uint64  `json:"total"`
+	Height  []uint64  `json:"height,omitempty"`
+	Time    []TimeDef `json:"time,omitempty"`
 }
 
 // Tx models a Decred transaction. It is stored in a Block.
 type Tx struct {
 	//blockDbID  int64
-	BlockHash   string    `json:"block_hash"`
-	BlockHeight int64     `json:"block_height"`
-	BlockTime   time.Time `json:"block_time"`
-	Time        time.Time `json:"time"`
-	TxType      int16     `json:"tx_type"`
-	Version     uint16    `json:"version"`
-	Tree        int8      `json:"tree"`
-	TxID        string    `json:"txid"`
-	BlockIndex  uint32    `json:"block_index"`
-	Locktime    uint32    `json:"locktime"`
-	Expiry      uint32    `json:"expiry"`
-	Size        uint32    `json:"size"`
-	Spent       int64     `json:"spent"`
-	Sent        int64     `json:"sent"`
-	Fees        int64     `json:"fees"`
-	NumVin      uint32    `json:"numvin"`
+	BlockHash   string  `json:"block_hash"`
+	BlockHeight int64   `json:"block_height"`
+	BlockTime   TimeDef `json:"block_time"`
+	Time        TimeDef `json:"time"`
+	TxType      int16   `json:"tx_type"`
+	Version     uint16  `json:"version"`
+	Tree        int8    `json:"tree"`
+	TxID        string  `json:"txid"`
+	BlockIndex  uint32  `json:"block_index"`
+	Locktime    uint32  `json:"locktime"`
+	Expiry      uint32  `json:"expiry"`
+	Size        uint32  `json:"size"`
+	Spent       int64   `json:"spent"`
+	Sent        int64   `json:"sent"`
+	Fees        int64   `json:"fees"`
+	NumVin      uint32  `json:"numvin"`
 	//Vins        VinTxPropertyARRAY `json:"vins"`
 	VinDbIds  []uint64 `json:"vindbids"`
 	NumVout   uint32   `json:"numvout"`
@@ -576,30 +598,30 @@ type Block struct {
 	NumStakeTx   uint32
 	STx          []string `json:"stx"`
 	STxDbIDs     []uint64
-	Time         time.Time `json:"time"`
-	Nonce        uint64    `json:"nonce"`
-	VoteBits     uint16    `json:"votebits"`
-	FinalState   []byte    `json:"finalstate"`
-	Voters       uint16    `json:"voters"`
-	FreshStake   uint8     `json:"freshstake"`
-	Revocations  uint8     `json:"revocations"`
-	PoolSize     uint32    `json:"poolsize"`
-	Bits         uint32    `json:"bits"`
-	SBits        uint64    `json:"sbits"`
-	Difficulty   float64   `json:"difficulty"`
-	ExtraData    []byte    `json:"extradata"`
-	StakeVersion uint32    `json:"stakeversion"`
-	PreviousHash string    `json:"previousblockhash"`
+	Time         TimeDef `json:"time"`
+	Nonce        uint64  `json:"nonce"`
+	VoteBits     uint16  `json:"votebits"`
+	FinalState   []byte  `json:"finalstate"`
+	Voters       uint16  `json:"voters"`
+	FreshStake   uint8   `json:"freshstake"`
+	Revocations  uint8   `json:"revocations"`
+	PoolSize     uint32  `json:"poolsize"`
+	Bits         uint32  `json:"bits"`
+	SBits        uint64  `json:"sbits"`
+	Difficulty   float64 `json:"difficulty"`
+	ExtraData    []byte  `json:"extradata"`
+	StakeVersion uint32  `json:"stakeversion"`
+	PreviousHash string  `json:"previousblockhash"`
 }
 
 type BlockDataBasic struct {
-	Height     uint32    `json:"height,omitemtpy"`
-	Size       uint32    `json:"size,omitemtpy"`
-	Hash       string    `json:"hash,omitemtpy"`
-	Difficulty float64   `json:"diff,omitemtpy"`
-	StakeDiff  float64   `json:"sdiff,omitemtpy"`
-	Time       time.Time `json:"time,omitemtpy"`
-	NumTx      uint32    `json:"txlength,omitempty"`
+	Height     uint32  `json:"height,omitemtpy"`
+	Size       uint32  `json:"size,omitemtpy"`
+	Hash       string  `json:"hash,omitemtpy"`
+	Difficulty float64 `json:"diff,omitemtpy"`
+	StakeDiff  float64 `json:"sdiff,omitemtpy"`
+	Time       TimeDef `json:"time,omitemtpy"`
+	NumTx      uint32  `json:"txlength,omitempty"`
 }
 
 // BlockStatus describes a block's status in the block chain.

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/decred/dcrdata/v3/db/dbtypes/internal"
 )
@@ -128,9 +129,9 @@ type BlocksGroupedInfo struct {
 	EndBlock           int64
 	Difficulty         float64
 	TicketPrice        int64
-	StartTime          int64
+	StartTime          time.Time
 	FormattedStartTime string
-	EndTime            int64
+	EndTime            time.Time
 	FormattedEndTime   string
 	Size               int64
 	FormattedSize      string
@@ -145,9 +146,9 @@ type BlocksGroupedInfo struct {
 // TimeBasedGroupings maps a given time grouping to its standard string value.
 var TimeBasedGroupings = map[TimeBasedGrouping]string{
 	AllGrouping:   "all",
-	YearGrouping:  "yr",
-	MonthGrouping: "mo",
-	WeekGrouping:  "wk",
+	YearGrouping:  "year",
+	MonthGrouping: "month",
+	WeekGrouping:  "week",
 	DayGrouping:   "day",
 }
 
@@ -409,7 +410,7 @@ type AddressRow struct {
 	// funding tx outputs.
 	MatchingTxHash   string
 	IsFunding        bool
-	TxBlockTime      uint64
+	TxBlockTime      time.Time
 	TxHash           string
 	TxVinVoutIndex   uint32
 	Value            uint64
@@ -432,29 +433,28 @@ type AddressMetrics struct {
 // ChartsData defines the fields that store the values needed to plot the charts
 // on the frontend.
 type ChartsData struct {
-	TimeStr     []string  `json:"timestr,omitempty"`
-	Difficulty  []float64 `json:"difficulty,omitempty"`
-	Time        []uint64  `json:"time,omitempty"`
-	Value       []uint64  `json:"value,omitempty"`
-	Size        []uint64  `json:"size,omitempty"`
-	ChainSize   []uint64  `json:"chainsize,omitempty"`
-	Count       []uint64  `json:"count,omitempty"`
-	SizeF       []float64 `json:"sizef,omitempty"`
-	ValueF      []float64 `json:"valuef,omitempty"`
-	Unspent     []uint64  `json:"unspent,omitempty"`
-	Revoked     []uint64  `json:"revoked,omitempty"`
-	Height      []uint64  `json:"height,omitempty"`
-	Pooled      []uint64  `json:"pooled,omitempty"`
-	Solo        []uint64  `json:"solo,omitempty"`
-	SentRtx     []uint64  `json:"sentRtx,omitempty"`
-	ReceivedRtx []uint64  `json:"receivedRtx,omitempty"`
-	Tickets     []uint64  `json:"tickets,omitempty"`
-	Votes       []uint64  `json:"votes,omitempty"`
-	RevokeTx    []uint64  `json:"revokeTx,omitempty"`
-	Amount      []float64 `json:"amount,omitempty"`
-	Received    []float64 `json:"received,omitempty"`
-	Sent        []float64 `json:"sent,omitempty"`
-	Net         []float64 `json:"net,omitempty"`
+	Difficulty  []float64   `json:"difficulty,omitempty"`
+	Time        []time.Time `json:"time,omitempty"`
+	Value       []uint64    `json:"value,omitempty"`
+	Size        []uint64    `json:"size,omitempty"`
+	ChainSize   []uint64    `json:"chainsize,omitempty"`
+	Count       []uint64    `json:"count,omitempty"`
+	SizeF       []float64   `json:"sizef,omitempty"`
+	ValueF      []float64   `json:"valuef,omitempty"`
+	Unspent     []uint64    `json:"unspent,omitempty"`
+	Revoked     []uint64    `json:"revoked,omitempty"`
+	Height      []uint64    `json:"height,omitempty"`
+	Pooled      []uint64    `json:"pooled,omitempty"`
+	Solo        []uint64    `json:"solo,omitempty"`
+	SentRtx     []uint64    `json:"sentRtx,omitempty"`
+	ReceivedRtx []uint64    `json:"receivedRtx,omitempty"`
+	Tickets     []uint64    `json:"tickets,omitempty"`
+	Votes       []uint64    `json:"votes,omitempty"`
+	RevokeTx    []uint64    `json:"revokeTx,omitempty"`
+	Amount      []float64   `json:"amount,omitempty"`
+	Received    []float64   `json:"received,omitempty"`
+	Sent        []float64   `json:"sent,omitempty"`
+	Net         []float64   `json:"net,omitempty"`
 }
 
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)
@@ -466,22 +466,22 @@ type ScriptPubKeyData struct {
 
 // VinTxProperty models a transaction input with previous outpoint information.
 type VinTxProperty struct {
-	PrevOut     string `json:"prevout"`
-	PrevTxHash  string `json:"prevtxhash"`
-	PrevTxIndex uint32 `json:"prevvoutidx"`
-	PrevTxTree  uint16 `json:"tree"`
-	Sequence    uint32 `json:"sequence"`
-	ValueIn     int64  `json:"amountin"`
-	TxID        string `json:"tx_hash"`
-	TxIndex     uint32 `json:"tx_index"`
-	TxTree      uint16 `json:"tx_tree"`
-	TxType      int16  `json:"tx_type"`
-	BlockHeight uint32 `json:"blockheight"`
-	BlockIndex  uint32 `json:"blockindex"`
-	ScriptHex   []byte `json:"scripthex"`
-	IsValid     bool   `json:"is_valid"`
-	IsMainchain bool   `json:"is_mainchain"`
-	Time        int64  `json:"time"`
+	PrevOut     string    `json:"prevout"`
+	PrevTxHash  string    `json:"prevtxhash"`
+	PrevTxIndex uint32    `json:"prevvoutidx"`
+	PrevTxTree  uint16    `json:"tree"`
+	Sequence    uint32    `json:"sequence"`
+	ValueIn     int64     `json:"amountin"`
+	TxID        string    `json:"tx_hash"`
+	TxIndex     uint32    `json:"tx_index"`
+	TxTree      uint16    `json:"tx_tree"`
+	TxType      int16     `json:"tx_type"`
+	BlockHeight uint32    `json:"blockheight"`
+	BlockIndex  uint32    `json:"blockindex"`
+	ScriptHex   []byte    `json:"scripthex"`
+	IsValid     bool      `json:"is_valid"`
+	IsMainchain bool      `json:"is_mainchain"`
+	Time        time.Time `json:"time"`
 }
 
 // PoolTicketsData defines the real time data
@@ -523,33 +523,33 @@ type ScriptSig struct {
 // the block heights, or a day, in which case Time contains the time stamps of
 // each interval. Total is always the sum of Yes, No, and Abstain.
 type AgendaVoteChoices struct {
-	Abstain []uint64 `json:"abstain"`
-	Yes     []uint64 `json:"yes"`
-	No      []uint64 `json:"no"`
-	Total   []uint64 `json:"total"`
-	Height  []uint64 `json:"height,omitempty"`
-	Time    []uint64 `json:"time,omitempty"`
+	Abstain []uint64    `json:"abstain"`
+	Yes     []uint64    `json:"yes"`
+	No      []uint64    `json:"no"`
+	Total   []uint64    `json:"total"`
+	Height  []uint64    `json:"height,omitempty"`
+	Time    []time.Time `json:"time,omitempty"`
 }
 
 // Tx models a Decred transaction. It is stored in a Block.
 type Tx struct {
 	//blockDbID  int64
-	BlockHash   string `json:"block_hash"`
-	BlockHeight int64  `json:"block_height"`
-	BlockTime   int64  `json:"block_time"`
-	Time        int64  `json:"time"`
-	TxType      int16  `json:"tx_type"`
-	Version     uint16 `json:"version"`
-	Tree        int8   `json:"tree"`
-	TxID        string `json:"txid"`
-	BlockIndex  uint32 `json:"block_index"`
-	Locktime    uint32 `json:"locktime"`
-	Expiry      uint32 `json:"expiry"`
-	Size        uint32 `json:"size"`
-	Spent       int64  `json:"spent"`
-	Sent        int64  `json:"sent"`
-	Fees        int64  `json:"fees"`
-	NumVin      uint32 `json:"numvin"`
+	BlockHash   string    `json:"block_hash"`
+	BlockHeight int64     `json:"block_height"`
+	BlockTime   time.Time `json:"block_time"`
+	Time        time.Time `json:"time"`
+	TxType      int16     `json:"tx_type"`
+	Version     uint16    `json:"version"`
+	Tree        int8      `json:"tree"`
+	TxID        string    `json:"txid"`
+	BlockIndex  uint32    `json:"block_index"`
+	Locktime    uint32    `json:"locktime"`
+	Expiry      uint32    `json:"expiry"`
+	Size        uint32    `json:"size"`
+	Spent       int64     `json:"spent"`
+	Sent        int64     `json:"sent"`
+	Fees        int64     `json:"fees"`
+	NumVin      uint32    `json:"numvin"`
 	//Vins        VinTxPropertyARRAY `json:"vins"`
 	VinDbIds  []uint64 `json:"vindbids"`
 	NumVout   uint32   `json:"numvout"`
@@ -576,30 +576,30 @@ type Block struct {
 	NumStakeTx   uint32
 	STx          []string `json:"stx"`
 	STxDbIDs     []uint64
-	Time         uint64  `json:"time"`
-	Nonce        uint64  `json:"nonce"`
-	VoteBits     uint16  `json:"votebits"`
-	FinalState   []byte  `json:"finalstate"`
-	Voters       uint16  `json:"voters"`
-	FreshStake   uint8   `json:"freshstake"`
-	Revocations  uint8   `json:"revocations"`
-	PoolSize     uint32  `json:"poolsize"`
-	Bits         uint32  `json:"bits"`
-	SBits        uint64  `json:"sbits"`
-	Difficulty   float64 `json:"difficulty"`
-	ExtraData    []byte  `json:"extradata"`
-	StakeVersion uint32  `json:"stakeversion"`
-	PreviousHash string  `json:"previousblockhash"`
+	Time         time.Time `json:"time"`
+	Nonce        uint64    `json:"nonce"`
+	VoteBits     uint16    `json:"votebits"`
+	FinalState   []byte    `json:"finalstate"`
+	Voters       uint16    `json:"voters"`
+	FreshStake   uint8     `json:"freshstake"`
+	Revocations  uint8     `json:"revocations"`
+	PoolSize     uint32    `json:"poolsize"`
+	Bits         uint32    `json:"bits"`
+	SBits        uint64    `json:"sbits"`
+	Difficulty   float64   `json:"difficulty"`
+	ExtraData    []byte    `json:"extradata"`
+	StakeVersion uint32    `json:"stakeversion"`
+	PreviousHash string    `json:"previousblockhash"`
 }
 
 type BlockDataBasic struct {
-	Height     uint32  `json:"height,omitemtpy"`
-	Size       uint32  `json:"size,omitemtpy"`
-	Hash       string  `json:"hash,omitemtpy"`
-	Difficulty float64 `json:"diff,omitemtpy"`
-	StakeDiff  float64 `json:"sdiff,omitemtpy"`
-	Time       int64   `json:"time,omitemtpy"`
-	NumTx      uint32  `json:"txlength,omitempty"`
+	Height     uint32    `json:"height,omitemtpy"`
+	Size       uint32    `json:"size,omitemtpy"`
+	Hash       string    `json:"hash,omitemtpy"`
+	Difficulty float64   `json:"diff,omitemtpy"`
+	StakeDiff  float64   `json:"sdiff,omitemtpy"`
+	Time       time.Time `json:"time,omitemtpy"`
+	NumTx      uint32    `json:"txlength,omitempty"`
 }
 
 // BlockStatus describes a block's status in the block chain.

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -439,7 +439,7 @@ type AddressRow struct {
 // grouping buttons on the address history page charts should be disabled
 // or enabled by default.
 type AddressMetrics struct {
-	OldestBlockTime int64
+	OldestBlockTime TimeDef
 	YearTxsCount    int64 // Years txs grouping
 	MonthTxsCount   int64 // Months txs grouping
 	WeekTxsCount    int64 // Weeks txs grouping

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -487,14 +487,14 @@ type VinTxProperty struct {
 // PoolTicketsData defines the real time data
 // needed for ticket pool visualization charts.
 type PoolTicketsData struct {
-	Time     []uint64  `json:"time,omitempty"`
-	Price    []float64 `json:"price,omitempty"`
-	Mempool  []uint64  `json:"mempool,omitempty"`
-	Immature []uint64  `json:"immature,omitempty"`
-	Live     []uint64  `json:"live,omitempty"`
-	Solo     uint64    `json:"solo,omitempty"`
-	Pooled   uint64    `json:"pooled,omitempty"`
-	TxSplit  uint64    `json:"txsplit,omitempty"`
+	Time     []time.Time `json:"time,omitempty"`
+	Price    []float64   `json:"price,omitempty"`
+	Mempool  []uint64    `json:"mempool,omitempty"`
+	Immature []uint64    `json:"immature,omitempty"`
+	Live     []uint64    `json:"live,omitempty"`
+	Solo     uint64      `json:"solo,omitempty"`
+	Pooled   uint64      `json:"pooled,omitempty"`
+	TxSplit  uint64      `json:"txsplit,omitempty"`
 }
 
 // Vin models a transaction input.

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -30,22 +30,6 @@ func (t *TimeDef) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 
-// TimeAPI is a fall back dbtypes.TimeDef wrapper that allows API endpoint that
-// previously accepted timestamp instead of a formatted string time to continue
-// working.
-type TimeAPI struct {
-	S TimeDef
-}
-
-func (t TimeAPI) String() string {
-	return t.S.T.Format("2006-01-02 15:04:05")
-}
-
-// MarshalJSON is set as the default marshalling function for TimeAPI struct.
-func (t *TimeAPI) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.S.T.Unix())
-}
-
 // Tickets have 6 states, 5 possible fates:
 // Live -...---> Voted
 //           \-> Missed (unspent) [--> Revoked]

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -38,12 +38,12 @@ type TimeAPI struct {
 }
 
 func (t TimeAPI) String() string {
-	return fmt.Sprintf("%d", t.S.T.Unix())
+	return t.S.T.Format("2006-01-02 15:04:05")
 }
 
 // MarshalJSON is set as the default marshalling function for TimeAPI struct.
 func (t *TimeAPI) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.String())
+	return json.Marshal(t.S.T.Unix())
 }
 
 // Tickets have 6 states, 5 possible fates:

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -21,8 +21,13 @@ type TimeDef struct {
 	T time.Time
 }
 
-func (t *TimeDef) String() string {
+func (t TimeDef) String() string {
 	return t.T.Format("2006-01-02 15:04:05")
+}
+
+// MarshalJSON is set as the default marshalling function for TimeDef struct.
+func (t *TimeDef) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }
 
 // TimeAPI is a fall back dbtypes.TimeDef wrapper that allows API endpoint that
@@ -32,8 +37,13 @@ type TimeAPI struct {
 	S TimeDef
 }
 
-func (t *TimeAPI) String() int64 {
-	return t.S.T.Unix()
+func (t TimeAPI) String() string {
+	return fmt.Sprintf("%d", t.S.T.Unix())
+}
+
+// MarshalJSON is set as the default marshalling function for TimeAPI struct.
+func (t *TimeAPI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }
 
 // Tickets have 6 states, 5 possible fates:

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -334,7 +334,7 @@ func MakeSelectAddressUnspentAmountByAddress(group string) string {
 	return formatGroupingQuery(selectAddressUnspentAmountByAddress, group, "block_time")
 }
 
-// Since date_trunc function doesn't have an option to group by "all"
+// Since date_trunc function doesn't have an option to group by "all" grouping,
 // formatGroupingQuery removes the date_trunc from the sql query as its not applicable.
 func formatGroupingQuery(mainQuery, group, column string) string {
 	if group == "all" {

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -8,7 +8,7 @@ const (
 		valid_mainchain BOOLEAN,
 		matching_tx_hash TEXT,
 		value INT8,
-		block_time INT8 NOT NULL,
+		block_time TIMESTAMP NOT NULL,
 		is_funding BOOLEAN,
 		tx_vin_vout_index INT4,
 		tx_vin_vout_row_id INT8,
@@ -196,7 +196,7 @@ const (
 	// given address using block time binning with bin size of block_time.
 	// Regular transactions are grouped into (SentRtx and ReceivedRtx), SSTx
 	// defines tickets, SSGen defines votes, and SSRtx defines revocations.
-	SelectAddressTxTypesByAddress = `SELECT (block_time/$1)*$1 as timestamp,
+	SelectAddressTxTypesByAddress = `SELECT date_trunc($1, block_time) as timestamp,
 		COUNT(CASE WHEN tx_type = 0 AND is_funding = false THEN 1 ELSE NULL END) as SentRtx,
 		COUNT(CASE WHEN tx_type = 0 AND is_funding = true THEN 1 ELSE NULL END) as ReceivedRtx,
 		COUNT(CASE WHEN tx_type = 1 THEN 1 ELSE NULL END) as SSTx,
@@ -204,12 +204,12 @@ const (
 		COUNT(CASE WHEN tx_type = 3 THEN 1 ELSE NULL END) as SSRtx
 		FROM addresses WHERE address=$2 GROUP BY timestamp ORDER BY timestamp;`
 
-	SelectAddressAmountFlowByAddress = `SELECT (block_time/$1)*$1 as timestamp,
+	SelectAddressAmountFlowByAddress = `SELECT date_trunc($1, block_time) as timestamp,
 		SUM(CASE WHEN is_funding = TRUE THEN value ELSE 0 END) as received,
 		SUM(CASE WHEN is_funding = FALSE THEN value ELSE 0 END) as sent FROM
 		addresses WHERE address=$2 GROUP BY timestamp ORDER BY timestamp;`
 
-	SelectAddressUnspentAmountByAddress = `SELECT (block_time/$1)*$1 as timestamp,
+	SelectAddressUnspentAmountByAddress = `SELECT date_trunc($1, block_time) as timestamp,
 		SUM(value) as unspent FROM addresses WHERE address=$2 AND is_funding=TRUE
 		AND matching_tx_hash ='' GROUP BY timestamp ORDER BY timestamp;`
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -100,10 +100,9 @@ const (
 			time DESC,
 			transactions.tx_hash ASC;`
 
-	// SelectAddressTimeGroupingCount return the count of record groups,
+	// selectAddressTimeGroupingCount return the count of record groups,
 	// where grouping is done by a specified time interval, for an addresss.
-	SelectAddressTimeGroupingCount = `SELECT COUNT(DISTINCT (block_time/$2)*$2)
-		FROM addresses WHERE address=$1;`
+	selectAddressTimeGroupingCount = `SELECT COUNT(DISTINCT %s) FROM addresses WHERE address=$1;`
 
 	SelectAddressUnspentCountANDValue = `SELECT COUNT(*), SUM(value) FROM addresses
 	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = TRUE;`
@@ -332,6 +331,10 @@ func MakeSelectAddressAmountFlowByAddress(group string) string {
 // MakeSelectAddressUnspentAmountByAddress returns the selectAddressUnspentAmountByAddress query
 func MakeSelectAddressUnspentAmountByAddress(group string) string {
 	return formatGroupingQuery(selectAddressUnspentAmountByAddress, group, "block_time")
+}
+
+func MakeSelectAddressTimeGroupingCount(group string) string {
+	return formatGroupingQuery(selectAddressTimeGroupingCount, group, "block_time")
 }
 
 // Since date_trunc function doesn't have an option to group by "all" grouping,

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -24,7 +24,7 @@ const (
 		num_stx INT4,
 		stx TEXT[],
 		stxDbIDs INT8[],
-		time INT8,
+		time TIMESTAMP,
 		nonce INT8,
 		vote_bits INT2,
 		final_state BYTEA,
@@ -125,7 +125,7 @@ const (
 		ORDER BY window_start DESC
 		LIMIT $2 OFFSET $3;`
 
-	SelectBlocksTimeListingByLimit = `SELECT (time-$2)/$1 as index_value,
+	SelectBlocksTimeListingByLimit = `SELECT date_trunc($1, time) as index_value,
 		MAX(height),
 		SUM(num_rtx) AS txs,
 		SUM(fresh_stake) AS tickets,
@@ -138,7 +138,7 @@ const (
 		FROM blocks
 		GROUP BY index_value
 		ORDER BY index_value DESC
-		LIMIT $3 OFFSET $4;`
+		LIMIT $2 OFFSET $3;`
 
 	SelectBlocksBlockSize = `SELECT time, size, numtx, height FROM blocks ORDER BY time;`
 

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -118,10 +118,10 @@ const (
 		WHERE pool_status = 0 AND tickets.is_mainchain = TRUE
 		GROUP BY price ORDER BY price;`
 
-	SelectTicketsByPurchaseDate = `SELECT date_trunc($1,transactions.block_time) as timestamp,
+	selectTicketsByPurchaseDate = `SELECT %s as timestamp,
 		SUM(price) as price,
-		SUM(CASE WHEN tickets.block_height >= $2 THEN 1 ELSE 0 END) as immature,
-		SUM(CASE WHEN tickets.block_height < $2 THEN 1 ELSE 0 END) as live
+		SUM(CASE WHEN tickets.block_height >= $1 THEN 1 ELSE 0 END) as immature,
+		SUM(CASE WHEN tickets.block_height < $1 THEN 1 ELSE 0 END) as live
 		FROM tickets JOIN transactions ON purchase_tx_db_id=transactions.id
 		WHERE pool_status = 0 AND tickets.is_mainchain = TRUE
 		GROUP BY timestamp ORDER BY timestamp;`
@@ -433,4 +433,9 @@ func MakeAgendaInsertStatement(checked bool) string {
 		return UpsertAgendaRow
 	}
 	return InsertAgendaRow
+}
+
+// MakeSelectTicketsByPurchaseDate returns the selectTicketsByPurchaseDate query
+func MakeSelectTicketsByPurchaseDate(group string) string {
+	return formatGroupingQuery(selectTicketsByPurchaseDate, group, "transactions.block_time")
 }

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -118,7 +118,7 @@ const (
 		WHERE pool_status = 0 AND tickets.is_mainchain = TRUE
 		GROUP BY price ORDER BY price;`
 
-	SelectTicketsByPurchaseDate = `SELECT (transactions.block_time/$1)*$1 as timestamp,
+	SelectTicketsByPurchaseDate = `SELECT date_trunc($1,transactions.block_time) as timestamp,
 		SUM(price) as price,
 		SUM(CASE WHEN tickets.block_height >= $2 THEN 1 ELSE 0 END) as immature,
 		SUM(CASE WHEN tickets.block_height < $2 THEN 1 ELSE 0 END) as live
@@ -328,7 +328,7 @@ const (
 		agenda_vote_choice INT2,
 		tx_hash TEXT NOT NULL,
 		block_height INT4,
-		block_time INT8,
+		block_time TIMESTAMP,
 		locked_in BOOLEAN,
 		activated BOOLEAN,
 		hard_forked BOOLEAN

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -12,8 +12,8 @@ const (
 		/*block_db_id INT4,*/
 		block_hash TEXT,
 		block_height INT8,
-		block_time INT8,
-		time INT8,
+		block_time TIMESTAMP,
+		time TIMESTAMP,
 		tx_type INT4,
 		version INT4,
 		tree INT2,
@@ -108,7 +108,7 @@ const (
 		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC
 		LIMIT 1;`
 
-	SelectTxsPerDay = `SELECT to_timestamp(time)::date as date, count(*) FROM transactions
+	SelectTxsPerDay = `SELECT date_trunc('day',time) AS date, count(*) FROM transactions
 		GROUP BY date ORDER BY date;`
 
 	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time, 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -18,7 +18,7 @@ const (
 		tx_tree INT2,
 		is_valid BOOLEAN,
 		is_mainchain BOOLEAN,
-		block_time INT8,
+		block_time TIMESTAMP,
 		prev_tx_hash TEXT,
 		prev_tx_index INT8,
 		prev_tx_tree INT2,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1214,13 +1214,12 @@ func (pgb *ChainDB) FillAddressTransactions(addrInfo *explorer.AddressInfo) erro
 		txn.FormattedSize = humanize.Bytes(uint64(dbTx.Size))
 		txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()
 		txn.Time = dbTx.BlockTime
-		if txn.Time.Unix() > 0 {
+		if txn.Time.T.Unix() > 0 {
 			txn.Confirmations = pgb.Height() - uint64(dbTx.BlockHeight) + 1
 		} else {
 			numUnconfirmed++
 			txn.Confirmations = 0
 		}
-		txn.FormattedTime = dbTx.BlockTime.Format("2006-01-02 15:04:05")
 
 		// Get the funding or spending transaction matching index if there is a
 		// matching tx hash already present.  During the next database
@@ -1362,7 +1361,7 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 	for i := range txs {
 		txsShort = append(txsShort, &apitypes.AddressTxShort{
 			TxID:          txs[i].TxID,
-			Time:          txs[i].Time,
+			Time:          dbtypes.TimeAPI{S:txs[i].Time},
 			Value:         txs[i].Total,
 			Confirmations: int64(txs[i].Confirmations),
 			Size:          int32(txs[i].Size),
@@ -1398,7 +1397,7 @@ func (pgb *ChainDB) AddressTransactionRawDetails(addr string, count, skip int64,
 			//
 			Confirmations: int64(txs[i].Confirmations),
 			//BlockHash: txs[i].
-			Time: txs[i].Time,
+			Time: dbtypes.TimeAPI{S:txs[i].Time},
 			//Blocktime:
 		})
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -829,7 +829,7 @@ func (pgb *ChainDB) PosIntervals(limit, offset uint64) ([]*dbtypes.BlocksGrouped
 func (pgb *ChainDB) TimeBasedIntervals(timeGrouping dbtypes.TimeBasedGrouping,
 	limit, offset uint64) ([]*dbtypes.BlocksGroupedInfo, error) {
 
-	return retrieveTimeBasedBlockListing(pgb.db, timeGrouping.String(),limit, offset)
+	return retrieveTimeBasedBlockListing(pgb.db, timeGrouping.String(), limit, offset)
 }
 
 // TicketPoolVisualization helps block consecutive and duplicate DB queries for
@@ -1361,7 +1361,7 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 	for i := range txs {
 		txsShort = append(txsShort, &apitypes.AddressTxShort{
 			TxID:          txs[i].TxID,
-			Time:          dbtypes.TimeAPI{S:txs[i].Time},
+			Time:          apitypes.TimeAPI{S: txs[i].Time},
 			Value:         txs[i].Total,
 			Confirmations: int64(txs[i].Confirmations),
 			Size:          int32(txs[i].Size),
@@ -1397,7 +1397,7 @@ func (pgb *ChainDB) AddressTransactionRawDetails(addr string, count, skip int64,
 			//
 			Confirmations: int64(txs[i].Confirmations),
 			//BlockHash: txs[i].
-			Time: dbtypes.TimeAPI{S:txs[i].Time},
+			Time: apitypes.TimeAPI{S: txs[i].Time},
 			//Blocktime:
 		})
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -740,12 +740,8 @@ func (pgb *ChainDB) GetAddressMetrics(addr string) (*dbtypes.AddressMetrics, err
 
 	for _, s := range []dbtypes.TimeBasedGrouping{dbtypes.YearGrouping,
 		dbtypes.MonthGrouping, dbtypes.WeekGrouping, dbtypes.DayGrouping} {
-		interval, err := dbtypes.TimeBasedGroupingToInterval(s)
-		if err != nil {
-			return nil, err
-		}
 
-		txCount, err := retrieveAddressTxsCount(pgb.db, addr, int64(interval))
+		txCount, err := retrieveAddressTxsCount(pgb.db, addr, s.String())
 		if err != nil {
 			return nil, fmt.Errorf("retrieveAddressAllTxsCount failed: error: %v", err)
 		}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -632,9 +632,9 @@ func retrieveTimeBasedBlockListing(db *sql.DB, timeInterval string, limit,
 
 	var data []*dbtypes.BlocksGroupedInfo
 	for rows.Next() {
-		var startTime, endTime time.Time
+		var startTime, endTime, indexVal time.Time
 		var txs, tickets, votes, revocations, blockSizes uint64
-		var blocksCount, indexVal, endBlock int64
+		var blocksCount, endBlock int64
 
 		err = rows.Scan(&indexVal, &endBlock, &txs, &tickets, &votes,
 			&revocations, &blockSizes, &blocksCount, &startTime, &endTime)
@@ -643,7 +643,7 @@ func retrieveTimeBasedBlockListing(db *sql.DB, timeInterval string, limit,
 		}
 
 		data = append(data, &dbtypes.BlocksGroupedInfo{
-			IndexVal:           indexVal,
+			//IndexVal:           indexVal,
 			EndBlock:           endBlock,
 			Voters:             votes,
 			Transactions:       txs,
@@ -744,7 +744,7 @@ func RetrieveTicketIDsByHashes(db *sql.DB, ticketHashes []string) (ids []uint64,
 // purchase date. The maturity block is needed to identify immature tickets.
 // The grouping interval size is specified in seconds.
 func retrieveTicketsByDate(db *sql.DB, maturityBlock int64, groupBy string) (*dbtypes.PoolTicketsData, error) {
-	rows, err := db.Query(internal.SelectTicketsByPurchaseDate, groupBy, maturityBlock)
+	rows, err := db.Query(internal.MakeSelectTicketsByPurchaseDate(groupBy), maturityBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -752,7 +752,8 @@ func retrieveTicketsByDate(db *sql.DB, maturityBlock int64, groupBy string) (*db
 
 	tickets := new(dbtypes.PoolTicketsData)
 	for rows.Next() {
-		var immature, live, timestamp uint64
+		var immature, live uint64
+		var timestamp time.Time
 		var price, total float64
 		err = rows.Scan(&timestamp, &price, &immature, &live)
 		if err != nil {
@@ -1379,8 +1380,8 @@ func retrieveTxHistoryByType(db *sql.DB, addr,
 	timeInterval string) (*dbtypes.ChartsData, error) {
 	var items = new(dbtypes.ChartsData)
 
-	rows, err := db.Query(internal.SelectAddressTxTypesByAddress,
-		timeInterval, addr)
+	rows, err := db.Query(internal.MakeSelectAddressTxTypesByAddress(timeInterval),
+		addr)
 	if err != nil {
 		return nil, err
 	}
@@ -1414,8 +1415,8 @@ func retrieveTxHistoryByAmountFlow(db *sql.DB, addr,
 	timeInterval string) (*dbtypes.ChartsData, error) {
 	var items = new(dbtypes.ChartsData)
 
-	rows, err := db.Query(internal.SelectAddressAmountFlowByAddress,
-		timeInterval, addr)
+	rows, err := db.Query(internal.MakeSelectAddressAmountFlowByAddress(timeInterval),
+		addr)
 	if err != nil {
 		return nil, err
 	}
@@ -1452,8 +1453,7 @@ func retrieveTxHistoryByUnspentAmount(db *sql.DB, addr,
 	var totalAmount uint64
 	var items = new(dbtypes.ChartsData)
 
-	rows, err := db.Query(internal.SelectAddressUnspentAmountByAddress,
-		timeInterval, addr)
+	rows, err := db.Query(internal.MakeSelectAddressUnspentAmountByAddress(timeInterval), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -599,19 +599,18 @@ func retrieveWindowBlocks(db *sql.DB, windowSize int64, limit,
 		index := dbtypes.CalculateWindowIndex(endBlock, windowSize)
 
 		data = append(data, &dbtypes.BlocksGroupedInfo{
-			IndexVal:           index, //window index at the endblock
-			EndBlock:           endBlock,
-			Voters:             votes,
-			Transactions:       txs,
-			FreshStake:         tickets,
-			Revocations:        revocations,
-			BlocksCount:        count,
-			Difficulty:         difficulty,
-			TicketPrice:        sbits,
-			Size:               int64(blockSizes),
-			FormattedSize:      humanize.Bytes(blockSizes),
-			StartTime:          timestamp,
-			FormattedStartTime: timestamp.T.Format("2006-01-02 15:04:05"),
+			IndexVal:      index, //window index at the endblock
+			EndBlock:      endBlock,
+			Voters:        votes,
+			Transactions:  txs,
+			FreshStake:    tickets,
+			Revocations:   revocations,
+			BlocksCount:   count,
+			Difficulty:    difficulty,
+			TicketPrice:   sbits,
+			Size:          int64(blockSizes),
+			FormattedSize: humanize.Bytes(blockSizes),
+			StartTime:     timestamp,
 		})
 	}
 
@@ -740,7 +739,8 @@ func RetrieveTicketIDsByHashes(db *sql.DB, ticketHashes []string) (ids []uint64,
 
 // retrieveTicketsByDate fetches the tickets in the current ticketpool order by the
 // purchase date. The maturity block is needed to identify immature tickets.
-// The grouping interval size is specified in seconds.
+// The grouping is done using the time-based group names provided e.g. months,
+// days, weeks and years.
 func retrieveTicketsByDate(db *sql.DB, maturityBlock int64, groupBy string) (*dbtypes.PoolTicketsData, error) {
 	rows, err := db.Query(internal.MakeSelectTicketsByPurchaseDate(groupBy), maturityBlock)
 	if err != nil {
@@ -773,7 +773,8 @@ func retrieveTicketsByDate(db *sql.DB, maturityBlock int64, groupBy string) (*db
 
 // retrieveTicketByPrice fetches the tickets in the current ticketpool ordered by the
 // purchase price. The maturity block is needed to identify immature tickets.
-// The grouping interval size is specified in seconds.
+// The grouping is done using the time-based group names provided e.g. months,
+// days, weeks and years.
 func retrieveTicketByPrice(db *sql.DB, maturityBlock int64) (*dbtypes.PoolTicketsData, error) {
 	// Create the query statement and retrieve rows
 	rows, err := db.Query(internal.SelectTicketsByPrice, maturityBlock)
@@ -1413,8 +1414,7 @@ func retrieveTxHistoryByAmountFlow(db *sql.DB, addr,
 	timeInterval string) (*dbtypes.ChartsData, error) {
 	var items = new(dbtypes.ChartsData)
 
-	rows, err := db.Query(internal.MakeSelectAddressAmountFlowByAddress(timeInterval),
-		addr)
+	rows, err := db.Query(internal.MakeSelectAddressAmountFlowByAddress(timeInterval), addr)
 	if err != nil {
 		return nil, err
 	}
@@ -2147,7 +2147,6 @@ func retrieveAgendaVoteChoices(db *sql.DB, agendaID string, byType int) (*dbtype
 	var a, y, n, t uint64
 	totalVotes := new(dbtypes.AgendaVoteChoices)
 	for rows.Next() {
-		// Parse the counts and time/height
 		var blockTime dbtypes.TimeDef
 		var abstain, yes, no, total, height uint64
 		if byType == 0 {
@@ -2906,7 +2905,7 @@ func UpdateLastVins(db *sql.DB, blockHash string, isValid, isMainchain bool) err
 	for i, txHash := range txs {
 		n, err := sqlExec(db, internal.SetIsValidIsMainchainByTxHash,
 			"failed to update last vins tx validity: ", isValid, isMainchain,
-			txHash, timestamps[i], trees[i])
+			txHash, timestamps[i].T, trees[i])
 		if err != nil {
 			return err
 		}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1081,8 +1081,8 @@ func RetrieveAddressSpent(db *sql.DB, address string) (count, totalAmount int64,
 
 // retrieveAddressTxsCount return the number of record groups, where grouping
 // is done by a specified time interval, for an address.
-func retrieveAddressTxsCount(db *sql.DB, address string, interval int64) (count int64, err error) {
-	err = db.QueryRow(internal.SelectAddressTimeGroupingCount, address, interval).Scan(&count)
+func retrieveAddressTxsCount(db *sql.DB, address, interval string) (count int64, err error) {
+	err = db.QueryRow(internal.MakeSelectAddressTimeGroupingCount(interval), address).Scan(&count)
 	return
 }
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -48,8 +48,8 @@ type dropDuplicatesInfo struct {
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 5
-	tablePatch = 6
+	tableMinor = 6
+	tablePatch = 0
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -49,7 +49,7 @@ type dropDuplicatesInfo struct {
 const (
 	tableMajor = 3
 	tableMinor = 5
-	tablePatch = 5
+	tablePatch = 6
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -275,9 +275,9 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 		// Go on to next upgrade
 		fallthrough
 
-	// Upgrade from 3.5.5 --> 3.5.6
+	// Upgrade from 3.5.5 --> 3.6.0
 	case version.major == 3 && version.minor == 5 && version.patch == 5:
-		toVersion = TableVersion{3, 5, 6}
+		toVersion = TableVersion{3, 6, 0}
 
 		theseUpgrades := []TableUpgradeType{
 			{"addresses", addressesBlockTimeDataTypeUpdate},

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1027,7 +1027,7 @@ func (pgb *ChainDB) handleAgendasTableUpgrade(msgBlock *wire.MsgBlock) (int64, e
 			}
 
 			err = pgb.db.QueryRow(internal.MakeAgendaInsertStatement(false),
-				val.ID, index, tx.TxID, tx.BlockHeight, tx.BlockTime,
+				val.ID, index, tx.TxID, tx.BlockHeight, tx.BlockTime.T,
 				progress.LockedIn == tx.BlockHeight,
 				progress.Activated == tx.BlockHeight,
 				progress.HardForked == tx.BlockHeight).Scan(&rowID)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -877,7 +877,7 @@ func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) 
 	for i := range txs {
 		tx = append(tx, &apitypes.AddressTxShort{
 			TxID:          txs[i].Txid,
-			Time:          time.Unix(txs[i].Time, 0),
+			Time:          dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Time, 0)}},
 			Value:         txhelpers.TotalVout(txs[i].Vout).ToCoin(),
 			Confirmations: int64(txs[i].Confirmations),
 			Size:          int32(len(txs[i].Hex) / 2),
@@ -926,8 +926,8 @@ func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, ski
 		copy(tx.Vin, txs[i].Vin)
 		tx.Confirmations = int64(txs[i].Confirmations)
 		tx.BlockHash = txs[i].BlockHash
-		tx.Blocktime = time.Unix(txs[i].Blocktime, 0)
-		tx.Time = time.Unix(txs[i].Time, 0)
+		tx.Blocktime = dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Blocktime, 0)}}
+		tx.Time = dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Time, 0)}}
 		tx.Vout = make([]apitypes.Vout, len(txs[i].Vout))
 		for j := range txs[i].Vout {
 			tx.Vout[j].Value = txs[i].Vout[j].Value
@@ -966,9 +966,8 @@ func makeExplorerBlockBasic(data *dcrjson.GetBlockVerboseResult, params *chaincf
 		Voters:         data.Voters,
 		Transactions:   len(data.RawTx),
 		FreshStake:     data.FreshStake,
-		BlockTime:      data.Time,
+		BlockTime:      dbtypes.TimeDef{T:time.Unix(data.Time,0)},
 		FormattedBytes: humanize.Bytes(uint64(data.Size)),
-		FormattedTime:  time.Unix(data.Time, 0).Format("2006-01-02 15:04:05"),
 	}
 
 	// Count the number of revocations
@@ -1021,8 +1020,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	tx.TxID = data.Txid
 	tx.FormattedSize = humanize.Bytes(uint64(len(data.Hex) / 2))
 	tx.Total = txhelpers.TotalVout(data.Vout).ToCoin()
-	tx.Time = time.Unix(data.Time, 0)
-	tx.FormattedTime = tx.Time.Format("2006-01-02 15:04:05")
+	tx.Time = dbtypes.TimeDef{T:time.Unix(data.Time, 0)}
 	tx.Confirmations = data.Confirmations
 
 	msgTx, err := txhelpers.MsgTxFromHex(data.Hex)
@@ -1240,9 +1238,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	tx.BlockIndex = txraw.BlockIndex
 	tx.BlockHash = txraw.BlockHash
 	tx.Confirmations = txraw.Confirmations
-	tx.Time = txraw.Time
-	t := time.Unix(tx.Time, 0)
-	tx.FormattedTime = t.Format("2006-01-02 15:04:05")
+	tx.Time = dbtypes.TimeDef{T:time.Unix(txraw.Time, 0)}
 
 	inputs := make([]explorer.Vin, 0, len(txraw.Vin))
 	for i, vin := range txraw.Vin {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -877,7 +877,7 @@ func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) 
 	for i := range txs {
 		tx = append(tx, &apitypes.AddressTxShort{
 			TxID:          txs[i].Txid,
-			Time:          dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Time, 0)}},
+			Time:          apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(txs[i].Time, 0)}},
 			Value:         txhelpers.TotalVout(txs[i].Vout).ToCoin(),
 			Confirmations: int64(txs[i].Confirmations),
 			Size:          int32(len(txs[i].Hex) / 2),
@@ -926,8 +926,8 @@ func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, ski
 		copy(tx.Vin, txs[i].Vin)
 		tx.Confirmations = int64(txs[i].Confirmations)
 		tx.BlockHash = txs[i].BlockHash
-		tx.Blocktime = dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Blocktime, 0)}}
-		tx.Time = dbtypes.TimeAPI{S:dbtypes.TimeDef{T:time.Unix(txs[i].Time, 0)}}
+		tx.Blocktime = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(txs[i].Blocktime, 0)}}
+		tx.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(txs[i].Time, 0)}}
 		tx.Vout = make([]apitypes.Vout, len(txs[i].Vout))
 		for j := range txs[i].Vout {
 			tx.Vout[j].Value = txs[i].Vout[j].Value
@@ -966,7 +966,7 @@ func makeExplorerBlockBasic(data *dcrjson.GetBlockVerboseResult, params *chaincf
 		Voters:         data.Voters,
 		Transactions:   len(data.RawTx),
 		FreshStake:     data.FreshStake,
-		BlockTime:      dbtypes.TimeDef{T:time.Unix(data.Time,0)},
+		BlockTime:      dbtypes.TimeDef{T: time.Unix(data.Time, 0)},
 		FormattedBytes: humanize.Bytes(uint64(data.Size)),
 	}
 
@@ -1020,7 +1020,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	tx.TxID = data.Txid
 	tx.FormattedSize = humanize.Bytes(uint64(len(data.Hex) / 2))
 	tx.Total = txhelpers.TotalVout(data.Vout).ToCoin()
-	tx.Time = dbtypes.TimeDef{T:time.Unix(data.Time, 0)}
+	tx.Time = dbtypes.TimeDef{T: time.Unix(data.Time, 0)}
 	tx.Confirmations = data.Confirmations
 
 	msgTx, err := txhelpers.MsgTxFromHex(data.Hex)
@@ -1238,7 +1238,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	tx.BlockIndex = txraw.BlockIndex
 	tx.BlockHash = txraw.BlockHash
 	tx.Confirmations = txraw.Confirmations
-	tx.Time = dbtypes.TimeDef{T:time.Unix(txraw.Time, 0)}
+	tx.Time = dbtypes.TimeDef{T: time.Unix(txraw.Time, 0)}
 
 	inputs := make([]explorer.Vin, 0, len(txraw.Vin))
 	for i, vin := range txraw.Vin {
@@ -1618,7 +1618,7 @@ func (db *wiredDB) GetTip() (*explorer.WebBasicBlock, error) {
 		Hash:        tip.Hash,
 		Difficulty:  tip.Difficulty,
 		StakeDiff:   tip.StakeDiff,
-		Time:        tip.Time,
+		Time:        tip.Time.S.T.Unix(),
 		NumTx:       tip.NumTx,
 		PoolSize:    tip.PoolInfo.Size,
 		PoolValue:   tip.PoolInfo.Value,

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -877,7 +877,7 @@ func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) 
 	for i := range txs {
 		tx = append(tx, &apitypes.AddressTxShort{
 			TxID:          txs[i].Txid,
-			Time:          txs[i].Time,
+			Time:          time.Unix(txs[i].Time, 0),
 			Value:         txhelpers.TotalVout(txs[i].Vout).ToCoin(),
 			Confirmations: int64(txs[i].Confirmations),
 			Size:          int32(len(txs[i].Hex) / 2),
@@ -926,8 +926,8 @@ func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, ski
 		copy(tx.Vin, txs[i].Vin)
 		tx.Confirmations = int64(txs[i].Confirmations)
 		tx.BlockHash = txs[i].BlockHash
-		tx.Blocktime = txs[i].Blocktime
-		tx.Time = txs[i].Time
+		tx.Blocktime = time.Unix(txs[i].Blocktime, 0)
+		tx.Time = time.Unix(txs[i].Time, 0)
 		tx.Vout = make([]apitypes.Vout, len(txs[i].Vout))
 		for j := range txs[i].Vout {
 			tx.Vout[j].Value = txs[i].Vout[j].Value
@@ -1021,9 +1021,8 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult, address st
 	tx.TxID = data.Txid
 	tx.FormattedSize = humanize.Bytes(uint64(len(data.Hex) / 2))
 	tx.Total = txhelpers.TotalVout(data.Vout).ToCoin()
-	tx.Time = data.Time
-	t := time.Unix(tx.Time, 0)
-	tx.FormattedTime = t.Format("2006-01-02 15:04:05")
+	tx.Time = time.Unix(data.Time, 0)
+	tx.FormattedTime = tx.Time.Format("2006-01-02 15:04:05")
 	tx.Confirmations = data.Confirmations
 
 	msgTx, err := txhelpers.MsgTxFromHex(data.Hex)

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -276,7 +276,7 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	if err != nil {
 		return err
 	}
-	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	// Update the DB block summary height.
 	db.Lock()
 	defer db.Unlock()
@@ -667,7 +667,7 @@ func (db *DB) RetrieveBlockSummaryByTimeRange(minTime, maxTime int64, limit int)
 			&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg); err != nil {
 			log.Errorf("Unable to scan for block fields")
 		}
-		bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+		bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 		blocks = append(blocks, *bd)
 	}
 	if err = rows.Err(); err != nil {
@@ -703,7 +703,7 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	return bd, nil
 }
@@ -749,7 +749,7 @@ func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic,
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	return bd, nil
 }
@@ -770,7 +770,7 @@ func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) 
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	// 2. Prepare + chained QueryRow/Scan
 	// stmt, err := db.Prepare(getBlockSQL)

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -268,15 +268,13 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 
 	// Insert the block.
 	winners := strings.Join(bd.PoolInfo.Winners, ";")
-	var timestamp int64
 	res, err := stmt.Exec(&bd.Height, &bd.Size, &bd.Hash,
-		&bd.Difficulty, &bd.StakeDiff, &timestamp,
+		&bd.Difficulty, &bd.StakeDiff, bd.Time.S.T.Unix(),
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
 		&winners)
 	if err != nil {
 		return err
 	}
-	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	// Update the DB block summary height.
 	db.Lock()
 	defer db.Unlock()

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -276,7 +276,7 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 	if err != nil {
 		return err
 	}
-	bd.Time = dbtypes.TimeDef{T: time.Unix(timestamp, 0)}
+	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	// Update the DB block summary height.
 	db.Lock()
 	defer db.Unlock()
@@ -531,6 +531,11 @@ func (db *DB) RetrieveAllPoolValAndSize() (*dbtypes.ChartsData, error) {
 		if err = rows.Scan(&psize, &pval, &timestamp); err != nil {
 			log.Errorf("Unable to scan for TicketPoolInfo fields: %v", err)
 		}
+
+		if timestamp == 0 {
+			continue
+		}
+
 		chartsData.Time = append(chartsData.Time, dbtypes.TimeDef{T: time.Unix(timestamp, 0)})
 		chartsData.SizeF = append(chartsData.SizeF, psize)
 		chartsData.ValueF = append(chartsData.ValueF, pval)
@@ -662,7 +667,7 @@ func (db *DB) RetrieveBlockSummaryByTimeRange(minTime, maxTime int64, limit int)
 			&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg); err != nil {
 			log.Errorf("Unable to scan for block fields")
 		}
-		bd.Time = dbtypes.TimeDef{T: time.Unix(timestamp, 0)}
+		bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 		blocks = append(blocks, *bd)
 	}
 	if err = rows.Err(); err != nil {
@@ -698,7 +703,7 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeDef{T: time.Unix(timestamp, 0)}
+	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	return bd, nil
 }
@@ -744,7 +749,7 @@ func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic,
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeDef{T: time.Unix(timestamp, 0)}
+	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	return bd, nil
 }
@@ -765,7 +770,7 @@ func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) 
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = dbtypes.TimeDef{T: time.Unix(timestamp, 0)}
+	bd.Time = dbtypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	// 2. Prepare + chained QueryRow/Scan
 	// stmt, err := db.Prepare(getBlockSQL)

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/v3/api/types"
@@ -526,11 +527,11 @@ func (db *DB) RetrieveAllPoolValAndSize() (*dbtypes.ChartsData, error) {
 
 	for rows.Next() {
 		var pval, psize float64
-		var timestamp uint64
+		var timestamp int64
 		if err = rows.Scan(&psize, &pval, &timestamp); err != nil {
 			log.Errorf("Unable to scan for TicketPoolInfo fields: %v", err)
 		}
-		chartsData.Time = append(chartsData.Time, timestamp)
+		chartsData.Time = append(chartsData.Time, time.Unix(timestamp, 0))
 		chartsData.SizeF = append(chartsData.SizeF, psize)
 		chartsData.ValueF = append(chartsData.ValueF, pval)
 	}

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -303,7 +303,7 @@ func (db *wiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       dbtypes.TimeDef{T:header.Timestamp},
+			Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 			PoolInfo:   tpi,
 		}
 

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -303,7 +303,7 @@ func (db *wiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       header.Timestamp.Unix(),
+			Time:       dbtypes.TimeDef{T:header.Timestamp},
 			PoolInfo:   tpi,
 		}
 

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -303,7 +303,7 @@ func (db *wiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       dbtypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+			Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
 			PoolInfo:   tpi,
 		}
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -431,7 +431,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	newBlockData := exp.blockData.GetExplorerBlock(msgBlock.BlockHash().String())
 
 	// Use the latest block's blocktime to get the last 24hr timestamp.
-	timestamp := newBlockData.BlockTime - 86400
+	timestamp := newBlockData.BlockTime.T.Unix() - 86400
 	targetTimePerBlock := float64(exp.ChainParams.TargetTimePerBlock)
 	// RetreiveDifficulty fetches the difficulty using the last 24hr timestamp,
 	// whereby the difficulty can have a timestamp equal to the last 24hrs

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -613,7 +613,7 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 	var mp dbtypes.PoolTicketsData
 	exp.MempoolData.RLock()
 	if len(exp.MempoolData.Tickets) > 0 {
-		mp.Time = append(mp.Time, time.Unix(exp.MempoolData.Tickets[0].Time, 0))
+		mp.Time = append(mp.Time, uint64(exp.MempoolData.Tickets[0].Time))
 		mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
 		mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
 	} else {
@@ -710,8 +710,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			BlockIndex:    dbTx0.BlockIndex,
 			BlockHash:     dbTx0.BlockHash,
 			Confirmations: exp.Height() - dbTx0.BlockHeight + 1,
-			Time:          dbTx0.Time.Unix(),
-			FormattedTime: dbTx0.Time.Format("2006-01-02 15:04:05"),
+			Time:          dbTx0.Time,
 		}
 
 		// Coinbase transactions are regular, but call them coinbase for the page.

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -416,7 +416,6 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		TimeGrouping string
 		Offset       int64
 		Limit        int64
-		Version      string
 		NetName      string
 		BestGrouping int64
 	}{
@@ -425,7 +424,6 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		TimeGrouping:   val,
 		Offset:         int64(offset),
 		Limit:          int64(rows),
-		Version:        exp.Version,
 		NetName:        exp.NetName,
 		BestGrouping:   maxOffset,
 	})
@@ -613,7 +611,8 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 	var mp dbtypes.PoolTicketsData
 	exp.MempoolData.RLock()
 	if len(exp.MempoolData.Tickets) > 0 {
-		mp.Time = append(mp.Time, uint64(exp.MempoolData.Tickets[0].Time))
+		t := time.Unix(exp.MempoolData.Tickets[0].Time, 0)
+		mp.Time = append(mp.Time, dbtypes.TimeDef{T: t})
 		mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
 		mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
 	} else {
@@ -1216,7 +1215,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 					TxID:          fundingTx.Hash().String(),
 					TxType:        txhelpers.DetermineTxTypeString(fundingTx.Tx),
 					InOutID:       f.Index,
-					Time:          time.Unix(fundingTx.MemPoolTime, 0),
+					Time:          dbtypes.TimeDef{T: time.Unix(fundingTx.MemPoolTime, 0)},
 					FormattedSize: humanize.Bytes(uint64(fundingTx.Tx.SerializeSize())),
 					Total:         txhelpers.TotalOutFromMsgTx(fundingTx.Tx).ToCoin(),
 					ReceivedTotal: dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
@@ -1271,7 +1270,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 					TxID:           spendingTx.Hash().String(),
 					TxType:         txhelpers.DetermineTxTypeString(spendingTx.Tx),
 					InOutID:        uint32(f.InputIndex),
-					Time:           time.Unix(spendingTx.MemPoolTime, 0),
+					Time:           dbtypes.TimeDef{T: time.Unix(spendingTx.MemPoolTime, 0)},
 					FormattedSize:  humanize.Bytes(uint64(spendingTx.Tx.SerializeSize())),
 					Total:          txhelpers.TotalOutFromMsgTx(spendingTx.Tx).ToCoin(),
 					SentTotal:      dcrutil.Amount(valuein).ToCoin(),
@@ -1307,7 +1306,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		if addrData.Transactions[i].Time == addrData.Transactions[j].Time {
 			return addrData.Transactions[i].InOutID > addrData.Transactions[j].InOutID
 		}
-		return addrData.Transactions[i].Time.Unix() > addrData.Transactions[j].Time.Unix()
+		return addrData.Transactions[i].Time.T.Unix() > addrData.Transactions[j].Time.T.Unix()
 	})
 
 	// Do not put this before the sort.Slice of addrData.Transactions above

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -710,8 +710,8 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			BlockIndex:    dbTx0.BlockIndex,
 			BlockHash:     dbTx0.BlockHash,
 			Confirmations: exp.Height() - dbTx0.BlockHeight + 1,
-			Time:          dbTx0.Time,
-			FormattedTime: time.Unix(dbTx0.Time, 0).Format("2006-01-02 15:04:05"),
+			Time:          dbTx0.Time.Unix(),
+			FormattedTime: dbTx0.Time.Format("2006-01-02 15:04:05"),
 		}
 
 		// Coinbase transactions are regular, but call them coinbase for the page.
@@ -1217,7 +1217,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 					TxID:          fundingTx.Hash().String(),
 					TxType:        txhelpers.DetermineTxTypeString(fundingTx.Tx),
 					InOutID:       f.Index,
-					Time:          fundingTx.MemPoolTime,
+					Time:          time.Unix(fundingTx.MemPoolTime, 0),
 					FormattedSize: humanize.Bytes(uint64(fundingTx.Tx.SerializeSize())),
 					Total:         txhelpers.TotalOutFromMsgTx(fundingTx.Tx).ToCoin(),
 					ReceivedTotal: dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
@@ -1272,7 +1272,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 					TxID:           spendingTx.Hash().String(),
 					TxType:         txhelpers.DetermineTxTypeString(spendingTx.Tx),
 					InOutID:        uint32(f.InputIndex),
-					Time:           spendingTx.MemPoolTime,
+					Time:           time.Unix(spendingTx.MemPoolTime, 0),
 					FormattedSize:  humanize.Bytes(uint64(spendingTx.Tx.SerializeSize())),
 					Total:          txhelpers.TotalOutFromMsgTx(spendingTx.Tx).ToCoin(),
 					SentTotal:      dcrutil.Amount(valuein).ToCoin(),
@@ -1308,7 +1308,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		if addrData.Transactions[i].Time == addrData.Transactions[j].Time {
 			return addrData.Transactions[i].InOutID > addrData.Transactions[j].InOutID
 		}
-		return addrData.Transactions[i].Time > addrData.Transactions[j].Time
+		return addrData.Transactions[i].Time.Unix() > addrData.Transactions[j].Time.Unix()
 	})
 
 	// Do not put this before the sort.Slice of addrData.Transactions above

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -613,7 +613,7 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 	var mp dbtypes.PoolTicketsData
 	exp.MempoolData.RLock()
 	if len(exp.MempoolData.Tickets) > 0 {
-		mp.Time = append(mp.Time, uint64(exp.MempoolData.Tickets[0].Time))
+		mp.Time = append(mp.Time, time.Unix(exp.MempoolData.Tickets[0].Time, 0))
 		mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
 		mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
 	} else {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -213,7 +213,7 @@ type Vout struct {
 
 // TrimmedBlockInfo models data needed to display block info on the new home page
 type TrimmedBlockInfo struct {
-	Time         int64
+	Time         dbtypes.TimeDef
 	Height       int64
 	Total        float64
 	Fees         float64

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson"
@@ -87,14 +88,13 @@ type AddressTx struct {
 	FormattedSize  string
 	Total          float64
 	Confirmations  uint64
-	Time           int64
+	Time           time.Time
 	FormattedTime  string
 	ReceivedTotal  float64
 	SentTotal      float64
 	IsFunding      bool
 	MatchedTx      string
 	MatchedTxIndex uint32
-	BlockTime      uint64
 	MergedTxnCount uint64 `json:",omitempty"`
 }
 
@@ -461,7 +461,7 @@ func ReduceAddressHistory(addrHist []*dbtypes.AddressRow) *AddressInfo {
 		}
 		coin := dcrutil.Amount(addrOut.Value).ToCoin()
 		tx := AddressTx{
-			BlockTime: addrOut.TxBlockTime,
+			Time:      addrOut.TxBlockTime,
 			InOutID:   addrOut.TxVinVoutIndex,
 			TxID:      addrOut.TxHash,
 			TxType:    txhelpers.TxTypeToString(int(addrOut.TxType)),

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson"
@@ -38,19 +37,18 @@ var blockchainSyncStatus = new(syncStatus)
 
 // BlockBasic models data for the explorer's explorer page
 type BlockBasic struct {
-	Height         int64  `json:"height"`
-	Hash           string `json:"hash"`
-	Size           int32  `json:"size"`
-	Valid          bool   `json:"valid"`
-	MainChain      bool   `json:"mainchain"`
-	Voters         uint16 `json:"votes"`
-	Transactions   int    `json:"tx"`
-	IndexVal       int64  `json:"windowIndex"`
-	FreshStake     uint8  `json:"tickets"`
-	Revocations    uint32 `json:"revocations"`
-	BlockTime      int64  `json:"time"`
-	FormattedTime  string `json:"formatted_time"`
-	FormattedBytes string `json:"formatted_bytes"`
+	Height         int64           `json:"height"`
+	Hash           string          `json:"hash"`
+	Size           int32           `json:"size"`
+	Valid          bool            `json:"valid"`
+	MainChain      bool            `json:"mainchain"`
+	Voters         uint16          `json:"votes"`
+	Transactions   int             `json:"tx"`
+	IndexVal       int64           `json:"windowIndex"`
+	FreshStake     uint8           `json:"tickets"`
+	Revocations    uint32          `json:"revocations"`
+	BlockTime      dbtypes.TimeDef `json:"time"`
+	FormattedBytes string          `json:"formatted_bytes"`
 }
 
 // WebBasicBlock is used for quick DB data without rpc calls
@@ -88,8 +86,7 @@ type AddressTx struct {
 	FormattedSize  string
 	Total          float64
 	Confirmations  uint64
-	Time           time.Time
-	FormattedTime  string
+	Time           dbtypes.TimeDef
 	ReceivedTotal  float64
 	SentTotal      float64
 	IsFunding      bool
@@ -136,8 +133,7 @@ type TxInfo struct {
 	BlockHash        string
 	BlockMiningFee   int64
 	Confirmations    int64
-	Time             int64
-	FormattedTime    string
+	Time             dbtypes.TimeDef
 	Mature           string
 	VoteFundsLocked  string
 	Maturity         int64   // Total number of blocks before mature

--- a/explorer/mempool.go
+++ b/explorer/mempool.go
@@ -351,7 +351,7 @@ func (exp *explorerUI) getLastBlock() (lastBlockHash string, lastBlock int64, la
 	exp.pageData.RLock()
 	defer exp.pageData.RUnlock()
 	lastBlock = exp.pageData.BlockInfo.Height
-	lastBlockTime = exp.pageData.BlockInfo.BlockTime
+	lastBlockTime = exp.pageData.BlockInfo.BlockTime.T.Unix()
 	lastBlockHash = exp.pageData.BlockInfo.Hash
 	return
 }

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -339,7 +339,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 				matchedGrouping = "blocks"
 				rowsCount = 20
 			}
-			
+
 			matchingVal := dbtypes.TimeGroupingFromStr(matchedGrouping)
 			intervalVal, err := dbtypes.TimeBasedGroupingToInterval(matchingVal)
 			if err != nil {

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -136,7 +136,7 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					var mp dbtypes.PoolTicketsData
 					exp.MempoolData.RLock()
 					if len(exp.MempoolData.Tickets) > 0 {
-						mp.Time = append(mp.Time, uint64(exp.MempoolData.Tickets[0].Time))
+						mp.Time = append(mp.Time, time.Unix(exp.MempoolData.Tickets[0].Time, 0))
 						mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
 						mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
 					} else {

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -136,7 +136,8 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					var mp dbtypes.PoolTicketsData
 					exp.MempoolData.RLock()
 					if len(exp.MempoolData.Tickets) > 0 {
-						mp.Time = append(mp.Time, time.Unix(exp.MempoolData.Tickets[0].Time, 0))
+						t := time.Unix(exp.MempoolData.Tickets[0].Time, 0)
+						mp.Time = append(mp.Time, dbtypes.TimeDef{T: t})
 						mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
 						mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
 					} else {

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -301,7 +301,7 @@
         }
 
         disableBtnsIfNotApplicable(){
-            var val = parseInt(this.addrTarget.dataset.oldestblockTime)
+            var val = new Date(this.addrTarget.dataset.oldestblocktime)
             var d = new Date()
 
             var pastYear = d.getFullYear() - 1;
@@ -311,7 +311,7 @@
 
             this.enabledButtons = []
             var setApplicableBtns = (className, ts, txCountByType) => {
-                var isDisabled = (val > ts) ||
+                var isDisabled = (val > new Date(ts)) ||
                     (this.options === 'unspent' && this.unspent == "0") ||
                     txCountByType < 2;
 

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -3,7 +3,7 @@
         var p = []
 
         d.time.map((n, i) => {
-            p.push([new Date(n*1000), d.sentRtx[i], d.receivedRtx[i], d.tickets[i], d.votes[i], d.revokeTx[i]])
+            p.push([new Date(n), d.sentRtx[i], d.receivedRtx[i], d.tickets[i], d.votes[i], d.revokeTx[i]])
         });
         return p
     }
@@ -17,7 +17,7 @@
             var netSent = 0
 
             v > 0 ? (netReceived = v) : (netSent = (v* -1))
-            p.push([new Date(n*1000), d.received[i], d.sent[i], netReceived, netSent])
+            p.push([new Date(n), d.received[i], d.sent[i], netReceived, netSent])
         });
         return p
     }
@@ -26,10 +26,11 @@
         var p = []
         // start plotting 6 days before the actual day
         if (d.length > 0) {
-            p.push([new Date((d.time[0] - 10000) * 1000), 0])
+            v = new Date(d.time[0])
+            p.push([new Date().setDate(v.getDate()-6), 0])
         }
 
-        d.time.map((n, i) => p.push([new Date(n*1000), d.amount[i]]));
+        d.time.map((n, i) => p.push([new Date(n), d.amount[i]]));
         return p
     }
 
@@ -300,7 +301,7 @@
         }
 
         disableBtnsIfNotApplicable(){
-            var val = parseInt(this.addrTarget.dataset.oldestblockTime)*1000
+            var val = parseInt(this.addrTarget.dataset.oldestblockTime)
             var d = new Date()
 
             var pastYear = d.getFullYear() - 1;
@@ -310,7 +311,7 @@
 
             this.enabledButtons = []
             var setApplicableBtns = (className, ts, txCountByType) => {
-                var isDisabled = (val > Number(new Date(ts))) ||
+                var isDisabled = (val > ts) ||
                     (this.options === 'unspent' && this.unspent == "0") ||
                     txCountByType < 2;
 

--- a/public/js/controllers/agenda.js
+++ b/public/js/controllers/agenda.js
@@ -54,7 +54,7 @@ function barchartPlotter(e) {
         if (!d.yes instanceof Array) return [[0,0,0]]
         return d.yes.map((n,i) => {
             return [
-                new Date(d.time[i]*1000),
+                new Date(d.time[i]),
                 + d.yes[i],
                 d.abstain[i], 
                 d.no[i]

--- a/public/js/controllers/charts.js
+++ b/public/js/controllers/charts.js
@@ -52,19 +52,15 @@
 
     function ticketsFunc(gData){
         return _.map(gData.time, (n,i) => {
-            return [
-                new Date (n*1000),
-                gData.valuef[i]
-            ]
-        })
+            return [new Date (n), gData.valuef[i]]})
     }
 
     function difficultyFunc(gData){
-        return _.map(gData.time, (n, i) => { return [new Date(n*1000), gData.difficulty[i]] })
+        return _.map(gData.time, (n, i) => { return [new Date(n), gData.difficulty[i]] })
     }
 
     function supplyFunc (gData){
-       return _.map(gData.time, (n, i) => { return [new Date(n*1000), gData.valuef[i]] });
+       return _.map(gData.time, (n, i) => { return [new Date(n), gData.valuef[i]] });
     }
 
     function timeBtwBlocksFunc(gData){
@@ -74,13 +70,11 @@
     }
 
     function blockSizeFunc(gData){
-        return _.map(gData.time,(n,i) => {
-            return [new Date(n*1000), gData.size[i]]
-        })
+        return _.map(gData.time,(n,i) => {return [new Date(n), gData.size[i]]})
     }
 
     function blockChainSizeFunc(gData){
-        return _.map(gData.time,(n,i) => { return [new Date(n*1000), gData.chainsize[i]] })
+        return _.map(gData.time,(n,i) => { return [new Date(n), gData.chainsize[i]] })
     }
 
     function txPerBlockFunc(gData){
@@ -88,15 +82,15 @@
     }
 
     function txPerDayFunc (gData){
-        return _.map(gData.timestr,(n,i) => { return [new Date(n), gData.count[i]] })
+        return _.map(gData.time,(n,i) => { return [new Date(n), gData.count[i]] })
     }
 
     function poolSizeFunc(gData){
-        return _.map(gData.time,(n,i) => { return [new Date(n*1000), gData.sizef[i]] })
+        return _.map(gData.time,(n,i) => { return [new Date(n), gData.sizef[i]] })
     }
 
     function poolValueFunc(gData) {
-        return _.map(gData.time,(n,i) => { return [new Date(n*1000), gData.valuef[i]] })
+        return _.map(gData.time,(n,i) => { return [new Date(n), gData.valuef[i]] })
     }
 
     function blockFeeFunc (gData){

--- a/public/js/controllers/main.js
+++ b/public/js/controllers/main.js
@@ -1,5 +1,8 @@
 
 (() => {
+    function isCorrectVal(value) {
+        return /^\d+$/.test(value) && value >0;
+    }
 
     app.register("main", class extends Stimulus.Controller {
         static get targets() {
@@ -39,8 +42,10 @@
               return
             }
             this.ageTargets.forEach((el,i) => {
-                if (el.dataset.age > 0) {
-                    el.textContent = humanize.timeSince(el.dataset.age, el.id)
+                if (isCorrectVal(el.dataset.age)) {
+                    el.textContent = humanize.timeSince(el.dataset.age)
+                } else if (el.dataset.age != '') {
+                    el.textContent = humanize.timeSince(Date.parse(el.dataset.age)/1000)
                 }
             })
         }

--- a/public/js/controllers/ticketpool.js
+++ b/public/js/controllers/ticketpool.js
@@ -46,12 +46,13 @@ function barchartPlotter(e) {
         var finalDate = "";
 
         items.time.map(function(n, i){
-            finalDate = new Date(n*1000);
+            finalDate = new Date(n);
             s.push([finalDate, 0, items.immature[i], items.live[i], items.price[i]]);
         });
 
         if (!isNaN(memP.time)){
-            s.push([new Date((memP.time[0] + 60) * 1000) , memP.mempool[0], 0, 0, memP.price[0]]); // add mempool
+            memPdate = new Date(memP.time[0])
+            s.push([new Date().setDate(memPdate.getMinutes() + 1) , memP.mempool[0], 0, 0, memP.price[0]]); // add mempool
         }
 
         origDate = s[0][0] - new Date(0)

--- a/systemstesting/serverPerformanceTest.go
+++ b/systemstesting/serverPerformanceTest.go
@@ -12,14 +12,15 @@ import (
 )
 
 const (
-	ticketPrice     = "/chart/ticket-price"
-	tpMonthGrouping = "/ticketpool/bydate/mo"
-	tpDayGrouping   = "/ticketpool/bydate/day"
-	tpAllGrouping   = "/ticketpool/bydate/all"
-	serverAPIUrl    = "http://127.0.0.1:7777/api"
+	ticketPrice      = "/chart/ticket-price"
+	tpMonthGrouping  = "/ticketpool/bydate/mo"
+	tpDayGrouping    = "/ticketpool/bydate/day"
+	tpAllGrouping    = "/ticketpool/bydate/all"
+	allProjectFundTx = "/address/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/types/all"
+	serverAPIUrl     = "http://127.0.0.1:7777/api"
 
 	statusOK      = http.StatusOK
-	maxIterations = 100
+	maxIterations = 10
 )
 
 // httpClient set the time out value, maximum connections and Disable compressions.
@@ -57,13 +58,14 @@ func queryEndpoint(urlStr string, statusCode int) error {
 // queryEndpoint function.
 func main() {
 	testingUrls := map[string]string{
-		"ticketPrice":       serverAPIUrl + ticketPrice,
-		"month ticket pool": serverAPIUrl + tpMonthGrouping,
-		"day ticket pool":   serverAPIUrl + tpDayGrouping,
-		// "all time ticket pool": serverAPIUrl + tpAllGrouping,
+		"ticketPrice":               serverAPIUrl + ticketPrice,
+		"month ticket pool":         serverAPIUrl + tpMonthGrouping,
+		"day ticket pool":           serverAPIUrl + tpDayGrouping,
+		"all time ticket pool":      serverAPIUrl + tpAllGrouping,
+		"all project fund txtypes ": serverAPIUrl + allProjectFundTx,
 	}
 
-	fmt.Println(" >>>>>> Intitiating the Server Perfomance Test by Response Time <<<<<<< ")
+	fmt.Printf(" >>>>>> Intitiating the Server Perfomance Test by Response Time for %d Iterations per URL<<<<<<< \n", maxIterations)
 	for urlType, val := range testingUrls {
 		startTime := time.Now()
 		err := queryEndpoint(val, statusOK)
@@ -72,6 +74,6 @@ func main() {
 			break
 		}
 
-		fmt.Printf("Server Performance testing on %s url took %v\n\n", urlType, time.Since(startTime))
+		fmt.Printf("Server Performance testing on '%s' url took %v \n\n", urlType, time.Since(startTime))
 	}
 }

--- a/systemstesting/serverPerformanceTest.go
+++ b/systemstesting/serverPerformanceTest.go
@@ -1,0 +1,76 @@
+package systemstesting
+
+// This trys to create a standard way we can measure the server performance
+// by measuring how long it takes query a given endpoint in dcrdata for a certain
+// number of defined iterations. This testing method focuses only on GET requests
+// whose status code is always expected to be 200 if successful.
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	ticketPrice     = "/chart/ticket-price"
+	tpMonthGrouping = "/ticketpool/bydate/mo"
+	tpDayGrouping   = "/ticketpool/bydate/day"
+	tpAllGrouping   = "/ticketpool/bydate/all"
+	serverAPIUrl    = "http://127.0.0.1/api"
+
+	statusOK      = http.StatusOK
+	maxIterations = 1000
+)
+
+// httpClient set the time out value, maximum connections and Disable compressions.
+func httpClient() *http.Client {
+	tr := &http.Transport{
+		MaxIdleConns:       10,
+		IdleConnTimeout:    10 * time.Second,
+		DisableCompression: true,
+	}
+	return &http.Client{Transport: tr}
+}
+
+// queryEndpoint querys the endpoint provided for the number of iterations defined
+// by maxIterations. An error is return when the client returns an error or when
+// an incorrect status code is returned by the url.
+func queryEndpoint(urlStr string, statusCode int) error {
+	client := httpClient()
+
+	for i := 0; i < maxIterations; i++ {
+		res, err := client.Get(urlStr)
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s url data at iteration %d", urlStr, i)
+		}
+
+		if res.StatusCode != statusCode {
+			return fmt.Errorf("on iteration %d expected status code %d but got %d",
+				i, statusCode, res.StatusCode)
+		}
+	}
+	return nil
+}
+
+// main initiates the server perfomance testing primarily measuring how long it
+// takes to query each of the given testingUrls if not error is returned by the
+// queryEndpoint function.
+func main() {
+	testingUrls := map[string]string{
+		"ticketPrice":          serverAPIUrl + ticketPrice,
+		"month ticket pool":    serverAPIUrl + tpMonthGrouping,
+		"day ticket pool":      serverAPIUrl + tpDayGrouping,
+		"all time ticket pool": serverAPIUrl + tpAllGrouping,
+	}
+
+	for urlType, val := range testingUrls {
+		startTime := time.Now()
+		err := queryEndpoint(val, statusOK)
+		if err != nil {
+			fmt.Println(err)
+			break
+		}
+
+		fmt.Printf("Server Performance testing on %s url took %v", urlType, time.Since(startTime))
+	}
+}

--- a/systemstesting/serverPerformanceTest.go
+++ b/systemstesting/serverPerformanceTest.go
@@ -1,4 +1,4 @@
-package systemstesting
+package main
 
 // This trys to create a standard way we can measure the server performance
 // by measuring how long it takes query a given endpoint in dcrdata for a certain
@@ -16,10 +16,10 @@ const (
 	tpMonthGrouping = "/ticketpool/bydate/mo"
 	tpDayGrouping   = "/ticketpool/bydate/day"
 	tpAllGrouping   = "/ticketpool/bydate/all"
-	serverAPIUrl    = "http://127.0.0.1/api"
+	serverAPIUrl    = "http://127.0.0.1:7777/api"
 
 	statusOK      = http.StatusOK
-	maxIterations = 1000
+	maxIterations = 100
 )
 
 // httpClient set the time out value, maximum connections and Disable compressions.
@@ -41,7 +41,7 @@ func queryEndpoint(urlStr string, statusCode int) error {
 	for i := 0; i < maxIterations; i++ {
 		res, err := client.Get(urlStr)
 		if err != nil {
-			return fmt.Errorf("failed to fetch %s url data at iteration %d", urlStr, i)
+			return fmt.Errorf("failed to fetch %s url data at iteration %d: error: %v", urlStr, i, err)
 		}
 
 		if res.StatusCode != statusCode {
@@ -57,12 +57,13 @@ func queryEndpoint(urlStr string, statusCode int) error {
 // queryEndpoint function.
 func main() {
 	testingUrls := map[string]string{
-		"ticketPrice":          serverAPIUrl + ticketPrice,
-		"month ticket pool":    serverAPIUrl + tpMonthGrouping,
-		"day ticket pool":      serverAPIUrl + tpDayGrouping,
-		"all time ticket pool": serverAPIUrl + tpAllGrouping,
+		"ticketPrice":       serverAPIUrl + ticketPrice,
+		"month ticket pool": serverAPIUrl + tpMonthGrouping,
+		"day ticket pool":   serverAPIUrl + tpDayGrouping,
+		// "all time ticket pool": serverAPIUrl + tpAllGrouping,
 	}
 
+	fmt.Println(" >>>>>> Intitiating the Server Perfomance Test by Response Time <<<<<<< ")
 	for urlType, val := range testingUrls {
 		startTime := time.Now()
 		err := queryEndpoint(val, statusOK)
@@ -71,6 +72,6 @@ func main() {
 			break
 		}
 
-		fmt.Printf("Server Performance testing on %s url took %v", urlType, time.Since(startTime))
+		fmt.Printf("Server Performance testing on %s url took %v\n\n", urlType, time.Since(startTime))
 	}
 }

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -13,7 +13,7 @@
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
                 <div class="mono" data-target="address.addr"
-                    data-oldestblockTime="{{$.Metrics.OldestBlockTime}}"
+                    data-oldestblocktime="{{$.Metrics.OldestBlockTime}}"
                     style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"
@@ -284,7 +284,7 @@
                                     {{end}}
                                 </td>
                                 <td class="addr-tx-age">
-                                {{if eq (.Time.Unix) 0}}
+                                {{if eq (.Time.T.Unix) 0}}
                                     N/A
                                 {{else}}
                                     <span data-controller="main" data-target="main.age" data-age="{{.Time}}"></span>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -280,7 +280,7 @@
                                     {{if eq .Confirmations 0}}
                                         <span data-target="address.formattedTime">Unconfirmed</span>
                                     {{else}}
-                                        {{.FormattedTime}}
+                                        {{.Time}}
                                     {{end}}
                                 </td>
                                 <td class="addr-tx-age">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -284,7 +284,7 @@
                                     {{end}}
                                 </td>
                                 <td class="addr-tx-age">
-                                {{if eq .Time 0}}
+                                {{if eq (.Time.Unix) 0}}
                                     N/A
                                 {{else}}
                                     <span data-controller="main" data-target="main.age" data-age="{{.Time}}"></span>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -133,7 +133,7 @@
                     <tr>
                         <td class="text-right lh1rem pr-2 xs-w117">TIME</td>
                         <td class="lh1rem" style="min-width: 178px;">
-                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.BlockTime}}"></span> ago)</span>
+                            ({{timezone}}) {{.BlockTime}}} <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.BlockTime}}"></span> ago)</span>
                         </td>
                     </tr>
                     <tr>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -110,7 +110,7 @@
                             <td>{{.Revocations}}</td>
                             <td>{{.FormattedBytes}}</td>
                             <td data-target="main.age" data-age="{{.BlockTime}}"></td>
-                            <td>{{.FormattedTime}}</td>
+                            <td>{{.BlockTime}}</td>
                         </tr>
                     {{end}}
                     </tbody>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -268,7 +268,7 @@
                 expTableRows.last().remove()
                 var newRow = '<tr id="' + b.height + '">' +
                     indexVal +
-                    '<td><a href="/block/' + b.height + '" class="fs18">' + b.height + '</a></td>' +
+                    '<td><a href="/block/' + b.height + '" class="fs16 height">' + b.height + '</a></td>' +
                     '<td>' + b.tx + '</td>' +
                     '<td>' + b.votes + '</td>' +
                     '<td>' + b.tickets + '</td>' +

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -275,7 +275,7 @@
                     '<td>' + b.revocations + '</td>' +
                     '<td>' + humanize.bytes(b.size) + '</td>' +
                     '<td data-target="main.age"  data-age=' + b.time + '>' + humanize.timeSince(b.time) + '</td>' +
-                    '<td>' + b.formatted_time + '</td>' +
+                    '<td>' + b.time + '</td>' +
                 '</tr>'
                 var newRowHtml = $.parseHTML(newRow)
                 $(newRowHtml).insertBefore(expTableRows.first())

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -248,7 +248,7 @@
                             <td>{{.Revocations}}</td>
                             <td>{{.FormattedBytes}}</td>
                             <td data-target="main.age" data-age="{{.BlockTime}}"></td>
-                            <td>{{.FormattedTime}}</td>
+                            <td>{{.BlockTime}}</td>
                         </tr>
                         {{end}}
                     </tbody>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -219,7 +219,7 @@
                     <h4>Latest Blocks</h4> <a href="/blocks" class="pl-2 keyboard-target"><small>see more ...</small></a>
                 </div>
 
-                <table class="table striped table-responsive full-width" id="explorertable">
+                <table class="table striped table-responsive-sm full-width" id="explorertable">
                     <thead>
                         <tr>
                             <th>Height</th>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -101,7 +101,7 @@
                         {{range .Data}}
                             <tr id="{{.EndBlock}}">
                                 <td>
-                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .EndTime}}">{{.FormattedStartTime}}</a>
+                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .EndTime.Unix}}">{{.FormattedStartTime}}</a>
                                 </td>
                                 {{if eq $lowerCaseVal "years"}}
                                 <td>{{.FormattedEndTime}}</td>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -101,7 +101,7 @@
                         {{range .Data}}
                             <tr id="{{.EndBlock}}">
                                 <td>
-                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .EndTime.T}}">{{.FormattedStartTime}}</a>
+                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .StartTime .EndTime}}">{{.FormattedStartTime}}</a>
                                 </td>
                                 {{if eq $lowerCaseVal "years"}}
                                 <td>{{.FormattedEndTime}}</td>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -101,7 +101,7 @@
                         {{range .Data}}
                             <tr id="{{.EndBlock}}">
                                 <td>
-                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .EndTime.Unix}}">{{.FormattedStartTime}}</a>
+                                   <a class="fs16 height" href="{{fetchRowLinkURL $lowerCaseVal .EndTime.T}}">{{.FormattedStartTime}}</a>
                                 </td>
                                 {{if eq $lowerCaseVal "years"}}
                                 <td>{{.FormattedEndTime}}</td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -266,10 +266,10 @@
                 <tr>
                     <td class="text-right pr-2">TIME</td>
                     <td class="lh1rem">
-                        {{if eq .Time 0}}
+                        {{if eq (.Time.Unix) 0}}
                             <span id="txFmtTime">N/A</span> <span class="op60 fs12 nowrap"><span id="txAge" data-target="main.age" data-age=""></span></span>
                         {{else}}
-                            <span>({{timezone}}) {{.FormattedTime}}</span> <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.Time}}"></span> ago)</span>
+                            <span>({{timezone}}) {{.Time}}</span> <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.Time}}"></span> ago)</span>
                         {{end}}
                     </td>
                 </tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -266,7 +266,7 @@
                 <tr>
                     <td class="text-right pr-2">TIME</td>
                     <td class="lh1rem">
-                        {{if eq (.Time.Unix) 0}}
+                        {{if eq (.Time.T.Unix) 0}}
                             <span id="txFmtTime">N/A</span> <span class="op60 fs12 nowrap"><span id="txAge" data-target="main.age" data-age=""></span></span>
                         {{else}}
                             <span>({{timezone}}) {{.Time}}</span> <span class="op60 fs12 nowrap">(<span data-target="main.age" data-age="{{.Time}}"></span> ago)</span>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -113,7 +113,7 @@
                             <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
                             <td class="text-right">{{printf "%.2f" (toFloat64Amount .TicketPrice)}}</td>
                             <td class="text-right" data-target="main.age" data-age="{{.StartTime}}"></td>
-                            <td>{{.FormattedStartTime}}</td>
+                            <td>{{.StartTime}}</td>
                         </tr>
                     {{end}}
                     </tbody>


### PR DESCRIPTION
As described in #776, This PR converts the block time values stored in the Auxiliary DB (postgresql) from `big int` data type to `timestamp` data type.

One of the reason behind this PR is that months and years don't have a constant number of days throughout but when grouping data we need it to be grouped as accurate as possible. The needed accuracy can only be obtained optimally when the builtin date/time functions e.g. `date_trunc` are used.

Performance wise no significant decrease that has been noted.

This PR results to a db upgrade (3.6.0), when testing one can use a separate db to avoid corrupting all the data available without a backup. To create a backup: `create database dcrdata_backup template dcrdata owner dcrdata;`