### PR TITLE
[3.1] jsonly removeClass in footer

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -95,7 +95,6 @@
 </header>
 <div id="watermark">HODL<br>HODL<br>HODL</div>
 <script data-turbolinks-eval="false">
-    $(".jsonly").removeClass('jsonly')
     $.ajaxSetup({
         cache: true
     });
@@ -715,6 +714,7 @@
 
 </script>
 <script>
+    $(".jsonly").removeClass('jsonly')
     $('.scriptDataStar').on('click', function(){
         $(this).next('.scriptData').slideToggle();
     });


### PR DESCRIPTION
The footer elements did not get jsonly removed.
Also, put the removeClass in a location without
data-turbolinks-eval="false".