### PR TITLE
dcrsqlite: Add purge block functions to WiredDB (sqlite)

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -695,11 +695,14 @@ func (pgb *ChainDB) TransactionBlocks(txHash string) ([]*dbtypes.BlockStatus, []
 	return blocks, inds, nil
 }
 
-// HeightDB queries the DB for the best block height.
+// HeightDB queries the DB for the best block height. When the tables are empty,
+// the returned height will be 0, so it is necessary to check if the error value
+// is sql.ErrNoRows in this case.
 func (pgb *ChainDB) HeightDB() (uint64, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	bestHeight, _, _, err := RetrieveBestBlockHeight(ctx, pgb.db)
+	// DO NOT change this to return -1 if err == sql.ErrNoRows.
 	return bestHeight, pgb.replaceCancelError(err)
 }
 

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -226,10 +226,116 @@ func (db *WiredDB) GetHeight() (int64, error) {
 func (db *WiredDB) GetBestBlockHash() (string, error) {
 	hash := db.DBDataSaver.GetBestBlockHash()
 	var err error
-	if len(hash) == 0 {
+	if hash == "" {
 		err = fmt.Errorf("unable to get best block hash")
 	}
 	return hash, err
+}
+
+// PurgeBlock deletes all data across all tables for the block with the
+// specified hash. The numbers of blocks removed from the block summary table
+// and stake info table are returned. PurgeBlock will not return sql.ErrNoRows,
+// but it may return without removing a block.
+func (db *WiredDB) PurgeBlock(hash string) (NSummaryRows, NStakeInfoRows int64, err error) {
+	NSummaryRows, NStakeInfoRows, err = db.DeleteBlock(hash)
+	// DeleteBlock should not return sql.ErrNoRows, but check anyway.
+	if err == sql.ErrNoRows {
+		err = nil
+	}
+	return
+}
+
+// PurgeBestBlock deletes all data across all tables for the best block in the
+// block summary table. The numbers of blocks removed from the block summary
+// table and stake info table are returned. PurgeBestBlock will not return
+// sql.ErrNoRows, but it will return without removing a block if the tables are
+// empty. The returned height and hash values represent the best block after
+// successful data removal, or before a failed removal attempt.
+func (db *WiredDB) PurgeBestBlock() (NSummaryRows, NStakeInfoRows, height int64, hash string, err error) {
+	var h chainhash.Hash
+	h, height, err = db.GetBestBlockHeightHash()
+	if err != nil {
+		if err == sql.ErrNoRows {
+			log.Warnf("No blocks to remove from SQLite summary table.")
+			err = nil
+		}
+		return
+	}
+	hash = h.String()
+
+	NSummaryRows, NStakeInfoRows, err = db.PurgeBlock(hash)
+	if err != nil {
+		return
+	}
+
+	h, height, err = db.GetBestBlockHeightHash()
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// Last block removed.
+			err = nil
+		}
+		hash = ""
+		return
+	}
+	hash = h.String()
+
+	return
+}
+
+// PurgeBestBlocks deletes all data across all tables for the N best blocks in
+// the block summary table. The number of blocks removed is returned.
+// PurgeBestBlocks will not return sql.ErrNoRows, but it will return without
+// removing the requested number of blocks if the tables are empty or become
+// empty. The returned height and hash values represent the best block after
+// successful data removal, or before a failed removal attempt.
+func (db *WiredDB) PurgeBestBlocks(N int64) (NSummaryRows, NStakeInfoRows, height int64, hash string, err error) {
+	// If N is less than 1, get the current best block height and hash, then
+	// return.
+	if N < 1 {
+		var h chainhash.Hash
+		h, height, err = db.GetBestBlockHeightHash()
+		if err == sql.ErrNoRows {
+			err = nil
+		}
+		hash = h.String()
+		return
+	}
+
+	for i := int64(0); i < N; i++ {
+		// Attempt removal of the best block.
+		var NSumi, Nstakei, heighti int64
+		var hashi string
+		NSumi, Nstakei, heighti, hashi, err = db.PurgeBestBlock()
+		if err != nil {
+			// Return with previous (or initial) best block info and block
+			// removal count.
+			return
+		}
+
+		if (i%100 == 0 && i > 0) || i == N-1 {
+			log.Debugf("Removed data for %d blocks.", i+1)
+		}
+
+		// Removal succeeded. Returned best block values are valid.
+		NSummaryRows += NSumi
+		NStakeInfoRows += Nstakei
+		height = heighti
+		hash = hashi
+
+		// Rewind stake database to this height.
+		var stakeDBHeight int64
+		stakeDBHeight, err = db.RewindStakeDB(context.Background(), height, true)
+		if err != nil {
+			return
+		}
+		if stakeDBHeight != height {
+			err = fmt.Errorf("rewind of StakeDatabase to height %d failed, "+
+				"reaching height %d instead", height, stakeDBHeight)
+			return
+		}
+	}
+
+	return
 }
 
 // GetBestBlockHeightHash retrieves the DB's best block hash and height.

--- a/main.go
+++ b/main.go
@@ -207,23 +207,77 @@ func _main(ctx context.Context) error {
 		}
 	}
 
-	// Optionally purge best blocks according to config.
-	if cfg.PurgeNBestBlocks > 0 {
-		N := int64(cfg.PurgeNBestBlocks)
-		log.Infof("Purging data for the %d best blocks in the aux. DB...", N)
-		s, heightDB, err := auxDB.PurgeBestBlocks(N)
-		if err != nil && err != sql.ErrNoRows {
-			return fmt.Errorf("Failed to purge %d blocks from the aux. DB: %v", N, err)
+	// Heights gets the current height of each DB, the minimum of the DB heights
+	// (dbHeight), and the chain server height.
+	Heights := func() (dbHeight, nodeHeight, baseDBHeight, auxDBHeight int64, err error) {
+		_, nodeHeight, err = dcrdClient.GetBestBlock()
+		if err != nil {
+			err = fmt.Errorf("unable to get block from node: %v", err)
+			return
 		}
-		if s != nil {
-			log.Infof("Sucessfully purged data for %d blocks from the aux. DB (new height = %d):\n%v",
-				s.Blocks, heightDB, s)
-		} // otherwise err == sql.ErrNoRows
+
+		baseDBHeight, err = baseDB.GetHeight()
+		if err != nil && err != sql.ErrNoRows {
+			log.Errorf("baseDB.GetHeight failed: %v", err)
+		}
+		log.Debugf("baseDB height: %d", baseDBHeight)
+		dbHeight = baseDBHeight
+
+		if usePG {
+			auxDBHeight, err = auxDB.GetHeight()
+			if err != nil && err != sql.ErrNoRows {
+				log.Errorf("auxDB.GetHeight failed: %v", err)
+			}
+			log.Debugf("auxDB height: %d", auxDBHeight)
+			if baseDBHeight > auxDBHeight {
+				dbHeight = auxDBHeight
+			}
+		}
+		return
 	}
 
-	blockHash, nodeHeight, err := dcrdClient.GetBestBlock()
-	if err != nil {
-		return fmt.Errorf("Unable to get block from node: %v", err)
+	// Optionally purge best blocks according to config.
+	if cfg.PurgeNBestBlocks > 0 {
+		// The number of blocks to purge for each DB is computed so that the DBs
+		// will end on the same height.
+		_, _, baseDBHeight, auxDBHeight, err := Heights()
+		if err != nil {
+			return err
+		}
+		// Determine the largest DB height.
+		maxHeight := baseDBHeight
+		if usePG && auxDBHeight > maxHeight {
+			maxHeight = auxDBHeight
+		}
+		// The final best block after purge.
+		purgeToBlock := maxHeight - int64(cfg.PurgeNBestBlocks)
+
+		// Purge NBase blocks from base DB.
+		NBase := baseDBHeight - purgeToBlock
+		log.Infof("Purging data for the %d best blocks in the base DB...", NBase)
+		nRemovedSummary, _, heightDB, _, err := baseDB.PurgeBestBlocks(NBase)
+		if err != nil && err != sql.ErrNoRows {
+			return fmt.Errorf("Failed to purge %d blocks from the base DB: %v", NBase, err)
+		}
+		// The number of rows removed from the summary table and stake table may
+		// be different if the DB was corrupted, but it is not important to log
+		// for the tables separately.
+		log.Infof("Sucessfully purged data for %d blocks from the base DB "+
+			"(new height = %d).", nRemovedSummary, heightDB)
+
+		if usePG {
+			// Purge NAux blocks from auxiliary DB.
+			NAux := auxDBHeight - purgeToBlock
+			log.Infof("Purging data for the %d best blocks in the aux. DB...", NAux)
+			s, heightDB, err := auxDB.PurgeBestBlocks(NAux)
+			if err != nil && err != sql.ErrNoRows {
+				return fmt.Errorf("Failed to purge %d blocks from the aux. DB: %v", NAux, err)
+			}
+			if s != nil {
+				log.Infof("Sucessfully purged data for %d blocks from the aux. DB "+
+					"(new height = %d):\n%v", s.Blocks, heightDB, s)
+			} // otherwise likely err == sql.ErrNoRows
+		}
 	}
 
 	// When in lite mode, baseDB should get blocks without having to coordinate
@@ -234,6 +288,8 @@ func _main(ctx context.Context) error {
 		var heightDB uint64
 		heightDB, err = auxDB.HeightDB()
 		lastBlockPG := int64(heightDB)
+		// If the tables are empty, heightDB will still be zero, so we check for
+		// sql.ErrNoRows to recognize this case and set lastBlockPG to -1.
 		if err != nil {
 			if err != sql.ErrNoRows {
 				return fmt.Errorf("Unable to get height from PostgreSQL DB: %v", err)
@@ -253,21 +309,29 @@ func _main(ctx context.Context) error {
 		// StakeDatabase when the required blocks are connected, the
 		// StakeDatabase must be at the same height or lower than auxDB.
 		stakedbHeight := int64(baseDB.GetStakeDB().Height())
-		fromHeight := stakedbHeight
-		if uint64(stakedbHeight) > heightDB {
-			// Rewind stakedb and log at intervals of 200 blocks.
-			if stakedbHeight == fromHeight || stakedbHeight%200 == 0 {
-				log.Infof("Rewinding StakeDatabase from %d to %d.", stakedbHeight, heightDB)
-			}
+		if stakedbHeight > int64(heightDB) {
+			// Have baseDB rewind it's the StakeDatabase. stakedbHeight is
+			// always rewound to a height of zero even when lastBlockPG is -1,
+			// hence we rewind to heightDB.
+			log.Infof("Rewinding StakeDatabase from block %d to %d.",
+				stakedbHeight, heightDB)
 			stakedbHeight, err = baseDB.RewindStakeDB(ctx, int64(heightDB))
 			if err != nil {
 				return fmt.Errorf("RewindStakeDB failed: %v", err)
 			}
-			// stakedbHeight is always rewound to a height of zero even when lastBlockPG is -1.
+
+			// Verify that the StakeDatabase is at the intended height.
 			if stakedbHeight != int64(heightDB) {
 				return fmt.Errorf("failed to rewind stakedb: got %d, expecting %d",
 					stakedbHeight, heightDB)
 			}
+		}
+
+		// TODO: just use getblockchaininfo to see if it still syncing and what
+		// height the network's best block is at.
+		blockHash, nodeHeight, err := dcrdClient.GetBestBlock()
+		if err != nil {
+			return fmt.Errorf("Unable to get block from node: %v", err)
 		}
 
 		block, err := dcrdClient.GetBlockHeader(blockHash)
@@ -374,29 +438,6 @@ func _main(ctx context.Context) error {
 
 	blockDataSavers = append(blockDataSavers, explore)
 
-	// Determine blocks to sync.
-	baseDBHeight, err := baseDB.GetHeight()
-	if err != nil && err != sql.ErrNoRows {
-		log.Errorf("baseDB.GetHeight failed: %v", err)
-	}
-	log.Debugf("baseDB height: %d", baseDBHeight)
-	blocksBehind := nodeHeight - baseDBHeight
-
-	var auxDBHeight int64
-	if usePG {
-		auxDBHeight, err = auxDB.GetHeight()
-		if err != nil && err != sql.ErrNoRows {
-			log.Errorf("auxDB.GetHeight failed: %v", err)
-		}
-		log.Debugf("auxDB height: %d", auxDBHeight)
-		if baseDBHeight > auxDBHeight {
-			blocksBehind = nodeHeight - auxDBHeight
-		}
-	}
-	// dbHeight is the smaller of baseDBHeight and auxDBHeight in full mode.
-	dbHeight := nodeHeight - blocksBehind
-	log.Debugf("dbHeight: %d / blocksBehind: %d", dbHeight, blocksBehind)
-
 	// Prepare for sync by setting up the channels for status/progress updates
 	// (barLoad) or full explorer page updates (latestBlockHash).
 
@@ -414,6 +455,12 @@ func _main(ctx context.Context) error {
 	// the node's best block height are more than the set limit. The sync status
 	// page should also be displayed when updateAllAddresses and newPGIndexes
 	// are true, indicating maintenance or an initial sync.
+	dbHeight, nodeHeight, _, _, err := Heights()
+	if err != nil {
+		return err
+	}
+	blocksBehind := nodeHeight - dbHeight
+	log.Debugf("dbHeight: %d / blocksBehind: %d", dbHeight, blocksBehind)
 	displaySyncStatusPage := blocksBehind > int64(cfg.SyncStatusLimit) || // over limit
 		updateAllAddresses || newPGIndexes // maintenance or initial sync
 
@@ -630,7 +677,7 @@ func _main(ctx context.Context) error {
 		return waitForSync(ctx, sqliteSyncRes, pgSyncRes, usePG)
 	}
 
-	baseDBHeight, auxDBHeight, err = getSyncd(updateAllAddresses,
+	baseDBHeight, auxDBHeight, err := getSyncd(updateAllAddresses,
 		updateAllVotes, newPGIndexes, fetchToHeight)
 	if err != nil {
 		return err


### PR DESCRIPTION
Purge data from the base (sqlite) DB too. The number of blocks to purge
for each DB is computed so that the DBs will end on the same height.
Add `PurgeBlock`, `PurgeBestBlock`, and `PurgeBestBlocks` to `WiredDB`.
Add `deleteBlock` and `DeleteBlock` to `sqlite.DB` (used by `WiredDB`).
Organize the `dcrsqlite.DB` struct.
Add `getBlockSummaryHeight` and `getStakeInfoHeight` which bypass the best
block caches.  These functions are now called by `GetBlockSummaryHeight`
and `GetStakeInfoHeight`, which update the caches.
Add `deleteStakeInfo` and `deleteStakeInfoHeightMainchain` to dcrsqlite.DB.
Remove the locking from `RetrieveAllPoolValAndSize` since the lock is only
meant to guard `lastStoredBlock`, `dbSummaryHeight`, and `dbStakeInfoHeight`.
Add an optional "quiet" bool argument to `(db *WiredDB).RewindStakeDB` to
disable logging progress.
In `main`, create the `Heights` closure for retrieving DB and node heights.