### PR TITLE
Hex field added to apitypes.ScriptPubKey. 

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -109,6 +109,7 @@ type TxInputID struct {
 // ScriptPubKey is the result of decodescript(ScriptPubKeyHex)
 type ScriptPubKey struct {
 	Asm       string   `json:"asm"`
+	Hex       string   `json:"hex"`
 	ReqSigs   int32    `json:"reqSigs,omitempty"`
 	Type      string   `json:"type"`
 	Addresses []string `json:"addresses,omitempty"`

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -511,6 +511,7 @@ func (db *wiredDB) getRawTransaction(txid string) (*apitypes.Tx, string) {
 		spk := &tx.Vout[i].ScriptPubKeyDecoded
 		spkRaw := &txraw.Vout[i].ScriptPubKey
 		spk.Asm = spkRaw.Asm
+		spk.Hex = spkRaw.Hex
 		spk.ReqSigs = spkRaw.ReqSigs
 		spk.Type = spkRaw.Type
 		spk.Addresses = make([]string, len(spkRaw.Addresses))
@@ -935,6 +936,7 @@ func (db *wiredDB) GetAddressTransactionsRawWithSkip(addr string, count int, ski
 			spk := &tx.Vout[j].ScriptPubKeyDecoded
 			spkRaw := &txs[i].Vout[j].ScriptPubKey
 			spk.Asm = spkRaw.Asm
+			spk.Hex = spkRaw.Hex
 			spk.ReqSigs = spkRaw.ReqSigs
 			spk.Type = spkRaw.Type
 			spk.Addresses = make([]string, len(spkRaw.Addresses))


### PR DESCRIPTION
For #802.

Vout hex fields populated in api calls for decoded raw transaction info.