### PR TITLE
views/home: remove extra white space

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -151,21 +151,16 @@
 </footer>
 {{end}}
 
-{{define "decimalParts"}}
-  <div class="decimal-parts d-inline-block">
-    {{if eq (len .) 4}}
-        <span class="int">{{ index . 0 }}.{{ index . 1 }}</span
-        >{{if gt (len (index . 2)) 0}}<span class="decimal">{{ index . 2 }}</span
-        ><span class="decimal trailing-zeroes">{{ index . 3 }}</span>{{end}}
-    {{else}}
-        <span class="int">{{index . 0}}</span
-        >{{if gt (len (index . 1)) 0}}<span class="decimal dot">.</span
-        ><span class="decimal">{{index . 1 }}</span
-        ><span class="decimal trailing-zeroes">{{index . 2}}</span>
-        {{end}}
-    {{end}}
-  </div
->{{end}}
+{{define "decimalParts"}}<div class="decimal-parts d-inline-block">{{if eq (len .) 4}}
+    <span class="int">{{ index . 0 }}.{{ index . 1 }}</span
+    >{{if gt (len (index . 2)) 0}}<span class="decimal">{{ index . 2 }}</span
+    ><span class="decimal trailing-zeroes">{{ index . 3 }}</span>{{end}}
+{{else}}
+    <span class="int">{{index . 0}}</span
+    >{{if gt (len (index . 1)) 0}}<span class="decimal dot">.</span
+    ><span class="decimal">{{index . 1 }}</span
+    ><span class="decimal trailing-zeroes">{{index . 2}}</span>{{end}}
+{{end}}</div>{{end}}
 
 {{define "fmtPercentage"}}
     {{if gt . 0.0}}<span style="color:green">+{{printf "%.2f" .}} %</span>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -48,7 +48,7 @@
                             <td>
                                 <div class="mono lh1rem p03rem0 fs14-decimal">
                                     <span class="fs24 font-weight-bold d-inline-block">
-                                        {{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 8 false)}}<span class="pl-1 unit font-weight-bold lh15rem">DCR</span></span>, <span class="fs18" style="line-height:1.3rem;">bounds: [{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}, {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}]</span>
+                                        {{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 8 false)}}<span class="pl-1 unit font-weight-bold lh15rem">DCR</span></span>, <span class="fs18" style="line-height:1.3rem;">bounds: [{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}},&hairsp;{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}]</span>
                                 </div>
                             </td>
                         </tr>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -47,8 +47,8 @@
                             <td class="text-right pr-2 lh1rem pt-1 pb-1">NEXT TICKET PRICE ESTIMATE</td>
                             <td>
                                 <div class="mono lh1rem p03rem0 fs14-decimal">
-                                    <span class="fs24 font-weight-bold d-inline-block">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 8 false)}}<span class="pl-1 unit font-weight-bold lh15rem">DCR</span></span>, <span class="fs18" style="line-height:1.3rem;">&nbsp;bounds: [
-                                        {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}, {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}]</span>
+                                    <span class="fs24 font-weight-bold d-inline-block">
+                                        {{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 8 false)}}<span class="pl-1 unit font-weight-bold lh15rem">DCR</span></span>, <span class="fs18" style="line-height:1.3rem;">bounds: [{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}, {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}]</span>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
This removes unwanted white space in the `"decimalFormat"` html template and in the formatting of the `NEXT TICKET PRICE ESTIMATE` values on the home page.

Before:

![image](https://user-images.githubusercontent.com/9373513/50647134-b0298700-0f2c-11e9-928e-52c6da3bbb1e.png)


After:

![image](https://user-images.githubusercontent.com/9373513/50647144-b3247780-0f2c-11e9-9220-161263234f15.png)

This may have snuck in with https://github.com/decred/dcrdata/pull/893.  The amount selection fix in PR #893 is preserved.