### PR TITLE
js: fix negative durations appearing on the frontend

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -46,7 +46,7 @@ async function createWebSocket (loc) {
   var updateBlockData = function (event) {
     console.log('Received newblock message', event)
     var newBlock = JSON.parse(event)
-    newBlock.block.unixStamp = (new Date(newBlock.block.time)).getTime() / 1000
+    newBlock.block.unixStamp = ((new Date(newBlock.block.time)).getTime() / 1000) - (new Date().getTimezoneOffset() * 60)
     globalEventBus.publish('BLOCK_RECEIVED', newBlock)
   }
   ws.registerEvtHandler('newblock', updateBlockData)

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -726,7 +726,7 @@ export default class extends Controller {
           row.querySelector('td.addr-tx-time').textContent = humanize.formatTxDate(block.time, false)
           let age = row.querySelector('td.addr-tx-age > span')
           age.dataset.age = block.time
-          age.textContent = humanize.timeSince(block.time)
+          age.textContent = humanize.timeSince(block.unixStamp)
           delete row.dataset.target
           // Increment the displayed tx count
           let count = this.txnCountTarget

--- a/public/js/controllers/time_controller.js
+++ b/public/js/controllers/time_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
       if (isCorrectVal(el.dataset.age)) {
         el.textContent = humanize.timeSince(el.dataset.age)
       } else if (el.dataset.age !== '') {
-        el.textContent = humanize.timeSince(Date.parse(el.dataset.age) / 1000)
+        el.textContent = humanize.timeSince((Date.parse(el.dataset.age) / 1000) - (new Date().getTimezoneOffset() * 60))
       }
     })
   }

--- a/public/js/controllers/tx_controller.js
+++ b/public/js/controllers/tx_controller.js
@@ -34,7 +34,7 @@ export default class extends Controller {
         this.formattedAgeTarget.textContent = humanize.formatTxDate(block.time, true)
         this.ageTarget.textContent = '( ago)'
         this.ageTarget.dataset.age = block.time
-        this.ageTarget.textContent = `(${humanize.timeSince(block.time)} ago)`
+        this.ageTarget.textContent = `(${humanize.timeSince(block.unixStamp)} ago)`
         this.ageTarget.dataset.target = 'time.age'
         if (this.hasProgressBarTarget) {
           this.progressBarTarget.dataset.confirmHeight = block.height


### PR DESCRIPTION
This update looks much better to me.  I no longer see the negative times mentioned in #875.

The main cause of this problem was a timezone issue with Javascript. The server returns timestamps in UTC but is unlabeled so when Javascript uses the value to create a Date object it assumes the timezone is whatever the browser is set to. This can result in negative values or positive values that are older than the correct time. The transaction age seemed to be correct in most places, but block times were not. The `block.unixStamp` that gets created in index.js needed to be adjusted for the timezone and so did one of the values in time_controller.js. I also noticed `block.time` being passed to `humanize.timeSince` in address_controller.js and tx_controller.js and adjusted them to the now correctly calculated `block.unixStamp`.

The TimeDef struct in Go could be extended to include the timezone or it could be eliminated in favor of Unix timestamps to reduce the amount of data being sent to the clients. Right now some of the timestamps are returned as TimeDef and others are returned as Unix timestamps. The inconsistency between the two timestamps led to this problem, but should be handled correctly now.  Making fundamental changes to TimeDef falls outside the scope of negative times and could be handled in a different pull request.