### PR TITLE
begin 3.2 dev cycle

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ const (
 const (
 	AppName  string = "dcrdata"
 	AppMajor uint   = 3
-	AppMinor uint   = 1
+	AppMinor uint   = 2
 	AppPatch uint   = 0
 )
 


### PR DESCRIPTION
Now that 3.1 is branched off, begin the 3.2 dev cycle.  By default, builds will now be versioned as `v3.2.0-pre+dev`.