### PR TITLE
make publicPath absolute, standardize bundle split across dev & prod

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,6 +11,11 @@ module.exports = {
     jquery: 'jQuery',
     turbolinks: 'Turbolinks'
   },
+  optimization: {
+    splitChunks: {
+      chunks: 'all'
+    }
+  },
   module: {
     rules: [
       {
@@ -47,6 +52,6 @@ module.exports = {
   output: {
     filename: 'js/[name].bundle.js',
     path: path.resolve(__dirname, 'public/dist'),
-    publicPath: 'dist/'
+    publicPath: '/dist/'
   }
 }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -14,10 +14,7 @@ module.exports = merge(common, {
         sourceMap: true // set to true if you want JS source maps
       }),
       new OptimizeCSSAssetsPlugin({})
-    ],
-    splitChunks: {
-      chunks: 'all'
-    }
+    ]
   },
   module: {
     rules: [


### PR DESCRIPTION
This fixes:
- script loading 404's in development mode due to bundles not being split.
- dynamic import 404 due to publicPath being relative ( eg entering app at /block/123 would result in attempts to load scripts at /block/dist/js ) 