### PR TITLE
.jsonly elements shown on every Turbolinks visit

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -20,7 +20,10 @@ const application = Application.start()
 const context = require.context('./js/controllers', true, /\.js$/)
 application.load(definitionsFromContext(context))
 
-$('.jsonly').removeClass('jsonly')
+document.addEventListener('turbolinks:load', function (e) {
+  $('.jsonly').removeClass('jsonly')
+})
+
 $.ajaxSetup({
   cache: true
 })


### PR DESCRIPTION
Followup to #853. I'm not sure how I didn't see this in testing. 