### PR TITLE
Added network name to /api/status

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -133,6 +133,7 @@ func NewContext(client *rpcclient.Client, params *chaincfg.Params, dataSource Da
 			NodeConnections: conns,
 			APIVersion:      APIVersion,
 			DcrdataVersion:  appver.Version(),
+			NetworkName:     params.Name,
 		},
 		JSONIndent: JSONIndent,
 	}

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -60,6 +60,7 @@ func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, pa
 			NodeConnections: conns,
 			APIVersion:      APIVersion,
 			DcrdataVersion:  version.String(),
+			NetworkName:     params.Name,
 		},
 	}
 	return &newContext

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -248,6 +248,7 @@ type Status struct {
 	NodeConnections int64  `json:"node_connections"`
 	APIVersion      int    `json:"api_version"`
 	DcrdataVersion  string `json:"dcrdata_version"`
+	NetworkName     string `json:"network_name"`
 }
 
 // CoinSupply models the coin supply at a certain best block.


### PR DESCRIPTION
As per #800. 

Makes no changes yet to `/insight/api/status`, which already has a boolean `testnet` attribute. 