### PR TITLE
CSV download link specifies line endings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2018, The Decred developers
+Copyright (c) 2018-2019, The Decred developers
 Copyright (c) 2017, Jonathan Chappelow
 Copyright (c) 2017, The dcrdata developers
 Copyright (c) 2015-2016 The Decred developers

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1159,10 +1159,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	// AddressPageData is the data structure passed to the HTML template
 	type AddressPageData struct {
 		*CommonPageData
-		Data       *dbtypes.AddressInfo
-		NetName    string
-		IsLiteMode bool
-		ChartData  *dbtypes.ChartsData
+		Data         *dbtypes.AddressInfo
+		NetName      string
+		IsLiteMode   bool
+		ChartData    *dbtypes.ChartsData
+		CRLFDownload bool
 	}
 
 	// Grab the URL query parameters
@@ -1240,12 +1241,17 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	addrData.IsDummyAddress = isZeroAddress // may be redundant
 	addrData.Path = r.URL.Path
 
+	// For Windows clients only, link to downloads with CRLF (\r\n) line
+	// endings.
+	UseCRLF := strings.Contains(r.UserAgent(), "Windows")
+
 	// Execute the HTML template.
 	pageData := AddressPageData{
 		CommonPageData: exp.commonData(),
 		Data:           addrData,
 		IsLiteMode:     exp.liteMode,
 		NetName:        exp.NetName,
+		CRLFDownload:   UseCRLF,
 	}
 	str, err := exp.templates.execTemplateToString("address", pageData)
 	if err != nil {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -166,7 +166,7 @@
                   <div
                       class="d-flex align-items-center justify-content-between"
                   >
-                    {{if gt $TxnCount 0}}<a class="d-inline-block p-2 rounded download" href="/download/address/io/{{.Address}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>{{end}}
+                    {{if gt $TxnCount 0}}<a class="d-inline-block p-2 rounded download" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>{{end}}
                     <!-- This dummy span ensures left/right alignment of the buttons, even if one is hidden -->
                     <span> </span>
                     <div class="d-inline-block">


### PR DESCRIPTION
Instead of the API's CSV download handler inspecting the user agent,
use a URL query parameter (cr=true) to request a CSV file with CRLF line
endings.
The address page handler inspects the user agent and generates the
appropriate API endpoint link.

> "GET http://127.0.0.1:7777/download/address/io/DcZKvuV4BDMpit1ppCXTyyHwuRU8G7nNVKV HTTP/1.1" from 127.0.0.1:43506 - 200 436140B in 9.772752ms
"GET http://127.0.0.1:7777/download/address/io/DcZKvuV4BDMpit1ppCXTyyHwuRU8G7nNVKV?cr=true HTTP/1.1" from 127.0.0.1:43528 - 200 438790B in 10.949158ms
