### PR TITLE
Increase time for websocket timeout to fix chart loading issue

### DIFF
--- a/explorer/websocket.go
+++ b/explorer/websocket.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	wsWriteTimeout = 10 * time.Second
-	wsReadTimeout  = 12 * time.Second
-	pingInterval   = 8 * time.Second
+	wsReadTimeout  = 60 * time.Second
+	pingInterval   = 60 * time.Second
 
 	tickerSigReset int = iota
 	tickerSigStop

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -469,8 +469,10 @@ export default class extends Controller {
       type: 'GET',
       url: '/api/address/' + ctrl.dcrAddress + '/' + chartKey + '/' + bin,
       complete: () => {
-        ctrl.chartboxTarget.classList.remove('loading')
         ctrl.ajaxing = false
+      },
+      error: () => {
+        ctrl.chartboxTarget.classList.remove('loading')
       },
       success: (data) => {
         ctrl.processData(chart, bin, data)
@@ -538,6 +540,7 @@ export default class extends Controller {
     if (chart === 'amountflow') {
       ctrl.updateFlow()
     }
+    ctrl.chartboxTarget.classList.remove('loading')
     ctrl.xRange = ctrl.graph.xAxisExtremes()
     ctrl.validateZoom(binSize)
   }


### PR DESCRIPTION
Processing the treasury block-binned chart data was taking longer that the websocket ping timeout, resulting in a dropped websocket connection. I've increased both the ping interval and the `wsReadTimeout` to 1 minute. 

The `jQuery.ajax` complete callback was also being fired before the data had processed, so I moved the removal of the 'loading' CSS class to accommodate.