### PR TITLE
dcrsqlite: have StoreBlock set existing blocks to side chain first

### DIFF
--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -59,9 +59,10 @@ func (p *ChainMonitor) switchToSideChain(reorgData *txhelpers.ReorgData) (int32,
 			reorgData.OldChainHeight, commonAncestorHeight)
 	}
 
-	// Update DB tables, just overwriting any existing data.
-	// TODO(chappjc): Remove rows for disconnected blocks just in case not
-	// everything gets overwritten, as intended.
+	// Update DB tables, just overwriting any existing data. TODO(chappjc): Set
+	// is_mainchain=false for the previous main chain (disconnected) blocks. For
+	// now, StoreBlockSummary first does this for any main chain block being
+	// added. This is unnecessary except during a reorg, but it does the job.
 
 	// Save blocks from previous side chain that is now the main chain
 	log.Infof("Saving %d new blocks from previous side chain to sqlite.", len(newChain))


### PR DESCRIPTION
When storing data for a main chain block, `(db *DB).StoreBlock` will first
set `is_mainchain=false` for any other block at this height. Previously,
this was only being done in `Store`, which was not used during a reorg.
However, `Store` uses `StoreBlockSummary`->`StoreBlock`, so now this will
always happen.
Note that his is usually an unnecessary query since most of the time
`StoreBlock` is used outside of a reorg context.  But this solution is very
simple.  If performance of this query is an issue, it can be done
only from the `ChainMonitor`'s reorg handler.

NOTE: this should be backported for 3.1.2.