### PR TITLE
use MempoolInfo for getmempooltxs response

### DIFF
--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -98,6 +98,20 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					}
 
 				case "getmempooltxs":
+					// MempoolInfo. Used on mempool and home page.
+					exp.MempoolData.RLock()
+					msg, err := json.Marshal(exp.MempoolData)
+					exp.MempoolData.RUnlock()
+
+					if err != nil {
+						log.Warn("Invalid JSON message: ", err)
+						webData.Message = "Error: Could not encode JSON message"
+						break
+					}
+					webData.Message = string(msg)
+
+				case "getmempooltrimmed":
+					// TrimmedMempoolInfo. Used in nexthome.
 					// construct mempool object with properties required in template
 					mempoolInfo := exp.TrimmedMempoolInfo()
 					// mempool fees appear incorrect, temporarily set to zero for now

--- a/public/js/controllers/mempool_controller.js
+++ b/public/js/controllers/mempool_controller.js
@@ -137,7 +137,7 @@ export default class extends Controller {
   handleTxsResp (event) {
     var m = JSON.parse(event)
     buildTable(this.regularTransactionsTarget, 'regular transactions', m.tx, txTableRow)
-    buildTable(this.revocationTransactionsTarget, 'revocations', m.revokes, txTableRow)
+    buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, txTableRow)
     buildTable(this.voteTransactionsTarget, 'votes', m.votes, voteTxTableRow)
     buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, txTableRow)
   }

--- a/public/js/controllers/visualBlocks_controller.js
+++ b/public/js/controllers/visualBlocks_controller.js
@@ -13,6 +13,7 @@ function makeNode (html) {
 
 function makeMempoolBlock (block) {
   let fees = 0
+  if (!block.Transactions) return
   for (const tx of block.Transactions) {
     fees += tx.Fees
   }
@@ -209,13 +210,13 @@ export default class extends Controller {
     this.handleNextHomeBlockUpdate = this._handleNextHomeBlockUpdate.bind(this)
     globalEventBus.on('BLOCK_RECEIVED', this.handleNextHomeBlockUpdate)
 
-    ws.registerEvtHandler('getmempooltxsResp', (event) => {
+    ws.registerEvtHandler('getmempooltrimmedResp', (event) => {
       console.log('received mempooltx response', event)
       this.handleMempoolUpdate(event)
     })
 
     ws.registerEvtHandler('mempool', (event) => {
-      ws.send('getmempooltxs', '')
+      ws.send('getmempooltrimmed', '')
     })
 
     this.refreshBlocksDisplay = this._refreshBlocksDisplay.bind(this)
@@ -227,7 +228,7 @@ export default class extends Controller {
   }
 
   disconnect () {
-    ws.deregisterEvtHandlers('getmempooltxsResp')
+    ws.deregisterEvtHandlers('getmempooltrimmedResp')
     ws.deregisterEvtHandlers('mempool')
     globalEventBus.off('BLOCK_RECEIVED', this.handleNextHomeBlockUpdate)
     window.removeEventListener('resize', this.refreshBlocksDisplay)


### PR DESCRIPTION
#718 changed the return type for the get `getmempooltxs` websocket response, but the homepage and mempool pages also use that response, and weren't updated. This PR re-instates the old `getmempooltxs` handling, and creates a new websocket handler for the trimmed data on /nexthome. 