### PR TITLE
pause Mousetrap on init if keynav is inactive

### DIFF
--- a/public/js/services/keyboard_navigation_service.js
+++ b/public/js/services/keyboard_navigation_service.js
@@ -139,7 +139,11 @@ Mousetrap.bind('q', function () {
   clearTargets()
 })
 
-if (keyNavEnabled()) Mousetrap.unpause()
+if (keyNavEnabled()) {
+  Mousetrap.unpause()
+} else {
+  Mousetrap.pause()
+}
 
 $('#keynav-toggle .text').text(keyNavEnabled() ? 'Disable Hot Keys' : 'Enable Hot Keys')
 document.addEventListener('turbolinks:load', function (e) {


### PR DESCRIPTION
* call Moustrap.pause() when initializing keyboard navigation service.

Fixes the current problems of bindings executing when they shouldn't:
<img width="721" alt="screen shot 2018-12-17 at 1 43 01 am" src="https://user-images.githubusercontent.com/25571523/50078955-26906000-019d-11e9-9247-f44dcb8f1dec.png">
