### PR TITLE
api: total fees and total sent for a block

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -63,7 +63,7 @@ type DataSourceLite interface {
 	GetStakeDiffEstimates() *apitypes.StakeDiff
 	//GetBestBlock() *blockdata.BlockData
 	GetSummary(idx int) *apitypes.BlockDataBasic
-	GetSummaryByHash(hash string) *apitypes.BlockDataBasic
+	GetSummaryByHash(hash string, withTxTotals bool) *apitypes.BlockDataBasic
 	GetBestBlockSummary() *apitypes.BlockDataBasic
 	GetBlockSize(idx int) (int32, error)
 	GetBlockSizeRange(idx0, idx1 int) ([]int32, error)
@@ -363,7 +363,10 @@ func (c *appContext) getBlockSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockSummary := c.BlockData.GetSummaryByHash(hash)
+	txTotalsParam := r.URL.Query().Get("txtotals")
+	withTxTotals := txTotalsParam == "1" || strings.EqualFold(txTotalsParam, "true")
+
+	blockSummary := c.BlockData.GetSummaryByHash(hash, withTxTotals)
 	if blockSummary == nil {
 		apiLog.Errorf("Unable to get block %s summary", hash)
 		http.Error(w, http.StatusText(422), 422)

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -305,15 +305,17 @@ type TicketPoolValsAndSizes struct {
 	Size        []float64 `json:"size"`
 }
 
-// BlockDataBasic models primary information about block at height Height
+// BlockDataBasic models primary information about a block.
 type BlockDataBasic struct {
-	Height     uint32  `json:"height,omitemtpy"`
-	Size       uint32  `json:"size,omitemtpy"`
-	Hash       string  `json:"hash,omitemtpy"`
-	Difficulty float64 `json:"diff,omitemtpy"`
-	StakeDiff  float64 `json:"sdiff,omitemtpy"`
-	Time       TimeAPI `json:"time,omitemtpy"`
-	NumTx      uint32  `json:"txlength,omitempty"`
+	Height     uint32  `json:"height"`
+	Size       uint32  `json:"size"`
+	Hash       string  `json:"hash"`
+	Difficulty float64 `json:"diff"`
+	StakeDiff  float64 `json:"sdiff"`
+	Time       TimeAPI `json:"time"`
+	NumTx      uint32  `json:"txlength"`
+	MiningFee  *int64  `json:"fees,omitempty"`
+	TotalSent  *int64  `json:"total_sent,omitempty"`
 	// TicketPoolInfo may be nil for side chain blocks.
 	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`
 }

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -682,8 +682,11 @@ func (db *WiredDB) GetSummaryByHash(hash string, withTxTotals bool) *apitypes.Bl
 				log.Errorf("Unable to decode transaction: %v", err)
 				return nil
 			}
-			fee, _ := txhelpers.TxFeeRate(msgTx)
-			totalFees += fee
+			// Do not compute fee for coinbase transaction.
+			if !data.RawTx[i].Vin[0].IsCoinBase() {
+				fee, _ := txhelpers.TxFeeRate(msgTx)
+				totalFees += fee
+			}
 			totalOut += txhelpers.TotalOutFromMsgTx(msgTx)
 		}
 		for i := range data.RawSTx {


### PR DESCRIPTION
This adds to total fees and total sent for a block to the API.

The following endpoints now have at total sent and total fees:
- /block/best
- /block/hash/{hash}
- /block/{idx}

The block range endpoints do not have these new fields.

The fields are omitted by default.  They must be requested with the txtotals URL query parameter, as in:

/api/block/303111?txtotals=true

```json
{
   "height": 303111,
   "size": 8846,
   "hash": "00000000000000001d2f9f9712c3e51717368a6768da8ef46080545ac13b57b4",
   "diff": 9876723357.051346,
   "sdiff": 107.10317865,
   "time": 1545537182,
   "txlength": 0,
   "fees": 611162,
   "total_sent": 240672707327,
   "ticket_pool": {
      "height": 0,
      "size": 41128,
      "value": 4218846.64176546,
      "valavg": 102.57845365117342,
      "winners": [
         "a2bc39293435b7b7fa75f18054ddfe9e7a954310ff7aa7cc2d20eb12f54e97fe",
         "3e7e70f4675fb29c422f5a1c16c353fa3f3c2aefd1d33d7d9eb799c18faae532",
         "fbc52abfcf04f9a6fd6ea503d6951c9b28d60fa537dead6cd81a4ba5f2f672ef",
         "1ad3b6150a602221a3a0c9dbf0ef88eff354f56bb6c6a9cf1537d6c4af5b0639",
         "41aa9bf0fa6aad7b18292b33a9e2d78f5b55cae07c8725f9035a130e16dec817"
      ]
   }
}
```