### PR TITLE
Fix the group by chart buttons

### DIFF
--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -266,7 +266,7 @@
         }
 
         changeGraph(e){
-            if (e.srcElement.className.includes('.chart-size')){
+            if (e.srcElement.className.includes('chart-size')){
                 $(e.srcElement).siblings().removeClass('btn-active');
                 $(e.srcElement).toggleClass('btn-active');
             }


### PR DESCRIPTION
The Group By buttons could change the active button because of an inaccurate class name comparing used to trigger state change.