### PR TITLE
[3.1.1] Change mempool last block age controller back to main

### DIFF
--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -27,7 +27,7 @@
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">LAST BLOCK</td>
-                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a><span class="jsonly"> (<span data-target="mempool.bestBlockTime  time.age" data-age="{{.LastBlockTime}}"></span> ago)</span></td>
+                            <td class="lh1rem"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a><span class="jsonly"> (<span data-target="mempool.bestBlockTime main.age" data-age="{{.LastBlockTime}}"></span> ago)</span></td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">VOTES</td>


### PR DESCRIPTION
Resolves issue #889.

This resolves the last block age not functioning on the /mempool page.

With 3.1.0 release, the age was not working:

![image](https://user-images.githubusercontent.com/9373513/50103251-d8a34880-01ec-11e9-9c0a-878b7525ea26.png)

This restores the correct Stimulus.js controller for the 3.1 branch.

![image](https://user-images.githubusercontent.com/9373513/50113298-1d3bdd80-0207-11e9-8367-890d61dc1dc8.png)
