### PR TITLE
Work with the new dcrd reorg ntfn sequence

### DIFF
--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -105,7 +105,8 @@ func (p *chainMonitor) collect(hash *chainhash.Hash) (*wire.MsgBlock, *BlockData
 	// relevant for the best block.
 	var blockData *BlockData
 	if chainHeight != height {
-		log.Infof("Behind on our collection...")
+		log.Debugf("Collecting data for block %v (%d), behind tip %d.",
+			hash, height, chainHeight)
 		blockData, _, err = p.collector.CollectHash(hash)
 		if err != nil {
 			return nil, nil, fmt.Errorf("blockdata.CollectHash(hash) failed: %v", err.Error())
@@ -199,7 +200,8 @@ out:
 			// Do not handle reorg and block connects simultaneously.
 			p.reorgLock.Lock()
 
-			log.Infof("Reorganize signaled to blockdata. Collecting data for NEW head block %v at height %d.",
+			log.Infof("Reorganize signaled to blockdata. "+
+				"Collecting data for NEW head block %v at height %d.",
 				newHash, newHeight)
 
 			// Collect data for the new best block.

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -14,15 +14,6 @@ import (
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
 
-// ReorgData contains the information from a reoranization notification
-type ReorgData struct {
-	OldChainHead   chainhash.Hash
-	OldChainHeight int32
-	NewChainHead   chainhash.Hash
-	NewChainHeight int32
-	WG             *sync.WaitGroup
-}
-
 // for getblock, ticketfeeinfo, estimatestakediff, etc.
 type chainMonitor struct {
 	ctx             context.Context
@@ -33,14 +24,14 @@ type chainMonitor struct {
 	watchaddrs      map[string]txhelpers.TxAction
 	blockChan       chan *chainhash.Hash
 	recvTxBlockChan chan *txhelpers.BlockWatchedTx
-	reorgChan       chan *ReorgData
+	reorgChan       chan *txhelpers.ReorgData
 	ConnectingLock  chan struct{}
 	DoneConnecting  chan struct{}
 	syncConnect     sync.Mutex
 
 	// reorg handling
 	reorgLock    sync.Mutex
-	reorgData    *ReorgData
+	reorgData    *txhelpers.ReorgData
 	sideChain    []chainhash.Hash
 	reorganizing bool
 }
@@ -49,7 +40,7 @@ type chainMonitor struct {
 func NewChainMonitor(ctx context.Context, collector *Collector, savers []BlockDataSaver,
 	reorgSavers []BlockDataSaver, wg *sync.WaitGroup, addrs map[string]txhelpers.TxAction,
 	blockChan chan *chainhash.Hash, recvTxBlockChan chan *txhelpers.BlockWatchedTx,
-	reorgChan chan *ReorgData) *chainMonitor {
+	reorgChan chan *txhelpers.ReorgData) *chainMonitor {
 	return &chainMonitor{
 		ctx:             ctx,
 		collector:       collector,

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
 
@@ -50,97 +50,11 @@ func (db *ChainDBRPC) NewChainMonitor(ctx context.Context, wg *sync.WaitGroup,
 	}
 }
 
-// BlockConnectedSync is the synchronous (blocking call) handler for the newly
-// connected block given by the hash.
-func (p *ChainMonitor) BlockConnectedSync(hash *chainhash.Hash) {
-	// Connections go one at a time so signals cannot be mixed
-	p.syncConnect.Lock()
-	defer p.syncConnect.Unlock()
-	// lock with buffered channel, accepting handoff in BlockConnectedHandler
-	p.ConnectingLock <- struct{}{}
-	p.blockChan <- hash
-	// wait
-	<-p.DoneConnecting
-}
-
-// BlockConnectedHandler handles block connected notifications, which trigger
-// data collection and storage.
-func (p *ChainMonitor) BlockConnectedHandler() {
-	defer p.wg.Done()
-out:
-	for {
-	keepon:
-		select {
-		case hash, ok := <-p.blockChan:
-			p.Lock()
-			release := func() { p.Unlock() }
-			select {
-			case <-p.ConnectingLock:
-				// send on unbuffered channel
-				release = func() { p.Unlock(); p.DoneConnecting <- struct{}{} }
-			default:
-			}
-
-			if !ok {
-				log.Warnf("Block connected channel closed.")
-				release()
-				break out
-			}
-
-			// If reorganizing, the block will first go to a side chain
-			reorg, reorgData := p.reorganizing, p.reorgData
-
-			// Otherwise this handler does nothing.
-			if !reorg {
-				release()
-				break keepon
-			}
-
-			p.sideChain = append(p.sideChain, *hash)
-			log.Infof("Adding block %v to sidechain", *hash)
-
-			// Just append to side chain until the new main chain tip block is reached
-			if reorgData.NewChainHead != *hash {
-				release()
-				break keepon
-			}
-
-			// Once all blocks in side chain are lined up, switch over
-			log.Info("Switching to side chain...")
-			newHeight, newHash, err := p.switchToSideChain()
-			if err != nil {
-				panic(err)
-			}
-
-			// Verify the hash of the new main chain tip is as expected.
-			if p.reorgData.NewChainHead != *newHash ||
-				p.reorgData.NewChainHeight != newHeight {
-				panic(fmt.Sprintf("Failed to reorg to %v. Got to %v (height %d) instead.",
-					p.reorgData.NewChainHead, newHash, newHeight))
-			}
-
-			// Reorg is complete
-			p.sideChain = nil
-			p.reorganizing = false
-			p.db.InReorg = false
-			log.Infof("Reorganization to block %v (height %d) complete",
-				p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
-
-			release()
-
-		case <-p.ctx.Done():
-			log.Debugf("Got quit signal. Exiting block connected handler.")
-			break out
-		}
-	}
-
-}
-
 // switchToSideChain attempts to switch to a new side chain by: determining a
 // common ancestor block, flagging elements of the old main chain as
 // is_mainchain, and connecting the side chain blocks onto the mainchain.
-func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
-	if len(p.sideChain) == 0 {
+func (p *ChainMonitor) switchToSideChain(reorgData *txhelpers.ReorgData) (int32, *chainhash.Hash, error) {
+	if reorgData == nil || len(reorgData.NewChain) == 0 {
 		return 0, nil, fmt.Errorf("no side chain")
 	}
 
@@ -149,29 +63,20 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 		log.Infof("dcrpg: switchToSideChain completed in %v", time.Since(start))
 	}(time.Now())
 
-	// Determine highest common ancestor of side chain and main chain
-	msgBlock, err := p.db.Client.GetBlock(&p.sideChain[0])
-	if err != nil {
-		return 0, nil, fmt.Errorf("unable to get block at root of side chain")
-	}
-	block := dcrutil.NewBlock(msgBlock)
+	newChain := reorgData.NewChain
+	// newChain does not include the common ancestor.
+	commonAncestorHeight := int64(reorgData.NewChainHeight) - int64(len(newChain))
 
-	mainRootHash := msgBlock.Header.PrevBlock
-	prevMsgBlock, err := p.db.Client.GetBlock(&mainRootHash)
-	if err != nil {
-		return 0, nil, fmt.Errorf("unable to get common ancestor on side chain")
-	}
-	prevBlock := dcrutil.NewBlock(prevMsgBlock)
-
-	commonAncestorHeight := block.Height() - 1
-	if prevBlock.Height() != commonAncestorHeight {
-		panic("Failed to determine common ancestor.")
+	mainTip := int64(p.db.Height())
+	if mainTip != int64(reorgData.OldChainHeight) {
+		log.Warnf("StakeDatabase height is %d, expected %d. Rewinding as "+
+			"needed to complete reorg from ancestor at %d", mainTip,
+			reorgData.OldChainHeight, commonAncestorHeight)
 	}
 
 	// Flag blocks from mainRoot+1 to mainTip as is_mainchain=false
 	startTime := time.Now()
-	mainTip := int64(p.db.Height())
-	mainRoot := mainRootHash.String()
+	mainRoot := reorgData.CommonAncestor.String()
 	log.Infof("Moving %d blocks to side chain...", mainTip-commonAncestorHeight)
 	newMainRoot, numBlocksmoved, err := p.db.TipToSideChain(mainRoot)
 	if err != nil || mainRoot != newMainRoot {
@@ -190,26 +95,32 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 	// Connect blocks in side chain onto main chain
 	log.Debugf("Connecting %d blocks", len(p.sideChain))
 	currentHeight := commonAncestorHeight + 1
-	for i := range p.sideChain {
+	var endHash chainhash.Hash
+	var endHeight int32
+	for i := range newChain {
+		var msgBlock *wire.MsgBlock
 		// Try to find block in stakedb cache
 		block, found := p.db.stakeDB.BlockCached(currentHeight)
 		if found {
 			msgBlock = block.MsgBlock()
 		}
 		// Fetch the block by RPC if not found or wrong hash
-		if !found || msgBlock.BlockHash() != p.sideChain[i] {
-			log.Debugf("block %v not found in stakedb cache, fetching from dcrd", p.sideChain[i])
+		if !found || msgBlock.BlockHash() != newChain[i] {
+			log.Debugf("block %v not found in stakedb cache, fetching from dcrd", newChain[i])
 			// Request MsgBlock from dcrd
-			msgBlock, err = p.db.Client.GetBlock(&p.sideChain[i])
+			msgBlock, err = p.db.Client.GetBlock(&newChain[i])
 			if err != nil {
-				return 0, nil, fmt.Errorf("unable to get side chain block %v", p.sideChain[i])
+				return 0, nil,
+					fmt.Errorf("unable to get side chain block %v", newChain[i])
 			}
 		}
 
 		// Get current winning votes from stakedb
-		tpi, found := p.db.stakeDB.PoolInfo(p.sideChain[i])
+		tpi, found := p.db.stakeDB.PoolInfo(newChain[i])
 		if !found {
-			return 0, nil, fmt.Errorf("stakedb.PoolInfo failed to return info for: %v", p.sideChain[i])
+			return 0, nil,
+				fmt.Errorf("stakedb.PoolInfo failed to return info for: %v",
+					newChain[i])
 		}
 		winners := tpi.Winners
 
@@ -221,11 +132,13 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 			updateExisting, true, true)
 		if err != nil {
 			return int32(p.db.Height()), p.db.Hash(),
-				fmt.Errorf("error connecting block %v", p.sideChain[i])
+				fmt.Errorf("error connecting block %v", newChain[i])
 		}
 
-		log.Infof("Connected block %v (height %d) from side chain.",
-			msgBlock.BlockHash(), msgBlock.Header.Height)
+		endHeight = int32(msgBlock.Header.Height)
+		endHash = msgBlock.BlockHash()
+
+		log.Infof("Connected block %v (height %d) from side chain.", endHash, endHeight)
 
 		currentHeight++
 	}
@@ -234,12 +147,12 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 		numBlocksmoved, time.Since(startTime))
 
 	mainTip = int64(p.db.Height())
-	if mainTip != int64(msgBlock.Header.Height) {
-		panic("connected block height not db tip height")
+	if mainTip != int64(endHeight) {
+		panic(fmt.Sprintf("connected block height %d not db tip height %d",
+			endHeight, mainTip))
 	}
 
-	blockHash := msgBlock.BlockHash()
-	return int32(mainTip), &blockHash, nil
+	return endHeight, &endHash, nil
 }
 
 // ReorgHandler receives notification of a chain reorganization and initiates a
@@ -248,7 +161,7 @@ func (p *ChainMonitor) ReorgHandler() {
 	defer p.wg.Done()
 out:
 	for {
-	keepon:
+		//keepon:
 		select {
 		case reorgData, ok := <-p.reorgChan:
 			p.Lock()
@@ -261,24 +174,26 @@ out:
 			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
 			newHash, oldHash := reorgData.NewChainHead, reorgData.OldChainHead
 
-			if p.reorganizing {
-				log.Errorf("Reorg notified for chain tip %v (height %v), but already "+
-					"processing a reorg to block %v", newHash, newHeight,
-					p.reorgData.NewChainHead)
-				p.Unlock()
-				break keepon
-			}
-
-			// This is the primary action of this handler.
-			p.db.InReorg = true
-			p.reorganizing = true
-			p.reorgData = reorgData
-			p.Unlock()
-
 			log.Infof("Reorganize started. NEW head block %v at height %d.",
 				newHash, newHeight)
 			log.Infof("Reorganize started. OLD head block %v at height %d.",
 				oldHash, oldHeight)
+
+			// Switch to the side chain.
+			stakeDBTipHeight, stakeDBTipHash, err := p.switchToSideChain(reorgData)
+			if err != nil {
+				log.Errorf("switchToSideChain failed: %v", err)
+			}
+			if stakeDBTipHeight != newHeight {
+				log.Errorf("stakeDBTipHeight is %d, expected %d",
+					stakeDBTipHeight, newHeight)
+			}
+			if *stakeDBTipHash != newHash {
+				log.Errorf("stakeDBTipHash is %d, expected %d",
+					stakeDBTipHash, newHash)
+			}
+
+			p.Unlock()
 
 			reorgData.WG.Done()
 

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -12,16 +12,8 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrdata/v3/txhelpers"
 )
-
-// ReorgData contains the information from a reorganization notification.
-type ReorgData struct {
-	OldChainHead   chainhash.Hash
-	OldChainHeight int32
-	NewChainHead   chainhash.Hash
-	NewChainHeight int32
-	WG             *sync.WaitGroup
-}
 
 // ChainMonitor responds to block connection and chain reorganization.
 type ChainMonitor struct {
@@ -29,21 +21,21 @@ type ChainMonitor struct {
 	db             *ChainDBRPC
 	wg             *sync.WaitGroup
 	blockChan      chan *chainhash.Hash
-	reorgChan      chan *ReorgData
+	reorgChan      chan *txhelpers.ReorgData
 	syncConnect    sync.Mutex
 	ConnectingLock chan struct{}
 	DoneConnecting chan struct{}
 
 	// reorg handling
 	sync.Mutex
-	reorgData    *ReorgData
+	reorgData    *txhelpers.ReorgData
 	sideChain    []chainhash.Hash
 	reorganizing bool
 }
 
 // NewChainMonitor creates a new ChainMonitor.
 func (db *ChainDBRPC) NewChainMonitor(ctx context.Context, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *ReorgData) *ChainMonitor {
+	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
 	if db == nil {
 		return nil
 	}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -111,7 +111,7 @@ func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *rpcclient.Client,
 }
 
 func (db *wiredDB) NewStakeDBChainMonitor(ctx context.Context, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *stakedb.ReorgData) *stakedb.ChainMonitor {
+	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *stakedb.ChainMonitor {
 	return db.sDB.NewChainMonitor(ctx, wg, blockChan, reorgChan)
 }
 

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -232,6 +232,17 @@ func (db *wiredDB) GetBestBlockHash() (string, error) {
 	return hash, err
 }
 
+// GetBestBlockHeightHash retrieves the DB's best block hash and height.
+func (db *wiredDB) GetBestBlockHeightHash() (chainhash.Hash, int64, error) {
+	bestBlockSummary := db.GetBestBlockSummary()
+	if bestBlockSummary == nil {
+		return chainhash.Hash{}, -1, fmt.Errorf("unable to retrieve best block summary")
+	}
+	height := int64(bestBlockSummary.Height)
+	hash, err := chainhash.NewHashFromStr(bestBlockSummary.Hash)
+	return *hash, height, err
+}
+
 func (db *wiredDB) GetChainParams() *chaincfg.Params {
 	return db.params
 }

--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -11,16 +11,8 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrdata/v3/blockdata"
+	"github.com/decred/dcrdata/v3/txhelpers"
 )
-
-// ReorgData contains the information from a reoranization notification
-type ReorgData struct {
-	OldChainHead   chainhash.Hash
-	OldChainHeight int32
-	NewChainHead   chainhash.Hash
-	NewChainHeight int32
-	WG             *sync.WaitGroup
-}
 
 // ChainMonitor handles change notifications from the node client
 type ChainMonitor struct {
@@ -29,21 +21,21 @@ type ChainMonitor struct {
 	collector      *blockdata.Collector
 	wg             *sync.WaitGroup
 	blockChan      chan *chainhash.Hash
-	reorgChan      chan *ReorgData
+	reorgChan      chan *txhelpers.ReorgData
 	ConnectingLock chan struct{}
 	DoneConnecting chan struct{}
 	syncConnect    sync.Mutex
 
 	// reorg handling
 	reorgLock    sync.Mutex
-	reorgData    *ReorgData
+	reorgData    *txhelpers.ReorgData
 	sideChain    []chainhash.Hash
 	reorganizing bool
 }
 
 // NewChainMonitor creates a new ChainMonitor
 func (db *wiredDB) NewChainMonitor(ctx context.Context, collector *blockdata.Collector, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *ReorgData) *ChainMonitor {
+	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
 	return &ChainMonitor{
 		ctx:            ctx,
 		db:             db,

--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -16,7 +16,6 @@ import (
 
 // ChainMonitor handles change notifications from the node client
 type ChainMonitor struct {
-	sync.Mutex     // coordinate reorg handling
 	ctx            context.Context
 	db             *wiredDB
 	collector      *blockdata.Collector
@@ -25,7 +24,6 @@ type ChainMonitor struct {
 	reorgChan      chan *txhelpers.ReorgData
 	ConnectingLock chan struct{}
 	DoneConnecting chan struct{}
-	syncConnect    sync.Mutex
 }
 
 // NewChainMonitor creates a new ChainMonitor
@@ -130,8 +128,6 @@ out:
 				log.Errorf("stakeDBTipHash is %d, expected %d",
 					stakeDBTipHash, newHash)
 			}
-
-			p.Unlock()
 
 			reorgData.WG.Done()
 

--- a/main.go
+++ b/main.go
@@ -798,10 +798,9 @@ func _main(ctx context.Context) error {
 	// Setup the synchronous handler functions called by the collectionQueue via
 	// OnBlockConnected.
 	collectionQueue.SetSynchronousHandlers([]func(*chainhash.Hash){
-		sdbChainMonitor.BlockConnectedSync,     // 1. Stake DB for pool info
-		wsChainMonitor.BlockConnectedSync,      // 2. blockdata for regular block data collection and storage
-		wiredDBChainMonitor.BlockConnectedSync, // 3. dcrsqlite for sqlite DB reorg handling
-		auxDBBlockConnectedSync,                // 4. dcrpg for postgres DB reorg handling
+		sdbChainMonitor.BlockConnectedSync, // 1. Stake DB for pool info
+		wsChainMonitor.BlockConnectedSync,  // 2. blockdata for regular block data collection and storage
+		auxDBBlockConnectedSync,            // 3. dcrpg for postgres DB reorg handling
 	})
 
 	// Initial data summary for web ui. stakedb must be at the same height, so
@@ -852,8 +851,7 @@ func _main(ctx context.Context) error {
 	go sdbChainMonitor.ReorgHandler()
 
 	// dcrsqlite does not handle new blocks except during reorg.
-	wg.Add(2)
-	go wiredDBChainMonitor.BlockConnectedHandler()
+	wg.Add(1)
 	go wiredDBChainMonitor.ReorgHandler()
 
 	if usePG {

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func _main(ctx context.Context) error {
 	if err != nil || dcrdClient == nil {
 		return fmt.Errorf("Connection to dcrd failed: %v", err)
 	}
+	go notify.ReorgSignaler(dcrdClient)
 
 	defer func() {
 		// The individial hander's loops should close the notifications channels

--- a/main.go
+++ b/main.go
@@ -827,6 +827,14 @@ func _main(ctx context.Context) error {
 		return err
 	}
 
+	// Set the current best block in the collection queue so that it can verify
+	// that subsequent blocks are in the correct sequence.
+	bestHash, bestHeight, err := baseDB.GetBestBlockHeightHash()
+	if err != nil {
+		return fmt.Errorf("Failed to determine base DB's best block: %v", err)
+	}
+	collectionQueue.SetPreviousBlock(bestHash, bestHeight)
+
 	// Start the monitors' event handlers.
 
 	// blockdata collector handlers

--- a/main.go
+++ b/main.go
@@ -112,7 +112,6 @@ func _main(ctx context.Context) error {
 	if err != nil || dcrdClient == nil {
 		return fmt.Errorf("Connection to dcrd failed: %v", err)
 	}
-	go notify.ReorgSignaler(dcrdClient)
 
 	defer func() {
 		// The individial hander's loops should close the notifications channels
@@ -812,7 +811,9 @@ func _main(ctx context.Context) error {
 		return fmt.Errorf("Failed to store initial block data for explorer pages: %v", err.Error())
 	}
 
-	// Register for notifications from dcrd.
+	// Register for notifications from dcrd. This also sets the daemon RPC
+	// client used by other functions in the notify/notification package (i.e.
+	// common ancestor identification in signalReorg).
 	cerr := notify.RegisterNodeNtfnHandlers(dcrdClient)
 	if cerr != nil {
 		return fmt.Errorf("RPC client error: %v (%v)", cerr.Error(), cerr.Cause())

--- a/notification/ntfnchans.go
+++ b/notification/ntfnchans.go
@@ -9,12 +9,8 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 
 	"github.com/decred/dcrdata/v3/api/insight"
-	"github.com/decred/dcrdata/v3/blockdata"
-	"github.com/decred/dcrdata/v3/db/dcrpg"
-	"github.com/decred/dcrdata/v3/db/dcrsqlite"
 	"github.com/decred/dcrdata/v3/explorer"
 	"github.com/decred/dcrdata/v3/mempool"
-	"github.com/decred/dcrdata/v3/stakedb"
 	"github.com/decred/dcrdata/v3/txhelpers"
 )
 
@@ -37,13 +33,13 @@ const (
 // NtfnChans collects the chain server notification channels
 var NtfnChans struct {
 	ConnectChan                       chan *chainhash.Hash
-	ReorgChanBlockData                chan *blockdata.ReorgData
+	ReorgChanBlockData                chan *txhelpers.ReorgData
 	ConnectChanWiredDB                chan *chainhash.Hash
-	ReorgChanWiredDB                  chan *dcrsqlite.ReorgData
+	ReorgChanWiredDB                  chan *txhelpers.ReorgData
 	ConnectChanStakeDB                chan *chainhash.Hash
-	ReorgChanStakeDB                  chan *stakedb.ReorgData
+	ReorgChanStakeDB                  chan *txhelpers.ReorgData
 	ConnectChanDcrpgDB                chan *chainhash.Hash
-	ReorgChanDcrpgDB                  chan *dcrpg.ReorgData
+	ReorgChanDcrpgDB                  chan *txhelpers.ReorgData
 	UpdateStatusNodeHeight            chan uint32
 	UpdateStatusDBHeight              chan uint32
 	SpendTxBlockChan, RecvTxBlockChan chan *txhelpers.BlockWatchedTx
@@ -71,10 +67,10 @@ func MakeNtfnChans(monitorMempool, postgresEnabled bool) {
 	NtfnChans.ConnectChanDcrpgDB = make(chan *chainhash.Hash, blockConnChanBuffer)
 
 	// Reorg data channels
-	NtfnChans.ReorgChanBlockData = make(chan *blockdata.ReorgData)
-	NtfnChans.ReorgChanWiredDB = make(chan *dcrsqlite.ReorgData)
-	NtfnChans.ReorgChanStakeDB = make(chan *stakedb.ReorgData)
-	NtfnChans.ReorgChanDcrpgDB = make(chan *dcrpg.ReorgData)
+	NtfnChans.ReorgChanBlockData = make(chan *txhelpers.ReorgData)
+	NtfnChans.ReorgChanWiredDB = make(chan *txhelpers.ReorgData)
+	NtfnChans.ReorgChanStakeDB = make(chan *txhelpers.ReorgData)
+	NtfnChans.ReorgChanDcrpgDB = make(chan *txhelpers.ReorgData)
 
 	// To update app status
 	NtfnChans.UpdateStatusNodeHeight = make(chan uint32, blockConnChanBuffer)

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -376,6 +376,10 @@ func SearchRawTransaction(client *rpcclient.Client, count int, address string) (
 // this function is to find a common ancestor for two chains with no common
 // blocks.
 func CommonAncestor(client *rpcclient.Client, hashA, hashB chainhash.Hash) (*chainhash.Hash, []chainhash.Hash, []chainhash.Hash, error) {
+	if client == nil {
+		return nil, nil, nil, errors.New("nil RPC client")
+	}
+
 	var length int
 	var chainA, chainB []chainhash.Hash
 	for {

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -56,8 +56,8 @@ func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
 	hashB, _ := chainhash.NewHashFromStr("000000000036c32da2a340574904726f463a497b7a16fca727420e5c62cf154b")                // main chain @ 72908
 
 	chainAHashes := []string{"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f"}
-	chainBHashes := []string{"000000000036c32da2a340574904726f463a497b7a16fca727420e5c62cf154b",
-		"0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059"}
+	chainBHashes := []string{"0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059",
+		"000000000036c32da2a340574904726f463a497b7a16fca727420e5c62cf154b"}
 
 	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)
 
@@ -114,8 +114,8 @@ func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
 
 	// Note that hashB is the last hash in both chains. The common ancestor is
 	// the previous block since a block is not the ancestor of itself.
-	chainAHashes := []string{"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f",
-		"000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e"}
+	chainAHashes := []string{"000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e",
+		"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f"}
 	chainBHashes := []string{"000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e"}
 
 	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -3,13 +3,211 @@
 package rpcutils
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/rpcclient"
 )
 
 const (
-	nodeUser = "dcrd"
-	nodePass = "dcrd"
+	nodeUser = "jdcrd"
+	nodePass = "jdcrdx"
 )
+
+func testCommonAncestorPositive(t *testing.T, client *rpcclient.Client, hashA, hashB, expectedAncestor *chainhash.Hash, chainAHashes, chainBHashes []string) {
+	var chainAExpected, chainBExpected []chainhash.Hash
+	for i := range chainAHashes {
+		h, _ := chainhash.NewHashFromStr(chainAHashes[i])
+		chainAExpected = append(chainAExpected, *h)
+	}
+	for i := range chainBHashes {
+		h, _ := chainhash.NewHashFromStr(chainBHashes[i])
+		chainBExpected = append(chainBExpected, *h)
+	}
+
+	hash, chainA, chainB, err := CommonAncestor(client, *hashA, *hashB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Allow expectedAncestor and hash to both be nil pointers, or indicate the
+	// same hash.
+	if hash != expectedAncestor && hash != nil && *hash != *expectedAncestor {
+		t.Errorf("hash should have been %v, got %v", expectedAncestor, hash)
+	}
+	if !reflect.DeepEqual(chainA, chainAExpected) {
+		t.Errorf("chainA should have been %v, got %v", chainAExpected, chainA)
+	}
+	if !reflect.DeepEqual(chainB, chainBExpected) {
+		t.Errorf("chainB should have been %v, got %v", chainBExpected, chainB)
+	}
+}
+
+func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// actual testnet side chain on a certain node
+	hashAncestorExpected, _ := chainhash.NewHashFromStr("000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e") // common ancestor at 72906
+	hashA, _ := chainhash.NewHashFromStr("0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f")                // side chain @ 72907
+	hashB, _ := chainhash.NewHashFromStr("000000000036c32da2a340574904726f463a497b7a16fca727420e5c62cf154b")                // main chain @ 72908
+
+	chainAHashes := []string{"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f"}
+	chainBHashes := []string{"000000000036c32da2a340574904726f463a497b7a16fca727420e5c62cf154b",
+		"0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059"}
+
+	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)
+
+	// swap A and B
+	testCommonAncestorPositive(t, client, hashB, hashA, hashAncestorExpected, chainBHashes, chainAHashes)
+}
+
+func TestCommonAncestorOnlineSameHeights(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// actual testnet side chain on a certain node
+	hashAncestorExpected, _ := chainhash.NewHashFromStr("000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e") // common ancestor at 72906
+	hashA, _ := chainhash.NewHashFromStr("0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f")                // side chain @ 72907
+	hashB, _ := chainhash.NewHashFromStr("0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059")                // main chain @ 72907
+
+	chainAHashes := []string{"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f"}
+	chainBHashes := []string{"0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059"}
+
+	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)
+}
+
+func TestCommonAncestorOnlineSameHashes(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	hashAncestorExpected, _ := chainhash.NewHashFromStr("000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e") // common ancestor at 72906
+	hashA, _ := chainhash.NewHashFromStr("0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059")                // main chain @ 72907
+	hashB := hashA                                                                                                          // same block
+
+	chainAHashes := []string{"0000000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059"}
+	chainBHashes := chainAHashes
+
+	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)
+}
+
+func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// actual testnet side chain on a certain node
+	hashAncestorExpected, _ := chainhash.NewHashFromStr("00000000078f12fb5cdf166a9fd04951755bbd7355d3b2f18dcd5158110ca573") // common ancestor at 72905
+	hashA, _ := chainhash.NewHashFromStr("0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f")                // side chain @ 72907
+	hashB, _ := chainhash.NewHashFromStr("000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e")                // main chain at 72906
+
+	// Note that hashB is the last hash in both chains. The common ancestor is
+	// the previous block since a block is not the ancestor of itself.
+	chainAHashes := []string{"0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f",
+		"000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e"}
+	chainBHashes := []string{"000000000002a17a0aeb56856b7b531926a7684e242a39aa5b1acb130a945f9e"}
+
+	testCommonAncestorPositive(t, client, hashA, hashB, hashAncestorExpected, chainAHashes, chainBHashes)
+
+	// swap A and B
+	testCommonAncestorPositive(t, client, hashB, hashA, hashAncestorExpected, chainBHashes, chainAHashes)
+}
+
+func TestCommonAncestorOnlineGenesis(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// var hashAncestorExpected *chainhash.Hash
+	GenesisHash, _ := chainhash.NewHashFromStr("a649dce53918caf422e9c711c858837e08d626ecfcd198969b24f7b634a49bac")
+	hashA, hashB := GenesisHash, GenesisHash // same block
+
+	chainAHashes := []string{"a649dce53918caf422e9c711c858837e08d626ecfcd198969b24f7b634a49bac"}
+	chainBHashes := chainAHashes
+
+	var chainAExpected, chainBExpected []chainhash.Hash
+	for i := range chainAHashes {
+		h, _ := chainhash.NewHashFromStr(chainAHashes[i])
+		chainAExpected = append(chainAExpected, *h)
+	}
+	for i := range chainBHashes {
+		h, _ := chainhash.NewHashFromStr(chainBHashes[i])
+		chainBExpected = append(chainBExpected, *h)
+	}
+
+	hash, chainA, chainB, err := CommonAncestor(client, *hashA, *hashB)
+	if err != ErrAncestorAtGenesis {
+		t.Error(err)
+	}
+	if hash != nil {
+		t.Errorf("hash should have been %v, got %v", nil, hash)
+	}
+	if !reflect.DeepEqual(chainA, chainAExpected) {
+		t.Errorf("chainA should have been %v, got %v", chainAExpected, chainA)
+	}
+	if !reflect.DeepEqual(chainB, chainBExpected) {
+		t.Errorf("chainB should have been %v, got %v", chainBExpected, chainB)
+	}
+}
+
+func TestCommonAncestorOnlineBadHash(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// actual testnet side chain on a certain node
+	hashA, _ := chainhash.NewHashFromStr("0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f") // side chain @ 72907
+	hashB, _ := chainhash.NewHashFromStr("1100000007771c758e95635dc5806441c3926b76f0fb8de3f23cd4ca24b23059") // main chain @ 72907
+
+	hash, chainA, chainB, err := CommonAncestor(client, *hashA, *hashB)
+	if err == nil {
+		t.Errorf("Invalid block hash should cause error.")
+	}
+	if hash != nil {
+		t.Errorf("Invalid block hash should return a nil common ancestor.")
+	}
+	if chainA != nil || chainB != nil {
+		t.Errorf("Invalid block hash should return nil chain slices.")
+	}
+}
+
+func TestCommonAncestorOnlineTooLong(t *testing.T) {
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	// actual testnet side chain on a certain node
+	hashA, _ := chainhash.NewHashFromStr("0000000004b7497db457e7159ebe9a3775f9c0389ed6558cbd50da6650d5520f") // side chain @ 72907
+	hashB, _ := chainhash.NewHashFromStr("00000000055ff907b535338734fbb1c2322d5fffc19a3d744e896a93800267d4") // main chain @ 60000
+
+	hash, chainA, chainB, err := CommonAncestor(client, *hashA, *hashB)
+	if err != ErrAncestorMaxChainLength {
+		t.Errorf("Invalid block hash should cause %v.", ErrAncestorMaxChainLength)
+	}
+	if hash != nil {
+		t.Errorf("Invalid block hash should return a nil common ancestor.")
+	}
+	if chainA != nil || chainB != nil {
+		t.Errorf("Invalid block hash should return nil chain slices.")
+	}
+}
 
 func TestSideChains(t *testing.T) {
 	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)

--- a/rpcutils/rpcclient_test.go
+++ b/rpcutils/rpcclient_test.go
@@ -1,6 +1,7 @@
 package rpcutils
 
 import (
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"reflect"
 	"testing"
 
@@ -113,4 +114,35 @@ func TestReverseStringSlice(t *testing.T) {
 	if !reflect.DeepEqual(s2, ref2) {
 		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s2, ref2)
 	}
+}
+
+func TestCommonAncestor(t *testing.T) {
+	// Equal starting hashes -> return hash an empty chains
+	hashA, _ := chainhash.NewHashFromStr("0000000000000000090442455c38da583f287f753215c430d7adc509bf762d5d")
+	hashB := hashA
+	hash, chainA, chainB, err := CommonAncestor(nil, *hashA, *hashB)
+	if err != nil {
+		t.Error(err)
+	}
+	if *hash != *hashA {
+		t.Errorf("hash should have been hashA")
+	}
+	if chainA != nil || chainB != nil {
+		t.Errorf("chains should have been empty")
+	}
+
+	// Equal starting hashes -> return hash an empty chains
+	hashA = &zeroHash
+	hashB = hashA
+	hash, chainA, chainB, err = CommonAncestor(nil, *hashA, *hashB)
+	if err != nil {
+		t.Error(err)
+	}
+	if *hash != *hashA {
+		t.Errorf("hash should have been hashA")
+	}
+	if chainA != nil || chainB != nil {
+		t.Errorf("chains should have been empty")
+	}
+	t.Log(hash, chainA, chainB)
 }

--- a/rpcutils/rpcclient_test.go
+++ b/rpcutils/rpcclient_test.go
@@ -1,7 +1,6 @@
 package rpcutils
 
 import (
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"reflect"
 	"testing"
 
@@ -114,35 +113,4 @@ func TestReverseStringSlice(t *testing.T) {
 	if !reflect.DeepEqual(s2, ref2) {
 		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s2, ref2)
 	}
-}
-
-func TestCommonAncestor(t *testing.T) {
-	// Equal starting hashes -> return hash an empty chains
-	hashA, _ := chainhash.NewHashFromStr("0000000000000000090442455c38da583f287f753215c430d7adc509bf762d5d")
-	hashB := hashA
-	hash, chainA, chainB, err := CommonAncestor(nil, *hashA, *hashB)
-	if err != nil {
-		t.Error(err)
-	}
-	if *hash != *hashA {
-		t.Errorf("hash should have been hashA")
-	}
-	if chainA != nil || chainB != nil {
-		t.Errorf("chains should have been empty")
-	}
-
-	// Equal starting hashes -> return hash an empty chains
-	hashA = &zeroHash
-	hashB = hashA
-	hash, chainA, chainB, err = CommonAncestor(nil, *hashA, *hashB)
-	if err != nil {
-		t.Error(err)
-	}
-	if *hash != *hashA {
-		t.Errorf("hash should have been hashA")
-	}
-	if chainA != nil || chainB != nil {
-		t.Errorf("chains should have been empty")
-	}
-	t.Log(hash, chainA, chainB)
 }

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -11,16 +11,8 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrdata/v3/txhelpers"
 )
-
-// ReorgData contains the information from a reoranization notification
-type ReorgData struct {
-	OldChainHead   chainhash.Hash
-	OldChainHeight int32
-	NewChainHead   chainhash.Hash
-	NewChainHeight int32
-	WG             *sync.WaitGroup
-}
 
 // ChainMonitor connects blocks to the stake DB as they come in.
 type ChainMonitor struct {
@@ -28,21 +20,21 @@ type ChainMonitor struct {
 	db             *StakeDatabase
 	wg             *sync.WaitGroup
 	blockChan      chan *chainhash.Hash
-	reorgChan      chan *ReorgData
+	reorgChan      chan *txhelpers.ReorgData
 	syncConnect    sync.Mutex
 	ConnectingLock chan struct{}
 	DoneConnecting chan struct{}
 
 	// reorg handling
 	sync.Mutex
-	reorgData    *ReorgData
+	reorgData    *txhelpers.ReorgData
 	sideChain    []chainhash.Hash
 	reorganizing bool
 }
 
 // NewChainMonitor creates a new ChainMonitor
 func (db *StakeDatabase) NewChainMonitor(ctx context.Context, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *ReorgData) *ChainMonitor {
+	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
 	return &ChainMonitor{
 		ctx:            ctx,
 		db:             db,

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
@@ -34,6 +35,20 @@ var (
 
 var CoinbaseFlags = "/dcrd/"
 var CoinbaseScript = append([]byte{0x00, 0x00}, []byte(CoinbaseFlags)...)
+
+// ReorgData contains details of a chain reorganization, including the full old
+// and new chains, and the common ancestor that should not be included in either
+// chain.
+type ReorgData struct {
+	CommonAncestor chainhash.Hash
+	OldChainHead   chainhash.Hash
+	OldChainHeight int32
+	OldChain       []chainhash.Hash
+	NewChainHead   chainhash.Hash
+	NewChainHeight int32
+	NewChain       []chainhash.Hash
+	WG             *sync.WaitGroup
+}
 
 // RawTransactionGetter is an interface satisfied by rpcclient.Client, and
 // required by functions that would otherwise require a rpcclient.Client just


### PR DESCRIPTION
Resolving https://github.com/decred/dcrdata/issues/823

- [x] Modify `collectionQueue` to verify that new blocks are in sequence
- [x] Bump required dcrd JSON RPC version to 5.0.0
- [x] Create `rpcutils.CommonAncestor` function to provide full reorg details to each reorg handler and avoid redundant RPCs.
- [x] Rewrite each `ChainMonitor`'s reorg handling.  Each of `dcrsqlite`, `dcrpg`, and `stakedb` use a `switchToSideChain` function.  With `blockdata`, `ReorgHandler` simply stores the new chain tip's block data in the `reorgDataSavers`, which is presently just the explorer UI update.

There is no longer a need for `BlockConnectedHandler` in dcrpg and dcrsqlite, so it is removed.  The goroutines are no longer started of course, and the synchronous `collectionQueue` now includes only `sdbChainMonitor.BlockConnectedSync` and `wsChainMonitor.BlockConnectedSync` (the synchronous collection and storage functions for the stakedb and blockdata packages.).

In short, the roles of each data saver's `ReorgHandler` are:

1. blockdata: Collect and store in the special reorgDataSavers the data for just the new chain tip block.  This is presently used to update the explorer UI.
2. stakedb: Disconnect the old chain blocks from the StakeDatabase, then connect the new chain blocks.
3. dcrsqlite: Collect and store data for the new chain blocks.  The data for the old chain is not presently removed as it is not critical.
4. dcrpg: This is the most complex one.  All data related to old chain blocks are updated to reflect their new side chain status.  The blocks in the new chain (from a side chain) are stored in the DB, while updating existing records, which may be from the disconnected blocks.

The entire process is much simpler overall.  One source of complexity is the new reorg queue in the `notification` package, and the new and expanded `txhelpers.ReorgData` type that adds the entire lists of blocks in the old and new chains as well as the common ancestor.  The reorg queue is processed by `notification.ReorgSignaler`, which uses the new `rpcutils.CommonAncestor` to get the common ancestor and the full list of block in the old and new chains.

`rpcutils.CommonAncestor` finds the common ancestor and full list of block in the old and new chain by iteratively interrogating dcrd via RPC for blocks' previous block hash until the same hash is encountered for both chains at the same height.  This approach is used as opposed to two other ways:
1. Figuring out the common ancestor in each package's ReorgHandler using whatever data resources they have.  This is redundant and more error prone.
2. Going back from the old chain tip until dcrd indicates the chain has gone from side (-1 confirmations) to main (non-negative confirmations).  This is not robust as there may be data races if subsequent reorganization takes place during the handling of an earlier reorg.