### PR TITLE
refactoring for httptest

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,9 +835,9 @@ the future.
 
 - A `sql.DB` wrapper type (`DB`) with the necessary SQLite queries for
   storage and retrieval of block and stake data.
-- The `wiredDB` type, intended to satisfy the `DataSourceLite` interface used by
+- The `WiredDB` type, intended to satisfy the `DataSourceLite` interface used by
   the dcrdata app's API. The block header is not stored in the DB, so a RPC
-  client is used by `wiredDB` to get it on demand. `wiredDB` also includes
+  client is used by `WiredDB` to get it on demand. `WiredDB` also includes
   methods to resync the database file.
 
 `package mempool` defines a `mempoolMonitor` type that can monitor a node's

--- a/cmd/rebuilddb/rebuilddb.go
+++ b/cmd/rebuilddb/rebuilddb.go
@@ -79,7 +79,7 @@ func mainCore() int {
 	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
 	//sqliteDB, err := dcrsqlite.InitDB(&dbInfo)
 	sqliteDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo, nil, client,
-		activeChain, "rebuild_data", true)
+		activeChain, "rebuild_data")
 	defer cleanupDB()
 	if err != nil {
 		log.Errorf("Unable to initialize SQLite database: %v", err)

--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -17,7 +17,7 @@ import (
 // ChainMonitor handles change notifications from the node client
 type ChainMonitor struct {
 	ctx            context.Context
-	db             *wiredDB
+	db             *WiredDB
 	collector      *blockdata.Collector
 	wg             *sync.WaitGroup
 	blockChan      chan *chainhash.Hash
@@ -27,7 +27,7 @@ type ChainMonitor struct {
 }
 
 // NewChainMonitor creates a new ChainMonitor
-func (db *wiredDB) NewChainMonitor(ctx context.Context, collector *blockdata.Collector, wg *sync.WaitGroup,
+func (db *WiredDB) NewChainMonitor(ctx context.Context, collector *blockdata.Collector, wg *sync.WaitGroup,
 	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
 	return &ChainMonitor{
 		ctx:            ctx,

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -96,12 +96,12 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 	})
 }
 
-// SyncStatusPageActivation serves only the syncing status page until its
-// deactivated when DisplaySyncStatusPage is set to false. This page is served
+// SyncStatusPageIntercept serves only the syncing status page until it is
+// deactivated when ShowingSyncStatusPage is set to false. This page is served
 // for all the possible routes supported until the background syncing is done.
-func (exp *explorerUI) SyncStatusPageActivation(next http.Handler) http.Handler {
+func (exp *explorerUI) SyncStatusPageIntercept(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if exp.DisplaySyncStatusPage() {
+		if exp.ShowingSyncStatusPage() {
 			exp.StatusPage(w, "Database Update Running. Please Wait...",
 				"Blockchain sync is running. Please wait ...", "", ExpStatusSyncing)
 			return
@@ -111,11 +111,11 @@ func (exp *explorerUI) SyncStatusPageActivation(next http.Handler) http.Handler 
 	})
 }
 
-// SyncStatusApiResponse returns a json response back instead of a web page when
-// display sync status is active for the api endpoints supported.
-func (exp *explorerUI) SyncStatusApiResponse(next http.Handler) http.Handler {
+// SyncStatusAPIIntercept returns a json response back instead of a web page
+// when display sync status is active for the api endpoints supported.
+func (exp *explorerUI) SyncStatusAPIIntercept(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if exp.DisplaySyncStatusPage() {
+		if exp.ShowingSyncStatusPage() {
 			exp.HandleApiRequestsOnSync(w, r)
 			return
 		}

--- a/explorer/explorerroutes_test.go
+++ b/explorer/explorerroutes_test.go
@@ -1,0 +1,84 @@
+package explorer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrdata/v4/db/dcrpg"
+	"github.com/decred/dcrdata/v4/db/dcrsqlite"
+	"github.com/decred/dcrdata/v4/explorer/types"
+)
+
+type WiredDBStub struct {
+	// Embed *ChainDB to get all the methods to satisfy the
+	// explorerDataSource interface, but not actually implement them.
+	// Only the methods required for this test need be implemented.
+	*dcrsqlite.WiredDB
+}
+
+func (ws *WiredDBStub) GetChainParams() *chaincfg.Params {
+	return &chaincfg.MainNetParams
+}
+
+// GetTip is required to populate a CommonPageData for the explorer.
+func (ws *WiredDBStub) GetTip() (*types.WebBasicBlock, error) {
+	return &types.WebBasicBlock{
+		Hash:       "00000000000000001cf26099864194b77b860fa11241baf9f39aad436d43c7a6",
+		Height:     295566,
+		Size:       10111,
+		Difficulty: 11926609305.972,
+		StakeDiff:  103.87403392,
+		Time:       1543259358,
+		PoolSize:   40779,
+		PoolValue:  4145018.51407483,
+		PoolValAvg: 101.645908778411,
+		PoolWinners: []string{
+			"77ea8ce00acc53782501635ffae22df4200acfe6d92d0e47a550079f24eab86f",
+			"57f309077a1abe8d4048ed0204ba78afafd50bf9896fcb7cf2c8162b241250f8",
+			"16dda0e79ac8e6c8b168d41d840017064b5be1180fcaefc3f29e50d678eefff6",
+			"b122bce0fb617edb4de40b4fc955ed64f4d3966b191b1d950a99759d8df0a6fa",
+			"3544a5dbad15f5de90cf4ada0204679748e63b5be440720c1fb0c22c648f23a2",
+		},
+	}, nil
+}
+
+type ChainDBStub struct {
+	// Embed *ChainDBRPC to get all the methods to satisfy the
+	// explorerDataSource interface, but not actually implement them. Only the
+	// methods required for this test need be implemented.
+	*dcrpg.ChainDBRPC
+}
+
+func TestStatusPageResponseCodes(t *testing.T) {
+	// req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	var wiredDBStub WiredDBStub
+	var chainDBStub ChainDBStub
+	exp := New(&wiredDBStub, &chainDBStub, false, "test", false, "../views")
+
+	// handler := http.HandlerFunc()
+	// handler.ServeHTTP(rr, req)
+
+	io := []struct {
+		ExpStatus expStatus
+		RespCode  int
+	}{
+		{
+			ExpStatusBitcoin, http.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, oi := range io {
+		exp.StatusPage(rr, "code", "msg", "junk", oi.ExpStatus)
+
+		resp := rr.Result()
+		if resp.StatusCode != oi.RespCode {
+			t.Errorf("wrong code %d (%s), expected %d (%s)",
+				resp.StatusCode, http.StatusText(resp.StatusCode),
+				oi.RespCode, http.StatusText(oi.RespCode))
+		}
+	}
+}

--- a/explorer/syncstatus.go
+++ b/explorer/syncstatus.go
@@ -1,0 +1,140 @@
+package explorer
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrdata/v4/db/dbtypes"
+)
+
+// SyncStatusInfo defines information for a single progress bar.
+type SyncStatusInfo struct {
+	// PercentComplete is the percentage of sync complete for a given progress bar.
+	PercentComplete float64 `json:"percentage_complete"`
+	// BarMsg holds the main bar message about the currect sync.
+	BarMsg string `json:"bar_msg"`
+	// BarSubtitle holds any other information about the current main sync. This
+	// value may include but not limited to; db indexing, deleting duplicates etc.
+	BarSubtitle string `json:"subtitle"`
+	// Time is the estimated time in seconds to the sync should be complete.
+	Time int64 `json:"seconds_to_complete"`
+	// ProgressBarID is the given entry progress bar id needed on the UI page.
+	ProgressBarID string `json:"progress_bar_id"`
+}
+
+// syncStatus makes it possible to update the user on the progress of the
+// blockchain db syncing that is running after new blocks were detected on
+// system startup. ProgressBars is an array whose every entry is one of the
+// progress bars data that will be displayed on the sync status page.
+type syncStatus struct {
+	sync.RWMutex
+	ProgressBars []SyncStatusInfo
+}
+
+// blockchainSyncStatus defines the status update displayed on the syncing
+// status page when new blocks are being appended into the db.
+var blockchainSyncStatus = new(syncStatus)
+
+// SyncStatus defines a thread-safe way to read the sync status updates
+func SyncStatus() []SyncStatusInfo {
+	blockchainSyncStatus.RLock()
+	defer blockchainSyncStatus.RUnlock()
+
+	return blockchainSyncStatus.ProgressBars
+}
+
+// ShowingSyncStatusPage is a thread-safe way to fetch the
+// displaySyncStatusPage.
+func (exp *explorerUI) ShowingSyncStatusPage() bool {
+	display, ok := exp.displaySyncStatusPage.Load().(bool)
+	return ok && display
+}
+
+// EnableSyncStatusPage enables or disables updates to the sync status page.
+func (exp *explorerUI) EnableSyncStatusPage(displayStatus bool) {
+	exp.displaySyncStatusPage.Store(displayStatus)
+}
+
+// BeginSyncStatusUpdates receives the progress updates and and updates the
+// blockchainSyncStatus.ProgressBars.
+func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarLoad) {
+	// Do not start listening for updates if channel is nil.
+	if barLoad == nil {
+		log.Warnf("Not updating sync status page.")
+		return
+	}
+
+	exp.EnableSyncStatusPage(true)
+
+	// Periodically trigger websocket hub to signal a progress update.
+	go func() {
+		timer := time.NewTicker(syncStatusInterval)
+		for range timer.C {
+			if barLoad == nil {
+				log.Debug("Stopping progress bar signals.")
+				timer.Stop()
+			}
+			log.Debug("Sending progress bar signal.")
+			exp.wsHub.HubRelay <- sigSyncStatus
+		}
+	}()
+
+	// Update the progress bar data when progress updates are received from the
+	// sync routine of a database backend.
+	go func() {
+		// The receive loop quits when barLoad is closed or a nil *Hash is sent.
+		// In either case, the barLoad channel is set to nil when the goroutine
+		// returns. As a result, the websocket trigger goroutine will return.
+		defer func() {
+			log.Debug("Finished with sync status updates.")
+			barLoad = nil
+			// Send the one last signal so that the websocket can send the final
+			// confirmation that syncing is done and home page auto reload should
+			// happen.
+			exp.wsHub.HubRelay <- sigSyncStatus
+			exp.EnableSyncStatusPage(false)
+		}()
+
+	barloop:
+		for bar := range barLoad {
+			if bar == nil {
+				return
+			}
+
+			var percentage float64
+			if bar.To > 0 {
+				percentage = math.Floor(float64(bar.From)/float64(bar.To)*10000) / 100
+			}
+
+			val := SyncStatusInfo{
+				PercentComplete: percentage,
+				BarMsg:          bar.Msg,
+				Time:            bar.Timestamp,
+				ProgressBarID:   bar.BarID,
+				BarSubtitle:     bar.Subtitle,
+			}
+
+			// Update existing progress bar if one is found with this ID.
+			blockchainSyncStatus.Lock()
+			for i, v := range blockchainSyncStatus.ProgressBars {
+				if v.ProgressBarID == bar.BarID {
+					// Existing progress bar data.
+					if len(bar.Subtitle) > 0 && bar.Timestamp == 0 {
+						// Handle case scenario when only subtitle should be updated.
+						blockchainSyncStatus.ProgressBars[i].BarSubtitle = bar.Subtitle
+					} else {
+						blockchainSyncStatus.ProgressBars[i] = val
+					}
+					// Go back to waiting for updates.
+					blockchainSyncStatus.Unlock()
+					continue barloop
+				}
+			}
+
+			// Existing bar with this ID not found, append new.
+			blockchainSyncStatus.ProgressBars = append(blockchainSyncStatus.ProgressBars, val)
+			blockchainSyncStatus.Unlock()
+		}
+	}()
+}

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/v4/explorer/types"
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -28,19 +29,19 @@ type pageTemplate struct {
 
 type templates struct {
 	templates map[string]pageTemplate
-	defaults  []string
+	common    []string
 	folder    string
 	helpers   template.FuncMap
 }
 
-func newTemplates(folder string, defaults []string, helpers template.FuncMap) templates {
-	var defs []string
-	for _, file := range defaults {
-		defs = append(defs, filepath.Join(folder, file+".tmpl"))
+func newTemplates(folder string, common []string, helpers template.FuncMap) templates {
+	var com []string
+	for _, file := range common {
+		com = append(com, filepath.Join(folder, file+".tmpl"))
 	}
 	return templates{
 		templates: make(map[string]pageTemplate),
-		defaults:  defs,
+		common:    com,
 		folder:    folder,
 		helpers:   helpers,
 	}
@@ -48,7 +49,7 @@ func newTemplates(folder string, defaults []string, helpers template.FuncMap) te
 
 func (t *templates) addTemplate(name string) error {
 	fileName := filepath.Join(t.folder, name+".tmpl")
-	files := append(t.defaults, fileName)
+	files := append(t.common, fileName)
 	temp, err := template.New(name).Funcs(t.helpers).ParseFiles(files...)
 	if err == nil {
 		t.templates[name] = pageTemplate{
@@ -314,7 +315,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"toLowerCase": func(a string) string {
 			return strings.ToLower(a)
 		},
-		"fetchRowLinkURL": func(groupingStr string, start, end dbtypes.TimeDef) string {
+		"fetchRowLinkURL": func(groupingStr string, start, end types.TimeDef) string {
 			// fetchRowLinkURL creates links url to be used in the blocks list views
 			// in heirachical order i.e. /years -> /months -> weeks -> /days -> /blocks
 			// (/years -> /months) simply means that on "/years" page every row has a
@@ -368,7 +369,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			}
 			return make([]int, length)
 		},
-		"clipSlice": func(arr []*TrimmedTxInfo, n int) []*TrimmedTxInfo {
+		"clipSlice": func(arr []*types.TrimmedTxInfo, n int) []*types.TrimmedTxInfo {
 			if len(arr) >= n {
 				return arr[:n]
 			} else {

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -15,6 +15,7 @@ import (
 
 	apitypes "github.com/decred/dcrdata/v4/api/types"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/v4/explorer/types"
 	"golang.org/x/net/websocket"
 )
 
@@ -223,7 +224,7 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				switch sig {
 				case sigNewBlock:
 					exp.pageData.RLock()
-					enc.Encode(WebsocketBlock{
+					enc.Encode(types.WebsocketBlock{
 						Block: exp.pageData.BlockInfo,
 						Extra: exp.pageData.HomeInfo,
 					})

--- a/notification/ntfnchans.go
+++ b/notification/ntfnchans.go
@@ -9,7 +9,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 
 	"github.com/decred/dcrdata/v4/api/insight"
-	"github.com/decred/dcrdata/v4/explorer"
+	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/mempool"
 	"github.com/decred/dcrdata/v4/txhelpers"
 )
@@ -45,7 +45,7 @@ var NtfnChans struct {
 	SpendTxBlockChan, RecvTxBlockChan chan *txhelpers.BlockWatchedTx
 	RelevantTxMempoolChan             chan *dcrutil.Tx
 	NewTxChan                         chan *mempool.NewTx
-	ExpNewTxChan                      chan *explorer.NewMempoolTx
+	ExpNewTxChan                      chan *exptypes.NewMempoolTx
 	InsightNewTxChan                  chan *insight.NewTx
 }
 
@@ -89,7 +89,7 @@ func MakeNtfnChans(monitorMempool, postgresEnabled bool) {
 	}
 
 	// New mempool tx chan for explorer
-	NtfnChans.ExpNewTxChan = make(chan *explorer.NewMempoolTx, expNewTxChanBuffer)
+	NtfnChans.ExpNewTxChan = make(chan *exptypes.NewMempoolTx, expNewTxChanBuffer)
 
 	if postgresEnabled {
 		NtfnChans.InsightNewTxChan = make(chan *insight.NewTx, expNewTxChanBuffer)

--- a/notification/ntfnhandlers.go
+++ b/notification/ntfnhandlers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/decred/dcrd/rpcclient"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/v4/api/insight"
-	"github.com/decred/dcrdata/v4/explorer"
+	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/mempool"
 	"github.com/decred/dcrdata/v4/rpcutils"
 	"github.com/decred/dcrdata/v4/txhelpers"
@@ -153,7 +153,7 @@ func (q *collectionQueue) processBlock(bh *blockHashHeight) {
 	}
 
 	select {
-	case NtfnChans.ExpNewTxChan <- &explorer.NewMempoolTx{
+	case NtfnChans.ExpNewTxChan <- &exptypes.NewMempoolTx{
 		Hex: "",
 	}:
 	default:
@@ -367,7 +367,7 @@ func MakeNodeNtfnHandlers() (*rpcclient.NotificationHandlers, *collectionQueue) 
 		OnTxAcceptedVerbose: func(txDetails *dcrjson.TxRawResult) {
 
 			select {
-			case NtfnChans.ExpNewTxChan <- &explorer.NewMempoolTx{
+			case NtfnChans.ExpNewTxChan <- &exptypes.NewMempoolTx{
 				Time: time.Now().Unix(),
 				Hex:  txDetails.Hex,
 			}:

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -4,11 +4,10 @@
     {{ template "html-head" printf "Decred Chain Parameters"}}
     <body class="{{ theme }}">
         {{template "navbar" . }}
-        {{with .Cp}}
         <div class="container main">
             <div class="row justify-content-between">
                 <div class="col-md-7 col-sm-6 d-flex">
-                    <h4 class="mb-2">Parameters for Decred {{$.ChainParams.Name}}
+                    <h4 class="mb-2">Parameters for Decred {{.ChainParams.Name}}
                       <span class="fs12" >
                         from <a href="https://github.com/decred/dcrd/blob/master/chaincfg/params.go">chaincfg/params.go</a>
                       </span>
@@ -27,8 +26,8 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{$.ChainParams.GenesisHash}}">GenesisBlock</a></td>
-                                <td class="mono">{{$.ChainParams.GenesisBlock.Header.Height}}</td>
+                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{.ChainParams.GenesisHash}}">GenesisBlock</a></td>
+                                <td class="mono">{{.ChainParams.GenesisBlock.Header.Height}}</td>
                                 <td>First block of the chain</td>
                             </tr>
                             <tr>
@@ -38,67 +37,67 @@
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">PowLimitBits</td>
-                                <td class="mono">{{$.ChainParams.PowLimitBits}} bits</td>
+                                <td class="mono">{{.ChainParams.PowLimitBits}} bits</td>
                                 <td>Highest allowed proof of work value for a block in compact form</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">ReduceMinDifficulty</td>
-                                <td class="mono">{{$.ChainParams.ReduceMinDifficulty}}</td>
+                                <td class="mono">{{.ChainParams.ReduceMinDifficulty}}</td>
                                 <td>Whether the network should reduce the minimum required difficulty after a long enough period of time has passed without finding a block</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MinDiffReductionTime</td>
-                                <td class="mono">{{$.ChainParams.MinDiffReductionTime}}</td>
+                                <td class="mono">{{.ChainParams.MinDiffReductionTime}}</td>
                                 <td>Amount of time after which the minimum required difficulty should be reduced when a block hasn't been found</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">GenerateSupported</td>
-                                <td class="mono">{{$.ChainParams.GenerateSupported}}</td>
+                                <td class="mono">{{.ChainParams.GenerateSupported}}</td>
                                 <td>Whether or not CPU mining is allowed</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MaximumBlockSize</td>
-                                <td class="mono">{{.MaximumBlockSize}} bytes</td>
+                                <td class="mono">{{.ExtendedParams.MaximumBlockSize}} bytes</td>
                                 <td>Maximum size of a block that can be generated on the network</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MaxTxSize</td>
-                                <td class="mono">{{$.ChainParams.MaxTxSize}} bytes</td>
+                                <td class="mono">{{.ChainParams.MaxTxSize}} bytes</td>
                                 <td>Largest allowable transaction size</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">WorkDiffAlpha</td>
-                                <td class="mono">{{$.ChainParams.WorkDiffAlpha}}</td>
+                                <td class="mono">{{.ChainParams.WorkDiffAlpha}}</td>
                                 <td>Stake difficulty EMA calculation alpha (smoothing) value</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">WorkDiffWindowSize</td>
-                                <td class="mono">{{$.ChainParams.WorkDiffWindowSize}} blocks</td>
+                                <td class="mono">{{.ChainParams.WorkDiffWindowSize}} blocks</td>
                                 <td>Number of windows (intervals) used for calculation of the exponentially weighted average</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">WorkDiffWindows</td>
-                                <td class="mono">{{$.ChainParams.WorkDiffWindows}}</td>
+                                <td class="mono">{{.ChainParams.WorkDiffWindows}}</td>
                                 <td>Number of windows (intervals) used for calculation of the exponentially weighted average</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TargetTimespan</td>
-                                <td class="mono">{{TimeDurationFormat $.ChainParams.TargetTimespan}}</td>
+                                <td class="mono">{{TimeDurationFormat .ChainParams.TargetTimespan}}</td>
                                 <td>Amount of time that should elapse before the block difficulty requirement is examined to determine how it should be changed in order to maintain the desired block generation rate</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TargetTimePerBlock</td>
-                                <td class="mono">{{TimeDurationFormat $.ChainParams.TargetTimePerBlock}}</td>
+                                <td class="mono">{{TimeDurationFormat .ChainParams.TargetTimePerBlock}}</td>
                                 <td>The desired amount of time to generate each block</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">RetargetAdjustmentFactor</td>
-                                <td class="mono">{{$.ChainParams.RetargetAdjustmentFactor}}</td>
+                                <td class="mono">{{.ChainParams.RetargetAdjustmentFactor}}</td>
                                 <td>Adjustment factor used to limit the minimum and maximum amount of adjustment that can occur between difficulty retargets</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">AcceptNonStdTxs</td>
-                                <td class="mono">{{$.ChainParams.AcceptNonStdTxs}}</td>
+                                <td class="mono">{{.ChainParams.AcceptNonStdTxs}}</td>
                                 <td>Mempool param to either accept and relay non standard txs to the network or reject them</td>
                             </tr>
                         </tbody>
@@ -114,7 +113,7 @@
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">BaseSubsidy</td>
                                 <td class="mono fs13">
-                                    <span class="rm-spacing">{{template "decimalParts" (amountAsDecimalParts $.ChainParams.BaseSubsidy true)}}
+                                    <span class="rm-spacing">{{template "decimalParts" (amountAsDecimalParts .ChainParams.BaseSubsidy true)}}
                                     <span class="pl-1 unit lh15rem">DCR</span>
                                     </span>
                                 </td>
@@ -122,32 +121,32 @@
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MulSubsidy</td>
-                                <td class="mono">{{$.ChainParams.MulSubsidy}}</td>
+                                <td class="mono">{{.ChainParams.MulSubsidy}}</td>
                                 <td>Subsidy reduction multiplier</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">DivSubsidy</td>
-                                <td class="mono">{{$.ChainParams.DivSubsidy}}</td>
+                                <td class="mono">{{.ChainParams.DivSubsidy}}</td>
                                 <td>Subsidy reduction divisor</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">SubsidyReductionInterval</td>
-                                <td class="mono">{{$.ChainParams.SubsidyReductionInterval}} blocks</td>
+                                <td class="mono">{{.ChainParams.SubsidyReductionInterval}} blocks</td>
                                 <td>Reduction interval in blocks</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">WorkRewardProportion</td>
-                                <td class="mono">{{uint16Mul $.ChainParams.WorkRewardProportion 10}}%</td>
+                                <td class="mono">{{uint16Mul .ChainParams.WorkRewardProportion 10}}%</td>
                                 <td>Comparative amount of the subsidy given for creating a block</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeRewardProportion</td>
-                                <td class="mono">{{uint16Mul $.ChainParams.StakeRewardProportion 10}}%</td>
+                                <td class="mono">{{uint16Mul .ChainParams.StakeRewardProportion 10}}%</td>
                                 <td>Comparative amount of the subsidy given for casting stake votes (collectively, per block)</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">BlockTaxProportion</td>
-                                <td class="mono">{{uint16Mul $.ChainParams.BlockTaxProportion 10}}%</td>
+                                <td class="mono">{{uint16Mul .ChainParams.BlockTaxProportion 10}}%</td>
                                 <td>Inverse of the percentage of funds for each block to allocate to the developer organization</td>
                             </tr>
                         </tbody>
@@ -162,92 +161,92 @@
                         <tbody>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MinimumStakeDiff</td>
-                                <td class="mono">{{template "decimalParts" (amountAsDecimalParts $.ChainParams.MinimumStakeDiff true)}} DCR</td>
+                                <td class="mono">{{template "decimalParts" (amountAsDecimalParts .ChainParams.MinimumStakeDiff true)}} DCR</td>
                                 <td>Minimum amount of Atoms required to purchase a stake ticket</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TicketPoolSize</td>
-                                <td class="mono">{{$.ChainParams.TicketPoolSize}} ({{.ActualTicketPoolSize}} actual)</td>
+                                <td class="mono">{{.ChainParams.TicketPoolSize}} ({{.ExtendedParams.ActualTicketPoolSize}} actual)</td>
                                 <td>Target size of ticket pool. (actual ticket count = TicketPoolSize x TicketsPerBlock)</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TicketsPerBlock</td>
-                                <td class="mono">{{$.ChainParams.TicketsPerBlock}}</td>
+                                <td class="mono">{{.ChainParams.TicketsPerBlock}}</td>
                                 <td>Average number of tickets per block for Decred PoS</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TicketMaturity</td>
-                                <td class="mono">{{$.ChainParams.TicketMaturity}} blocks</td>
+                                <td class="mono">{{.ChainParams.TicketMaturity}} blocks</td>
                                 <td>Number of blocks for tickets to mature</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TicketExpiry</td>
-                                <td class="mono">{{$.ChainParams.TicketExpiry}} blocks</td>
+                                <td class="mono">{{.ChainParams.TicketExpiry}} blocks</td>
                                 <td>Number of blocks for tickets to expire after they have matured</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">CoinbaseMaturity</td>
-                                <td class="mono">{{$.ChainParams.CoinbaseMaturity}} blocks</td>
+                                <td class="mono">{{.ChainParams.CoinbaseMaturity}} blocks</td>
                                 <td>Number of blocks required before newly mined coins (coinbase transactions) can be spent</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">SStxChangeMaturity</td>
-                                <td class="mono">{{$.ChainParams.SStxChangeMaturity}} blocks</td>
+                                <td class="mono">{{.ChainParams.SStxChangeMaturity}} blocks</td>
                                 <td>Maturity for spending SStx change outputs</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TicketPoolSizeWeight</td>
-                                <td class="mono">{{$.ChainParams.TicketPoolSizeWeight}}</td>
+                                <td class="mono">{{.ChainParams.TicketPoolSizeWeight}}</td>
                                 <td>Multiplicative weight applied to the ticket pool size difference between a window period and its target when determining the stake system</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeDiffAlpha</td>
-                                <td class="mono">{{$.ChainParams.StakeDiffAlpha}}</td>
+                                <td class="mono">{{.ChainParams.StakeDiffAlpha}}</td>
                                 <td>stake difficulty EMA calculation alpha (smoothing) value</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeDiffWindowSize</td>
-                                <td class="mono">{{$.ChainParams.StakeDiffWindowSize}} blocks</td>
+                                <td class="mono">{{.ChainParams.StakeDiffWindowSize}} blocks</td>
                                 <td>Number of blocks used for each interval in exponentially weighted average</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeDiffWindows</td>
-                                <td class="mono">{{$.ChainParams.StakeDiffWindows}} windows</td>
+                                <td class="mono">{{.ChainParams.StakeDiffWindows}} windows</td>
                                 <td>Number of windows (intervals) used for calculation of the exponentially weighted average</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeVersionInterval</td>
-                                <td class="mono">{{$.ChainParams.StakeVersionInterval}} blocks</td>
+                                <td class="mono">{{.ChainParams.StakeVersionInterval}} blocks</td>
                                 <td>Interval where the stake version is calculated</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">MaxFreshStakePerBlock</td>
-                                <td class="mono">{{$.ChainParams.MaxFreshStakePerBlock}} tickets</td>
+                                <td class="mono">{{.ChainParams.MaxFreshStakePerBlock}} tickets</td>
                                 <td>Maximum number of new tickets that may be submitted per block</td>
                             </tr>
                             <tr>
-                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{$.ChainParams.StakeEnabledHeight}}">StakeEnabledHeight</a></td>
-                                <td class="mono">{{$.ChainParams.StakeEnabledHeight}}</td>
+                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{.ChainParams.StakeEnabledHeight}}">StakeEnabledHeight</a></td>
+                                <td class="mono">{{.ChainParams.StakeEnabledHeight}}</td>
                                 <td>Height in which the first ticket could possibly mature</td>
                             </tr>
                             <tr>
-                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{$.ChainParams.StakeValidationHeight}}">StakeValidationHeight</a></td>
-                                <td class="mono">{{$.ChainParams.StakeValidationHeight}}</a></td>
+                                <td class="mono text-left pr-2 nowrap p03rem0"><a href="/block/{{.ChainParams.StakeValidationHeight}}">StakeValidationHeight</a></td>
+                                <td class="mono">{{.ChainParams.StakeValidationHeight}}</a></td>
                                 <td>Height at which votes (SSGen) are required to add a new block to the top of the blockchain</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeBaseSigScript</td>
-                                <td class="mono">{{convertByteArrayToString $.ChainParams.StakeBaseSigScript}}</td>
+                                <td class="mono">{{convertByteArrayToString .ChainParams.StakeBaseSigScript}}</td>
                                 <td>Consensus stakebase signature script for all votes on the network</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeMajorityMultiplier</td>
-                                <td class="mono">{{$.ChainParams.StakeMajorityMultiplier}}</td>
+                                <td class="mono">{{.ChainParams.StakeMajorityMultiplier}}</td>
                                 <td>Calculate the super majority of stake votes using integer math</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">StakeMajorityDivisor</td>
-                                <td class="mono">{{$.ChainParams.StakeMajorityDivisor}}</td>
+                                <td class="mono">{{.ChainParams.StakeMajorityDivisor}}</td>
                                 <td>Calculate the super majority of stake votes using integer math</td>
                             </tr>
                         </tbody>
@@ -262,37 +261,37 @@
                         <tbody>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">RuleChangeActivationQuorum</td>
-                                <td class="mono">{{$.ChainParams.RuleChangeActivationQuorum}}</td>
+                                <td class="mono">{{.ChainParams.RuleChangeActivationQuorum}}</td>
                                 <td>Number of votes required for a vote to take effect</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">RuleChangeActivationMultiplier</td>
-                                <td class="mono">{{$.ChainParams.RuleChangeActivationMultiplier}}</td>
+                                <td class="mono">{{.ChainParams.RuleChangeActivationMultiplier}}</td>
                                 <td></td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">RuleChangeActivationDivisor</td>
-                                <td class="mono">{{$.ChainParams.RuleChangeActivationDivisor}}</td>
+                                <td class="mono">{{.ChainParams.RuleChangeActivationDivisor}}</td>
                                 <td></td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">RuleChangeActivationInterval</td>
-                                <td class="mono">{{$.ChainParams.RuleChangeActivationInterval}} blocks</td>
+                                <td class="mono">{{.ChainParams.RuleChangeActivationInterval}} blocks</td>
                                 <td>Number of blocks in each threshold state retarget window</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">BlockEnforceNumRequired</td>
-                                <td class="mono">{{$.ChainParams.BlockEnforceNumRequired}} blocks</td>
+                                <td class="mono">{{.ChainParams.BlockEnforceNumRequired}} blocks</td>
                                 <td>Enforce current block version once network has upgraded</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">BlockRejectNumRequired</td>
-                                <td class="mono">{{$.ChainParams.BlockRejectNumRequired}} blocks</td>
+                                <td class="mono">{{.ChainParams.BlockRejectNumRequired}} blocks</td>
                                 <td>Reject previous block versions once network has upgraded</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">BlockUpgradeNumToCheck</td>
-                                <td class="mono">{{$.ChainParams.BlockUpgradeNumToCheck}} blocks</td>
+                                <td class="mono">{{.ChainParams.BlockUpgradeNumToCheck}} blocks</td>
                                 <td>The number of nodes to check</td>
                             </tr>
                         </tbody>
@@ -307,24 +306,21 @@
                         <tbody>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">NetworkAddressPrefix</td>
-                                <td class="mono">{{$.ChainParams.NetworkAddressPrefix}}</td>
+                                <td class="mono">{{.ChainParams.NetworkAddressPrefix}}</td>
                                 <td>First letter of the network for any given address encoded as a string</td>
                             </tr>
-                            {{range $i, $v := .AddressPrefix}}
-                            {{with $v}}
+                            {{range $i, $v := .ExtendedParams.AddressPrefix}}
                             <tr>
-                                <td class="mono text-left pr-2 nowrap p03rem0">{{.Name}}</td>
-                                <td class="mono">{{.Prefix}}</td>
-                                <td class="mono">{{.Description}}</td>
+                                <td class="mono text-left pr-2 nowrap p03rem0">{{$v.Name}}</td>
+                                <td class="mono">{{$v.Prefix}}</td>
+                                <td class="mono">{{$v.Description}}</td>
                             </tr>
-                            {{end}}
                             {{end}}
                         </tbody>
                     </table>
                 </div>
             </div>
         </div>
-        {{end}}
         {{ template "footer" . }}
     </body>
 </html>


### PR DESCRIPTION
Note: this builds on a commit from @buck54321 in his PR https://github.com/decred/dcrdata/pull/845 so that this can integrate more easily.

This moves several types and functions to explorer/types (new package).
CommonPageData and all expStatus values are moved to explorerroutes.go

Export `wiredDB` -> `WiredDB`.

Views folder is now an argument to `explorer.New`.

Refactor sync status page coordination (ideally a separate PR, but it's tied pretty tightly now):
- Move sync status functions into new syncstatus.go
- two nil channels initially (`barLoad` and `latestBlockHash`)
- `explore.BeginSyncStatusUpdates` function takes `barLoad`
- Anonymous goroutine in main takes `latestBlockHash`
- Eliminate several unneeded functions
- One DB's sync function gets the non-nil channels
- Non-nil channels closed in `main` after first sync completes
- Both `WebsocketHub` and `explorerUI` now have a `dbsSyncing` `atomic.Value` with accessors.
- Create `sendProgressUpdate` and `sendPageData` closures in both `WiredDB.resyncDB` and
  `ChainDB.SyncChainDB` which handle the sends on (either) `barLoad` or `latestBlockHash`.

Add explorerroutes_test.go, with a basic test of the explorerUI.StatusPage handler.