### PR TITLE
dcrpg: remove several unused columns from blocks table.

### DIFF
--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -29,13 +29,11 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 
 	// Assemble the block
 	return &Block{
-		Hash:       blockHeader.BlockHash().String(),
-		Size:       uint32(msgBlock.SerializeSize()),
-		Height:     blockHeader.Height,
-		Version:    uint32(blockHeader.Version),
-		MerkleRoot: blockHeader.MerkleRoot.String(),
-		StakeRoot:  blockHeader.StakeRoot.String(),
-		NumTx:      uint32(len(msgBlock.Transactions) + len(msgBlock.STransactions)),
+		Hash:    blockHeader.BlockHash().String(),
+		Size:    uint32(msgBlock.SerializeSize()),
+		Height:  blockHeader.Height,
+		Version: uint32(blockHeader.Version),
+		NumTx:   uint32(len(msgBlock.Transactions) + len(msgBlock.STransactions)),
 		// nil []int64 for TxDbIDs
 		NumRegTx:     uint32(len(msgBlock.Transactions)),
 		Tx:           txHashStrs,
@@ -44,7 +42,6 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 		Time:         TimeDef{T: blockHeader.Timestamp},
 		Nonce:        uint64(blockHeader.Nonce),
 		VoteBits:     blockHeader.VoteBits,
-		FinalState:   blockHeader.FinalState[:],
 		Voters:       blockHeader.Voters,
 		FreshStake:   blockHeader.FreshStake,
 		Revocations:  blockHeader.Revocations,
@@ -52,7 +49,6 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 		Bits:         blockHeader.Bits,
 		SBits:        uint64(blockHeader.SBits),
 		Difficulty:   txhelpers.GetDifficultyRatio(blockHeader.Bits, chainParams),
-		ExtraData:    blockHeader.ExtraData[:],
 		StakeVersion: blockHeader.StakeVersion,
 		PreviousHash: blockHeader.PrevBlock.String(),
 		ChainWork:    chainWork,

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -668,8 +668,6 @@ type Block struct {
 	Size         uint32 `json:"size"`
 	Height       uint32 `json:"height"`
 	Version      uint32 `json:"version"`
-	MerkleRoot   string `json:"merkleroot"`
-	StakeRoot    string `json:"stakeroot"`
 	NumTx        uint32
 	NumRegTx     uint32
 	Tx           []string `json:"tx"`
@@ -680,7 +678,6 @@ type Block struct {
 	Time         TimeDef `json:"time"`
 	Nonce        uint64  `json:"nonce"`
 	VoteBits     uint16  `json:"votebits"`
-	FinalState   []byte  `json:"finalstate"`
 	Voters       uint16  `json:"voters"`
 	FreshStake   uint8   `json:"freshstake"`
 	Revocations  uint8   `json:"revocations"`
@@ -688,7 +685,6 @@ type Block struct {
 	Bits         uint32  `json:"bits"`
 	SBits        uint64  `json:"sbits"`
 	Difficulty   float64 `json:"difficulty"`
-	ExtraData    []byte  `json:"extradata"`
 	StakeVersion uint32  `json:"stakeversion"`
 	PreviousHash string  `json:"previousblockhash"`
 	ChainWork    string  `json:"chainwork"`

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -97,7 +97,6 @@ const (
 	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
 	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
 
-	//RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
 	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks
 		ORDER BY height DESC LIMIT 1;`
 	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -15,8 +15,6 @@ const (
 		is_valid BOOLEAN,
 		is_mainchain BOOLEAN,
 		version INT4,
-		merkle_root TEXT,
-		stake_root TEXT,
 		numtx INT4,
 		num_rtx INT4,
 		tx TEXT[],
@@ -27,7 +25,6 @@ const (
 		time TIMESTAMP,
 		nonce INT8,
 		vote_bits INT2,
-		final_state BYTEA,
 		voters INT2,
 		fresh_stake INT2,
 		revocations INT2,
@@ -35,7 +32,6 @@ const (
 		bits INT4,
 		sbits INT8,
 		difficulty FLOAT8,
-		extra_data BYTEA,
 		stake_version INT4,
 		previous_hash TEXT,
 		chainwork TEXT
@@ -48,16 +44,16 @@ const (
 
 	// insertBlockRow is the basis for several block insert/upsert statements.
 	insertBlockRow = `INSERT INTO blocks (
-		hash, height, size, is_valid, is_mainchain, version, merkle_root, stake_root,
+		hash, height, size, is_valid, is_mainchain, version,
 		numtx, num_rtx, tx, txDbIDs, num_stx, stx, stxDbIDs,
-		time, nonce, vote_bits, final_state, voters,
+		time, nonce, vote_bits, voters,
 		fresh_stake, revocations, pool_size, bits, sbits,
-		difficulty, extra_data, stake_version, previous_hash, chainwork)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
-		$9, $10, %s, %s, $11, %s, %s,
-		$12, $13, $14, $15, $16,
-		$17, $18, $19, $20, $21,
-		$22, $23, $24, $25, $26) `
+		difficulty, stake_version, previous_hash, chainwork)
+	VALUES ($1, $2, $3, $4, $5, $6,
+		$7, $8, %s, %s, $9, %s, %s,
+		$10, $11, $12, $13,
+		$14, $15, $16, $17, $18,
+		$19, $20, $21, $22) `
 
 	// InsertBlockRow inserts a new block row without checking for unique index
 	// conflicts. This should only be used before the unique indexes are created
@@ -101,7 +97,7 @@ const (
 	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
 	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
 
-	RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
+	//RetrieveBestBlock          = `SELECT * FROM blocks ORDER BY height DESC LIMIT 0, 1;`
 	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks
 		ORDER BY height DESC LIMIT 1;`
 	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2673,13 +2673,11 @@ func InsertBlock(db *sql.DB, dbBlock *dbtypes.Block, isValid, isMainchain, check
 	var id uint64
 	err := db.QueryRow(insertStatement,
 		dbBlock.Hash, dbBlock.Height, dbBlock.Size, isValid, isMainchain,
-		dbBlock.Version, dbBlock.MerkleRoot, dbBlock.StakeRoot,
-		dbBlock.NumTx, dbBlock.NumRegTx, dbBlock.NumStakeTx,
-		dbBlock.Time.T, dbBlock.Nonce, dbBlock.VoteBits,
-		dbBlock.FinalState, dbBlock.Voters, dbBlock.FreshStake,
-		dbBlock.Revocations, dbBlock.PoolSize, dbBlock.Bits,
-		dbBlock.SBits, dbBlock.Difficulty, dbBlock.ExtraData,
-		dbBlock.StakeVersion, dbBlock.PreviousHash, dbBlock.ChainWork).Scan(&id)
+		dbBlock.Version, dbBlock.NumTx, dbBlock.NumRegTx, dbBlock.NumStakeTx,
+		dbBlock.Time.T, dbBlock.Nonce, dbBlock.VoteBits, dbBlock.Voters,
+		dbBlock.FreshStake, dbBlock.Revocations, dbBlock.PoolSize, dbBlock.Bits,
+		dbBlock.SBits, dbBlock.Difficulty, dbBlock.StakeVersion,
+		dbBlock.PreviousHash, dbBlock.ChainWork).Scan(&id)
 	return id, err
 }
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -48,7 +48,7 @@ type dropDuplicatesInfo struct {
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 7
+	tableMinor = 8
 	tablePatch = 0
 )
 

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1127,16 +1127,11 @@ func makeDeleteColumnsStmt(table string, columns []string) string {
 
 func deleteColumnsIfFound(db *sql.DB, table string, columns []string) (bool, error) {
 	dropStmt := makeDeleteColumnsStmt(table, columns)
-	result, err := db.Exec(dropStmt)
+	_, err := db.Exec(dropStmt)
 	if err != nil {
 		return false, err
 	}
-
-	N, err := result.RowsAffected()
-	if err != nil {
-		return false, err
-	}
-	return N > 0, nil
+	return true, nil
 }
 
 type newColumn struct {

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1131,6 +1131,11 @@ func deleteColumnsIfFound(db *sql.DB, table string, columns []string) (bool, err
 	if err != nil {
 		return false, err
 	}
+	log.Infof("Reclaiming disk space from removed columns...")
+	_, err = db.Exec(fmt.Sprintf("VACUUM FULL %s;", table))
+	if err != nil {
+		return false, err
+	}
 	return true, nil
 }
 

--- a/db/dcrpg/upgrades_test.go
+++ b/db/dcrpg/upgrades_test.go
@@ -1,0 +1,16 @@
+package dcrpg
+
+import (
+	"testing"
+)
+
+func TestMakeDeleteColumnsStmt(t *testing.T) {
+	table := "blocks"
+	cols := []string{"extra_data", "final_state"}
+	expected := "ALTER TABLE blocks DROP COLUMN IF EXISTS extra_data, DROP COLUMN IF EXISTS final_state;"
+
+	dropStmt := makeDeleteColumnsStmt(table, cols)
+	if dropStmt != expected {
+		t.Errorf("expected %s, got %s", expected, dropStmt)
+	}
+}

--- a/explorer/syncstatus.go
+++ b/explorer/syncstatus.go
@@ -76,7 +76,7 @@ func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarL
 				timer.Stop()
 				return
 			}
-			log.Debug("Sending progress bar signal.")
+			log.Trace("Sending progress bar signal.")
 			exp.wsHub.HubRelay <- sigSyncStatus
 		}
 	}()


### PR DESCRIPTION
Remove `extra_data`, `final_state`, `merkle_root`, and `stake_root` from `blocks`.
Remove the corresponding fields from `dbtypes.Block`.
Bump dcrpg tables version from 3.7.0 to 3.8.0.
Implement upgrade of table versions that removes the columns.
Add `deleteColumnsIfFound` to upgrades.go for future use.