### PR TITLE
charts: explicitly set initial labels

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -187,6 +187,7 @@ export default class extends Controller {
 
   drawInitialGraph () {
     var options = {
+      labels: ['Date', 'Ticket Price'],
       digitsAfterDecimal: 8,
       showRangeSelector: true,
       rangeSelectorPlotFillColor: '#8997A5',
@@ -223,7 +224,7 @@ export default class extends Controller {
     switch (chartName) {
       case 'ticket-price': // price graph
         d = ticketsFunc(data)
-        assign(gOptions, mapDygraphOptions(d, ['Date', 'Price'], true, 'Price (Decred)', 'Date', undefined, false, false))
+        assign(gOptions, mapDygraphOptions(d, ['Date', 'Ticket Price'], true, 'Price (DCR)', 'Date', undefined, false, false))
         break
 
       case 'ticket-pool-size': // pool size graph
@@ -267,7 +268,7 @@ export default class extends Controller {
 
       case 'coin-supply': // supply graph
         d = supplyFunc(data)
-        assign(gOptions, mapDygraphOptions(d, ['Date', 'Coin Supply'], true, 'Coin Supply', 'Date', undefined, true, false))
+        assign(gOptions, mapDygraphOptions(d, ['Date', 'Coin Supply'], true, 'Coin Supply (DCR)', 'Date', undefined, true, false))
         break
 
       case 'fee-per-block': // block fee graph
@@ -278,7 +279,7 @@ export default class extends Controller {
 
       case 'duration-btw-blocks': // Duration between blocks graph
         d = timeBtwBlocksFunc(data)
-        assign(gOptions, mapDygraphOptions(d, ['Block Height', 'Duration Between Block'], false, 'Duration Between Block (Seconds)', 'Block Height',
+        assign(gOptions, mapDygraphOptions(d, ['Block Height', 'Duration Between Block'], false, 'Duration Between Block (seconds)', 'Block Height',
           undefined, false, false))
         break
 

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -29,7 +29,7 @@
                             <option name="tx-per-block" value="tx-per-block">Transactions Per Block</option>
                             <option name="tx-per-day" value="tx-per-day">Transactions Per Day</option>
                             <option name="pow-difficulty" value="pow-difficulty">PoW Difficulty</option>
-                            <option name="coin-supply" value="coin-supply">Total Coin Supply</option>
+                            <option name="coin-supply" value="coin-supply">Coin Supply</option>
                             <option name="fee-per-block" value="fee-per-block">Total Fee Per Block</option>
                             <option name="duration-btw-blocks" value="duration-btw-blocks">Duration Between Blocks</option>
                             <option name="ticket-spend-type" value="ticket-spend-type">Ticket Spend Types</option>


### PR DESCRIPTION
This explicitly sets the initial Dygraph labels to match the initial chart (tickets-price). Without the labels set, they are inferred, and a browser console warning is shown:

    Using default labels. Set labels explicitly via 'labels' in the options parameter.

This change avoids the message and keeps the labels consistent.

Add units to Coin Supply, (DCR).
Remove the word "Total" from Total Coin Supply chart name.