### PR TITLE
Extended search to check aux DB for blocks

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -67,6 +67,8 @@ type explorerDataSourceLite interface {
 // faster solution than RPC, or additional functionality.
 type explorerDataSource interface {
 	BlockHeight(hash string) (int64, error)
+	HeightDB() (uint64, error)
+	BlockHash(height int64) (string, error)
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
 	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -47,11 +47,12 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 			var maxHeight int64
 			if exp.liteMode {
 				maxHeight = int64(exp.blockData.GetHeight())
-			}else {
+			} else {
 				bestBlockHeight, err := exp.explorerSource.HeightDB()
 				if err != nil {
 					log.Errorf("HeightDB() failed: %v", err)
-					exp.StatusPage(w, defaultErrorCode, "an unexpected error had occured while retrieving the best block", NotFoundStatusType)
+					exp.StatusPage(w, defaultErrorCode,
+						"an unexpected error had occured while retrieving the best block", ErrorStatusType)
 					return
 				}
 				maxHeight = int64(bestBlockHeight)
@@ -66,7 +67,7 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 
 			hash, err = exp.blockData.GetBlockHash(height)
 			if err != nil {
-				f := "GetBlockHeight"
+				f := "GetBlockHash"
 				if !exp.liteMode {
 					hash, err = exp.explorerSource.BlockHash(height)
 					f = "BlockHash"

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1403,14 +1403,21 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Attempt to get a block hash by calling GetBlockHash to see if the value
-	// is a block index and then redirect to the block page if it is.
+	// Attempt to get a block hash by calling GetBlockHash of wiredDB and BlockHash of ChainDB (if not int lite) to see
+	// if the value is a block index and then redirect to the block page if it is.
 	idx, err := strconv.ParseInt(searchStr, 10, 0)
 	if err == nil {
 		_, err = exp.blockData.GetBlockHash(idx)
 		if err == nil {
 			http.Redirect(w, r, "/block/"+searchStr, http.StatusPermanentRedirect)
 			return
+		}
+		if !exp.liteMode {
+			_, err = exp.explorerSource.BlockHash(idx)
+			if err == nil {
+				http.Redirect(w, r, "/block/"+searchStr, http.StatusPermanentRedirect)
+				return
+			}
 		}
 		exp.StatusPage(w, "search failed", "Block "+searchStr+" has not yet been mined", NotFoundStatusType)
 		return

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -25,7 +25,7 @@ import (
 	"github.com/decred/dcrdata/v3/db/agendadb"
 	"github.com/decred/dcrdata/v3/db/dbtypes"
 	"github.com/decred/dcrdata/v3/txhelpers"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 )
 
 // Status page strings
@@ -1464,6 +1464,17 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 	if tx != nil {
 		http.Redirect(w, r, "/tx/"+searchStr, http.StatusPermanentRedirect)
 		return
+	}
+	if !exp.liteMode {
+		// Search for occurrences of the transaction in the database.
+		dbTxs, err := exp.explorerSource.Transaction(searchStr)
+		if err != nil && err != sql.ErrNoRows {
+			log.Errorf("Searching for transaction failed: %v", err)
+		}
+		if dbTxs != nil {
+			http.Redirect(w, r, "/tx/"+searchStr, http.StatusPermanentRedirect)
+			return
+		}
 	}
 
 	exp.StatusPage(w, "search failed", "The search string does not match any address, block, or transaction: "+searchStr, NotFoundStatusType)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1441,6 +1441,10 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 	// Attempt to get a block index by calling GetBlockHeight to see if the
 	// value is a block hash and then redirect to the block page if it is.
 	_, err = exp.blockData.GetBlockHeight(searchStr)
+	// Also check the ChainDB if the hash is not found and the app is in full mode
+	if err != nil && !exp.liteMode {
+		_, err = exp.explorerSource.BlockHeight(searchStr)
+	}
 	if err == nil {
 		http.Redirect(w, r, "/block/"+searchStr, http.StatusPermanentRedirect)
 		return


### PR DESCRIPTION
Resolve [Issue 746](https://github.com/decred/dcrdata/issues/746)

Extended the search page to search for block and address in the chaindb if the specified block height index or hash is not found in the sqlite db and the app is running the full mode.

Transaction uses rpc and so was not altered as that should cover all cases in both full and lite mode