### PR TITLE
js: replace history state when address page goes to list-view

### DIFF
--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -142,7 +142,7 @@
                 var hashVal = window.location.hash.replace('#', '') || _this.defaultHash;
 
                 if (hashVal.length === 0 || hashVal === _this.defaultHash){
-                    history.pushState({},  this.addr, "#" + _this.defaultHash);
+                    history.replaceState({},  this.addr, "#" + _this.defaultHash);
                 } else {
                     var selectedVal = this.optionsTarget.namedItem(hashVal)
                     $(this.optionsTarget).val((selectedVal ? selectedVal.value : 'types'))


### PR DESCRIPTION
When the address page is loaded with no URL #anchor, the default
anchor $list-view is used in a new URL history state. This caused an
unnecessary step in the brower history and made it nearly impossible
to navigate back to say the /tx page because of the pushState.  Instead
using replaceState resolves the issue.

**Note**: this is FOR DISCUSSION.  I think it is likely we will need use turbolinks
instead of the history API directly.