### PR TITLE
css: trailing zeros should not have negative margin

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -316,6 +316,9 @@ body.darkBG .progress {
 .trailing-zeroes {
   opacity: .3
 }
+.decimal.trailing-zeroes {
+  margin-left: 0 !important;
+}
 .op70 {
   opacity: .7
 }


### PR DESCRIPTION
When the `trailing-zeros` class is used with the `decimal` class, which adds
`margin-left: -2px;`, the zeros overlap with the other `decimal` digits to
the left. This overrides `margin-left` for elements with both classes.

Before:

![image](https://user-images.githubusercontent.com/9373513/48367893-b6f7f400-e677-11e8-9d84-38abefb6788a.png)

After:

![image](https://user-images.githubusercontent.com/9373513/48367911-c8d99700-e677-11e8-9c59-890827e15c60.png)
