### PR TITLE
Disable buttons that plot a chart with one record.

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -418,6 +418,17 @@ type AddressRow struct {
 	TxType           int16
 }
 
+// AddressMetrics defines address metrics needed to make decisions by which
+// grouping buttons on the address history page charts should be disabled
+// or enabled by default.
+type AddressMetrics struct {
+	OldestBlockTime int64
+	YearTxsCount    int64 // Years txs grouping
+	MonthTxsCount   int64 // Months txs grouping
+	WeekTxsCount    int64 // Weeks txs grouping
+	DayTxsCount     int64 // Days txs grouping
+}
+
 // ChartsData defines the fields that store the values needed to plot the charts
 // on the frontend.
 type ChartsData struct {

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -98,6 +98,11 @@ const (
 			time DESC,
 			transactions.tx_hash ASC;`
 
+	// SelectAddressTimeGroupingCount returns the expected count of records
+	// grouped by time in second for years, months, days and weeks groupings.
+	SelectAddressTimeGroupingCount = `SELECT COUNT(*) FROM (SELECT COUNT(*)
+		FROM addresses WHERE address=$1 GROUP BY (block_time/$2)*$2) AS prev;`
+
 	SelectAddressUnspentCountANDValue = `SELECT COUNT(*), SUM(value) FROM addresses
 	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = TRUE;`
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -98,10 +98,10 @@ const (
 			time DESC,
 			transactions.tx_hash ASC;`
 
-	// SelectAddressTimeGroupingCount returns the expected count of records
-	// grouped by time in second for years, months, days and weeks groupings.
-	SelectAddressTimeGroupingCount = `SELECT COUNT(*) FROM (SELECT COUNT(*)
-		FROM addresses WHERE address=$1 GROUP BY (block_time/$2)*$2) AS prev;`
+	// SelectAddressTimeGroupingCount return the count of record groups,
+	// where grouping is done by a specified time interval, for an addresss.
+	SelectAddressTimeGroupingCount = `SELECT COUNT(DISTINCT (block_time/$2)*$2)
+		FROM addresses WHERE address=$1;`
 
 	SelectAddressUnspentCountANDValue = `SELECT COUNT(*), SUM(value) FROM addresses
 	    WHERE address = $1 AND is_funding = TRUE AND matching_tx_hash = '' AND valid_mainchain = TRUE;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -731,11 +731,43 @@ func (pgb *ChainDB) AgendaVotes(agendaID string, chartType int) (*dbtypes.Agenda
 	return retrieveAgendaVoteChoices(pgb.db, agendaID, chartType)
 }
 
-// GetOldestTxBlockTime returns the block time of the oldest transaction made in
-// relation to the provided address. This helps provide more meaningful graphs
-// with the addresses history plotted.
-func (pgb *ChainDB) GetOldestTxBlockTime(addr string) (int64, error) {
-	return retrieveOldestTxBlockTime(pgb.db, addr)
+// GetAddressMetrics returns the block time of the oldest transaction and the
+// total count for all the transactions linked to the provided address grouped
+// by years, months, weeks and days time grouping in seconds.
+// This helps provide more meaningful graphs with the addresses history plotted.
+func (pgb *ChainDB) GetAddressMetrics(addr string) (*dbtypes.AddressMetrics, error) {
+	var metrics dbtypes.AddressMetrics
+
+	for _, s := range []dbtypes.TimeBasedGrouping{dbtypes.YearGrouping,
+		dbtypes.MonthGrouping, dbtypes.WeekGrouping, dbtypes.DayGrouping} {
+		interval, err := dbtypes.TimeBasedGroupingToInterval(s)
+		if err != nil {
+			return nil, err
+		}
+
+		txCount, err := retrieveAddressTxsCount(pgb.db, addr, int64(interval))
+		if err != nil {
+			return nil, fmt.Errorf("retrieveAddressAllTxsCount failed: error: %v", err)
+		}
+		switch s {
+		case dbtypes.YearGrouping:
+			metrics.YearTxsCount = txCount
+		case dbtypes.MonthGrouping:
+			metrics.MonthTxsCount = txCount
+		case dbtypes.WeekGrouping:
+			metrics.WeekTxsCount = txCount
+		case dbtypes.DayGrouping:
+			metrics.DayTxsCount = txCount
+		}
+	}
+
+	blockTime, err := retrieveOldestTxBlockTime(pgb.db, addr)
+	if err != nil {
+		return nil, fmt.Errorf("retrieveOldestTxBlockTime failed: error: %v", err)
+	}
+
+	metrics.OldestBlockTime = blockTime
+	return &metrics, err
 }
 
 // AddressTransactions retrieves a slice of *dbtypes.AddressRow for a given

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -734,7 +734,7 @@ func (pgb *ChainDB) AgendaVotes(agendaID string, chartType int) (*dbtypes.Agenda
 // GetAddressMetrics returns the block time of the oldest transaction and the
 // total count for all the transactions linked to the provided address grouped
 // by years, months, weeks and days time grouping in seconds.
-// This helps provide more meaningful graphs with the addresses history plotted.
+// This helps plot more meaningful address history graphs to the user.
 func (pgb *ChainDB) GetAddressMetrics(addr string) (*dbtypes.AddressMetrics, error) {
 	var metrics dbtypes.AddressMetrics
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1077,7 +1077,8 @@ func RetrieveAddressSpent(db *sql.DB, address string) (count, totalAmount int64,
 	return
 }
 
-// retrieveAddressTxsCount returns the txs count linked to the address provided.
+// retrieveAddressTxsCount return the number of record groups, where grouping
+// is done by a specified time interval, for an address.
 func retrieveAddressTxsCount(db *sql.DB, address string, interval int64) (count int64, err error) {
 	err = db.QueryRow(internal.SelectAddressTimeGroupingCount, address, interval).Scan(&count)
 	return

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1077,6 +1077,12 @@ func RetrieveAddressSpent(db *sql.DB, address string) (count, totalAmount int64,
 	return
 }
 
+// retrieveAddressTxsCount returns the txs count linked to the address provided.
+func retrieveAddressTxsCount(db *sql.DB, address string, interval int64) (count int64, err error) {
+	err = db.QueryRow(internal.SelectAddressTimeGroupingCount, address, interval).Scan(&count)
+	return
+}
+
 // RetrieveAddressSpentUnspent gets the numbers of spent and unspent outpoints
 // for the given address, the total amounts spent and unspent, and the the
 // number of distinct spending transactions.

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -81,7 +81,7 @@ type explorerDataSource interface {
 	DisapprovedBlocks() ([]*dbtypes.BlockStatus, error)
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
 	BlockFlags(hash string) (bool, bool, error)
-	GetOldestTxBlockTime(addr string) (int64, error)
+	GetAddressMetrics(addr string) (*dbtypes.AddressMetrics, error)
 	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
 	Transaction(txHash string) ([]*dbtypes.Tx, error)

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -238,7 +238,7 @@
         }
 
         disableBtnsIfNotApplicable(){
-            var val = parseInt(this.addrTarget.id)*1000
+            var val = parseInt(this.addrTarget.dataset.address)*1000
             var d = new Date()
 
             var pastYear = d.getFullYear() - 1;
@@ -247,9 +247,10 @@
             var pastDay = d.getDate() - 1
 
             this.enabledButtons = []
-            var setApplicableBtns = (className, ts) => {
+            var setApplicableBtns = (className, ts, txCountByType) => {
                 var isDisabled = (val > Number(new Date(ts))) ||
-                    (this.options === 'unspent' && this.unspent == "0")
+                    (this.options === 'unspent' && this.unspent == "0") ||
+                    txCountByType < 2;
 
                 if (isDisabled) {
                     this.zoomTarget.getElementsByClassName(className)[0].setAttribute("disabled", isDisabled)
@@ -261,10 +262,10 @@
                 }
             }
 
-            setApplicableBtns('year', new Date().setFullYear(pastYear))
-            setApplicableBtns('month', new Date().setMonth(pastMonth))
-            setApplicableBtns('week', new Date().setDate(pastWeek))
-            setApplicableBtns('day', new Date().setDate(pastDay))
+            setApplicableBtns('year', new Date().setFullYear(pastYear), this.intervalTarget.dataset.year)
+            setApplicableBtns('month', new Date().setMonth(pastMonth),this.intervalTarget.dataset.month)
+            setApplicableBtns('week', new Date().setDate(pastWeek), this.intervalTarget.dataset.week)
+            setApplicableBtns('day', new Date().setDate(pastDay), this.intervalTarget.dataset.day)
 
             if (parseInt(this.intervalTarget.dataset.txcount) < 20 || this.enabledButtons.length === 0) {
                 this.enabledButtons[0] = "all"

--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -238,7 +238,7 @@
         }
 
         disableBtnsIfNotApplicable(){
-            var val = parseInt(this.addrTarget.dataset.address)*1000
+            var val = parseInt(this.addrTarget.dataset.oldestblockTime)*1000
             var d = new Date()
 
             var pastYear = d.getFullYear() - 1;

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -13,7 +13,8 @@
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
                 <div class="mono" data-target="address.addr"
-                    id="{{$.OldestTxTime}}" style="margin-bottom: 12px;">
+                    data-address="{{$.Metrics.OldestBlockTime}}"
+                    style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"
                         href="javascript:showAddressQRCode('{{.Address}}');"
@@ -39,7 +40,7 @@
                 >
                     <input id="addr-btn" type="button" class="btn btn_sm btn-active" value="List" name="list">
                     <input id="addr-btn" type="button" class="btn btn_sm" value="Charts"
-                    name="chart" {{if $.IsLiteMode}}disabled{{end}}>
+                    name="chart" {{if or $.IsLiteMode (le (len .Transactions) 1)}}disabled{{end}}>
                 </div>
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">
@@ -161,6 +162,10 @@
                             data-txcount="{{$TxnCount}}"
                             data-target="address.interval"
                             data-action="click->address#changeGraph"
+                            data-year="{{$.Metrics.YearTxsCount}}"
+                            data-month="{{$.Metrics.MonthTxsCount}}"
+                            data-week="{{$.Metrics.WeekTxsCount}}"
+                            data-day="{{$.Metrics.DayTxsCount}}"
                         >
                             <input id="chart-size" type="button" class="btn btn_sm year" value="Year" name="yr">
                             <input id="chart-size" type="button" class="btn btn_sm month" value="Month" name="mo">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -13,7 +13,7 @@
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
                 <div class="mono" data-target="address.addr"
-                    data-address="{{$.Metrics.OldestBlockTime}}"
+                    data-oldestblockTime="{{$.Metrics.OldestBlockTime}}"
                     style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"


### PR DESCRIPTION
Bug https://github.com/decred/dcrdata/issues/656 happens when when a dataset with only one record is plotted. The charts button will always be disabled by default if the current address has only one or no transaction.

![screenshot from 2018-11-08 00-23-57](https://user-images.githubusercontent.com/22055953/48162642-abf73980-e2ee-11e8-827a-c567b040fd61.png)

"Zoom" and "Group By" buttons that are likely to plot a graph with one record only are also disabled by default.

![screenshot from 2018-11-08 00-40-58](https://user-images.githubusercontent.com/22055953/48162795-0b554980-e2ef-11e8-9e5b-821e3a104c81.png)
