### PR TITLE
sample-nginx.conf updates

### DIFF
--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -62,7 +62,7 @@ http {
                 font/otf font/ttf image/bmp image/svg+xml image/x-icon application/octet-stream;
 
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Content-Security-Policy "script-src 'self' data: 'unsafe-inline'; font-src 'self' data:" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.dcrdata.org; manifest-src 'self'" always;
         add_header X-Content-Type-Options nosniff always;
         add_header X-Frame-Options SAMEORIGIN always;
         add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
Remove "http2" from port 80 server since that does not work.
Add "gzip_vary on" to allow proxies to distinguish content types.
Tweak gzip compression settings, adding more types to match recently
added assets and more.
Add a number of security related headers.
Add "expires modified 2d;"  to the static assets location to set the
Cache-Control and Expires headers.