### PR TITLE
dcrsqlite: Only move blocks to side chain during reorg.

### DIFF
--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -515,14 +515,6 @@ func (db *DB) getMainchainStatus(blockhash string) (bool, error) {
 // StoreBlock attempts to store the block data in the database, and
 // returns an error on failure.
 func (db *DB) StoreBlock(bd *apitypes.BlockDataBasic, isMainchain bool, isValid bool) error {
-	// When storing data for a main chain block, set is_mainchain=false for any
-	// other block at this height.
-	if isMainchain {
-		if err := db.setHeightToSideChain(int64(bd.Height)); err != nil {
-			return err
-		}
-	}
-
 	stmt, err := db.Prepare(db.insertBlockSQL)
 	if err != nil {
 		return err


### PR DESCRIPTION
`StoreBlock` previously set all blocks at a given height as side chain
(`is_mainchain=false`) before adding the new block data, but this was
unnecessary unless the new block was being added as part of a reorg,
where there are actually such blocks that are being orphaned/demoted.
This change moves the `setHeightToSideChain` call from `StoreBlock` to
`switchToSideChain` where it belongs.

This resolves a significant performance regression with initial sync.