### PR TITLE
Link to /rejects and /side pages.

### DIFF
--- a/public/scss/utils.scss
+++ b/public/scss/utils.scss
@@ -94,6 +94,34 @@
   height: 3rem;
 }
 
+.h20 {
+  height: 20px;
+}
+
+.h30 {
+  height: 30px;
+}
+
+.h40 {
+  height: 40px;
+}
+
+.h80 {
+  height: 80px;
+}
+
+.w20 {
+  width: 20px;
+}
+
+.w30 {
+  width: 30px;
+}
+
+.w40 {
+  width: 40px;
+}
+
 .w80 {
   width: 80px;
 }
@@ -106,8 +134,16 @@
   width: 142px;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .vam {
   vertical-align: middle;
+}
+
+.p2tb {
+  padding: 2px 0;
 }
 
 .p03rem0 {

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -126,6 +126,7 @@
             {{template  "blocksPagination" .}}
         </div>
         {{end}}
+        <p class="text-center">Looking for <a href="/side">orphaned blocks</a> or <a href="/rejects">PoS invalidated blocks?</a><p>
     </div>
 {{ template "footer" . }}
 </body>

--- a/views/rejects.tmpl
+++ b/views/rejects.tmpl
@@ -6,7 +6,7 @@
 <body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time">
-        <h4><span title="blocks disapproved by stakeholder voting"><img class="img-size40" src="/images/pos-hammer.svg" alt="pos hammer"> Stakeholder Disapproved Blocks</span></h4>
+        <h4><span title="blocks disapproved by stakeholder voting"><img class="h30 p2tb" src="/images/pos-hammer.svg" alt="pos hammer"> Stakeholder Disapproved Blocks</span></h4>
         <h6>There are currently {{len .Data}} blocks that have been <a href="https://docs.decred.org/faq/proof-of-stake/general/#9-what-is-proof-of-stake-voting">disapproved via PoS voting.</a></h6>
         <div class="row">
             <div class="col-md-12">

--- a/views/sidechains.tmpl
+++ b/views/sidechains.tmpl
@@ -6,7 +6,7 @@
 <body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time">
-        <h4><span title="side chain blocks known to this dcrdata instance"><img class="img-size40" src="/images/dcr-side-chains.svg" alt="side chain"> Side Chain Blocks</span></h4>
+        <h4><span title="side chain blocks known to this dcrdata instance"><img class="h30 p2tb" src="/images/dcr-side-chains.svg" alt="side chain"> Side Chain Blocks</span></h4>
 
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
This creates links to the /side and /rejects pages at the bottom of the /blocks page:

![image](https://user-images.githubusercontent.com/9373513/49890047-b1253800-fe08-11e8-9f28-80217bda4c19.png)

This also fixes the size of the side chain and hammer icon used on those pages.