### PR TITLE
[3.1] Get address for charts AJAX from stimulus dataset

### DIFF
--- a/public/js/controllers/address.js
+++ b/public/js/controllers/address.js
@@ -280,7 +280,7 @@
         }
 
         get addr(){
-            return this.addrTarget.outerText
+            return this.addrTarget.dataset.address
         }
 
         get unspent(){

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -12,7 +12,7 @@
         <div class="row">
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
-                <div class="mono" data-target="address.addr"
+                <div class="mono" data-target="address.addr" data-address="{{.Address}}"
                     id="{{$.OldestTxTime}}" style="margin-bottom: 12px;">
                     {{.Address}}<a
                         id="qrcode-init"


### PR DESCRIPTION
Using outerText was flawed, and the new AddressValidation seems to
reject it while previously it was loaded.