### PR TITLE
dcrsqlite: mitigate database is locked errors

### DIFF
--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -47,6 +47,10 @@ const (
 	// A couple database queries that are called before NewWiredDB
 	SetCacheSizeSQL       = "PRAGMA cache_size = 32768;"
 	SetSynchrounousOffSQL = "pragma synchronous = OFF;"
+
+	// DBBusyTimeout is the length of time in milliseconds for sqlite to retry
+	// DB access when the SQLITE_BUSY error would otherwise be returned.
+	DBBusyTimeout = "30000"
 )
 
 // DB is a wrapper around sql.DB that adds methods for storing and retrieving
@@ -193,12 +197,22 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 		return nil, err
 	}
 
+	// "shared-cache" mode has multiple connections share a single data and
+	// schema cache. _busy_timeout helps prevent SQLITE_BUSY ("database is
+	// locked") errors by sleeping for a certain amount of time when the
+	// database is locked. See https://www.sqlite.org/c3ref/busy_timeout.html.
+	dbPath = dbPath + "?cache=shared&_busy_timeout=" + DBBusyTimeout
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil || db == nil {
 		return nil, err
 	}
 
-	// These are db-wide settings
+	// SQLite does not handle concurrent writes internally, necessitating a
+	// limitation of just 1 open connecton. With a busy_timeout set, this is
+	// less important.
+	db.SetMaxOpenConns(1)
+
+	// These are db-wide settings that persist for the entire session.
 	_, err = db.Exec(SetCacheSizeSQL)
 	if err != nil {
 		log.Error("Error setting SQLite Cache size")


### PR DESCRIPTION
This resolves an issue with go-sqlite3 where the following error may be encountered:

    database is locked

which corresponds to the [SQLITE_BUSY error](https://sqlite.org/rescode.html).

The issue is discussed at length in https://github.com/mattn/go-sqlite3/issues/274, but the gist is:

1. SQLite should be compiled in "sequential mode" to handle multithreaded access. This change was made for go-sqlite v1.10.0  in https://github.com/mattn/go-sqlite3/commit/acfa60124032040b9f5a9406f5a772ee16fe845e. This dependency update is made in https://github.com/decred/dcrdata/pull/877
2. Limiting the sql driver to just one active connection (the driver it maintains a connection pool) prevents concurrent access. 

   ```go
   db.SetMaxOpenConns(1)
   ```

3. Setting a non-zero value for "busy_timeout" instructs SQLite to retry the DB access for the specified amount of time before throwing the `SQLITE_BUSY` error.  This is a partial resolution.

   ```go
   dbPath = dbPath + "?cache=shared&_busy_timeout="  + DBBusyTimeout
   ```

