### PR TITLE
Chainwork DB upgrade. Hashrate and Chainwork charts. 

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -318,6 +318,12 @@ func mainCore() error {
 			return fmt.Errorf("GetBlock failed (%s): %v", blockHash, err)
 		}
 
+		// Grab the chainwork.
+		chainWork, err := rpcutils.GetChainWork(client, blockHash)
+		if err != nil {
+			return fmt.Errorf("GetChainWork failed (%s): %v", blockHash, err)
+		}
+
 		// stake db always has genesis, so do not connect it
 		var winners []string
 		if ib > 0 {
@@ -339,7 +345,7 @@ func mainCore() error {
 		isValid, isMainchain, updateExistingRecords := true, true, true
 		numVins, numVouts, _, err = db.StoreBlock(block.MsgBlock(), winners,
 			isValid, isMainchain, updateExistingRecords,
-			cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch)
+			cfg.AddrSpendInfoOnline, !cfg.TicketSpendInfoBatch, chainWork)
 		if err != nil {
 			return fmt.Errorf("StoreBlock failed: %v", err)
 		}

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -10,7 +10,7 @@ import (
 )
 
 // MsgBlockToDBBlock creates a dbtypes.Block from a wire.MsgBlock
-func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params) *Block {
+func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, chainWork string) *Block {
 	// Create the dbtypes.Block structure
 	blockHeader := msgBlock.Header
 
@@ -55,6 +55,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params) *B
 		ExtraData:    blockHeader.ExtraData[:],
 		StakeVersion: blockHeader.StakeVersion,
 		PreviousHash: blockHeader.PrevBlock.String(),
+		ChainWork:    chainWork,
 	}
 }
 

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -506,6 +506,8 @@ type ChartsData struct {
 	Received    []float64 `json:"received,omitempty"`
 	Sent        []float64 `json:"sent,omitempty"`
 	Net         []float64 `json:"net,omitempty"`
+	ChainWork   []uint64  `json:"chainwork,omitempty"`
+	NetHash     []uint64  `json:"nethash,omitempty"`
 }
 
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)
@@ -641,6 +643,7 @@ type Block struct {
 	ExtraData    []byte  `json:"extradata"`
 	StakeVersion uint32  `json:"stakeversion"`
 	PreviousHash string  `json:"previousblockhash"`
+	ChainWork    string  `json:"chainwork"`
 }
 
 type BlockDataBasic struct {

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -117,12 +117,19 @@ func (p *ChainMonitor) switchToSideChain(reorgData *txhelpers.ReorgData) (int32,
 		}
 		winners := tpi.Winners
 
+		// Get the chainWork
+		blockHash := msgBlock.BlockHash()
+		chainWork, err := p.db.GetChainWork(&blockHash)
+		if err != nil {
+			return 0, nil, fmt.Errorf("GetChainWork failed (%s): %v", blockHash.String(), err)
+		}
+
 		// New blocks stored this way are considered part of mainchain. They are
 		// also considered valid unless invalidated by the next block
 		// (invalidation of previous handled inside StoreBlock).
 		isValid, isMainChain, updateExisting := true, true, true
-		_, _, _, err := p.db.StoreBlock(msgBlock, winners, isValid, isMainChain,
-			updateExisting, true, true)
+		_, _, _, err = p.db.StoreBlock(msgBlock, winners, isValid, isMainChain,
+			updateExisting, true, true, chainWork)
 		if err != nil {
 			return int32(p.db.Height()), p.db.Hash(),
 				fmt.Errorf("error connecting block %v", newChain[i])

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -289,13 +289,19 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		}
 		winners := tpi.Winners
 
+		// Get the chainwork
+		chainWork, err := client.GetChainWork(blockHash)
+		if err != nil {
+			return ib - 1, fmt.Errorf("GetChainWork failed (%s): %v", blockHash, err)
+		}
+
 		// Store data from this block in the database
 		isValid, isMainchain := true, true
 		// updateExisting is ignored if dupCheck=false, but true since this is
 		// processing main chain blocks.
 		updateExisting := true
 		numVins, numVouts, numAddresses, err := db.StoreBlock(block.MsgBlock(), winners, isValid,
-			isMainchain, updateExisting, !updateAllAddresses, !updateAllVotes)
+			isMainchain, updateExisting, !updateAllAddresses, !updateAllVotes, chainWork)
 		if err != nil {
 			return ib - 1, fmt.Errorf("StoreBlock failed: %v", err)
 		}

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -48,7 +48,7 @@ type dropDuplicatesInfo struct {
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 6
+	tableMinor = 7
 	tablePatch = 0
 )
 
@@ -210,6 +210,7 @@ func CreateTables(db *sql.DB) error {
 			log.Tracef("Table \"%s\" exist.", tableName)
 		}
 	}
+
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,10 +18,10 @@ require (
 	github.com/decred/dcrd/database v1.0.2
 	github.com/decred/dcrd/dcrec v0.0.0-20180926135934-93133096234e // indirect
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180926135934-93133096234e // indirect
-	github.com/decred/dcrd/dcrjson v1.0.0
+	github.com/decred/dcrd/dcrjson v1.0.1-0.20181016163058-6d647094eedd
 	github.com/decred/dcrd/dcrutil v1.1.1
 	github.com/decred/dcrd/gcs v1.0.2 // indirect
-	github.com/decred/dcrd/rpcclient v1.0.2
+	github.com/decred/dcrd/rpcclient v1.0.3-0.20181016163058-6d647094eedd
 	github.com/decred/dcrd/txscript v1.0.1
 	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/dcrwallet/wallet v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.0 h1:Le54WTGdTQv7XYXpS31uhFE8LZE7ypw
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.0/go.mod h1:JPMFscGlgXTV684jxQNDijae2qrh0fLG7pJBimaYotE=
 github.com/decred/dcrd/dcrjson v1.0.0 h1:50DnA0XeV2JrQXoHh43TCKmH+kz2gHjZ1Mj/Pdk7Oz0=
 github.com/decred/dcrd/dcrjson v1.0.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
+github.com/decred/dcrd/dcrjson v1.0.1-0.20181016163058-6d647094eedd h1:vcMqF91uOAPzea99430ah0xG35a+6H61Rr5QJejdybQ=
+github.com/decred/dcrd/dcrjson v1.0.1-0.20181016163058-6d647094eedd/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
 github.com/decred/dcrd/dcrutil v1.0.0/go.mod h1:CBpbItyMKkL/4i1qPJDsE/cdSYklsWFcTYgprRZh4yk=
 github.com/decred/dcrd/dcrutil v1.1.1 h1:zOkGiumN/JkobhAgpG/zfFgUoolGKVGYT5na1hbYUoE=
 github.com/decred/dcrd/dcrutil v1.1.1/go.mod h1:Jsttr0pEvzPAw+qay1kS1/PsbZYPyhluiNwwY6yBJS4=
@@ -90,6 +92,8 @@ github.com/decred/dcrd/rpcclient v1.0.1 h1:mSkVtOQKXnMJ2P08xPFnD2J9w54+YFQuMeBd5
 github.com/decred/dcrd/rpcclient v1.0.1/go.mod h1:tApXK3wwrAQtz7lcXeeqBwuktUZesvrFfvhAdedYqdM=
 github.com/decred/dcrd/rpcclient v1.0.2 h1:f+9mPiLOCu0NtTfbf279izaKFdl5gmHOty7IAugT42s=
 github.com/decred/dcrd/rpcclient v1.0.2/go.mod h1:pg9jawMwMmNnJwI+swUGTR9XrNUDm6bl6lJJ/vEgzXo=
+github.com/decred/dcrd/rpcclient v1.0.3-0.20181016163058-6d647094eedd h1:R6RbGAHBmBjUxoOWXeXNY+MTXmWEbcnflQ22Yru+MR8=
+github.com/decred/dcrd/rpcclient v1.0.3-0.20181016163058-6d647094eedd/go.mod h1:pg9jawMwMmNnJwI+swUGTR9XrNUDm6bl6lJJ/vEgzXo=
 github.com/decred/dcrd/txscript v1.0.0/go.mod h1:9byvrOaBSBVVnDG7Cm0JgN8bZytl1oi9Ba245VBeI18=
 github.com/decred/dcrd/txscript v1.0.1 h1:IMgxZFCw3AyG4EbKwywE3SDNshOSHsoUK1Wk/5GqWJ0=
 github.com/decred/dcrd/txscript v1.0.1/go.mod h1:FqUX07Y+u3cJ1eIGPoyWbJg+Wk1NTllln/TyDpx9KnY=

--- a/main.go
+++ b/main.go
@@ -685,6 +685,13 @@ func _main(ctx context.Context) error {
 					continue
 				}
 
+				// Get the chainwork
+				chainWork, err := rpcutils.GetChainWork(auxDB.Client, blockHash)
+				if err != nil {
+					log.Errorf("GetChainWork failed (%s): %v", blockHash, err)
+					continue
+				}
+
 				// SQLite / base DB
 				// TODO: Make hash the primary key instead of height, otherwise
 				// the main chain block will be overwritten.
@@ -719,7 +726,7 @@ func _main(ctx context.Context) error {
 
 				// Store data in the aux (dcrpg) DB.
 				_, _, _, err = auxDB.StoreBlock(msgBlock, blockData.WinningTickets,
-					isValid, isMainchain, updateExistingRecords, true, true)
+					isValid, isMainchain, updateExistingRecords, true, true, chainWork)
 				if err != nil {
 					// If data collection succeeded, but storage fails, bail out
 					// to diagnose the DB trouble.

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -119,13 +119,13 @@ function ticketByOutputCountFunc (gData) {
   return map(gData.height, (n, i) => { return [n, gData.solo[i], gData.pooled[i]] })
 }
 
-  function chainWorkFunc(gData){
-      return _.map(gData.time,(n,i) => { return [new Date(n), gData.chainwork[i]] })
-  }
+function chainWorkFunc (gData) {
+  return map(gData.time, (n, i) => { return [new Date(n), gData.chainwork[i]] })
+}
 
-  function hashrateFunc(gData){
-      return _.map(gData.time,(n,i) => { return [new Date(n), gData.nethash[i]] })
-  }
+function hashrateFunc (gData) {
+  return map(gData.time, (n, i) => { return [new Date(n), gData.nethash[i]] })
+}
 
 function mapDygraphOptions (data, labelsVal, isDrawPoint, yLabel, xLabel, titleName, labelsMG, labelsMG2) {
   return merge({
@@ -317,17 +317,17 @@ export default class extends Controller {
         })
         break
 
-        case 'chainwork': // Total chainwork over time
-          d = chainWorkFunc(data)
-          _.assign(gOptions, mapDygraphOptions(d, ['Date', 'Cumulative Chainwork (exahash)'],
-            false, 'Cumulative Chainwork (exahash)','Date', undefined, true, false))
-        break;
+      case 'chainwork': // Total chainwork over time
+        d = chainWorkFunc(data)
+        assign(gOptions, mapDygraphOptions(d, ['Date', 'Cumulative Chainwork (exahash)'],
+          false, 'Cumulative Chainwork (exahash)', 'Date', undefined, true, false))
+        break
 
-        case 'hashrate': // Total chainwork over time
-          d = hashrateFunc(data)
-          _.assign(gOptions, mapDygraphOptions(d, ['Date', 'Network Hashrate (terahash/s)'],
-            false, 'Network Hashrate (terahash/s)','Date', undefined, true, false))
-        break;
+      case 'hashrate': // Total chainwork over time
+        d = hashrateFunc(data)
+        assign(gOptions, mapDygraphOptions(d, ['Date', 'Network Hashrate (terahash/s)'],
+          false, 'Network Hashrate (terahash/s)', 'Date', undefined, true, false))
+        break
     }
     this.chartsView.updateOptions(gOptions, false)
     this.chartsView.resetZoom()

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -119,6 +119,14 @@ function ticketByOutputCountFunc (gData) {
   return map(gData.height, (n, i) => { return [n, gData.solo[i], gData.pooled[i]] })
 }
 
+  function chainWorkFunc(gData){
+      return _.map(gData.time,(n,i) => { return [new Date(n), gData.chainwork[i]] })
+  }
+
+  function hashrateFunc(gData){
+      return _.map(gData.time,(n,i) => { return [new Date(n), gData.nethash[i]] })
+  }
+
 function mapDygraphOptions (data, labelsVal, isDrawPoint, yLabel, xLabel, titleName, labelsMG, labelsMG2) {
   return merge({
     'file': data,
@@ -308,6 +316,18 @@ export default class extends Controller {
           plotter: barChartPlotter
         })
         break
+
+        case 'chainwork': // Total chainwork over time
+          d = chainWorkFunc(data)
+          _.assign(gOptions, mapDygraphOptions(d, ['Date', 'Cumulative Chainwork (exahash)'],
+            false, 'Cumulative Chainwork (exahash)','Date', undefined, true, false))
+        break;
+
+        case 'hashrate': // Total chainwork over time
+          d = hashrateFunc(data)
+          _.assign(gOptions, mapDygraphOptions(d, ['Date', 'Network Hashrate (terahash/s)'],
+            false, 'Network Hashrate (terahash/s)','Date', undefined, true, false))
+        break;
     }
     this.chartsView.updateOptions(gOptions, false)
     this.chartsView.resetZoom()

--- a/rpcutils/blockgate.go
+++ b/rpcutils/blockgate.go
@@ -21,6 +21,7 @@ type BlockGetter interface {
 	Block(chainhash.Hash) (*dcrutil.Block, error)
 	WaitForHeight(int64) chan chainhash.Hash
 	WaitForHash(chainhash.Hash) chan int64
+	GetChainWork(*chainhash.Hash) (string, error)
 }
 
 // MasterBlockGetter builds on BlockGetter, adding functions that fetch blocks
@@ -299,4 +300,15 @@ func (g *BlockGate) WaitForHash(hash chainhash.Hash) chan int64 {
 		go g.signalHash(hash)
 	}
 	return waitChain
+}
+
+// GetChainwork fetches the dcrjson.BlockHeaderVerbose
+// and returns only the ChainWork attribute as a string
+func (g *BlockGate) GetChainWork(hash *chainhash.Hash) (string, error) {
+	return GetChainWork(g.client, hash)
+}
+
+// Client is just an access function to get the BlockGate's RPC client.
+func (g *BlockGate) Client() *rpcclient.Client {
+	return g.client
 }

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -447,3 +447,12 @@ func CommonAncestor(client *rpcclient.Client, hashA, hashB chainhash.Hash) (*cha
 	// hashA == hashB
 	return &hashA, chainA, chainB, nil
 }
+
+// GetChainwork fetches the dcrjson.BlockHeaderVerbose
+// and returns only the ChainWork field as a string.
+func GetChainWork(client *rpcclient.Client, hash *chainhash.Hash) (string, error) {
+	header, err := client.GetBlockHeaderVerbose(hash)
+	if err != nil {
+		return "", err
+	}
+	return header.ChainWork, nil

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -456,3 +456,4 @@ func GetChainWork(client *rpcclient.Client, hash *chainhash.Hash) (string, error
 		return "", err
 	}
 	return header.ChainWork, nil
+}

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -35,6 +35,8 @@
                             <option name="ticket-spend-type" value="ticket-spend-type">Ticket Spend Types</option>
                             <option name="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
                             <option name="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option>
+                            <option name="chainwork" value="chainwork">Total Work</option>
+                            <option name="hashrate" value="hashrate">Network Hashrate</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Resolves #744 and #723.

This PR performs a PostgreSQL DB upgrade, adding a `TEXT` column, `chainwork`. Relevant block insertion routines are updated to grab the [newly available chainwork value](https://github.com/decred/dcrd/pull/1498) from dcrd.  Having chainwork also enables quick calculation of network hashrate data. A network hashrate chart and "total work" chart have been added to `/charts`. 