### PR TITLE
fix function scope mismatch when changing themes on chart page

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -167,11 +167,10 @@ export default class extends Controller {
   }
 
   connect () {
-    let _this = this
-    $.getScript('/js/vendor/dygraphs.min.js', function () {
-      _this.drawInitialGraph()
-      $(document).on('nightMode', this, function (event, params) {
-        event.data.chartsView.updateOptions(
+    $.getScript('/js/vendor/dygraphs.min.js', () => {
+      this.drawInitialGraph()
+      $(document).on('nightMode', (event, params) => {
+        this.chartsView.updateOptions(
           nightModeOptions(params.nightMode)
         )
       })


### PR DESCRIPTION
`event.data.chartsView` on line 174 was undefined.
Fixed by using arrow functions to maintain the top level `this` reference to the controller.