### PR TITLE
return after exp.StatusPage

### DIFF
--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -94,10 +94,10 @@ func (exp *explorerUI) SyncStatusPageActivation(next http.Handler) http.Handler 
 		if exp.DisplaySyncStatusPage() {
 			exp.StatusPage(w, "Database Update Running. Please Wait...",
 				"Blockchain sync is running. Please wait ...", BlockchainSyncingType)
-		} else {
-			// Pass the token to the next middleware handler
-			next.ServeHTTP(w, r)
+			return
 		}
+		// Otherwise, proceed to the next http handler.
+		next.ServeHTTP(w, r)
 	})
 }
 
@@ -107,10 +107,10 @@ func (exp *explorerUI) SyncStatusApiResponse(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if exp.DisplaySyncStatusPage() {
 			exp.HandleApiRequestsOnSync(w, r)
-		} else {
-			// Pass the token to the next middleware handler
-			next.ServeHTTP(w, r)
+			return
 		}
+		// Otherwise, proceed to the next http handler.
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -294,6 +294,7 @@ func (exp *explorerUI) StakeDiffWindows(w http.ResponseWriter, r *http.Request) 
 	if exp.liteMode {
 		exp.StatusPage(w, fullModeRequired,
 			"Windows page cannot run in lite mode.", NotSupportedStatusType)
+		return
 	}
 
 	offsetWindow, err := strconv.ParseUint(r.URL.Query().Get("offset"), 10, 64)


### PR DESCRIPTION
This ports https://github.com/decred/dcrdata/pull/846/commits/b736cb57490703ec2cfc47e9ad8a70b96bd94a26 to 3.1-stable.