### PR TITLE
npm: address webpack-dev-server vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack": "^4.26.1",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10",
+    "webpack-dev-server": "^3.1.14",
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {


### PR DESCRIPTION
This avoids a vulnerability of in versions of webpack-dev-server prior
to 3.1.11 in which origin validation is missing. The vulnerability
allows source code to be accessed remotely when running `npm run watch`
(not done in production). For dcrdata, which is an open source project, this
is a minor issue or non-issue.

Ref: https://www.npmjs.com/advisories/725

This resolves the issue by updating webpack-dev-server in
devDependencies to ^3.1.14 from ^3.1.10.