### PR TITLE
Move connection indicator & desktop notification logic out of index.js

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -4,8 +4,7 @@ import 'regenerator-runtime/runtime'
 /* global Turbolinks */
 import ws from './js/services/messagesocket_service'
 import humanize from './js/helpers/humanize_helper'
-import Notify from 'notifyjs'
-
+import './js/services/desktop_notification_service'
 import { Application } from 'stimulus'
 import { definitionsFromContext } from 'stimulus/webpack-helpers'
 import { darkEnabled } from './js/services/theme_service'
@@ -61,9 +60,6 @@ async function createWebSocket (loc) {
     confirmAddrMempool(b)
 
     globalEventBus.publish('BLOCK_RECEIVED', newBlock)
-
-    // block summary data
-    desktopNotifyNewBlock(b)
 
     // Update the blocktime counter.
     window.DCRThings.counter.data('time-lastblocktime', b.unixStamp).removeClass('text-danger')
@@ -156,47 +152,6 @@ async function createWebSocket (loc) {
       handleMempoolUpdate(event)
     }
   })
-}
-
-// desktop notifications
-function onShowNotification () {
-  console.log('block ntfn shown')
-}
-function onCloseNotification () {
-  console.log('block ntfn closed')
-}
-function onClickNotification () {
-  console.log('block ntfn clicked')
-}
-function onErrorNotification () {
-  console.error('Error showing notification. You may need to request permission.')
-}
-function onPermissionGranted () {
-  console.log('Permission has been granted by the user')
-}
-function onPermissionDenied () {
-  console.warn('Permission has been denied by the user')
-}
-
-function doNotification (block) {
-  var newBlockNtfn = new Notify('New Decred Block Mined', {
-    body: 'Block mined at height ' + block.height,
-    tag: 'blockheight',
-    image: '/images/dcrdata144x128.png',
-    icon: '/images/dcrdata144x128.png',
-    notifyShow: onShowNotification,
-    notifyClose: onCloseNotification,
-    notifyClick: onClickNotification,
-    notifyError: onErrorNotification,
-    timeout: 10
-  })
-  newBlockNtfn.show()
-}
-
-function desktopNotifyNewBlock (block) {
-  if (!Notify.needsPermission) {
-    doNotification(block)
-  }
 }
 
 // Check for the txid in the given block
@@ -308,9 +263,3 @@ $('.scriptDataStar').on('click', function () {
 })
 
 window.DCRThings.counter = $('[data-time-lastblocktime]')
-
-$('#connection').on('click', function () {
-  if (Notify.needsPermission) {
-    Notify.requestPermission(onPermissionGranted, onPermissionDenied)
-  }
-})

--- a/public/index.js
+++ b/public/index.js
@@ -28,19 +28,6 @@ $.ajaxSetup({
   cache: true
 })
 
-function updateConnectionStatus (msg, connected) {
-  var el = $('#connection')
-  el.removeClass('hidden')
-  if (connected) {
-    el.addClass('connected')
-    el.removeClass('disconnected')
-  } else {
-    el.removeClass('connected')
-    el.addClass('disconnected')
-  }
-  el.html(msg + '<div></div>')
-}
-
 function getSocketURI (loc) {
   var protocol = (loc.protocol === 'https:') ? 'wss' : 'ws'
   return protocol + '://' + loc.host + '/ws'
@@ -60,29 +47,9 @@ function formatTxDate (stamp, withTimezone) {
 
 async function createWebSocket (loc) {
   // wait a bit to prevent websocket churn from drive by page loads
-  $('#connection').removeClass('hidden')
   var uri = getSocketURI(loc)
   await sleep(3000)
   ws.connect(uri)
-
-  ws.registerEvtHandler('open', function () {
-    console.log('Connected')
-    updateConnectionStatus('Connected', true)
-  })
-
-  ws.registerEvtHandler('close', function () {
-    console.log('Disconnected')
-    updateConnectionStatus('Disconnected', false)
-  })
-
-  ws.registerEvtHandler('error', function (evt) {
-    console.log('WebSocket error:', evt)
-    updateConnectionStatus('Disconnected', false)
-  })
-
-  ws.registerEvtHandler('ping', function (evt) {
-    console.debug('ping. users online: ', evt)
-  })
 
   var updateBlockData = function (event) {
     console.log('Received newblock message', event)
@@ -339,16 +306,9 @@ createWebSocket(window.location)
 $('.scriptDataStar').on('click', function () {
   $(this).next('.scriptData').slideToggle()
 })
-$('#connection').on('click', function () {
-  if (Notify.needsPermission) {
-    Notify.requestPermission(onPermissionGranted, onPermissionDenied)
-  }
-})
+
 window.DCRThings.counter = $('[data-time-lastblocktime]')
 
-$('.scriptDataStar').on('click', function () {
-  $(this).next('.scriptData').slideToggle()
-})
 $('#connection').on('click', function () {
   if (Notify.needsPermission) {
     Notify.requestPermission(onPermissionGranted, onPermissionDenied)

--- a/public/js/controllers/connection_controller.js
+++ b/public/js/controllers/connection_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from 'stimulus'
 import ws from '../services/messagesocket_service'
+import Notify from 'notifyjs'
 
 export default class extends Controller {
   static get targets () {
@@ -39,4 +40,18 @@ export default class extends Controller {
     }
     this.indicatorTarget.innerHTML = msg + '<div></div>'
   }
+
+  requestNotifyPermission () {
+    if (Notify.needsPermission) {
+      Notify.requestPermission(onPermissionGranted, onPermissionDenied)
+    }
+  }
+}
+
+function onPermissionGranted () {
+  console.log('Permission has been granted by the user')
+}
+
+function onPermissionDenied () {
+  console.warn('Permission has been denied by the user')
 }

--- a/public/js/controllers/connection_controller.js
+++ b/public/js/controllers/connection_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from 'stimulus'
+import ws from '../services/messagesocket_service'
+
+export default class extends Controller {
+  static get targets () {
+    return ['indicator']
+  }
+
+  connect () {
+    this.indicatorTarget.classList.remove('hidden')
+
+    ws.registerEvtHandler('open', () => {
+      console.log('Connected')
+      this.updateConnectionStatus('Connected', true)
+    })
+
+    ws.registerEvtHandler('close', () => {
+      console.log('Disconnected')
+      this.updateConnectionStatus('Disconnected', false)
+    })
+
+    ws.registerEvtHandler('error', (evt) => {
+      console.log('WebSocket error:', evt)
+      this.updateConnectionStatus('Disconnected', false)
+    })
+
+    ws.registerEvtHandler('ping', (evt) => {
+      console.debug('ping. users online: ', evt)
+    })
+  }
+
+  updateConnectionStatus (msg, connected) {
+    if (connected) {
+      this.indicatorTarget.classList.add('connected')
+      this.indicatorTarget.classList.remove('disconnected')
+    } else {
+      this.indicatorTarget.classList.remove('connected')
+      this.indicatorTarget.classList.add('disconnected')
+    }
+    this.indicatorTarget.innerHTML = msg + '<div></div>'
+  }
+}

--- a/public/js/services/desktop_notification_service.js
+++ b/public/js/services/desktop_notification_service.js
@@ -1,0 +1,36 @@
+import globalEventBus from './event_bus_service'
+import Notify from 'notifyjs'
+
+function onShowNotification () {
+  console.log('block ntfn shown')
+}
+function onCloseNotification () {
+  console.log('block ntfn closed')
+}
+function onClickNotification () {
+  console.log('block ntfn clicked')
+}
+function onErrorNotification () {
+  console.error('Error showing notification. You may need to request permission.')
+}
+
+globalEventBus.on('BLOCK_RECEIVED', (newBlock) => {
+  if (!Notify.needsPermission) {
+    notifyNewBlock(newBlock.block)
+  }
+})
+
+function notifyNewBlock (block) {
+  var newBlockNtfn = new Notify('New Decred Block Mined', {
+    body: 'Block mined at height ' + block.height,
+    tag: 'blockheight',
+    image: '/images/dcrdata144x128.png',
+    icon: '/images/dcrdata144x128.png',
+    notifyShow: onShowNotification,
+    notifyClose: onCloseNotification,
+    notifyClick: onClickNotification,
+    notifyError: onErrorNotification,
+    timeout: 10
+  })
+  newBlockNtfn.show()
+}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -129,10 +129,11 @@
             <li class="text-right connection-wrapper">
                 <span
                     id="connection"
-                    class="nav-item align-items-center"
+                    class="nav-item align-items-center clickable"
                     data-turbolinks-permanent
                     data-controller="connection"
                     data-target="connection.indicator"
+                    data-action="click->connection#requestNotifyPermission"
                     title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
                     ><span>Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
                 </span>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -131,6 +131,8 @@
                     id="connection"
                     class="nav-item align-items-center"
                     data-turbolinks-permanent
+                    data-controller="connection"
+                    data-target="connection.indicator"
                     title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
                     ><span>Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
                 </span>


### PR DESCRIPTION
* Move logic for styling and handling clicks connection beacon into a stimulus controller
* Add 'clickable' styling to connection beacon
* Switch to using native DOM api [classList methods](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) to update classes for connection beacon ( in an effort to start eliminating jQuery dependency ) 
* Move desktop notification logic into a service module