### PR TITLE
ticketpool chart data inline -> AJAX

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -198,6 +198,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 	mux.Route("/ticketpool", func(r chi.Router) {
 		r.Get("/", app.getTicketPoolByDate)
 		r.With(m.TicketPoolCtx).Get("/bydate/{tp}", app.getTicketPoolByDate)
+		r.Get("/charts", app.getTicketPoolCharts)
 	})
 
 	mux.NotFound(func(w http.ResponseWriter, r *http.Request) {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -435,3 +435,20 @@ type MempoolTicketDetails struct {
 // TicketsDetails is an array of pointers of TicketDetails used in
 // MempoolTicketDetails
 type TicketsDetails []*TicketDetails
+
+// TicketPoolChartsData is for data used to display ticket pool statistics at
+// /ticketpool.
+type TicketPoolChartsData struct {
+	ChartHeight uint64                   `json:"height"`
+	TimeChart   *dbtypes.PoolTicketsData `json:"time_chart"`
+	PriceChart  *dbtypes.PoolTicketsData `json:"price_chart"`
+	DonutChart  *dbtypes.PoolTicketsData `json:"donut_chart"`
+	Mempool     *PriceCountTime          `json:"mempool"`
+}
+
+// PriceCountTime is a basic set of information about ticket in the mempool.
+type PriceCountTime struct {
+	Price float64         `json:"price"`
+	Count int             `json:"count"`
+	Time  dbtypes.TimeDef `json:"time"`
+}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -874,6 +874,12 @@ func (db *wiredDB) GetMempoolSSTxDetails(N int) *apitypes.MempoolTicketDetails {
 	return &mpTicketDetails
 }
 
+// GetMempoolPriceCountTime retreives from mempool: the ticket price, the number
+// of tickets in mempool, the time of the first ticket.
+func (db *wiredDB) GetMempoolPriceCountTime() *apitypes.PriceCountTime {
+	return db.MPC.GetPriceCountTime(int(db.params.MaxFreshStakePerBlock))
+}
+
 // GetAddressTransactionsWithSkip returns an apitypes.Address Object with at most the
 // last count transactions the address was in
 func (db *wiredDB) GetAddressTransactionsWithSkip(addr string, count, skip int) *apitypes.Address {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -877,7 +877,7 @@ func (db *wiredDB) GetMempoolSSTxDetails(N int) *apitypes.MempoolTicketDetails {
 // GetMempoolPriceCountTime retreives from mempool: the ticket price, the number
 // of tickets in mempool, the time of the first ticket.
 func (db *wiredDB) GetMempoolPriceCountTime() *apitypes.PriceCountTime {
-	return db.MPC.GetPriceCountTime(int(db.params.MaxFreshStakePerBlock))
+	return db.MPC.GetTicketPriceCountTime(int(db.params.MaxFreshStakePerBlock))
 }
 
 // GetAddressTransactionsWithSkip returns an apitypes.Address Object with at most the

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -83,7 +83,7 @@ type explorerDataSource interface {
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
 	BlockFlags(hash string) (bool, bool, error)
 	AddressMetrics(addr string) (*dbtypes.AddressMetrics, error)
-	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) ([]*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
+	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) (*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, uint64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)
 	Transaction(txHash string) ([]*dbtypes.Tx, error)
 	VinsForTx(*dbtypes.Tx) (vins []dbtypes.VinTxProperty, prevPkScripts []string, scriptVersions []uint16, err error)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -637,44 +637,13 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 			"Ticketpool page cannot run in lite mode", "", ExpStatusNotSupported)
 		return
 	}
-	interval := dbtypes.AllGrouping
-
-	barGraphs, donutChart, height, err := exp.explorerSource.TicketPoolVisualization(interval)
-	if exp.timeoutErrorPage(w, err, "TicketPoolVisualization") {
-		return
-	}
-	if err != nil {
-		log.Errorf("Template execute failure: %v", err)
-		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
-		return
-	}
-
-	var mp dbtypes.PoolTicketsData
-	exp.MempoolData.RLock()
-	if len(exp.MempoolData.Tickets) > 0 {
-		t := time.Unix(exp.MempoolData.Tickets[0].Time, 0)
-		mp.Time = append(mp.Time, dbtypes.TimeDef{T: t})
-		mp.Price = append(mp.Price, exp.MempoolData.Tickets[0].TotalOut)
-		mp.Mempool = append(mp.Mempool, uint64(len(exp.MempoolData.Tickets)))
-	} else {
-		log.Debug("No tickets exist in the mempool")
-	}
-	exp.MempoolData.RUnlock()
 
 	str, err := exp.templates.execTemplateToString("ticketpool", struct {
 		*CommonPageData
-		NetName      string
-		ChartsHeight uint64
-		ChartData    []*dbtypes.PoolTicketsData
-		GroupedData  *dbtypes.PoolTicketsData
-		Mempool      *dbtypes.PoolTicketsData
+		NetName string
 	}{
 		CommonPageData: exp.commonData(),
 		NetName:        exp.NetName,
-		ChartsHeight:   height,
-		ChartData:      barGraphs,
-		GroupedData:    donutChart,
-		Mempool:        &mp,
 	})
 
 	if err != nil {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -289,6 +289,7 @@ type MempoolData struct {
 	Ticketfees        *dcrjson.TicketFeeInfoResult
 	MinableFees       *MinableFeeInfo
 	AllTicketsDetails TicketsDetails
+	StakeDiff         float64
 }
 
 // GetHeight returns the mempool height
@@ -343,6 +344,12 @@ func (t *mempoolDataCollector) Collect() (*MempoolData, error) {
 		return nil, err
 	}
 	numVotes := len(mempoolVotes)
+
+	// Grab the current stake difficulty (ticket price).
+	stakeDiff, err := c.GetStakeDifficulty()
+	if err != nil {
+		return nil, err
+	}
 
 	// Fee info
 	var numFeeWindows, numFeeBlocks uint32 = 0, 0
@@ -432,6 +439,7 @@ func (t *mempoolDataCollector) Collect() (*MempoolData, error) {
 		MinableFees:       mineables,
 		NumVotes:          uint32(numVotes),
 		AllTicketsDetails: allTicketsDetails,
+		StakeDiff:         stakeDiff.CurrentStakeDifficulty,
 	}
 
 	return mpoolData, err

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -155,8 +155,8 @@ func (c *MempoolDataCache) GetTicketsDetails(N int) (uint32, int64, int, Tickets
 	return c.height, c.timestamp.Unix(), numSSTx, details
 }
 
-// GetPriceCountTime gathers the nominal info for mempool.
-func (c *MempoolDataCache) GetPriceCountTime(feeAvgLength int) *apitypes.PriceCountTime {
+// GetTicketPriceCountTime gathers the nominal info for mempool tickets.
+func (c *MempoolDataCache) GetTicketPriceCountTime(feeAvgLength int) *apitypes.PriceCountTime {
 	c.RLock()
 	defer c.RUnlock()
 

--- a/public/js/controllers/ticketpool_controller.js
+++ b/public/js/controllers/ticketpool_controller.js
@@ -10,7 +10,7 @@ import { barChartPlotter } from '../helpers/chart_helper'
 function legendFormatter (data) {
   if (data.x == null) return ''
   var html = this.getLabels()[0] + ': ' + data.xHTML
-  data.series.map(function (series) {
+  data.series.map((series) => {
     var labeledData = ' <span style="color: ' + series.color + ';">' + series.labelHTML + ': ' + series.yHTML
     html += '<br>' + series.dashHTML + labeledData + '</span>'
   })
@@ -31,7 +31,7 @@ function purchasesGraphData (items, memP) {
   var s = []
   var finalDate = ''
 
-  items.time.map(function (n, i) {
+  items.time.map((n, i) => {
     finalDate = new Date(n)
     s.push([finalDate, 0, items.immature[i], items.live[i], items.price[i]])
   })
@@ -154,16 +154,16 @@ export default class extends Controller {
   }
 
   fetchAll () {
-    $('body').addClass('loading')
     var controller = this
+    controller.wrapperTarget.classList.add('loading')
     $.ajax({
       type: 'GET',
       url: '/api/ticketpool/charts',
-      success: function (data) {
+      success: (data) => {
         controller.processData(data)
       },
-      complete: function () {
-        $('body').removeClass('loading')
+      complete: () => {
+        controller.wrapperTarget.classList.remove('loading')
       }
     })
   }
@@ -223,17 +223,14 @@ export default class extends Controller {
     })
     controller.bars = e.target.name
     $(e.target).addClass('btn-active')
-    $('body').addClass('loading')
+    controller.wrapperTarget.classList.add('loading')
     $.ajax({
       type: 'GET',
       url: '/api/ticketpool/bydate/' + controller.bars,
-      beforeSend: function () {},
-      error: function () {
-        $('body').removeClass('loading')
-      },
-      success: function (data) {
+      beforeSend: () => {},
+      complete: () => { controller.wrapperTarget.classList.remove('loading') },
+      success: (data) => {
         controller.purchasesGraph.updateOptions({ 'file': purchasesGraphData(data['time_chart']) })
-        $('body').removeClass('loading')
       }
     })
   }
@@ -252,7 +249,7 @@ export default class extends Controller {
           plotter: Dygraph.Plotters.linePlotter
         }
       },
-      axes: { y2: { axisLabelFormatter: function (d) { return d.toFixed(1) } } }
+      axes: { y2: { axisLabelFormatter: (d) => { return d.toFixed(1) } } }
     }
     return new Dygraph(
       document.getElementById('tickets_by_purchase_date'),
@@ -291,7 +288,7 @@ export default class extends Controller {
           },
           tooltips: {
             callbacks: {
-              label: function (tooltipItem, data) {
+              label: (tooltipItem, data) => {
                 var sum = 0
                 var currentValue = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
                 d.map((u) => { sum += u })

--- a/views/ticketpool.tmpl
+++ b/views/ticketpool.tmpl
@@ -6,7 +6,7 @@
 
     {{template "navbar" . }}
 
-    <div class="container main" data-controller="ticketpool">
+    <div class="container main" data-controller="ticketpool" data-target="ticketpool.wrapper">
       <div>
         <h2 style="text-align: center; margin-top: 0px">Ticket Pool Visualization</h2>
         <p style="text-align: center; margin-bottom: 5px">
@@ -15,48 +15,43 @@
       </div>
       <br>
 
-      <label>Zoom :</label>
-      <div class="btn-group" data-toggle="buttons">
-        <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm all" value="All Time" name="all">
-        <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm btn-active 1d" value="Day" name="day">
-        <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm 1wk" value="Week" name="wk">
-        <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm 1m" value="Month" name="mo">
-      </div>
+      <div class="position-relative">
+        <div class="modal position-absolute"></div>
+        <label>Zoom :</label>
+        <div class="btn-group" data-toggle="buttons">
+          <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm all" value="All Time" name="all">
+          <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm btn-active 1d" value="Day" name="day">
+          <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm 1wk" value="Week" name="wk">
+          <input data-target="ticketpool.zoom" data-action="click->ticketpool#onZoom" type="button" class="btn btn_sm 1m" value="Month" name="mo">
+        </div>
 
-      <label>&nbsp;&nbsp;Bars :</label>
-      <div class="btn-group" data-toggle="buttons">
-        <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm all btn-active" value="All Time" name="all">
-        <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1d" value="Day" name="day">
-        <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1wk" value="Week" name="wk">
-        <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1m" value="Month" name="mo">
-      </div>
+        <label>&nbsp;&nbsp;Bars :</label>
+        <div class="btn-group" data-toggle="buttons">
+          <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm all btn-active" value="All Time" name="all">
+          <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1d" value="Day" name="day">
+          <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1wk" value="Week" name="wk">
+          <input data-target="ticketpool.bars" data-action="click->ticketpool#onBarsChange" type="button" class="btn btn_sm 1m" value="Month" name="mo">
+        </div>
 
-      <div id="tickets_by_purchase_date" class="tickets"></div>
+        <div id="tickets_by_purchase_date" class="tickets"></div>
 
-      <br>
-      <div id="tickets_by_purchase_price" class="tickets"></div>
+        <br>
+        <div id="tickets_by_purchase_price" class="tickets"></div>
 
-      <br>
-      <div id="tickets_by_type_doughnut" class="doughnutGraph">
-        <canvas id="doughnutGraph" width="220" height="180"
-                chart-options="{tooltipTemplate: '<%=label%>: <%= numeral(value).format('($00[.]00)') %> - <%= numeral(circumference / 6.283).format('(0[.][00]%)') %>'">
-        </canvas>
+        <br>
+        <div id="tickets_by_type_doughnut" class="doughnutGraph">
+          <canvas id="doughnutGraph" width="220" height="180"
+                  chart-options="{tooltipTemplate: '<%=label%>: <%= numeral(value).format('($00[.]00)') %> - <%= numeral(circumference / 6.283).format('(0[.][00]%)') %>'">
+          </canvas>
 
-        <div class="ticket_by_types">
-          <b style="color:#2971FF;">3 Outputs:</b> - typically solo.<br><br>
-          <b style="color:#FF8C00;">5 Outputs:</b> - typically Voting Service Provider (VSP).<br><br>
-          <b style="color:#41BF53;">More than 5 Outputs:</b> - likely multi-party (split) tickets.<br>
+          <div class="ticket_by_types">
+            <b style="color:#2971FF;">3 Outputs:</b> - typically solo.<br><br>
+            <b style="color:#FF8C00;">5 Outputs:</b> - typically Voting Service Provider (VSP).<br><br>
+            <b style="color:#41BF53;">More than 5 Outputs:</b> - likely multi-party (split) tickets.<br>
+          </div>
         </div>
       </div>
     </div>
-    <div class="modal position-fixed"></div>
-
-    <script>
-      var graph = {{.ChartData}}
-      var chart = {{.GroupedData}}
-      var mpl = {{.Mempool}}
-    </script>
-
     {{ template "footer" . }}
 </body>
 </html>

--- a/views/ticketpool.tmpl
+++ b/views/ticketpool.tmpl
@@ -6,7 +6,7 @@
 
     {{template "navbar" . }}
 
-    <div class="container main" data-controller="ticketpool" data-target="ticketpool.wrapper">
+    <div class="container main" data-controller="ticketpool">
       <div>
         <h2 style="text-align: center; margin-top: 0px">Ticket Pool Visualization</h2>
         <p style="text-align: center; margin-bottom: 5px">
@@ -15,7 +15,7 @@
       </div>
       <br>
 
-      <div class="position-relative">
+      <div class="position-relative" data-target="ticketpool.wrapper">
         <div class="modal position-absolute"></div>
         <label>Zoom :</label>
         <div class="btn-group" data-toggle="buttons">


### PR DESCRIPTION
Removes inline data from the ticketpool page. Initial chart data is retrieved instead via AJAX. 

There is a websocket call that retrieves the same data. I left the websocket source, though now that there is an API endpoint, there may be an argument against the duplication. 