### PR TITLE
convert mousetrap pause extension into module format

### DIFF
--- a/public/js/services/keyboard_navigation_service.js
+++ b/public/js/services/keyboard_navigation_service.js
@@ -3,7 +3,9 @@
 import { toggleMenu, toggleSun, closeMenu } from '../services/theme_service'
 import { setCookie } from './cookie_service'
 import Mousetrap from 'mousetrap'
-import '../vendor/mousetrap-pause.min'
+import { addPauseToMousetrap } from '../vendor/mousetrap-pause'
+
+addPauseToMousetrap(Mousetrap)
 
 // Keyboard Navigation
 var targets

--- a/public/js/vendor/mousetrap-pause.js
+++ b/public/js/vendor/mousetrap-pause.js
@@ -1,0 +1,23 @@
+export function addPauseToMousetrap (Mousetrap) {
+  var _originalStopCallback = Mousetrap.prototype.stopCallback
+  Mousetrap.prototype.stopCallback = function (e, element, combo) {
+    var self = this
+
+    if (self.paused) {
+      return true
+    }
+
+    return _originalStopCallback.call(self, e, element, combo)
+  }
+
+  Mousetrap.prototype.pause = function () {
+    var self = this
+    self.paused = true
+  }
+
+  Mousetrap.prototype.unpause = function () {
+    var self = this
+    self.paused = false
+  }
+  Mousetrap.init()
+}

--- a/public/js/vendor/mousetrap-pause.min.js
+++ b/public/js/vendor/mousetrap-pause.min.js
@@ -1,1 +1,0 @@
-(function(a){var b=a.prototype.stopCallback;a.prototype.stopCallback=function(a,c,d){return this.paused?!0:b.call(this,a,c,d)};a.prototype.pause=function(){this.paused=!0};a.prototype.unpause=function(){this.paused=!1};a.init()})(Mousetrap);


### PR DESCRIPTION
Resolving the following issue:

```
app.bundle.js:1 Uncaught TypeError: l.a.unpause is not a function
    at Object.<anonymous> (app.bundle.js:1)
    at d (app.bundle.js:1)
    at Module.<anonymous> (app.bundle.js:1)
    at d (app.bundle.js:1)
    at a (app.bundle.js:1)
    at vendors~app.bundle.js:1
    at vendors~app.bundle.js:1
    at Array.map (<anonymous>)
    at r (vendors~app.bundle.js:1)
    at Module.<anonymous> (app.bundle.js:1)
```