### PR TITLE
3.2 -> 4.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -24,8 +24,8 @@ const (
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	AppName  string = "dcrdata"
-	AppMajor uint   = 3
-	AppMinor uint   = 2
+	AppMajor uint   = 4
+	AppMinor uint   = 0
 	AppPatch uint   = 0
 )
 


### PR DESCRIPTION
3.2 will never be released as 3.2.  The changes are sufficiently
significant to warrant a major version bump.