### PR TITLE
Removed multiply by 1000 on a formatted date string. #876

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -44,7 +44,7 @@ function sleep (ms) {
 
 // `formatTxDate`: Format a string to match the format `(UTC) YYYY-MM-DD HH:MM:SS` used by explorer.TxPage and tx.tmpl
 function formatTxDate (stamp, withTimezone) {
-  var d = new Date(stamp * 1000)
+  var d = new Date(stamp)
   var zone = withTimezone ? '(' + d.toLocaleTimeString('en-us', { timeZoneName: 'short' }).split(' ')[2] + ') ' : ''
   return zone + String(d.getFullYear()) + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0') + ' ' +
         String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0') + ':' + String(d.getSeconds()).padStart(2, '0')


### PR DESCRIPTION
This is for issue #876.