### PR TITLE
api cache: Cache stake info too.

### DIFF
--- a/api/types/apicache_test.go
+++ b/api/types/apicache_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func TestCheckBlockHeightHash(t *testing.T) {
+	d := &cachedBlockData{&BlockDataBasic{Height: 1001}, nil}
+	height, hash, mismatch := checkBlockHeightHash(d)
+	if mismatch {
+		t.Errorf("checkBlockHeightHash: %v", mismatch)
+	}
+	t.Log(height, hash)
+}
+
 // TODO: Make a proper test rather than a playground
 
 func TestBlockPriorityQueue(t *testing.T) {
@@ -18,16 +27,16 @@ func TestBlockPriorityQueue(t *testing.T) {
 	cachedBlocks := []*CachedBlock{
 		newCachedBlock(&BlockDataBasic{
 			Height: 123,
-		}),
+		}, nil),
 		newCachedBlock(&BlockDataBasic{
 			Height: 1000,
-		}),
+		}, nil),
 		newCachedBlock(&BlockDataBasic{
 			Height: 1,
-		}),
+		}, nil),
 		newCachedBlock(&BlockDataBasic{
 			Height: 400,
-		}),
+		}, nil),
 	}
 
 	// reheap, which resets all access counts and times
@@ -42,16 +51,15 @@ func TestBlockPriorityQueue(t *testing.T) {
 
 	t.Log(pq.capacity, pq.Len(), pq.minHeight, pq.maxHeight)
 
-	// heap.Push(pq, &BlockDataBasic{Height: 1001})
-	pq.Insert(&BlockDataBasic{Height: 1001})
-	// heap.Push(pq, &BlockDataBasic{Height: 1002})
-	pq.Insert(&BlockDataBasic{Height: 0})
-	pq.Insert(&BlockDataBasic{Height: 6})
+	pq.Insert(&BlockDataBasic{Height: 1001}, nil)
+	pq.Insert(&BlockDataBasic{Height: 0}, nil)
+	pq.Insert(&BlockDataBasic{Height: 6}, nil)
 
 	for pq.Len() > 0 {
 		cachedBlock := heap.Pop(pq).(*CachedBlock)
 		t.Logf("%8d\t%4d\t%d\t%4d\n", cachedBlock.summary.Height, cachedBlock.accesses, cachedBlock.accessTime, pq.Len())
 	}
 
-	heap.Push(pq, &BlockDataBasic{Height: 1})
+	blockData := &cachedBlockData{&BlockDataBasic{Height: 1}, nil}
+	heap.Push(pq, blockData)
 }


### PR DESCRIPTION
Add `StakeInfoExtended`, `height`, and `hash` to `CachedBlock`.
Create `(*APICache).StoreStakeInfo`.
Create `(*APICache).GetStakeInfo` and `(*APICache).GetStakeInfoByHash`, and
use them in `(*DB).RetrieveStakeInfoExtended[ByHash]`.
Do not enable API cache by default; enable it in `main` after sync.