### PR TITLE
back and forward navigation fixed for charts page

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -1,4 +1,5 @@
 /* global Dygraph */
+/* global Turbolinks */
 /* global $ */
 
 import { Controller } from 'stimulus'
@@ -181,6 +182,7 @@ export default class extends Controller {
     if (this.chartsView !== undefined) {
       this.chartsView.destroy()
     }
+    selectedChart = null
   }
 
   drawInitialGraph () {
@@ -214,7 +216,7 @@ export default class extends Controller {
 
   plotGraph (chartName, data) {
     var d = []
-    window.history.pushState({}, chartName, `#${chartName}`)
+    Turbolinks.controller.replaceHistoryWithLocationAndRestorationIdentifier(Turbolinks.Location.wrap(`#${chartName}`), Turbolinks.uuid())
     var gOptions = {
       rollPeriod: 1
     }


### PR DESCRIPTION
Replaces pushState with a Turbolinks version of `replaceState` so that page navigation works with the browsers forward and back arrows. 