### PR TITLE
use getblockchain info for MaximumBlockSize

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -232,6 +232,11 @@ func (db *WiredDB) GetBestBlockHash() (string, error) {
 	return hash, err
 }
 
+// BlockchainInfo retrieves the result of the getblockchaininfo node RPC.
+func (db *WiredDB) BlockchainInfo() (*dcrjson.GetBlockChainInfoResult, error) {
+	return db.client.GetBlockChainInfo()
+}
+
 // PurgeBlock deletes all data across all tables for the block with the
 // specified hash. The numbers of blocks removed from the block summary table
 // and stake info table are returned. PurgeBlock will not return sql.ErrNoRows,

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -177,8 +177,9 @@ func TicketStatusText(s dbtypes.TicketSpendType, p dbtypes.TicketPoolStatus) str
 
 type pageData struct {
 	sync.RWMutex
-	BlockInfo *types.BlockInfo
-	HomeInfo  *types.HomeInfo
+	BlockInfo      *types.BlockInfo
+	BlockchainInfo *dcrjson.GetBlockChainInfoResult
+	HomeInfo       *types.HomeInfo
 }
 
 type explorerUI struct {
@@ -417,8 +418,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	p := exp.pageData
 	p.Lock()
 
-	// Store current block data.
+	// Store current block and blockchain data.
 	p.BlockInfo = newBlockData
+	p.BlockchainInfo = blockData.BlockchainInfo
 
 	// Update HomeInfo.
 	p.HomeInfo.HashRate = hashrate

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1206,7 +1206,6 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		Data         *dbtypes.AddressInfo
 		NetName      string
 		IsLiteMode   bool
-		ChartData    *dbtypes.ChartsData
 		CRLFDownload bool
 	}
 
@@ -1643,8 +1642,17 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 	addrPrefix := types.AddressPrefixes(params)
 	actualTicketPoolSize := int64(params.TicketPoolSize * params.TicketsPerBlock)
 
+	exp.pageData.RLock()
+	var maxBlockSize int64
+	if exp.pageData.BlockchainInfo != nil {
+		maxBlockSize = exp.pageData.BlockchainInfo.MaxBlockSize
+	} else {
+		maxBlockSize = int64(params.MaximumBlockSizes[0])
+	}
+	exp.pageData.RUnlock()
+
 	type ExtendedParams struct {
-		MaximumBlockSize     int
+		MaximumBlockSize     int64
 		ActualTicketPoolSize int64
 		AddressPrefix        []types.AddrPrefix
 	}
@@ -1656,7 +1664,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		CommonPageData: exp.commonData(),
 		ExtendedParams: ExtendedParams{
-			MaximumBlockSize:     params.MaximumBlockSizes[0],
+			MaximumBlockSize:     maxBlockSize,
 			AddressPrefix:        addrPrefix,
 			ActualTicketPoolSize: actualTicketPoolSize,
 		},


### PR DESCRIPTION
blockdata: Add `BlockchainInfo` to `BlockData` struct, and retrieve the
`dcrjson.GetBlockChainInfoResult` in `Collect` and `CollectHash`. This
makes it available to all `BlockDataSaver`s.
explorer: Add `BlockchainInfo` to `pageData`. Remove `ChartData` from
`AddressPageData` since it is no longer used.

Resolving issue https://github.com/decred/dcrdata/issues/678.