### PR TITLE
add a timeout context to the pg DB

### DIFF
--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -16,12 +16,12 @@ func (c *insightApiContext) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.
 	return c.DcrToInsightTxns(txs, false, false, false)
 }
 
-// DcrToInsightTxns takes struct with filter params
-func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
-	noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
+// DcrToInsightTxns converts a dcrjson TxRawResult to a InsightTx. The asm,
+// scriptSig, and spending status may be skipped by setting the appropriate
+// input arguments.
+func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
 	var newTxs []apitypes.InsightTx
 	for _, tx := range txs {
-
 		// Build new InsightTx
 		txNew := apitypes.InsightTx{
 			Txid:          tx.Txid,
@@ -36,10 +36,8 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 		}
 
 		// Vins fill
-		var vInSum, vOutSum float64
-
+		var vInSum float64
 		for vinID, vin := range tx.Vin {
-
 			InsightVin := &apitypes.InsightVin{
 				Txid:     vin.Txid,
 				Vout:     vin.Vout,
@@ -60,8 +58,9 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 				}
 			}
 
-			// Note, this only gathers information from the database which does not include mempool transactions
-			_, addresses, value, err := c.BlockData.ChainDB.RetrieveAddressIDsByOutpoint(vin.Txid, vin.Vout)
+			// Note: this only gathers information from the database, which does
+			// not include mempool transactions.
+			_, addresses, value, err := c.BlockData.ChainDB.AddressIDsByOutpoint(vin.Txid, vin.Vout)
 			if err == nil {
 				if len(addresses) > 0 {
 					// Update Vin due to DCRD AMOUNTIN - START
@@ -82,6 +81,7 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 		}
 
 		// Vout fill
+		var vOutSum float64
 		for _, v := range tx.Vout {
 			InsightVout := &apitypes.InsightVout{
 				Value: v.Value,
@@ -109,7 +109,7 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 		dcramt, _ = dcrutil.NewAmount(txNew.ValueIn - txNew.ValueOut)
 		txNew.Fees = dcramt.ToCoin()
 
-		// Return true if coinbase value is not empty, return 0 at some fields
+		// Return true if coinbase value is not empty, return 0 at some fields.
 		if txNew.Vins != nil && txNew.Vins[0].CoinBase != "" {
 			txNew.IsCoinBase = true
 			txNew.ValueIn = 0
@@ -121,9 +121,13 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult,
 		}
 
 		if !noSpent {
-			// populate the spending status of all vouts
-			// Note, this only gathers information from the database which does not include mempool transactions
-			addrFull := c.BlockData.ChainDB.GetSpendDetailsByFundingHash(txNew.Txid)
+			// Populate the spending status of all vouts. Note: this only
+			// gathers information from the database, which does not include
+			// mempool transactions.
+			addrFull, err := c.BlockData.ChainDB.SpendDetailsForFundingTx(txNew.Txid)
+			if err != nil {
+				return nil, err
+			}
 			for _, dbaddr := range addrFull {
 				txNew.Vouts[dbaddr.FundingTxVoutIndex].SpentIndex = dbaddr.SpendingTxVinIndex
 				txNew.Vouts[dbaddr.FundingTxVoutIndex].SpentTxID = dbaddr.SpendingTxHash

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018, The Decred developers
 // Copyright (c) 2017, Jonathan Chappelow
 // See LICENSE for details.
 
@@ -9,8 +10,7 @@ import (
 	"github.com/decred/dcrdata/v3/db/dbtypes"
 )
 
-// InsightAddress models an address transactions
-//
+// InsightAddress models an address' transactions.
 type InsightAddress struct {
 	Address      string      `json:"address,omitempty"`
 	From         int         `json:"from"`
@@ -18,8 +18,7 @@ type InsightAddress struct {
 	Transactions []InsightTx `json:"items,omitempty"`
 }
 
-// InsightAddressInfo models basic information
-// about an address
+// InsightAddressInfo models basic information about an address.
 type InsightAddressInfo struct {
 	Address                  string   `json:"addrStr,omitempty"`
 	Balance                  float64  `json:"balance"`
@@ -35,13 +34,12 @@ type InsightAddressInfo struct {
 	TransactionsID           []string `json:"transactions,omitempty"`
 }
 
-// InsightRawTx contains the raw transaction string
-// of a transaction
+// InsightRawTx contains the raw transaction string of a transaction.
 type InsightRawTx struct {
 	Rawtx string `json:"rawtx"`
 }
 
-// InsightMultiAddrsTx models multi address post data structure
+// InsightMultiAddrsTx models multi-address post data structure.
 type InsightMultiAddrsTx struct {
 	Addresses   string      `json:"addrs"`
 	From        json.Number `json:"from,Number,omitempty"`
@@ -58,20 +56,19 @@ type InsightMultiAddrsTxOutput struct {
 	Items      []InsightTx `json:"items"`
 }
 
-// InsightAddr models the multi address post data structure
+// InsightAddr models the multi-address post data structure.
 type InsightAddr struct {
 	Addrs string `json:"addrs"`
 }
 
-// InsightPagination models basic pagination output
-// for a result
+// InsightPagination models basic pagination output for a result.
 type InsightPagination struct {
 	Next    string `json:"next,omitempty"`
 	Prev    string `json:"prev,omitempty"`
 	IsToday string `json:"isToday,omitempty"`
 }
 
-// AddressTxnOutput models an address transaction outputs
+// AddressTxnOutput models an address transaction outputs.
 type AddressTxnOutput struct {
 	Address       string  `json:"address"`
 	TxnID         string  `json:"txid"`
@@ -86,8 +83,7 @@ type AddressTxnOutput struct {
 	Confirmations int64   `json:"confirmations"`
 }
 
-// SpendByFundingHash models a return from
-// GetSpendDetailsByFundingHash
+// SpendByFundingHash models a return from SpendDetailsForFundingTx.
 type SpendByFundingHash struct {
 	FundingTxVoutIndex uint32
 	SpendingTxVinIndex interface{}

--- a/config_test.go
+++ b/config_test.go
@@ -29,8 +29,10 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Args = os.Args[:1]
 	// Run the tests now that the testing package flags have been parsed.
-	m.Run()
+	retCode := m.Run()
 	os.Unsetenv("DCRDATA_CONFIG_FILE")
+
+	os.Exit(retCode)
 }
 
 // disableConfigFileEnv checks if the DCRDATA_CONFIG_FILE environment variable

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -83,7 +83,6 @@ const (
 		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
 
 	SelectAddressAllByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses WHERE address=$1 ORDER BY block_time DESC;`
-	SelectAddressRecvCount    = `SELECT COUNT(*) FROM addresses WHERE address=$1 AND valid_mainchain = TRUE;`
 
 	SelectAddressesAllTxn = `SELECT
 			transactions.tx_hash,

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -202,8 +202,12 @@ const (
 
 	SelectPkScriptByID       = `SELECT version, pkscript FROM vouts WHERE id=$1;`
 	SelectPkScriptByOutpoint = `SELECT version, pkscript FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
-	SelectVoutIDByOutpoint   = `SELECT id FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
-	SelectVoutByID           = `SELECT * FROM vouts WHERE id=$1;`
+	SelectPkScriptByVinID    = `SELECT version, pkscript FROM vouts
+		JOIN vins ON vouts.tx_hash=vins.prev_tx_hash and vouts.tx_index=vins.prev_tx_index
+		WHERE vins.id=$1;`
+
+	SelectVoutIDByOutpoint = `SELECT id FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
+	SelectVoutByID         = `SELECT * FROM vouts WHERE id=$1;`
 
 	RetrieveVoutValue  = `SELECT value FROM vouts WHERE tx_hash=$1 and tx_index=$2;`
 	RetrieveVoutValues = `SELECT value, tx_index, tx_tree FROM vouts WHERE tx_hash=$1;`

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -154,6 +154,9 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		}
 		totalVoutPerSec := totalVouts / int64(totalElapsed)
 		totalTxPerSec := totalTxs / int64(totalElapsed)
+		if totalTxs == 0 {
+			return
+		}
 		log.Infof("Avg. speed: %d tx/s, %d vout/s", totalTxPerSec, totalVoutPerSec)
 	}
 	speedReport := func() { o.Do(speedReporter) }
@@ -320,9 +323,10 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 	// and clear the general address balance cache.
 	if err = db.FreshenAddressCaches(false); err != nil {
 		log.Warnf("FreshenAddressCaches: %v", err)
+		err = nil // not an error with sync
 	}
 
-	// Signal the end of the initial load sync
+	// Signal the end of the initial load sync.
 	if barLoad != nil {
 		barLoad <- &dbtypes.ProgressBarLoad{
 			From:  nodeHeight,

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -78,12 +78,12 @@ type explorerDataSource interface {
 	BlockMissedVotes(blockHash string) ([]string, error)
 	AgendaVotes(agendaID string, chartType int) (*dbtypes.AgendaVoteChoices, error)
 	GetPgChartsData() (map[string]*dbtypes.ChartsData, error)
-	GetTicketsPriceByHeight() (*dbtypes.ChartsData, error)
+	TicketsPriceByHeight() (*dbtypes.ChartsData, error)
 	SideChainBlocks() ([]*dbtypes.BlockStatus, error)
 	DisapprovedBlocks() ([]*dbtypes.BlockStatus, error)
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
 	BlockFlags(hash string) (bool, bool, error)
-	GetAddressMetrics(addr string) (*dbtypes.AddressMetrics, error)
+	AddressMetrics(addr string) (*dbtypes.AddressMetrics, error)
 	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
 	Transaction(txHash string) ([]*dbtypes.Tx, error)
@@ -429,6 +429,10 @@ func (exp *explorerUI) prePopulateChartsData() {
 	log.Info("Pre-populating the charts data. This may take a minute...")
 	var err error
 	pgData, err := exp.explorerSource.GetPgChartsData()
+	if dbtypes.IsTimeoutErr(err) {
+		log.Warnf("GetPgChartsData DB timeout: %v", err)
+		return
+	}
 	if err != nil {
 		log.Errorf("Invalid PG data found: %v", err)
 		return

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -17,18 +17,19 @@ import (
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
 
-// statusType defines the various status types supported by the system.
-type statusType string
+// expStatus defines the various status types supported by the system.
+type expStatus string
 
 const (
-	ErrorStatusType          statusType = "Error"
-	NotFoundStatusType       statusType = "Not Found"
-	FutureBlockStatusType    statusType = "Future Block"
-	NotSupportedStatusType   statusType = "Not Supported"
-	NotImplementedStatusType statusType = "Not Implemented"
-	WrongNetworkStatusType   statusType = "Wrong Network"
-	DeprecatedStatusType     statusType = "Deprecated"
-	BlockchainSyncingType    statusType = "Blocks Syncing"
+	ExpStatusError          expStatus = "Error"
+	ExpStatusNotFound       expStatus = "Not Found"
+	ExpStatusFutureBlock    expStatus = "Future Block"
+	ExpStatusNotSupported   expStatus = "Not Supported"
+	ExpStatusNotImplemented expStatus = "Not Implemented"
+	ExpStatusWrongNetwork   expStatus = "Wrong Network"
+	ExpStatusDeprecated     expStatus = "Deprecated"
+	ExpStatusSyncing        expStatus = "Blocks Syncing"
+	ExpStatusDBTimeout      expStatus = "Database Timeout"
 )
 
 // blockchainSyncStatus defines the status update displayed on the syncing status page

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -121,6 +121,11 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// although it is automatically updated by the first caller
 					// who requests data from a stale cache.
 					cData, gData, chartHeight, err := exp.explorerSource.TicketPoolVisualization(interval)
+					if dbtypes.IsTimeoutErr(err) {
+						log.Warnf("TicketPoolVisualization DB timeout: %v", err)
+						webData.Message = "Error: DB timeout"
+						break
+					}
 					if err != nil {
 						if strings.HasPrefix(err.Error(), "unknown interval") {
 							log.Debugf("invalid ticket pool interval provided "+

--- a/main.go
+++ b/main.go
@@ -165,11 +165,12 @@ func _main(ctx context.Context) error {
 			}
 		}
 		dbi := dcrpg.DBInfo{
-			Host:   pgHost,
-			Port:   pgPort,
-			User:   cfg.PGUser,
-			Pass:   cfg.PGPass,
-			DBName: cfg.PGDBName,
+			Host:         pgHost,
+			Port:         pgPort,
+			User:         cfg.PGUser,
+			Pass:         cfg.PGPass,
+			DBName:       cfg.PGDBName,
+			QueryTimeout: cfg.PGQueryTimeout,
 		}
 		chainDB, err := dcrpg.NewChainDBWithCancel(ctx, &dbi, activeChain, baseDB.GetStakeDB(), !cfg.NoDevPrefetch)
 		if chainDB != nil {

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -310,10 +310,10 @@
             var pastDay = d.getDate() - 1
 
             this.enabledButtons = []
-            var setApplicableBtns = (className, ts, txCountByType) => {
+            var setApplicableBtns = (className, ts, numIntervals) => {
                 var isDisabled = (val > new Date(ts)) ||
                     (this.options === 'unspent' && this.unspent == "0") ||
-                    txCountByType < 2;
+                    numIntervals < 2;
 
                 if (isDisabled) {
                     this.zoomTarget.getElementsByClassName(className)[0].setAttribute("disabled", isDisabled)


### PR DESCRIPTION
This builds on the cancelable context added in PR https://github.com/decred/dcrdata/pull/761 by creating a configurable query timeout.

The timeout is set with `-T/--pgtimeout`, and is in seconds (`float64`).  The default is 1 day (effectively no timeout).

This adds `replaceCancelError` to recognize the standard postgres error message for a user-cancelled statement, and replace the message with a more user friendly message.

The error value returned by Retrieve* functions that use a context are now filtered in the wrapping functions with `replaceCancelError`.

Several functions in api/insight now have an error returned.

Lots of linting.

This also fixes a bug in the transaction page handler when the aux DB is used to get an orphaned transaction.  The inputs were incorrect previously.  Now SelectPkScriptByVinID is used to get the pkScript from the vouts table via the vins table and a given vin row ID.  `(*ChainDB).PkScriptByVinID` wraps this function.

A somewhat unrelated change is renaming `statusType` and the different variables of that type so that they all begin with the same prefix.  This is helpful in a number of ways.  e.g.:

![image](https://user-images.githubusercontent.com/9373513/48429762-5a5a0f00-e733-11e8-868e-8d670f5f0668.png)
