### PR TITLE
Last of the inline JS removed

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -27,6 +27,13 @@ $.ajaxSetup({
   cache: true
 })
 
+{
+  let navBar = document.getElementById('navBar')
+  window.DCRThings = {}
+  window.DCRThings.targetBlockTime = navBar.dataset.blocktime
+  window.DCRThings.ticketPoolSize = navBar.dataset.poolsize
+}
+
 function getSocketURI (loc) {
   var protocol = (loc.protocol === 'https:') ? 'wss' : 'ws'
   return protocol + '://' + loc.host + '/ws'

--- a/public/js/controllers/ticketwindow_controller.js
+++ b/public/js/controllers/ticketwindow_controller.js
@@ -1,0 +1,15 @@
+/* global Turbolinks */
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static get targets () {
+    return ['pagesize']
+  }
+
+  setPageSize () {
+    Turbolinks.visit(
+      window.location.pathname + '?offset=' + this.pagesizeTarget.dataset.offset +
+      '&rows=' + this.pagesizeTarget.selectedOptions[0].value
+    )
+  }
+}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -29,7 +29,10 @@
 {{end}}
 
 {{define "navbar"}}
-<header class="top-nav">
+<header class="top-nav"
+        id="navBar"
+        data-blocktime="{{.BlockTimeUnix}}"
+        data-poolsize="{{.ChainParams.TicketPoolSize}}">
     <div class="container">
         <div class="d-flex align-items-center flex-wrap">
             <div class="d-flex align-items-center">
@@ -89,11 +92,6 @@
             </nav>
         </div>
     </div>
-    <script data-turbolinks-eval="false">
-        var DCRThings = {};
-        DCRThings.targetBlockTime = {{$.BlockTimeUnix}};
-        DCRThings.ticketPoolSize = {{$.ChainParams.TicketPoolSize}};
-    </script>
 </header>
 <div id="watermark">HODL<br>HODL<br>HODL</div>
 {{end}}

--- a/views/statistics.tmpl
+++ b/views/statistics.tmpl
@@ -116,7 +116,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Tickets In Mempool</div>
                         <div class="card-body card-body-padding-top">
-                            <span class="stat-data" id="bsubsidy_total">{{.TicketsInMempool}}</span>
+                            <span class="stat-data">{{.TicketsInMempool}}</span>
                             </br>
                             <span class="stat-details unit">Ticket{{if gt .TicketsInMempool 1}}s{{end}}</span>
                         </div>
@@ -124,7 +124,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Votes In Mempool</div>
                         <div class="card-body card-body-padding-top">
-                            <span class="stat-data" id="bsubsidy_total">{{.VotesInMempool}}</span>
+                            <span class="stat-data">{{.VotesInMempool}}</span>
                             </br>
                                 <span class="stat-details unit">Vote{{if gt .VotesInMempool 1}}s{{end}}</span>
                         </div>
@@ -132,7 +132,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Ticket Price</div>
                         <div class="card-body card-body-padding-top">
-                            <span  class="stat-data" id="bsubsidy_total">{{template "decimalParts" (float64AsDecimalParts .TicketPrice 8 false)}}</span>
+                            <span  class="stat-data">{{template "decimalParts" (float64AsDecimalParts .TicketPrice 8 false)}}</span>
                             </br>
                             <span class="stat-details unit">DCR</span>
                         </div>
@@ -177,7 +177,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Ticket Rewards</div>
                         <div class="card-body card-body-padding-top">
-                            <span  class="stat-data" id="bsubsidy_total"
+                            <span  class="stat-data"
                                    data-toggle="tooltip"
                                    title="Price based on continous re-staking and variable ticket price.">
                                     +{{printf "%.2f" .TicketsROI}}%
@@ -197,7 +197,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Ticket Pool Size</div>
                         <div class="card-body card-body-padding-top">
-                            <span class="stat-data" id="bsubsidy_total">{{intComma .TicketPoolSize}}</span>
+                            <span class="stat-data">{{intComma .TicketPoolSize}}</span>
                             </br>
                             {{if ge .TicketPoolSizePerToTarget 100.0}}
                             <span class="stat-details">+{{printf "%.2f" (floatsubtract .TicketPoolSizePerToTarget 100.0)}}% above target 40,960</span>
@@ -209,7 +209,7 @@
                     <div width="45%" class="card">
                         <div class="card-header proof-of-stake">Ticket Pool Value</div>
                         <div class="card-body card-body-padding-top">
-                            <span class="stat-data no-decimal" id="bsubsidy_total">{{template "decimalParts" (float64AsDecimalParts  .TicketPoolValue 8 true)}}</span>
+                            <span class="stat-data no-decimal">{{template "decimalParts" (float64AsDecimalParts  .TicketPoolValue 8 true)}}</span>
                             </br>
                             <span class="stat-details unit">DCR</span>
                             </br>
@@ -221,14 +221,6 @@
         </div>
         {{end}}
         {{template "footer" . }}
-
-        <script>
-          // enable tool tips
-          $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-          });
-
-        </script>
     </body>
 </html>
 {{end}}

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -3,9 +3,9 @@
 <html lang="en">
 
 {{template "html-head" "Decred Windows List"}}
-<body class="{{ theme }}">
+<body class="{{ theme }}" data-controller="ticketwindow">
     {{template "navbar" . }}
-    <div class="container main" data-controller="time">
+    <div class="container main">
         <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>
 
         {{block "windowsPagination" .}}
@@ -19,10 +19,13 @@
                 {{template "listViewRouting" "windows"}}
 
                 <span class="fs12 nowrap text-right">
-                    <label class="mb-0 mr-1" for="windows-pagesize">Page Size</label>
+                    <label class="mb-0 mr-1" for="windowsPagesize">Page Size</label>
                     <select
                         name="windows-pagesize"
-                        id="windows-pagesize"
+                        data-target="ticketwindow.pagesize"
+                        data-action="change->ticketwindow#setPageSize"
+                        data-offset="{{$.OffsetWindow}}"
+                        id="windowsPagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pendingWindows 20}}disabled{{end}}"
                         {{if lt $pendingWindows 20}}disabled="disabled"{{end}}
                     >
@@ -112,7 +115,7 @@
                             <td>{{.FormattedSize}}</td>
                             <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
                             <td class="text-right">{{printf "%.2f" (toFloat64Amount .TicketPrice)}}</td>
-                            <td class="text-right jsonly" data-target="time.age" data-age="{{.StartTime}}"></td>
+                            <td class="text-right jsonly" data-controller="time" data-target="time.age" data-age="{{.StartTime}}"></td>
                             <td>{{.StartTime}}</td>
                         </tr>
                     {{end}}
@@ -128,22 +131,6 @@
     </div>
 
 {{ template "footer" . }}
-
-<script>
-    $("#windows-pagesize").change(function(ev) {
-        var pagesize = "20"
-        var offset = {{$.OffsetWindow}}
-        if (ev.currentTarget.id.indexOf("windows-pagesize") != -1){
-            pagesize = $("#windows-pagesize option:selected").val()
-        }
-
-        Turbolinks.visit(
-            window.location.pathname
-            + "?offset="+ offset
-            + "&rows=" + pagesize
-        )
-    })
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
1. Inline `DCRThings` moved to index.js
2. The `stats` page is a mystery to me (is there a link to it somewhere?), but it had some code for tooltips using a bootstrap jQuery plugin, which doesn't appear to be installed. I just removed the code. It does have a title that renders pretty nicely on dektop, though the page itself has some issues in firefox. I also removed some extraneous and duplicate `id` attributes I suspect of being copypasta.
3. New stimulus controller for the ticket price windows page. 
