### PR TITLE
Run npm install and run build in CI

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,12 +20,6 @@ DOCKER_IMAGE_TAG=dcrdata-golang-builder-$GOVERSION
 testrepo () {
   TMPFILE=$(mktemp)
   export GO111MODULE=on
-
-  git clone --branch v1.12.3 https://github.com/golangci/golangci-lint ~/golangci-lint
-  pushd ~/golangci-lint/cmd/golangci-lint
-  go install
-  popd
-  #go get -u -v github.com/golangci/golangci-lint/cmd/golangci-lint
   
   golangci-lint run --deadline=10m --disable-all --enable govet --enable staticcheck \
     --enable gosimple --enable unconvert --enable ineffassign --enable structcheck\

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,7 +15,7 @@ set -ex
 
 GOVERSION=${1:-1.11}
 REPO=dcrdata
-DOCKER_IMAGE_TAG=decred-golang-builder-$GOVERSION
+DOCKER_IMAGE_TAG=dcrdata-golang-builder-$GOVERSION
 
 testrepo () {
   TMPFILE=$(mktemp)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -52,6 +52,19 @@ testrepo () {
     exit 1
   fi
 
+  # webpack
+  npm install
+  if [ $? != 0 ]; then
+    echo 'npm install failed'
+    exit 1
+  fi
+
+  npm run build
+  if [ $? != 0 ]; then
+    echo 'npm packaging failed'
+    exit 1
+  fi
+
   echo "------------------------------------------"
   echo "Tests completed successfully!"
 }


### PR DESCRIPTION
The runs `npm install` and `npm run build` and checks the exit codes to ensure everything webpack does succeeds, including linting with eslinter and stylelint.

This requires https://github.com/decred/dcrdocker/pull/43 to update the docker build image.