### PR TITLE
Decode OP_RETURN data on tx page

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1491,11 +1491,13 @@ func (db *WiredDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 		if strings.Contains(vout.ScriptPubKey.Asm, "OP_RETURN") {
 			opReturn = vout.ScriptPubKey.Asm
 
-			// decode op_return data
-			opReturnData := strings.TrimPrefix(vout.ScriptPubKey.Asm, "OP_RETURN ")
-			opReturnDataBytes, err := hex.DecodeString(opReturnData)
-			if err == nil && len(opReturnDataBytes) > 0 {
-				opReturnDecoded = string(opReturnDataBytes)
+			if tx.Type == "Regular" || tx.Type == "Coinbase" {
+				// decode op_return data
+				opReturnData := strings.TrimPrefix(vout.ScriptPubKey.Asm, "OP_RETURN ")
+				opReturnDataBytes, err := hex.DecodeString(opReturnData)
+				if err == nil && len(opReturnDataBytes) > 0 {
+					opReturnDecoded = string(opReturnDataBytes)
+				}
 			}
 		}
 		outputs = append(outputs, exptypes.Vout{

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1492,7 +1492,7 @@ func (db *WiredDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 			opReturn = vout.ScriptPubKey.Asm
 
 			// decode op_return data
-			opReturnData := strings.TrimLeft(vout.ScriptPubKey.Asm, "OP_RETURN ")
+			opReturnData := strings.TrimPrefix(vout.ScriptPubKey.Asm, "OP_RETURN ")
 			opReturnDataBytes, err := hex.DecodeString(opReturnData)
 			if err == nil && len(opReturnDataBytes) > 0 {
 				opReturnDecoded = string(opReturnDataBytes)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1487,17 +1487,26 @@ func (db *WiredDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 			log.Warnf("Failed to determine if tx out is spent for output %d of tx %s", i, txid)
 		}
 		var opReturn string
+		var opReturnDecoded string
 		if strings.Contains(vout.ScriptPubKey.Asm, "OP_RETURN") {
 			opReturn = vout.ScriptPubKey.Asm
+
+			// decode op_return data
+			opReturnData := strings.TrimLeft(vout.ScriptPubKey.Asm, "OP_RETURN ")
+			opReturnDataBytes, err := hex.DecodeString(opReturnData)
+			if err == nil && len(opReturnDataBytes) > 0 {
+				opReturnDecoded = string(opReturnDataBytes)
+			}
 		}
 		outputs = append(outputs, exptypes.Vout{
-			Addresses:       vout.ScriptPubKey.Addresses,
-			Amount:          vout.Value,
-			FormattedAmount: humanize.Commaf(vout.Value),
-			OP_RETURN:       opReturn,
-			Type:            vout.ScriptPubKey.Type,
-			Spent:           txout == nil,
-			Index:           vout.N,
+			Addresses:         vout.ScriptPubKey.Addresses,
+			Amount:            vout.Value,
+			FormattedAmount:   humanize.Commaf(vout.Value),
+			OP_RETURN:         opReturn,
+			OP_RETURN_DECODED: opReturnDecoded,
+			Type:              vout.ScriptPubKey.Type,
+			Spent:             txout == nil,
+			Index:             vout.N,
 		})
 	}
 	tx.Vout = outputs

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -838,7 +838,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(asm, "OP_RETURN") {
 				opReturn = asm
 				// decode op_return data
-				opReturnData := strings.TrimLeft(asm, "OP_RETURN ")
+				opReturnData := strings.TrimPrefix(asm, "OP_RETURN ")
 				opReturnDataBytes, err := hex.DecodeString(opReturnData)
 				if err == nil && len(opReturnDataBytes) > 0 {
 					opReturnDecoded = string(opReturnDataBytes)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -837,11 +837,13 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			asm, _ := txscript.DisasmString(vouts[iv].ScriptPubKey)
 			if strings.Contains(asm, "OP_RETURN") {
 				opReturn = asm
-				// decode op_return data
-				opReturnData := strings.TrimPrefix(asm, "OP_RETURN ")
-				opReturnDataBytes, err := hex.DecodeString(opReturnData)
-				if err == nil && len(opReturnDataBytes) > 0 {
-					opReturnDecoded = string(opReturnDataBytes)
+				if tx.Type == "Regular" || tx.Type == "Coinbase" {
+					// decode op_return data
+					opReturnData := strings.TrimPrefix(asm, "OP_RETURN ")
+					opReturnDataBytes, err := hex.DecodeString(opReturnData)
+					if err == nil && len(opReturnDataBytes) > 0 {
+						opReturnDecoded = string(opReturnDataBytes)
+					}
 				}
 			}
 			// Determine if the outpoint is spent

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -205,13 +205,14 @@ type Vin struct {
 
 // Vout models basic data about a tx output for display
 type Vout struct {
-	Addresses       []string
-	Amount          float64
-	FormattedAmount string
-	Type            string
-	Spent           bool
-	OP_RETURN       string
-	Index           uint32
+	Addresses         []string
+	Amount            float64
+	FormattedAmount   string
+	Type              string
+	Spent             bool
+	OP_RETURN         string
+	OP_RETURN_DECODED string
+	Index             uint32
 }
 
 // TrimmedBlockInfo models data needed to display block info on the new home page

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -398,6 +398,12 @@
                                 <div>
                                     <span class="break-word">{{.OP_RETURN}}</span>
                                 </div>
+                                {{if .OP_RETURN_DECODED}}
+                                <div class="fs13 open-return-decoded-ctn">
+                                    <span class="open-return-decoded-label">Decoded OP_RETURN:</span>
+                                    <span class="break-word open-return-decoded-data">{{.OP_RETURN_DECODED}}</span>
+                                </div>
+                                {{end}}
                                 {{end}}
                             {{end}}
                         </td>


### PR DESCRIPTION
For https://github.com/decred/dcrdata/issues/635
Just decode the OP_RETURN hex data to utf-8 and showed on tx page.

Demo: http://testnet.dcr.teakki.top/tx/92e6e6e7d2877e105435787fd73ec572cc85e3e620332cbfd65478c6c20aa0e2
http://testnet.dcr.teakki.top/tx/999a974faa42b030f20408f4bc2630edea65996324dc9125583dfe9ad4b21da7
![image](https://user-images.githubusercontent.com/1699428/51083715-53fb0a00-1759-11e9-8fe9-ec8f7d38e3e3.png)
