### PR TITLE
fix broken path to x axis (timestr => time) in txPerDayFunc

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -99,7 +99,7 @@ function txPerBlockFunc (gData) {
 }
 
 function txPerDayFunc (gData) {
-  return map(gData.timestr, (n, i) => { return [new Date(n), gData.count[i]] })
+  return map(gData.time, (n, i) => { return [new Date(n), gData.count[i]] })
 }
 
 function poolSizeFunc (gData) {


### PR DESCRIPTION
* fix broken path for x-axis in transactions per day chart by changing `timestr` to `time` in txPerDayFunc