### PR TITLE
Cleaning up ill-defined `.ConfirmHeight` values.

### DIFF
--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -6,7 +6,6 @@
 <body class="{{ theme }}">
     {{template "navbar" . }}
     {{with .Data}}
-    {{$heights := $.ConfirmHeight}}
     {{$TxnCount := .TxnCount}}
     {{$txType := .TxnType}}
     <div class="container main" data-controller="address">
@@ -226,7 +225,7 @@
                         </thead>
                         <tbody>
                             {{range $i, $v := .Transactions}}
-                            <tr>
+                            <tr {{if eq .Confirmations 0}} data-addr-tx-pending="{{.TxID}}" {{end}}>
                                 {{with $v}}
                                 <td>{{.TxType}}</td>
                                 <td><a href="/tx/{{.TxID}}/{{if .IsFunding}}out{{else}}in{{end}}/{{.InOutID}}" class="hash" data-keynav-priority>{{.IOID $txType}}</a></td>
@@ -252,7 +251,7 @@
                                 {{if ne .SentTotal 0.0}}
                                     {{if lt 0.0 .SentTotal}}
                                     {{if eq $txType "merged_debit"}}
-                                            <td class="text-right fs15"> 
+                                            <td class="text-right fs15">
                                             <span class="rm-spacing">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</span>
                                             </td>
                                         {{else}}
@@ -270,21 +269,27 @@
                                         <td>unspent</td>
                                     {{end}}
                                 {{end}}
-                                <td>
+                                <td class="addr-tx-time">
                                     {{if eq .Confirmations 0}}
                                         Unconfirmed
                                     {{else}}
                                         {{.FormattedTime}}
                                     {{end}}
                                 </td>
-                                <td>
+                                <td class="addr-tx-age">
                                 {{if eq .Time 0}}
                                     N/A
                                 {{else}}
                                     <span data-controller="main" data-target="main.age" data-age="{{.Time}}"></span>
                                 {{end}}
                                 </td>
-                                <td data-confirmation-block-height="{{index $.ConfirmHeight $i}}">{{.Confirmations}}</td>
+                                <td
+                                  {{if eq .Confirmations 0}}
+                                    class="addr-tx-confirms"
+                                  {{else}}
+                                    data-tx-block-height="{{index $.TxBlockHeights $i}}"
+                                  {{end}}
+                                  >{{.Confirmations}}</td>
                                 <td class="text-right">{{.FormattedSize}}</td>
                                 {{end}}
                             </tr>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -12,13 +12,15 @@
                 <h4 class="mb-2">
                     Block #{{.Height}}
                     {{ if not .MainChain }}
-                        <span class="attention">(side chain)</span>
+                      <span class="attention">(side chain)</span>
                     {{else}}
+                      <span class="op60 fs12" data-confirmation-block-height="{{.Height}}">
                         {{ if gt .Confirmations 1 }}
-                            <span class="op60 fs12">( <span data-confirmation-block-height="{{$.ConfirmHeight}}">{{.Confirmations}}</span> confirmations)</span>
+                          ({{.Confirmations}} confirmations)
                         {{else}}
-                            <span class="op60 fs12">best block</span>
+                          (best block)
                         {{end}}
+                      </span>
                     {{end}}
                     <a class="fs12" href="/api/block/{{.Height}}/verbose?indent=true" data-turbolinks="false">api</a>
                 </h4>
@@ -226,7 +228,7 @@
                 {{if not .Votes}}
                     <table class="table table-sm striped">
                             <tr>
-                                <td>No votes in this block. 
+                                <td>No votes in this block.
                                     {{if lt .Height .StakeValidationHeight}}
                                         (Voting starts at block {{.StakeValidationHeight}}.)
                                     {{end}}
@@ -402,7 +404,7 @@
                     </table>
                 {{end}}
             </div>
-        </div> 
+        </div>
     {{end}}
     </div>
 </div>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -190,10 +190,10 @@
     }
 
     // `formatTxDate`: Format a string to match the format `(UTC) YYYY-MM-DD HH:MM:SS` used by explorer.TxPage and tx.tmpl
-    function formatTxDate(stamp) {
+    function formatTxDate(stamp, withTimezone) {
         var d = new Date(stamp*1000);
-        var zone = d.toLocaleTimeString('en-us',{timeZoneName:'short'}).split(' ')[2];
-        return "("+zone+") "+String(d.getFullYear())+"-"+String(d.getMonth()+1).padStart(2, "0")+"-"+String(d.getDate()).padStart(2, "0")+" "
+        var zone = withTimezone ? "("+d.toLocaleTimeString('en-us',{timeZoneName:'short'}).split(' ')[2]+") " : "";
+        return zone+String(d.getFullYear())+"-"+String(d.getMonth()+1).padStart(2, "0")+"-"+String(d.getDate()).padStart(2, "0")+" "
             +String(d.getHours()).padStart(2, "0")+":"+String(d.getMinutes()).padStart(2, "0")+":"+String(d.getSeconds()).padStart(2, "0");
     }
 
@@ -245,7 +245,7 @@
                 if (isNaN($(v).text())) {
                     $(v).text("0");
                 }
-                var confirmations = newBlock.block.height - $(v).data('confirmation-block-height');
+                var confirmations = newBlock.block.height - $(v).data('confirmation-block-height') + 1;
                 $(v).text("(" + confirmations + (confirmations > 1? " confirmations": " confirmation") + ")")
             })
 
@@ -259,6 +259,8 @@
             DCRThings.counter.html(humanize.timeSince(b.time))
 
             advanceTicketProgress(b)
+            confirmAddrMempool(b)
+
             var expTableRows = $('#explorertable tbody tr');
             //var CurrentHeight = parseInt($('#explorertable tbody tr td').first().text());
             if (expTableRows){
@@ -397,37 +399,47 @@
         }
     }
 
+    // Check for the txid in the given block
+    function txInBlock(txid, block) {
+      var txTypes = [block.Tx, block.Tickets, block.Revs, block.Votes]
+      for(txIdx in txTypes){
+          txs = txTypes[txIdx]
+          for(idx in txs){
+              if(txs[idx].TxID ==  txid){
+                  return true;
+              }
+          }
+      }
+      return false;
+    }
+
     // Advance various progress bars on /tx.
     function advanceTicketProgress(block){
         // Check for confirmations on mempool transactions.
         var needsConfirmation = $("[data-txid-mempool-display]")
         if(needsConfirmation.length && needsConfirmation.text() == "mempool"){
             var txid = needsConfirmation.data("txid-mempool-display");
-            var k, txs, idx;
-            $.each([block.Tx, block.Tickets, block.Revs, block.Votes], function(k, txs){
-                for(idx in txs){
-                    if(txs[idx].TxID ==  txid){
-                        needsConfirmation.remove();
-                        $("[data-confirmation-block-height]").data("confirmation-block-height", block.height - 1).html("(1 confirmation)");
-                        $("#txMempoolLink").html(block.height).attr("href", "/block/"+block.hash);
-                        $("#txFmtTime").html(formatTxDate(block.time));
-                        $("#txAge").html(humanize.timeSince(block.time)).before("(").after(" ago)").attr("data-age",block.time);
-                        var progressBar = $("#txMaturityProgress")
-                        var remainingBlocks = parseInt(progressBar.attr("aria-valuemax")) - 1
-                        var remainingTime = remainingBlocks*DCRThings.targetBlockTime
-                        progressBar.css({"width":"0.4%"}).attr("aria-valuenow","1"
-                      ).children("span").html("Immature, eligible to vote in "+remainingBlocks+" blocks ("+remainingTime.toFixed(1)+" hours remaining)")
-                        return false
-                    }
-                }
-            })
+            if(txInBlock(txid, block)){
+              needsConfirmation.remove();
+              $("[data-confirmation-block-height]").data("confirmation-block-height", block.height).html("(1 confirmation)");
+              $("#txMempoolLink").html(block.height).attr("href", "/block/"+block.hash);
+              $("#txFmtTime").html(formatTxDate(block.time, true));
+              $("#txAge").html(humanize.timeSince(block.time)).before("(").after(" ago)").attr("data-age",block.time);
+              var progressBar = $("#txMaturityProgress")
+              var remainingBlocks = parseInt(progressBar.attr("aria-valuemax")) - 1
+              progressBar.attr('data-confirm-height', block.height)
+            }
         }
         // Advance the progress bars.
         var ticketProgress = $("#txMaturityProgress");
         if(!ticketProgress.length){
             return;
         }
-        var confirmations = block.height - ticketProgress.data("confirm-height") + 1;
+        var txBlockHeight = ticketProgress.data("confirm-height")
+        if(txBlockHeight == 0){
+          return;
+        }
+        var confirmations = block.height - txBlockHeight + 1;
         var txType = ticketProgress.data("tx-type");
         var complete = parseInt(ticketProgress.attr("aria-valuemax"));
         if(confirmations == complete + 1){
@@ -445,8 +457,9 @@
         }
         else{
             var blocksLeft = complete+1-confirmations;
+            var remainingTime = blocksLeft*DCRThings.targetBlockTime
             if(txType == "LiveTicket"){
-                ticketProgress.children("span").html("block "+confirmations+" of "+complete+" ("+((1-ratio)*142.2).toFixed(1)+" days remaining)");
+                ticketProgress.children("span").html("block "+confirmations+" of "+complete+" ("+(remainingTime/86400.).toFixed(1)+" days remaining)");
                 // Chance of expiring is (1-P)^N where P := single-block probability of being picked, N := blocks remaining.
                 // This probability is using the network parameter rather than the calculated value. So far, the ticket pool size seems stable enough to do that.
                 var pctChance = Math.pow(1 - 1/DCRThings.ticketPoolSize, blocksLeft)*100;
@@ -454,10 +467,41 @@
             }
             else{
                 var typeStub = txType == "Ticket" ? "eligible to vote" : "spendable";
-                ticketProgress.children("span").html("Immature, "+typeStub+" in "+blocksLeft+" blocks ("+((1-ratio)*21.3).toFixed(1)+" hours remaining)");
+                ticketProgress.children("span").html("Immature, "+typeStub+" in "+blocksLeft+" blocks ("+(remainingTime/3600.).toFixed(1)+" hours remaining)");
             }
             ticketProgress.attr("aria-valuenow", confirmations).css({"width":(ratio*100).toString()+"%"});
         }
+    }
+
+    // Check the block for mempool transactions on the address page.
+    function confirmAddrMempool(block){
+      var mempoolRows = $("[data-addr-tx-pending]");
+      mempoolRows.each(function(idx, tr){
+        var row = $(tr)
+        var txid = row.data('addr-tx-pending')
+        if(txInBlock(txid, block)){
+          var confirms = row.children('.addr-tx-confirms');
+          confirms.attr('data-tx-block-height', block.height);
+          row.removeAttr('data-addr-tx-pending');
+          row.children('.addr-tx-time').html(formatTxDate(block.time, false));
+          row.children('.addr-tx-age').children('span').attr("data-age", block.time).html(humanize.timeSince(block.time));
+          confirms.html("1")
+        }
+      });
+      var confirmTds = $('[data-tx-block-height]');
+      confirmTds.each(function(idx, td){
+        confirms = $(td);
+        confirms.html(block.height - parseInt(confirms.data('tx-block-height')) + 1);
+      });
+      var pendingCounters = $('[data-tx-confirmations-pending]');
+      pendingCounters.each(function(i,c){
+        var counter = $(c);
+        var txid = counter.data('tx-confirmations-pending')
+        if(txInBlock(txid, block)){
+          counter.removeAttr('data-tx-confirmations-pending')
+          counter.attr('data-confirmation-block-height', block.height).html('(1 confirmation)')
+        }
+      });
     }
 
 </script>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -12,9 +12,9 @@
                 Transaction
                 <span class="fs15">
                 {{if eq .Confirmations 0}}
-                    <strong data-confirmation-block-height="{{$.ConfirmHeight}}">(unconfirmed)</strong>
+                    <strong data-tx-confirmations-pending="{{.TxID}}">(unconfirmed)</strong>
                 {{else}}
-                    <strong data-confirmation-block-height="{{$.ConfirmHeight}}">
+                    <strong data-confirmation-block-height="{{.BlockHeight}}">
                         ({{.Confirmations}} {{if gt .Confirmations 1}}confirmations{{else}}confirmation{{end}})
                     </strong>
                 {{end}}
@@ -107,7 +107,7 @@
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="{{.TicketInfo.TicketMaturity}}"
-                                            data-confirm-height="{{add $.ConfirmHeight 1}}"
+                                            data-confirm-height="{{$.Data.BlockHeight}}"
                                             data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
@@ -153,7 +153,7 @@
                                             aria-valuenow="{{.Confirmations}}"
                                             aria-valuemin="0"
                                             aria-valuemax="{{.Maturity}}"
-                                            data-confirm-height="{{add $.ConfirmHeight 1}}"
+                                            data-confirm-height="{{$.Data.BlockHeight}}"
                                             data-tx-type="{{.Type}}"
                                         >
                                             <span class="nowrap pl-1 pr-1">
@@ -218,7 +218,7 @@
                                                     aria-valuenow="{{.Confirmations}}"
                                                     aria-valuemin="0"
                                                     aria-valuemax="{{.TicketInfo.TicketExpiry}}"
-                                                    data-confirm-height="{{add (add $.ConfirmHeight 1) (uint16toInt64 $.ChainParams.TicketMaturity)}}"
+                                                    data-confirm-height="{{add $.Data.BlockHeight (uint16toInt64 $.ChainParams.TicketMaturity)}}"
                                                     data-tx-type="LiveTicket"
                                                 >
                                                     <span class="nowrap pl-1 pr-1">


### PR DESCRIPTION
data-confirmation-block-height is now a relevant block height. Tx Type also now displayed correctly for mempool transactions on the address page.

@ademuanthony Please note that `data-confirmation-block-height` is now defined as the height of the block the transaction was in, so `confirmations = bestBlockHeight - x.data('confirmation-block-height') + 1`. You'll need the `+1` now. 

