### PR TITLE
dcrpg: Add block deletion/purge queries and functions.

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,6 +102,8 @@ type config struct {
 	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)." env:"DCRDATA_SQLITE_DB_FILE_NAME"`
 	AgendaDBFileName   string `long:"agendadbfile" description:"Agenda DB file name (default is agendas.db)." env:"DCRDATA_AGENDA_DB_FILE_NAME"`
 
+	PurgeNBestBlocks int `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
+
 	FullMode       bool          `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support" env:"DCRDATA_ENABLE_FULL_MODE"`
 	PGDBName       string        `long:"pgdbname" description:"PostgreSQL DB name." env:"DCRDATA_PG_DB_NAME"`
 	PGUser         string        `long:"pguser" description:"PostgreSQL DB user." env:"DCRDATA_POSTGRES_USER"`
@@ -499,6 +501,11 @@ func loadConfig() (*config, error) {
 			return nil, fmt.Errorf("sync-status-limit should not be set to "+
 				"a value less than 2 or more than %d", maxSyncStatusLimit)
 		}
+	}
+
+	// Validate block purge options.
+	if cfg.PurgeNBestBlocks < 0 {
+		return nil, fmt.Errorf("purge-n-blocks must be non-negative")
 	}
 
 	// Set the host names and ports to the default if the user does not specify

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -362,6 +362,45 @@ func (p *VinTxPropertyARRAY) Scan(src interface{}) error {
 	return nil
 }
 
+// DeletionSummary provides the number of rows removed from the tables when a
+// block is removed.
+type DeletionSummary struct {
+	Blocks, Vins, Vouts, Addresses, Transactions, Tickets, Votes, Misses int64
+	Timings                                                              *DeletionSummary
+}
+
+// String makes a pretty summary of the totals.
+func (s DeletionSummary) String() string {
+	summary := fmt.Sprintf("\t%5d Blocks purged\n", s.Blocks)
+	summary = summary + fmt.Sprintf("\t%5d Vins purged\n", s.Vins)
+	summary = summary + fmt.Sprintf("\t%5d Vouts purged\n", s.Vouts)
+	summary = summary + fmt.Sprintf("\t%5d Addresses purged\n", s.Addresses)
+	summary = summary + fmt.Sprintf("\t%5d Transactions purged\n", s.Transactions)
+	summary = summary + fmt.Sprintf("\t%5d Tickets purged\n", s.Tickets)
+	summary = summary + fmt.Sprintf("\t%5d Votes purged\n", s.Votes)
+	summary = summary + fmt.Sprintf("\t%5d Misses purged", s.Misses)
+	return summary
+}
+
+// DeletionSummarySlice is used to define methods on DeletionSummary slices.
+type DeletionSummarySlice []DeletionSummary
+
+// Reduce returns a single DeletionSummary with the corresponding fields summed.
+func (ds DeletionSummarySlice) Reduce() DeletionSummary {
+	var s DeletionSummary
+	for i := range ds {
+		s.Blocks += ds[i].Blocks
+		s.Vins += ds[i].Vins
+		s.Vouts += ds[i].Vouts
+		s.Addresses += ds[i].Addresses
+		s.Transactions += ds[i].Transactions
+		s.Tickets += ds[i].Tickets
+		s.Votes += ds[i].Votes
+		s.Misses += ds[i].Misses
+	}
+	return s
+}
+
 // VinTxPropertyARRAY is a slice of VinTxProperty sturcts that implements
 // sql.Scanner and driver.Valuer.
 type VinTxPropertyARRAY []VinTxProperty

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -198,8 +198,9 @@ const (
 
 	SelectBlockChainRowIDByHash = `SELECT block_db_id FROM block_chain WHERE this_hash = $1;`
 
-	UpdateBlockNext       = `UPDATE block_chain SET next_hash = $2 WHERE block_db_id = $1;`
-	UpdateBlockNextByHash = `UPDATE block_chain SET next_hash = $2 WHERE this_hash = $1;`
+	UpdateBlockNext           = `UPDATE block_chain SET next_hash = $2 WHERE block_db_id = $1;`
+	UpdateBlockNextByHash     = `UPDATE block_chain SET next_hash = $2 WHERE this_hash = $1;`
+	UpdateBlockNextByNextHash = `UPDATE block_chain SET next_hash = $2 WHERE next_hash = $1;`
 
 	// Grab the timestamp and chainwork.
 	SelectChainWork = `SELECT time, chainwork FROM blocks WHERE is_mainchain = true ORDER BY time;`

--- a/db/dcrpg/internal/rewind.go
+++ b/db/dcrpg/internal/rewind.go
@@ -1,0 +1,161 @@
+package internal
+
+const (
+	// address row deletion by block hash
+
+	// DeleteAddresses deletes rows of the addresses table (funding and
+	// spending) corresponding to all of the transactions (regular and stake)
+	// for a given block.
+	DeleteAddresses = `DELETE FROM addresses
+		USING transactions, blocks
+		WHERE (
+				(addresses.tx_vin_vout_row_id=ANY(transactions.vin_db_ids) AND addresses.is_funding=false)
+				OR
+				(addresses.tx_vin_vout_row_id=ANY(transactions.vout_DB_IDs) AND addresses.is_funding=true)
+			)
+			AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+			AND blocks.hash=$1;`
+
+	DeleteStakeAddressesFunding = `DELETE FROM addresses
+		USING transactions, blocks
+		WHERE addresses.tx_vin_vout_row_id=ANY(transactions.vin_db_ids)
+			AND addresses.is_funding=false
+			AND transactions.id = ANY(blocks.stxdbids)
+			AND blocks.hash=$1;`
+
+	DeleteStakeAddressesSpending = `DELETE FROM addresses
+		USING transactions, blocks
+		WHERE addresses.tx_vin_vout_row_id=ANY(transactions.vout_DB_IDs)
+			AND addresses.is_funding=true
+			AND transactions.id = ANY(blocks.stxdbids)
+			AND blocks.hash=$1;`
+
+	// vin row deletion by block hash
+
+	DeleteVins = `DELETE FROM vins
+		USING transactions, blocks
+		WHERE vins.id=ANY(transactions.vin_db_ids)
+			AND transactions.id = ANY(array_cat(blocks.txdbids,blocks.stxdbids))
+			AND blocks.hash=$1;`
+
+	// DeleteStakeVins deletes rows of the vins table corresponding to inputs of
+	// the stake transactions (transactions.vin_db_ids) for a block
+	// (blocks.stxdbids) specified by its hash (blocks.hash).
+	DeleteStakeVins = `DELETE FROM vins
+		USING transactions, blocks
+		WHERE vins.id=ANY(transactions.vin_db_ids)
+			AND transactions.id = ANY(blocks.stxdbids)
+			AND blocks.hash=$1;`
+	// DeleteStakeVinsSubSelect is like DeleteStakeVins except it is implemented
+	// using sub-queries rather than a join.
+	DeleteStakeVinsSubSelect = `DELETE FROM vins
+		WHERE id IN (
+			SELECT UNNEST(vin_db_ids)
+			FROM transactions
+			WHERE id IN (
+				SELECT UNNEST(stxdbids)
+				FROM blocks
+				WHERE hash=$1
+				)
+			);`
+
+	// DeleteRegularVins deletes rows of the vins table corresponding to inputs
+	// of the regular/non-stake transactions (transactions.vin_db_ids) for a
+	// block (blocks.txdbids) specified by its hash (blocks.hash).
+	DeleteRegularVins = `DELETE FROM vins
+		USING transactions, blocks
+		WHERE vins.id=ANY(transactions.vin_db_ids)
+			AND transactions.id = ANY(blocks.txdbids)
+			AND blocks.hash=$1;`
+	// DeleteRegularVinsSubSelect is like DeleteRegularVins except it is
+	// implemented using sub-queries rather than a join.
+	DeleteRegularVinsSubSelect = `DELETE FROM vins
+		WHERE id IN (
+			SELECT UNNEST(vin_db_ids)
+			FROM transactions
+			WHERE id IN (
+				SELECT UNNEST(txdbids)
+				FROM blocks
+				WHERE hash=$1
+				)
+			);`
+
+	// vout row deletion by block hash
+
+	DeleteVouts = `DELETE FROM vouts
+		USING transactions, blocks
+		WHERE vouts.id=ANY(transactions.vout_db_ids)
+			AND transactions.id = ANY(array_cat(blocks.txdbids,blocks.stxdbids))
+			AND blocks.hash=$1;`
+
+	// DeleteStakeVouts deletes rows of the vouts table corresponding to inputs
+	// of the stake transactions (transactions.vout_db_ids) for a block
+	// (blocks.stxdbids) specified by its hash (blocks.hash).
+	DeleteStakeVouts = `DELETE FROM vouts
+		USING transactions, blocks
+		WHERE vouts.id=ANY(transactions.vout_db_ids)
+			AND transactions.id = ANY(blocks.stxdbids)
+			AND blocks.hash=$1;`
+	// DeleteStakeVoutsSubSelect is like DeleteStakeVouts except it is
+	// implemented using sub-queries rather than a join.
+	DeleteStakeVoutsSubSelect = `DELETE FROM vouts
+		WHERE id IN (
+			SELECT UNNEST(vout_db_ids)
+			FROM transactions
+			WHERE id IN (
+				SELECT UNNEST(stxdbids)
+				FROM blocks
+				WHERE hash=$1
+				)
+			);`
+
+	// DeleteRegularVouts deletes rows of the vouts table corresponding to
+	// inputs of the regular/non-stake transactions (transactions.vout_db_ids)
+	// for a block (blocks.txdbids) specified by its hash (blocks.hash).
+	DeleteRegularVouts = `DELETE FROM vouts
+		USING transactions, blocks
+		WHERE vouts.id=ANY(transactions.vout_db_ids)
+			AND transactions.id = ANY(blocks.txdbids)
+			AND blocks.hash=$1;`
+	// DeleteRegularVoutsSubSelect is like DeleteRegularVouts except it is
+	// implemented using sub-queries rather than a join.
+	DeleteRegularVoutsSubSelect = `DELETE FROM vouts
+		WHERE id IN (
+			SELECT UNNEST(vout_db_ids)
+			FROM transactions
+			WHERE id IN (
+				SELECT UNNEST(txdbids)
+				FROM blocks
+				WHERE hash=$1
+				)
+			);`
+
+	DeleteMisses = `DELETE FROM misses
+		WHERE block_hash=$1;`
+
+	DeleteVotes = `DELETE FROM votes
+		WHERE block_hash=$1;`
+
+	DeleteTickets = `DELETE FROM tickets
+		USING blocks
+		WHERE purchase_tx_db_id = ANY(blocks.stxdbids)
+			AND blocks.hash=$1;`
+	DeleteTicketsSimple = `DELETE FROM tickets
+		WHERE block_hash=$1;`
+
+	DeleteTransactions = `DELETE FROM transactions
+		USING blocks
+		WHERE transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+		AND blocks.hash=$1;`
+
+	DeleteBlock = `DELETE FROM blocks
+		WHERE hash=$1;`
+
+	DeleteBlockFromChain = `DELETE FROM block_chain
+		WHERE this_hash=$1
+		RETURNING prev_hash;`
+
+	ClearBlockChainNextHash = `UPDATE block_chain
+		SET next_hash=''
+		WHERE next_hash=$1;`
+)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1829,6 +1829,19 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 	return err
 }
 
+// PurgeBestBlocks deletes all data for the N best blocks in the DB.
+func (pgb *ChainDB) PurgeBestBlocks(N int64) (*dbtypes.DeletionSummary, int64, error) {
+	res, _, _, err := DeleteBlocks(N, pgb.db)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	summary := dbtypes.DeletionSummarySlice(res).Reduce()
+
+	height, err := pgb.HeightDB()
+	return &summary, int64(height), err
+}
+
 // TxHistoryData fetches the address history chart data for specified chart
 // type and time grouping.
 func (pgb *ChainDB) TxHistoryData(address string, addrChart dbtypes.HistoryChart,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1831,9 +1831,9 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 
 // PurgeBestBlocks deletes all data for the N best blocks in the DB.
 func (pgb *ChainDB) PurgeBestBlocks(N int64) (*dbtypes.DeletionSummary, int64, error) {
-	res, _, _, err := DeleteBlocks(N, pgb.db)
+	res, _, _, err := DeleteBlocks(pgb.ctx, N, pgb.db)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, pgb.replaceCancelError(err)
 	}
 
 	summary := dbtypes.DeletionSummarySlice(res).Reduce()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1831,14 +1831,13 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 
 // PurgeBestBlocks deletes all data for the N best blocks in the DB.
 func (pgb *ChainDB) PurgeBestBlocks(N int64) (*dbtypes.DeletionSummary, int64, error) {
-	res, _, _, err := DeleteBlocks(pgb.ctx, N, pgb.db)
+	res, height, _, err := DeleteBlocks(pgb.ctx, N, pgb.db)
 	if err != nil {
-		return nil, 0, pgb.replaceCancelError(err)
+		return nil, int64(height), pgb.replaceCancelError(err)
 	}
 
 	summary := dbtypes.DeletionSummarySlice(res).Reduce()
 
-	height, err := pgb.HeightDB()
 	return &summary, int64(height), err
 }
 

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -51,7 +51,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestDeleteBestBlock(t *testing.T) {
-	res, height, hash, err := DeleteBestBlock(db.db)
+	ctx := context.Background()
+	res, height, hash, err := DeleteBestBlock(ctx, db.db)
 	t.Logf("Deletion summary for block %d (%s): %v", height, hash, res)
 	if err != nil {
 		t.Errorf("Failed to delete best block data: %v", err)
@@ -83,8 +84,9 @@ func TestDeleteBlocks(t *testing.T) {
 	t.Logf("Initial best block %d (%s).", height0, hash0)
 
 	start := time.Now()
+	ctx := context.Background()
 
-	res, _, _, err := DeleteBlocks(N, db.db)
+	res, _, _, err := DeleteBlocks(ctx, N, db.db)
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,7 +94,7 @@ func TestDeleteBlocks(t *testing.T) {
 		t.Errorf("Expected to delete %d blocks; actually deleted %d.", N, len(res))
 	}
 
-	height, hash, _, err := RetrieveBestBlockHeight(context.Background(), db.db)
+	height, hash, _, err := RetrieveBestBlockHeight(ctx, db.db)
 	if err != nil {
 		t.Error(err)
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -37,6 +37,8 @@ type outputCountType int
 const (
 	outputCountByAllBlocks outputCountType = iota
 	outputCountByTicketPoolWindow
+
+	NotOneRowErrMsg = "failed to update exactly 1 row"
 )
 
 // Maintenance functions
@@ -3145,7 +3147,7 @@ func UpdateBlockNext(db SqlExecutor, blockDbID uint64, next string) error {
 		return err
 	}
 	if numRows != 1 {
-		return fmt.Errorf("UpdateBlockNext failed to update exactly 1 row (%d)", numRows)
+		return fmt.Errorf("%s (%d)", NotOneRowErrMsg, numRows)
 	}
 	return nil
 }
@@ -3162,7 +3164,7 @@ func UpdateBlockNextByHash(db SqlExecutor, this, next string) error {
 		return err
 	}
 	if numRows != 1 {
-		return fmt.Errorf("UpdateBlockNextByHash failed to update exactly 1 row (%d)", numRows)
+		return fmt.Errorf("%s (%d)", NotOneRowErrMsg, numRows)
 	}
 	return nil
 }
@@ -3179,7 +3181,7 @@ func UpdateBlockNextByNextHash(db SqlExecutor, currentNext, newNext string) erro
 		return err
 	}
 	if numRows != 1 {
-		return fmt.Errorf("UpdateBlockNextByNexHash failed to update exactly 1 row (%d)", numRows)
+		return fmt.Errorf("%s (%d)", NotOneRowErrMsg, numRows)
 	}
 	return nil
 }

--- a/db/dcrpg/rewind.go
+++ b/db/dcrpg/rewind.go
@@ -1,0 +1,179 @@
+package dcrpg
+
+// Deletion of all data for a certain block (identified by hash), is performed
+// using the following relationships:
+//
+// blocks -> hash identifies: votes, misses, tickets, transactions
+//        -> txdbids & stxdbids identifies: transactions
+//        -> use previous_hash to continue to parent block
+//
+// transactions -> vin_db_ids identifies: vins, addresses where is_funding=false
+//              -> vout_db_ids identifies vouts, addresses where is_funding=true
+//
+// tickets -> purchase_tx_db_id identifies the corresponding txn (but rows may
+//            be removed directly by block hash)
+//
+// addresses -> tx_vin_vout_row_id where is_funding=true corresponds to transactions.vout_db_ids
+//           -> tx_vin_vout_row_id where is_funding=false corresponds to transactions.vin_db_ids
+//
+// For example, REMOVAL of a block's data could be performed in the following
+// manner, where [] indicates primary key/row ID lookup:
+//	1. vin_DB_IDs = transactions[blocks.txdbids].vin_db_ids
+//	2. Remove vins[vin_DB_IDs]
+//	3. vout_DB_IDs = transactions[blocks.txdbids].vout_db_ids
+//	4. Remove vouts[vout_DB_IDs]
+//	5. Remove addresses WHERE tx_vin_vout_row_id=vout_DB_IDs AND is_funding=true
+//	6. Remove addresses WHERE tx_vin_vout_row_id=vin_DB_IDs AND is_funding=false
+//	7. Repeat 1-6 for blocks.stxdbids (instead of blocks.txdbids)
+//	8. Remove tickets where purchase_tx_db_id = blocks.stxdbids
+//	   OR Remove tickets by block_hash
+//	9. Remove votes by block_hash
+//	10. Remove misses by block_hash
+//	11. Remove transactions[txdbids] and transactions[stxdbids]
+//
+// Use DeleteBlockData to delete all data across these tables for a certain block.
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
+)
+
+func deleteMissesForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteMisses, "failed to delete misses", hash)
+}
+
+func deleteVotesForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteVotes, "failed to delete votes", hash)
+}
+
+func deleteTicketsForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteTickets, "failed to delete tickets", hash)
+}
+
+func deleteTransactionsForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteTransactions, "failed to delete transactions", hash)
+}
+
+func deleteVoutsForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteVouts, "failed to delete vouts", hash)
+}
+
+func deleteVinsForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteVins, "failed to delete vins", hash)
+}
+
+func deleteAddressesForBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteAddresses, "failed to delete addresses", hash)
+}
+
+func deleteBlock(db *sql.DB, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(db, internal.DeleteBlock, "failed to delete block", hash)
+}
+
+func deleteBlockFromChain(db *sql.DB, hash string) (err error) {
+	// Delete the row from block_chain where this_hash is the specified hash,
+	// returning the previous block hash in the chain.
+	var prev_hash string
+	err = db.QueryRow(internal.DeleteBlockFromChain, hash).Scan(&prev_hash)
+	if err != nil {
+		return
+	}
+
+	// For any row where next_hash is the prev_hash of the removed row, set
+	// next_hash to and empty string since that block is no longer in the chain.
+	return UpdateBlockNextByHash(db, prev_hash, "")
+}
+
+// DeleteBlockData removes all data for the specified block from every table.
+// Data are removed from tables in the following order: vins, vouts, addresses,
+// transactions, tickets, votes, misses, blocks, block_chain.
+// TODO: Consider a transaction for atomic operation.
+func DeleteBlockData(db *sql.DB, hash string) (res dbtypes.DeletionSummary, err error) {
+	res.Timings = new(dbtypes.DeletionSummary)
+
+	start := time.Now()
+	if res.Vins, err = deleteVinsForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Vins = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Vouts, err = deleteVoutsForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Vouts = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Addresses, err = deleteAddressesForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Addresses = time.Since(start).Nanoseconds()
+
+	// Deleting transactions rows follow deletion of vins, vouts, and addresses
+	// rows since the transactions table is used to identify the vin and vout DB
+	// row IDs for a transaction.
+	start = time.Now()
+	if res.Transactions, err = deleteTransactionsForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Transactions = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Tickets, err = deleteTicketsForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Tickets = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Votes, err = deleteVotesForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Votes = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Misses, err = deleteMissesForBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Misses = time.Since(start).Nanoseconds()
+
+	start = time.Now()
+	if res.Blocks, err = deleteBlock(db, hash); err != nil {
+		return
+	}
+	res.Timings.Blocks = time.Since(start).Nanoseconds()
+	if res.Blocks != 1 {
+		log.Errorf("Expected to delete 1 row of blocks table; actually removed %d.",
+			res.Blocks)
+	}
+
+	err = deleteBlockFromChain(db, hash)
+
+	return
+}
+
+// DeleteBestBlock removes all data for the best block in the DB from every
+// table via DeleteBlockData.
+func DeleteBestBlock(db *sql.DB) (res dbtypes.DeletionSummary, height uint64, hash string, err error) {
+	height, hash, _, err = RetrieveBestBlockHeight(context.Background(), db)
+	if err != nil {
+		return
+	}
+
+	res, err = DeleteBlockData(db, hash)
+	return
+}
+
+// DeleteBlocks removes all data for the N best blocks in the DB from every
+// table via repeated calls to DeleteBestBlock.
+func DeleteBlocks(N int64, db *sql.DB) (res []dbtypes.DeletionSummary, height uint64, hash string, err error) {
+	for i := int64(0); i < N; i++ {
+		var resi dbtypes.DeletionSummary
+		resi, height, hash, err = DeleteBestBlock(db)
+		res = append(res, resi)
+	}
+	return
+}

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -70,10 +70,15 @@ func (db *WiredDB) RewindStakeDB(ctx context.Context, toHeight int64) (stakeDBHe
 		toHeight = 0
 	}
 	fromHeight := stakeDBHeight
-	log.Infof("Rewinding from %d to %d", fromHeight, toHeight)
+
+	pStep := int64(1000)
 	for stakeDBHeight > toHeight {
-		if stakeDBHeight == fromHeight || stakeDBHeight%200 == 0 {
-			log.Infof("Rewinding from %d to %d", stakeDBHeight, toHeight)
+		if stakeDBHeight == fromHeight || stakeDBHeight%pStep == 0 {
+			endSegment := pStep * ((stakeDBHeight - 1) / pStep)
+			if endSegment < toHeight {
+				endSegment = toHeight
+			}
+			log.Infof("Rewinding from %d to %d", stakeDBHeight, endSegment)
 		}
 		// check for quit signal
 		select {

--- a/main.go
+++ b/main.go
@@ -212,11 +212,13 @@ func _main(ctx context.Context) error {
 		N := int64(cfg.PurgeNBestBlocks)
 		log.Infof("Purging data for the %d best blocks in the aux. DB...", N)
 		s, heightDB, err := auxDB.PurgeBestBlocks(N)
-		if err != nil {
+		if err != nil && err != sql.ErrNoRows {
 			return fmt.Errorf("Failed to purge %d blocks from the aux. DB: %v", N, err)
 		}
-		log.Infof("Sucessfully purged data for %d blocks from the aux. DB (new height = %d):\n%v",
-			N, heightDB, s)
+		if s != nil {
+			log.Infof("Sucessfully purged data for %d blocks from the aux. DB (new height = %d):\n%v",
+				s.Blocks, heightDB, s)
+		} // otherwise err == sql.ErrNoRows
 	}
 
 	blockHash, nodeHeight, err := dcrdClient.GetBestBlock()

--- a/main.go
+++ b/main.go
@@ -286,16 +286,26 @@ func _main(ctx context.Context) error {
 			return fmt.Errorf("Node is still syncing. Node height = %d, "+
 				"DB height = %d", expectedHeight, heightDB)
 		}
-		if blocksBehind > 7500 {
-			log.Warnf("Setting PSQL sync to rebuild address table after large "+
-				"import (%d blocks).", blocksBehind)
-			updateAllAddresses = true
-			if blocksBehind > 40000 {
-				log.Warnf("Setting PSQL sync to drop indexes prior to bulk data "+
-					"import (%d blocks).", blocksBehind)
-				newPGIndexes = true
-			}
-		}
+		// (TODO@chappjc) The following overrides of updateAllAddresses and
+		// newPGIndexes are COMMENTED OUT until the utxoStore/utxoCache can be
+		// pre-charged. This is because without indexes and without a
+		// well-populated utxo cache, the query the value and corresponding
+		// address for a UTXO is far too slow. In an initial sync, the utxo
+		// cache is effective as it gets filled from the start of the chain, but
+		// when starting at an arbitrary block the cache is empty. But the
+		// queries to look up the data on a cache miss rely on the indexes for
+		// acceptable performance.
+		//
+		// if blocksBehind > 7500 {
+		//  log.Warnf("Setting PSQL sync to rebuild address table after large "+
+		//      "import (%d blocks).", blocksBehind)
+		//  updateAllAddresses = true
+		//  if blocksBehind > 40000 {
+		//      log.Warnf("Setting PSQL sync to drop indexes prior to bulk data "+
+		//          "import (%d blocks).", blocksBehind)
+		//      newPGIndexes = true
+		//  }
+		// }
 
 		// PG gets winning tickets out of baseDB's pool info cache, so it must
 		// be big enough to hold the needed blocks' info, and charged with the

--- a/main.go
+++ b/main.go
@@ -207,6 +207,18 @@ func _main(ctx context.Context) error {
 		}
 	}
 
+	// Optionally purge best blocks according to config.
+	if cfg.PurgeNBestBlocks > 0 {
+		N := int64(cfg.PurgeNBestBlocks)
+		log.Infof("Purging data for the %d best blocks in the aux. DB...", N)
+		s, heightDB, err := auxDB.PurgeBestBlocks(N)
+		if err != nil {
+			return fmt.Errorf("Failed to purge %d blocks from the aux. DB: %v", N, err)
+		}
+		log.Infof("Sucessfully purged data for %d blocks from the aux. DB (new height = %d):\n%v",
+			N, heightDB, s)
+	}
+
 	blockHash, nodeHeight, err := dcrdClient.GetBestBlock()
 	if err != nil {
 		return fmt.Errorf("Unable to get block from node: %v", err)

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -689,7 +689,7 @@ func (db *StakeDatabase) disconnectBlock(neglectCache bool) error {
 		}
 	}
 
-	log.Debugf("Disconnecting block %d.", childHeight)
+	log.Tracef("Disconnecting block %d.", childHeight)
 	childUndoData := append(stake.UndoTicketDataSlice(nil), db.BestNode.UndoData()...)
 
 	// previous best node


### PR DESCRIPTION
Purging a block and all associated data from the DB involves removing
rows from several tables. This adds db/dcrpg/internal/rewind.go, which
defines the query strings to delete rows based on block hash, and
db/dcrpg/rewind.go, which defines the functions to execute the queries.
The added `DeleteBlockData` function performs the queries in the correct
order: vins, vouts, addresses, transactions, tickets, votes, misses,
blocks, and finally block_chain.

`DeleteBlockData` returns an instance of the new `dbtypes.DeletionSummary`
type that contains counts of the number of rows removed from each table,
and optionally timings for each query.

This also adds the helper functions `DeleteBestBlock` and `DeleteBlocks`.

`DeleteBestBlock` (and `DeleteBlocks`) returns the best block height _after_
attempting data removal.
Define `dcrpg.NotOneRowErrMsg`.
Do not return error from `DeleteBlockData` if `deleteBlockFromChain` has an
error with `NotOneRowErrMsg`, but _do warn_.
If `DeleteBestBlock` returns an empty string hash, that is a full rewind,
so do not return, and do add the last `DeletionSummary` to the result.

This adds the config option `--purge-n-blocks`, which is intended to rewind
the DBs from the highest best block across the DBs down by N blocks.
However, it presently only purges blocks from PostgreSQL (aux. DB).
`(*ChainDB).PurgeBestBlocks` wraps `DeleteBlocks` and a new best block
query.  Call it from `main` immediately after creating `auxDB`.

All rewind functions use a `sql.Tx`, where the new transaction is created in
`DeleteBlockData` for these functions.  `DeleteBlockData` is atomic with a single
`Tx` Commit/Rollback.

Define the `SqlExecutor` interface that is implemented by both `sql.DB` and
`sql.Tx`.  Use `SqlExecutor` to make functions like `sqlExec`,
`SetSpendingForFundingOP`, `UpdateBlockNext`, etc. more versatile.

Add `UpdateBlockNextByNextHash` to set `next_hash` in a row of the
`block_chain` table where `next_hash` is currently set to a given value.

**TODO**: Also purge blocks from `baseDB`. The `StakeDatabase` it manages is
already rewound automatically as this was needed for `auxDB`, but the SQLite
tables are unmodified.

---

e.g. with `--purge-n-blocks=666`:

```
2019-01-07 18:18:58.972 [INF] DATD: Sucessfully purged data for 666 blocks from the aux. DB (new height = 307043):
	  666 Blocks purged
	24501 Vins purged
	39210 Vouts purged
	47530 Addresses purged
	11166 Transactions purged
	 3217 Tickets purged
	 3318 Votes purged
	   12 Misses purged
2019-01-07 18:18:58.972 [INF] DATD: Rewinding StakeDatabase from 307709 to 307043.
2019-01-07 18:18:58.972 [INF] SQLT: Rewinding from 307709 to 307600
2019-01-07 18:18:59.170 [INF] SQLT: Rewinding from 307600 to 307400
2019-01-07 18:18:59.547 [INF] SQLT: Rewinding from 307400 to 307200
2019-01-07 18:18:59.899 [INF] SQLT: Rewinding from 307200 to 307043
```

**NOTE:** These changes are intended to support a thorough rewind (removal
of all data for the N best blocks in the dcrpg DB). Functionality exists to
remove N blocks from the main chain tip, but this moves the blocks to a side
chain, and does not actually remove any entries from the tables.  Completely
purging block data is helpful in a number of situations including: testing, and
recovery from DB corruption.