### PR TITLE
no-JS fixes

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1093,6 +1093,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		} else {
 			voutStr := strconv.Itoa(int(vin.Vout))
 			vin.DisplayText = vin.Txid + ":" + voutStr
+			vin.TextIsHash = true
 			vin.Link = "/tx/" + vin.Txid + "/out/" + voutStr
 		}
 	}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -199,6 +199,7 @@ type Vin struct {
 	FormattedAmount string
 	Index           uint32
 	DisplayText     string
+	TextIsHash      bool
 	Link            string
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -75,10 +75,10 @@ html {
   padding-top: 35px;
 }
 .mono {
-  font-family: 'inconsolata-v15-latin-regular';
+  font-family: 'inconsolata-v15-latin-regular', 'Courier New', Courier, monospace;
 }
 body {
-  font-family: 'source-sans-pro-v9-latin-regular';
+  font-family: 'source-sans-pro-v9-latin-regular', Arial, Helvetica, sans-serif;
   padding-bottom: 2.1rem;
   background: #F3F5F6;
 }
@@ -573,7 +573,7 @@ table.align-baseline-rows tr {
   padding-left: 0px;
 }
 .table-mono-cells td {
-  font-family: 'inconsolata-v15-latin-regular';
+  font-family: 'inconsolata-v15-latin-regular', 'Courier New', Courier, monospace;
   font-size: 14px;
 }
 .table .address {
@@ -606,7 +606,7 @@ table.align-baseline-rows tr {
 .elidedhash {
   position:relative;
   display:inline-block;
-  font-family: 'inconsolata-v15-latin-regular', monospace;
+  font-family: 'inconsolata-v15-latin-regular', 'Courier New', Courier, monospace;
   color:transparent;
 /*   border: 1px solid #aaa; */
   max-width:100%;
@@ -688,7 +688,7 @@ a.elidedhash:hover {
   z-index: -1;
   display: none;
   border-top: 1px solid #ccc;
-  font-family: 'source-sans-pro-v9-latin-regular';
+  font-family: 'source-sans-pro-v9-latin-regular', Arial, Helvetica, sans-serif;
 }
 
 /*content*/
@@ -743,7 +743,7 @@ a.elidedhash:hover {
 }
 .hash {
   font-size: 14px;
-  font-family: 'inconsolata-v15-latin-regular', monospace;
+  font-family: 'inconsolata-v15-latin-regular', 'Courier New', Courier, monospace;
   display: inline-block;
   word-wrap: break-word;
   transition: .133s transform;

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -226,7 +226,7 @@
                                 <th>Debit DCR</th>
                             {{end}}
                             <th>Time UTC</th>
-                            <th>Age</th>
+                            <th class="jsonly">Age</th>
                             <th>Confirms</th>
                             <th>Size</th>
                         </thead>
@@ -283,7 +283,7 @@
                                         {{.Time}}
                                     {{end}}
                                 </td>
-                                <td class="addr-tx-age">
+                                <td class="jsonly addr-tx-age">
                                 {{if eq (.Time.T.Unix) 0}}
                                     N/A
                                 {{else}}

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -133,7 +133,7 @@
                     <tr>
                         <td class="text-right lh1rem pr-2 xs-w117">TIME</td>
                         <td class="lh1rem" style="min-width: 178px;">
-                            ({{timezone}}) {{.BlockTime}}} <span class="op60 fs12 nowrap">(<span data-target="time.age" data-age="{{.BlockTime}}"></span> ago)</span>
+                            ({{timezone}}) {{.BlockTime}}<span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.BlockTime}}"></span> ago)/span>
                         </td>
                     </tr>
                     <tr>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -95,7 +95,7 @@
                                 <span>Revokes</span>
                             </th>
                             <th>Size</th>
-                            <th>Age</th>
+                            <th class="jsonly" >Age</th>
                             <th>Time ({{timezone}})</th>
                         </tr>
                     </thead>
@@ -109,7 +109,7 @@
                             <td>{{.FreshStake}}</td>
                             <td>{{.Revocations}}</td>
                             <td>{{.FormattedBytes}}</td>
-                            <td data-target="time.age" data-age="{{.BlockTime}}"></td>
+                            <td class="jsonly" data-target="time.age" data-age="{{.BlockTime}}"></td>
                             <td>{{.BlockTime}}</td>
                         </tr>
                     {{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -77,7 +77,7 @@
                         {{else}}
                             <a data-keynav-skip href="https://explorer.dcrdata.org/" title="Home">Switch To Mainnet</a>
                         {{end}}
-                        <span data-keynav-skip data-action="click->menu#onSunClick" class="jsonly d-inline-block"><span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span> Night Mode</span>
+                        <span data-keynav-skip data-action="click->menu#onSunClick" class="jsonly d-inline-block"><span id="sun-icon" class="dcricon-sun-fill no-underline pr-2 jsonly"></span> Night Mode</span>
                         <a data-keynav-skip data-turbolinks="false" href="#" class="jsonly" id="keynav-toggle">
                             <span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
                         </a>
@@ -99,7 +99,7 @@
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
     <div class="container d-flex justify-content-between align-items-center">
-        <ul class="nav justify-contents-left nowrap blockcounter">
+        <ul class="nav justify-contents-left nowrap blockcounter jsonly">
           <li class="nav-item text-left">
             <span data-controller="time" data-target="time.age" data-time-lastblocktime="{{$.Tip.Time}}"></span> <span class="block-msg">since last block</span>
           </li>
@@ -123,7 +123,7 @@
                 >© 2018 The Decred developers (ISC)</a>
             </li>
         </ul>
-        <ul class="nav justify-content-right align-items-center">
+        <ul class="nav justify-content-right align-items-center jsonly">
             <li class="text-right connection-wrapper">
                 <span
                     id="connection"

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -198,7 +198,7 @@
                         <span style="flex: 0 0 65px" class="lh1rem text-right ml-1">Type</span>
                         <span style="flex: 0 0 105px" class="lh1rem text-right ml-1">Total Sent</span>
                         <span style="flex: 0 0 50px" class="lh1rem text-right ml-1">Size</span>
-                        <span style="flex: 0 0 62px" class="lh1rem text-right ml-1">Age</span>
+                        <span style="flex: 0 0 62px" class="lh1rem text-right ml-1 jsonly">Age</span>
                     </div>
                     <div data-target="homepageMempool.transactions" class="transactions md-height-rows rows">
                     {{range .Mempool.LatestTransactions}}
@@ -209,7 +209,7 @@
                                 <span class="rm-spacing-tb">{{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}</span>
                             </span>
                             <span style="flex: 0 0 50px" class="mono text-right ml-1">{{.Size}} B</span>
-                            <span style="flex: 0 0 62px" class="mono text-right ml-1" data-target="time.age" data-age="{{.Time}}"></span>
+                            <span style="flex: 0 0 62px" class="mono text-right ml-1 jsonly" data-target="time.age" data-age="{{.Time}}"></span>
                         </div>
                     {{end}}
                     </div>
@@ -234,7 +234,7 @@
                                 <span class="d-lg-none">Revoke</span>
                             </th>
                             <th>Size</th>
-                            <th>Age</th>
+                            <th class="jsonly">Age</th>
                             <th>Time ({{timezone}})</th>
                         </tr>
                     </thead>
@@ -247,7 +247,7 @@
                             <td>{{.FreshStake}}</td>
                             <td>{{.Revocations}}</td>
                             <td>{{.FormattedBytes}}</td>
-                            <td data-target="time.age" data-age="{{.BlockTime}}"></td>
+                            <td class="jsonly" data-target="time.age" data-age="{{.BlockTime}}"></td>
                             <td>{{.BlockTime}}</td>
                         </tr>
                         {{end}}

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -27,7 +27,7 @@
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">LAST BLOCK</td>
-                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a> (<span data-target="mempool.bestBlockTime  main.age" data-age="{{.LastBlockTime}}"></span> ago)</td>
+                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a><span class="jsonly"> (<span data-target="mempool.bestBlockTime  main.age" data-age="{{.LastBlockTime}}"></span> ago)</span></td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTES</td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -273,7 +273,7 @@
                         {{if eq (.Time.T.Unix) 0}}
                             <span id="txFmtTime">N/A</span> <span class="op60 fs12 nowrap"><span id="txAge" data-target="time.age" data-age=""></span></span>
                         {{else}}
-                            <span>({{timezone}}) {{.Time}}</span> <span class="op60 fs12 nowrap">(<span data-target="time.age" data-age="{{.Time}}"></span> ago)</span>
+                            <span>({{timezone}}) {{.Time}}</span><span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.Time}}"></span> ago)</span>
                         {{end}}
                     </td>
                 </tr>
@@ -320,7 +320,7 @@
                         <td class="position-relative">
                           <div class="hash-box">
                             <div class="hash-fill">
-                              {{template "hashElide" (hashlink .DisplayText .Link)}}
+                              {{if .TextIsHash}}{{template "hashElide" (hashlink .DisplayText .Link)}}{{else}}{{.DisplayText}}{{end}}
                             </div>
                           </div>
                         </td>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -90,7 +90,7 @@
                             <th>Total Size</th>
                             <th class="text-right">Difficulty</th>
                             <th class="text-right">Ticket Price (DCR)</th>
-                            <th class="text-right">Age</th>
+                            <th class="text-right jsonly">Age</th>
                             <th>Start Time ({{timezone}})</th>
                         </tr>
                     </thead>
@@ -112,7 +112,7 @@
                             <td>{{.FormattedSize}}</td>
                             <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
                             <td class="text-right">{{printf "%.2f" (toFloat64Amount .TicketPrice)}}</td>
-                            <td class="text-right" data-target="time.age" data-age="{{.StartTime}}"></td>
+                            <td class="text-right jsonly" data-target="time.age" data-age="{{.StartTime}}"></td>
                             <td>{{.StartTime}}</td>
                         </tr>
                     {{end}}


### PR DESCRIPTION
Set fallback fonts of the same class as the webfonts:
- monospace for inconsolata-v15-latin-regular
- sans-serif for source-sans-pro-v9-latin-regular
Hide all "Age" columns with jsonly class since all age values are set
via stimulus.js.
Also hide all ages in "(X ago)" spots.
Hide the sun/moon icon with jsonly since it is also a webfont. Ideally
both the Night Mode and Enable Hot Keys menu items would be hidden
entirely, but they are difficult to eliminate. `d-inline-block` uses
`display: inline-block !important`, which seems to neutralize jQuery's `show()`.
Hide the "since last block" and websocket status footer elements.
Prevent text like Coinbase and Stakebase from being hash-elided by
defining a new flag, TextIsHash, that is set in Go to avoid heuristics
in the frontend.