### PR TITLE
History charts urls

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -411,6 +411,7 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 	}
 
 	str, err := exp.templates.execTemplateToString("timelisting", struct {
+		*CommonPageData
 		Data         []*dbtypes.BlocksGroupedInfo
 		TimeGrouping string
 		Offset       int64
@@ -419,13 +420,14 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		NetName      string
 		BestGrouping int64
 	}{
-		data,
-		val,
-		int64(offset),
-		int64(rows),
-		exp.Version,
-		exp.NetName,
-		maxOffset,
+		CommonPageData: exp.commonData(),
+		Data:           data,
+		TimeGrouping:   val,
+		Offset:         int64(offset),
+		Limit:          int64(rows),
+		Version:        exp.Version,
+		NetName:        exp.NetName,
+		BestGrouping:   maxOffset,
 	})
 
 	if err != nil {

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -138,11 +138,11 @@
                     fillGraph: true
                 }
 
-                var defaultHash = 'list-view'
-                var hashVal = window.location.hash.replace('#', '') || defaultHash;
+                _this.defaultHash = 'list-view'
+                var hashVal = window.location.hash.replace('#', '') || _this.defaultHash;
 
-                if (hashVal.length === 0 || hashVal === defaultHash){
-                    history.pushState({},  this.addr, "#" + defaultHash);
+                if (hashVal.length === 0 || hashVal === _this.defaultHash){
+                    history.pushState({},  this.addr, "#" + _this.defaultHash);
                 } else {
                     var selectedVal = this.optionsTarget.namedItem(hashVal)
                     $(this.optionsTarget).val((selectedVal ? selectedVal.value : 'types'))
@@ -256,6 +256,7 @@
             if (divShow !== 'chart') {
                 divHide = 'chart'
                 $('body').removeClass('loading');
+                history.pushState({}, this.addr, "#" + _this.defaultHash);
             } else {
                 _this.drawGraph()
             }

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -137,6 +137,21 @@
                     visibility: [true],
                     fillGraph: true
                 }
+
+                var defaultHash = 'list-view'
+                var hashVal = window.location.hash.replace('#', '') || defaultHash;
+
+                if (hashVal.length === 0 || hashVal === defaultHash){
+                    history.pushState({},  defaultHash, defaultHash);
+                } else {
+                    var selectedVal = this.optionsTarget.namedItem(hashVal)
+                    $(this.optionsTarget).val(selectedVal ? selectedVal.value : 'types')
+
+                    $('.addr-btn').removeClass('btn-active');
+                    $('#chart').addClass('btn-active');
+
+                    this.changeView()
+                }
             })
         }
 
@@ -167,6 +182,9 @@
             var _this = this
             var graphType = _this.options
             var interval = _this.interval
+
+            var selectedHash = this.optionsTarget.value
+            history.pushState({}, selectedHash, "#"+selectedHash);
 
             $('#no-bal').addClass('d-hide');
             $('#history-chart').removeClass('d-hide');
@@ -216,6 +234,8 @@
                         }
                         _this.updateFlow()
                         _this.xVal = _this.graph.xAxisExtremes()
+
+                        window.location.hash = graphType
                     }else{
                         $('#no-bal').removeClass('d-hide');
                         $('#history-chart').addClass('d-hide');
@@ -313,8 +333,7 @@
         }
 
         get options(){
-            var selectedValue = this.optionsTarget
-            return selectedValue.options[selectedValue.selectedIndex].value;
+            return this.optionsTarget.value
         }
 
         get addr(){

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -146,10 +146,6 @@
                 } else {
                     var selectedVal = this.optionsTarget.namedItem(hashVal)
                     $(this.optionsTarget).val((selectedVal ? selectedVal.value : 'types'))
-
-                    $('.addr-btn').removeClass('btn-active');
-                    $('.chart').addClass('btn-active');
-
                     this.changeView()
                 }
             })
@@ -244,7 +240,10 @@
             });
         }
 
-        changeView() {
+        changeView(e) {
+            $('.addr-btn').removeClass('btn-active');
+            $(e ? e.srcElement : '.chart').addClass('btn-active');
+
             var _this = this
             _this.disableBtnsIfNotApplicable()
 
@@ -265,7 +264,12 @@
             $('.'+divHide+'-display').addClass('d-hide');
         }
 
-        changeGraph(){
+        changeGraph(e){
+            if (e.srcElement.className.includes('.chart-size')){
+                $(e.srcElement).siblings().removeClass('btn-active');
+                $(e.srcElement).toggleClass('btn-active');
+            }
+
             $('body').addClass('loading');
             this.drawGraph()
         }
@@ -278,7 +282,10 @@
            }
         }
 
-        onZoom(){
+        onZoom(e){
+            $(e.srcElement).siblings().removeClass('btn-active');
+            $(e.srcElement).toggleClass('btn-active');
+
             if (this.graph == undefined) {
                 return
             }

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -142,13 +142,13 @@
                 var hashVal = window.location.hash.replace('#', '') || defaultHash;
 
                 if (hashVal.length === 0 || hashVal === defaultHash){
-                    history.pushState({},  defaultHash, defaultHash);
+                    history.pushState({},  this.addr, "#" + defaultHash);
                 } else {
                     var selectedVal = this.optionsTarget.namedItem(hashVal)
-                    $(this.optionsTarget).val(selectedVal ? selectedVal.value : 'types')
+                    $(this.optionsTarget).val((selectedVal ? selectedVal.value : 'types'))
 
-                    $('.addr-btn').removeClass('btn-active');
-                    $('#chart').addClass('btn-active');
+                    $('#addr-btn').removeClass('btn-active');
+                    $('.chart').addClass('btn-active');
 
                     this.changeView()
                 }
@@ -183,8 +183,7 @@
             var graphType = _this.options
             var interval = _this.interval
 
-            var selectedHash = this.optionsTarget.value
-            history.pushState({}, selectedHash, "#"+selectedHash);
+            history.pushState({}, this.addr, "#" + graphType);
 
             $('#no-bal').addClass('d-hide');
             $('#history-chart').removeClass('d-hide');
@@ -234,8 +233,6 @@
                         }
                         _this.updateFlow()
                         _this.xVal = _this.graph.xAxisExtremes()
-
-                        window.location.hash = graphType
                     }else{
                         $('#no-bal').removeClass('d-hide');
                         $('#history-chart').addClass('d-hide');

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -147,7 +147,7 @@
                     var selectedVal = this.optionsTarget.namedItem(hashVal)
                     $(this.optionsTarget).val((selectedVal ? selectedVal.value : 'types'))
 
-                    $('#addr-btn').removeClass('btn-active');
+                    $('.addr-btn').removeClass('btn-active');
                     $('.chart').addClass('btn-active');
 
                     this.changeView()
@@ -326,8 +326,8 @@
                 this.enabledButtons[0] = "all"
             }
 
-            $("input#chart-size").removeClass("btn-active")
-            $("input#chart-size." + this.enabledButtons[0]).addClass("btn-active");
+            $("input.chart-size").removeClass("btn-active")
+            $("input.chart-size." + this.enabledButtons[0]).addClass("btn-active");
         }
 
         get options(){

--- a/public/js/controllers/charts.js
+++ b/public/js/controllers/charts.js
@@ -157,9 +157,7 @@
                         nightModeOptions(params.nightMode)
                     );
                 })
-
             });
-
         }
 
         disconnect(){
@@ -192,7 +190,9 @@
                 [[1,1]],
                 options
             );
-            $(this.chartSelectTarget).val(window.location.hash.replace("#","") || 'ticket-price')
+
+            var val = this.chartSelectTarget.namedItem(window.location.hash.replace("#",""))
+            $(this.chartSelectTarget).val((val ? val.value : 'ticket-price'))
             this.selectChart()
         }
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -149,11 +149,11 @@
                             data-target="address.zoom"
                             data-action="click->address#onZoom"
                         >
-                            <input id="chart-zoom" type="button" class="btn btn_sm btn-active all" value="All Time" name="0">
-                            <input id="chart-zoom" type="button" class="btn btn_sm year" value="Year" name="3.154e+10">
-                            <input id="chart-zoom" type="button" class="btn btn_sm month" value="Month" name="2.628e+9">
-                            <input id="chart-zoom" type="button" class="btn btn_sm week" value="Week" name="6.048e+8">
-                            <input id="chart-zoom" type="button" class="btn btn_sm day" value="Day" name="8.64e+7">
+                            <input type="button" class="chart-zoom btn btn_sm btn-active all" value="All Time" name="0">
+                            <input type="button" class="chart-zoom btn btn_sm year" value="Year" name="3.154e+10">
+                            <input type="button" class="chart-zoom btn btn_sm month" value="Month" name="2.628e+9">
+                            <input type="button" class="chart-zoom btn btn_sm week" value="Week" name="6.048e+8">
+                            <input type="button" class="chart-zoom btn btn_sm day" value="Day" name="8.64e+7">
                         </div>
                         <label style="margin: 0 1% 0 2%;">Group By </label>
                         <div
@@ -167,11 +167,11 @@
                             data-week="{{$.Metrics.WeekTxsCount}}"
                             data-day="{{$.Metrics.DayTxsCount}}"
                         >
-                            <input id="chart-size" type="button" class="btn btn_sm year" value="Year" name="yr">
-                            <input id="chart-size" type="button" class="btn btn_sm month" value="Month" name="mo">
-                            <input id="chart-size" type="button" class="btn btn_sm week" value="Week" name="wk">
-                            <input id="chart-size" type="button" class="btn btn_sm day" value="Day" name="day">
-                            <input id="chart-size" type="button" class="btn btn_sm all btn-active" value="All Blocks" name="all">
+                            <input type="button" class="chart-size btn btn_sm year" value="Year" name="yr">
+                            <input type="button" class="chart-size btn btn_sm month" value="Month" name="mo">
+                            <input type="button" class="chart-size btn btn_sm week" value="Week" name="wk">
+                            <input type="button" class="chart-size btn btn_sm day" value="Day" name="day">
+                            <input type="button" class="chart-size btn btn_sm all btn-active" value="All Blocks" name="all">
                         </div>
                     </div>
                     <h5 class="mr-auto mb-0 list-display">History</h5>
@@ -426,8 +426,8 @@
             })
         }
 
-        $('input[type=button]').on('click', function(){
-            $('input#'+this.id).removeClass('btn-active');
+        $('.addr-btn, .chart-zoom, .chart-size').on('click', function(){
+            $(this).siblings().removeClass('btn-active');
             $(this).toggleClass('btn-active');
         });
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -123,9 +123,9 @@
                             data-target="address.options"
                             data-action="change->address#changeGraph"
                         >
-                            <option id="types" value="types">Transactions Types</option>
-                            <option id="amountflow" value="amountflow">Sent and Received</option>
-                            <option id="unspent" value="unspent">Total Unspent</option>
+                            <option name="types" value="types">Transactions Types</option>
+                            <option name="amountflow" value="amountflow">Sent and Received</option>
+                            <option name="unspent" value="unspent">Total Unspent</option>
                         </select>
                         <div id="toggle-charts" class="row t-charts d-hide" data-target="address.flow"
                             data-action="change->address#updateFlow">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -38,9 +38,9 @@
                     data-target="address.btns"
                     data-action="click->address#changeView"
                 >
-                    <input id="addr-btn" type="button" class="btn btn_sm btn-active" value="List" name="list">
-                    <input id="addr-btn" type="button" class="btn btn_sm" value="Charts"
-                    name="chart" {{if or $.IsLiteMode (le (len .Transactions) 1)}}disabled{{end}}>
+                    <input id="list" type="button" class="addr-btn btn btn_sm btn-active" value="List" name="list">
+                    <input id="chart" type="button" class="addr-btn btn btn_sm" value="Charts"
+                        name="chart" {{if or $.IsLiteMode (le (len .Transactions) 1)}}disabled{{end}}>
                 </div>
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">
@@ -123,9 +123,9 @@
                             data-target="address.options"
                             data-action="change->address#changeGraph"
                         >
-                            <option value="types" selected>Transaction Types</option>
-                            <option value="amountflow">Sent and Received</option>
-                            <option value="unspent">Total Unspent</option>
+                            <option id="types" value="types">Transactions Types</option>
+                            <option id="amountflow" value="amountflow">Sent and Received</option>
+                            <option id="unspent" value="unspent">Total Unspent</option>
                         </select>
                         <div id="toggle-charts" class="row t-charts d-hide" data-target="address.flow"
                             data-action="change->address#updateFlow">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -38,8 +38,8 @@
                     data-target="address.btns"
                     data-action="click->address#changeView"
                 >
-                    <input id="list" type="button" class="addr-btn btn btn_sm btn-active" value="List" name="list">
-                    <input id="chart" type="button" class="addr-btn btn btn_sm" value="Charts"
+                    <input type="button" class="addr-btn list btn btn_sm btn-active" value="List" name="list">
+                    <input type="button" class="addr-btn chart btn btn_sm" value="Charts"
                         name="chart" {{if or $.IsLiteMode (le (len .Transactions) 1)}}disabled{{end}}>
                 </div>
             </div>
@@ -425,11 +425,6 @@
                 }
             })
         }
-
-        $('.addr-btn, .chart-zoom, .chart-size').on('click', function(){
-            $(this).siblings().removeClass('btn-active');
-            $(this).toggleClass('btn-active');
-        });
 
     </script>
     {{end}}

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -21,20 +21,20 @@
                             data-action="charts#selectChart"
                             style="width: 250px"
                         >
-                            <option value="ticket-price">Ticket Price</option>
-                            <option value="ticket-pool-size">Ticket Pool Size</option>
-                            <option value="ticket-pool-value">Ticket Pool Value</option>
-                            <option value="avg-block-size">Average Block Size</option>
-                            <option value="blockchain-size">BlockChain Size</option>
-                            <option value="tx-per-block">Transactions Per Block</option>
-                            <option value="tx-per-day">Transactions Per Day</option>
-                            <option value="pow-difficulty">PoW Difficulty</option>
-                            <option value="coin-supply">Total Coin Supply</option>
-                            <option value="fee-per-block">Total Fee Per Block</option>
-                            <option value="duration-btw-blocks">Duration Between Blocks</option>
-                            <option value="ticket-spend-type">Ticket Spend Types</option>
-                            <option value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
-                            <option value="ticket-by-outputs-blocks">Ticket Outputs by Block</option>
+                            <option id="ticket-price" value="ticket-price">Ticket Price</option>
+                            <option id="ticket-pool-size" value="ticket-pool-size">Ticket Pool Size</option>
+                            <option id="ticket-pool-value" value="ticket-pool-value">Ticket Pool Value</option>
+                            <option id="avg-block-size" value="avg-block-size">Average Block Size</option>
+                            <option id="blockchain-size" value="blockchain-size">BlockChain Size</option>
+                            <option id="tx-per-block" value="tx-per-block">Transactions Per Block</option>
+                            <option id="tx-per-day" value="tx-per-day">Transactions Per Day</option>
+                            <option id="pow-difficulty" value="pow-difficulty">PoW Difficulty</option>
+                            <option id="coin-supply" value="coin-supply">Total Coin Supply</option>
+                            <option id="fee-per-block" value="fee-per-block">Total Fee Per Block</option>
+                            <option id="duration-btw-blocks" value="duration-btw-blocks">Duration Between Blocks</option>
+                            <option id="ticket-spend-type" value="ticket-spend-type">Ticket Spend Types</option>
+                            <option id="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
+                            <option id="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option>
                         </select>
                     </div>
                 </div>

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -21,20 +21,20 @@
                             data-action="charts#selectChart"
                             style="width: 250px"
                         >
-                            <option id="ticket-price" value="ticket-price">Ticket Price</option>
-                            <option id="ticket-pool-size" value="ticket-pool-size">Ticket Pool Size</option>
-                            <option id="ticket-pool-value" value="ticket-pool-value">Ticket Pool Value</option>
-                            <option id="avg-block-size" value="avg-block-size">Average Block Size</option>
-                            <option id="blockchain-size" value="blockchain-size">BlockChain Size</option>
-                            <option id="tx-per-block" value="tx-per-block">Transactions Per Block</option>
-                            <option id="tx-per-day" value="tx-per-day">Transactions Per Day</option>
-                            <option id="pow-difficulty" value="pow-difficulty">PoW Difficulty</option>
-                            <option id="coin-supply" value="coin-supply">Total Coin Supply</option>
-                            <option id="fee-per-block" value="fee-per-block">Total Fee Per Block</option>
-                            <option id="duration-btw-blocks" value="duration-btw-blocks">Duration Between Blocks</option>
-                            <option id="ticket-spend-type" value="ticket-spend-type">Ticket Spend Types</option>
-                            <option id="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
-                            <option id="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option>
+                            <option name="ticket-price" value="ticket-price">Ticket Price</option>
+                            <option name="ticket-pool-size" value="ticket-pool-size">Ticket Pool Size</option>
+                            <option name="ticket-pool-value" value="ticket-pool-value">Ticket Pool Value</option>
+                            <option name="avg-block-size" value="avg-block-size">Average Block Size</option>
+                            <option name="blockchain-size" value="blockchain-size">BlockChain Size</option>
+                            <option name="tx-per-block" value="tx-per-block">Transactions Per Block</option>
+                            <option name="tx-per-day" value="tx-per-day">Transactions Per Day</option>
+                            <option name="pow-difficulty" value="pow-difficulty">PoW Difficulty</option>
+                            <option name="coin-supply" value="coin-supply">Total Coin Supply</option>
+                            <option name="fee-per-block" value="fee-per-block">Total Fee Per Block</option>
+                            <option name="duration-btw-blocks" value="duration-btw-blocks">Duration Between Blocks</option>
+                            <option name="ticket-spend-type" value="ticket-spend-type">Ticket Spend Types</option>
+                            <option name="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
+                            <option name="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Add Hash tag urls to each view of the /address page
- `/address/{{address}}#list-view` - Default view - List the address history transactions
- `/address/{{address}}#types` - Displays Transactions Types Chart
- `/address/{{address}}#amountflow`- Displays Send and Receive Chart
- `/address/{{address}}#unspent` - Displays Cumulative Total Unspent Chart 

Fixes a bug that results to no chart display on `/charts` if the wrong chart is fetched with a hashtag.
e.g. `/charts#hjgdjadbnmabcnfbcuj` defaults to `/charts#ticket-price`