### PR TITLE
add merged and merged credit views

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -940,7 +940,7 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 
 	// Get Confirmed Balances
 	var unconfirmedBalanceSat int64
-	_, _, totalSpent, totalUnspent, _, err := c.BlockData.ChainDB.AddressSpentUnspent(address)
+	_, _, totalSpent, totalUnspent, err := c.BlockData.ChainDB.AddressSpentUnspent(address)
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressSpentUnspent: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -78,11 +78,11 @@ func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight 
 }
 
 // AddressSpentUnspent retrieves balance information for a specific address.
-func (pgb *ChainDB) AddressSpentUnspent(address string) (int64, int64, int64, int64, int64, error) {
+func (pgb *ChainDB) AddressSpentUnspent(address string) (int64, int64, int64, int64, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
-	ns, nu, as, au, am, err := RetrieveAddressSpentUnspent(ctx, pgb.db, address)
-	return ns, nu, as, au, am, pgb.replaceCancelError(err)
+	ns, nu, as, au, err := RetrieveAddressSpentUnspent(ctx, pgb.db, address)
+	return ns, nu, as, au, pgb.replaceCancelError(err)
 }
 
 // AddressIDsByOutpoint fetches all address row IDs for a given outpoint

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1466,6 +1466,7 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 		return nil, fmt.Errorf("UnconfirmedTxnsForAddress failed for address %s: %v", address, err)
 	}
 	addrData.NumUnconfirmed = numUnconfirmed
+	addrData.NumTransactions += numUnconfirmed
 	if addrData.UnconfirmedTxns == nil {
 		addrData.UnconfirmedTxns = new(dbtypes.AddressTransactions)
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -942,9 +942,12 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 		addrFunc = RetrieveAddressTxns
 	case dbtypes.AddrTxnDebit:
 		addrFunc = RetrieveAddressDebitTxns
-
 	case dbtypes.AddrMergedTxnDebit:
 		addrFunc = RetrieveAddressMergedDebitTxns
+	case dbtypes.AddrMergedTxnCredit:
+		addrFunc = RetrieveAddressMergedCreditTxns
+	case dbtypes.AddrMergedTxn:
+		addrFunc = RetrieveAddressMergedTxns
 	default:
 		return nil, fmt.Errorf("unknown AddrTxnType %v", txnType)
 	}
@@ -1256,18 +1259,17 @@ func (pgb *ChainDB) addressBalance(address string) (*dbtypes.AddressBalance, err
 	}
 
 	if !fresh {
-		numSpent, numUnspent, amtSpent, amtUnspent, numMergedSpent, err :=
+		numSpent, numUnspent, amtSpent, amtUnspent, err :=
 			pgb.AddressSpentUnspent(address)
 		if err != nil {
 			return nil, err
 		}
 		balanceInfo = dbtypes.AddressBalance{
-			Address:        address,
-			NumSpent:       numSpent,
-			NumUnspent:     numUnspent,
-			NumMergedSpent: numMergedSpent,
-			TotalSpent:     amtSpent,
-			TotalUnspent:   amtUnspent,
+			Address:      address,
+			NumSpent:     numSpent,
+			NumUnspent:   numUnspent,
+			TotalSpent:   amtSpent,
+			TotalUnspent: amtUnspent,
 		}
 
 		totals.balance[address] = balanceInfo
@@ -1335,18 +1337,17 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 		}
 	} else {
 		log.Debugf("Obtaining balance via DB query.")
-		numSpent, numUnspent, amtSpent, amtUnspent, numMergedSpent, err :=
+		numSpent, numUnspent, amtSpent, amtUnspent, err :=
 			pgb.AddressSpentUnspent(address)
 		if err != nil {
 			return nil, nil, err
 		}
 		balanceInfo = dbtypes.AddressBalance{
-			Address:        address,
-			NumSpent:       numSpent,
-			NumUnspent:     numUnspent,
-			NumMergedSpent: numMergedSpent,
-			TotalSpent:     amtSpent,
-			TotalUnspent:   amtUnspent,
+			Address:      address,
+			NumSpent:     numSpent,
+			NumUnspent:   numUnspent,
+			TotalSpent:   amtSpent,
+			TotalUnspent: amtUnspent,
 		}
 	}
 
@@ -1411,15 +1412,33 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 		addrData.KnownTransactions = (balance.NumSpent * 2) + balance.NumUnspent
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.KnownSpendingTxns = balance.NumSpent
-		addrData.KnownMergedSpendingTxns = balance.NumMergedSpent
 
 		// Transactions to fetch with FillAddressTransactions. This should be a
 		// noop if ReduceAddressHistory is working right.
 		switch txnType {
-		case dbtypes.AddrTxnAll, dbtypes.AddrMergedTxnDebit:
+		case dbtypes.AddrTxnAll:
+			addrData.TxnCount = addrData.KnownFundingTxns + addrData.KnownSpendingTxns
+		case dbtypes.AddrMergedTxnDebit, dbtypes.AddrMergedTxnCredit, dbtypes.AddrMergedTxn:
+			addrData.IsMerged = true
+			ctx, cancel := context.WithTimeout(db.ctx, db.queryTimeout)
+			defer cancel()
+			switch txnType {
+			case dbtypes.AddrMergedTxnDebit:
+				addrData.TxnCount, err = CountMergedSpendingTxns(ctx, db.db, address)
+			case dbtypes.AddrMergedTxnCredit:
+				addrData.TxnCount, err = CountMergedFundingTxns(ctx, db.db, address)
+			case dbtypes.AddrMergedTxn:
+				addrData.TxnCount, err = CountMergedTxns(ctx, db.db, address)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("AddressHistory: %v", err)
+			}
+
 		case dbtypes.AddrTxnCredit:
+			addrData.TxnCount = addrData.KnownFundingTxns
 			addrData.Transactions = addrData.TxnsFunding
 		case dbtypes.AddrTxnDebit:
+			addrData.TxnCount = addrData.KnownSpendingTxns
 			addrData.Transactions = addrData.TxnsSpending
 		default:
 			log.Warnf("Unknown address transaction type: %v", txnType)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1253,7 +1253,7 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		TxnCount int64  `json:"tx_count"`
 		HTML     string `json:"html"`
 	}{
-		TxnCount: addrData.TxnCount,
+		TxnCount: addrData.TxnCount + addrData.NumUnconfirmed,
 	}
 
 	response.HTML, err = exp.templates.execTemplateToString("addresstable", struct {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1249,7 +1249,14 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	str, err := exp.templates.execTemplateToString("addresstable", struct {
+	response := struct {
+		TxnCount int64  `json:"tx_count"`
+		HTML     string `json:"html"`
+	}{
+		TxnCount: addrData.TxnCount,
+	}
+
+	response.HTML, err = exp.templates.execTemplateToString("addresstable", struct {
 		Data *dbtypes.AddressInfo
 	}{
 		Data: addrData,
@@ -1261,11 +1268,13 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html")
-	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
-	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, str)
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		jsonBytes = []byte("JSON error")
+	}
 
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonBytes)
 }
 
 // parseAddressParams is used by both /address and /addresstable.

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -185,11 +185,8 @@ export default class extends Controller {
     var cdata = ctrl.data
     ctrl.dcrAddress = cdata.get('dcraddress')
     ctrl.paginationParams = {
-      'offset': parseInt(cdata.get('offset')),
-      'all': parseInt(cdata.get('fundingCount')) + parseInt(cdata.get('spendingCount')),
-      'credit': parseInt(cdata.get('fundingCount')),
-      'debit': parseInt(cdata.get('spendingCount')),
-      'merged_debit': parseInt(cdata.get('mergedCount'))
+      offset: parseInt(cdata.get('offset')),
+      count: parseInt(cdata.get('txnCount')),
     }
     ctrl.balance = cdata.get('balance')
 
@@ -289,7 +286,7 @@ export default class extends Controller {
     var count = ctrl.pageSize
     var txType = ctrl.txnType
     var requestedOffset = params.offset + count * direction
-    if (requestedOffset >= params[txType]) return
+    if (requestedOffset >= params.count) return
     if (requestedOffset < 0) requestedOffset = 0
     ctrl.fetchTable(txType, count, requestedOffset)
   }
@@ -297,13 +294,15 @@ export default class extends Controller {
   async fetchTable (txType, count, offset) {
     var ctrl = this
     ctrl.listboxTarget.classList.add('loading')
-    let tableResponse = await axios.get(ctrl.makeTableUrl(txType, count, offset))
-    let html = tableResponse.data
-    ctrl.tableTarget.innerHTML = dompurify.sanitize(html)
+    var requestCount = count > 20 ? count : 20
+    let tableResponse = await axios.get(ctrl.makeTableUrl(txType, requestCount, offset))
+    let data = tableResponse.data
+    ctrl.tableTarget.innerHTML = dompurify.sanitize(data.html)
     var settings = ctrl.listSettings
     settings.n = count
     settings.start = offset
     settings.txntype = txType
+    ctrl.paginationParams.count = data.tx_count
     ctrl.query.replace(settings)
     ctrl.paginationParams.offset = offset
     ctrl.setPageability()
@@ -313,7 +312,7 @@ export default class extends Controller {
   setPageability () {
     var ctrl = this
     var params = ctrl.paginationParams
-    var rowMax = params[ctrl.txnType]
+    var rowMax = params.count
     var count = ctrl.pageSize
     if (rowMax > count) {
       ctrl.pagebuttonsTarget.classList.remove('d-hide')

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -142,7 +142,7 @@ export default class extends Controller {
       'pagesize', 'txntype', 'txnCount', 'qricon', 'qrimg', 'qrbox',
       'paginator', 'pageplus', 'pageminus', 'listbox', 'table',
       'range', 'chartbox', 'noconfirms', 'chart', 'pagebuttons',
-      'pending', 'hash', 'matchhash', 'view']
+      'pending', 'hash', 'matchhash', 'view', 'mergedMsg']
   }
 
   async connect () {
@@ -186,7 +186,7 @@ export default class extends Controller {
     ctrl.dcrAddress = cdata.get('dcraddress')
     ctrl.paginationParams = {
       offset: parseInt(cdata.get('offset')),
-      count: parseInt(cdata.get('txnCount')),
+      count: parseInt(cdata.get('txnCount'))
     }
     ctrl.balance = cdata.get('balance')
 
@@ -306,6 +306,11 @@ export default class extends Controller {
     ctrl.query.replace(settings)
     ctrl.paginationParams.offset = offset
     ctrl.setPageability()
+    if (txType.indexOf('merged') === -1) {
+      this.mergedMsgTarget.classList.add('d-hide')
+    } else {
+      this.mergedMsgTarget.classList.remove('d-hide')
+    }
     ctrl.listboxTarget.classList.remove('loading')
   }
 

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -6,7 +6,7 @@
 <body class="{{ theme }}">
     {{template "navbar" . }}
     {{with .Data}}
-    {{$TxnCount := .TxnCount}}
+    {{$TxnCount := add .TxnCount .NumUnconfirmed}}
     {{$txType := .TxnType}}
     <div class="container main"
       data-controller="address newblock"
@@ -174,8 +174,11 @@
                   >
                     {{if gt $TxnCount 0}}<a class="d-inline-block p-2 rounded download" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>{{end}}
                     <!-- This dummy span ensures left/right alignment of the buttons, even if one is hidden -->
-                    <span> </span>
-                    <div class="d-inline-block">
+                    <span></span>
+                    <div class="d-inline-block text-right">
+                      <span class="fs14 d-block{{if not .IsMerged}} d-hide{{end}}" data-target="address.mergedMsg">
+                          *No unconfirmed transactions shown in merged views.
+                      </span>
                       <label class="mb-0 mr-1" for="txntype">Type</label>
                       <select
                           name="txntype"
@@ -194,9 +197,9 @@
                     </div>
                   </div>
                   {{if and (not .Fullmode) (ge .KnownTransactions .MaxTxLimit)}}
-                  <div>
-                      *Limit of {{.MaxTxLimit}} transactions shown in lite mode.
-                  </div>
+                    <div>
+                        *Limit of {{.MaxTxLimit}} transactions shown in lite mode.
+                    </div>
                   {{end}}
                   <div
                       class="hidden d-flex align-items-center justify-content-end"

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -12,9 +12,7 @@
       data-controller="address newblock"
       data-address-offset="{{.Offset}}"
       data-address-dcraddress="{{.Address}}"
-      data-address-merged-count="{{.KnownMergedSpendingTxns}}"
-      data-address-spending-count="{{.KnownSpendingTxns}}"
-      data-address-funding-count="{{.KnownFundingTxns}}"
+      data-address-txn-count="{{$TxnCount}}"
       data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"
     >
         <div class="row">
@@ -189,6 +187,8 @@
                           <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
                           <option {{if eq $txType "credit"}}selected{{end}} value="credit">Credits</option>
                           <option {{if eq $txType "debit"}}selected{{end}} value="debit">Debits</option>
+                          <option {{if eq $txType "merged"}}selected{{end}} value="merged">Merged View</option>
+                          <option {{if eq $txType "merged_credit"}}selected{{end}} value="merged_credit">Merged Credits</option>
                           <option {{if eq $txType "merged_debit"}}selected{{end}} value="merged_debit">Merged Debits</option>
                       </select>
                     </div>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -214,7 +214,7 @@
               <th># of Outputs(s)</th>
               <th class="text-center">Credit DCR</th>
           {{else if eq $txType "merged" }}
-              <th title="Count of address's inputs and outputs in the merged block.">I/O&nbsp;Count</th>
+              <th title="Count of address's inputs and outputs in the transaction.">I/O&nbsp;Count</th>
               <th class="text-center">Credit DCR</th>
               <th class="text-center">Debit DCR</th>
           {{else}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -214,7 +214,7 @@
               <th># of Outputs(s)</th>
               <th class="text-center">Credit DCR</th>
           {{else if eq $txType "merged" }}
-              <th>I/O&nbsp;Count</th>
+              <th title="Count of address's inputs and outputs in the merged block.">I/O&nbsp;Count</th>
               <th class="text-center">Credit DCR</th>
               <th class="text-center">Debit DCR</th>
           {{else}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -201,6 +201,7 @@
 {{define "addressTable"}}
   {{$TxnCount := .TxnCount}}
   {{$txType := .TxnType}}
+  {{$isMerged := .IsMerged}}
   {{if .Transactions}}
   <table class="table table-mono-cells table-sm striped" style="width: 100%;">
       <thead>
@@ -208,12 +209,16 @@
           <th>Input/Output ID</th>
           {{if eq $txType "merged_debit"}}
               <th># of Input(s)</th>
-          {{else}}
-              <th class="text-right">Credit DCR</th>
-          {{end}}
-          {{if eq $txType "merged_debit"}}
+              <th class="text-center">Debit DCR</th>
+          {{else if eq $txType "merged_credit" }}
+              <th># of Outputs(s)</th>
+              <th class="text-center">Credit DCR</th>
+          {{else if eq $txType "merged" }}
+              <th>I/O&nbsp;Count</th>
+              <th class="text-center">Credit DCR</th>
               <th class="text-center">Debit DCR</th>
           {{else}}
+              <th class="text-right">Credit DCR</th>
               <th>Debit DCR</th>
           {{end}}
           <th>Time ({{timezone}})</th>
@@ -226,59 +231,75 @@
           <tr {{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}" {{end}}>
               {{with $v}}
               <td>{{.TxType}}</td>
-              <td><a href="/tx/{{.TxID}}/{{if .IsFunding}}out{{else}}in{{end}}/{{.InOutID}}"
-                data-target="address.hash"
-                class="hash"
-                data-keynav-priority
-                >{{.IOID $txType}}</a>
-              </td>
-              {{if eq $txType "merged_debit"}}
-                  <td class="text-right">{{.MergedTxnCount}}</td>
+              {{if $isMerged}}
+                <td><a href="/tx/{{.TxID}}"
+                  data-target="address.hash"
+                  class="hash"
+                  data-keynav-priority
+                  >{{.TxID}}</a>
               {{else}}
-                  {{if ne .ReceivedTotal 0.0}}
-                      <td class="text-right fs15">
-                      {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-                      </td>
-                  {{else}}
-                      {{if eq .SentTotal 0.0}}
-                      <td class="text-right">sstxcommitment</td>
-                      {{else}}
-                          {{if ne .MatchedTx ""}}
-                          <td class="text-right"><a
-                            href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}"
-                            data-action="mouseover->address#hashOver mouseout->address#hashOut"
-                            >source</a></td>
+                <td><a href="/tx/{{.TxID}}/{{if .IsFunding}}out{{else}}in{{end}}/{{.InOutID}}"
+                  data-target="address.hash"
+                  class="hash"
+                  data-keynav-priority
+                  >{{.IOID $txType}}</a>
+              {{end}}
 
-                          {{else}}
-                          <td class="text-right">N/A</td>
-                          {{end}}
-                      {{end}}
-                  {{end}}
+              {{if eq $txType "merged_debit"}}
+                <td class="text-center">{{.MergedTxnCount}}</td>
+                <td class="text-right fs15">
+                  {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+                </td>
+
+              {{else if eq $txType "merged_credit"}}
+                <td class="text-center">{{.MergedTxnCount}}</td>
+                <td class="text-right fs15">
+                  {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+                </td>
+
+              {{else if eq $txType "merged"}}
+                <td class="text-center">{{.MergedTxnCount}}</td>
+                {{if .IsFunding}}
+                  <td class="text-center fs15">
+                    {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+                  </td>
+                  <td class="text-center">&mdash;</td>
+                {{else}}
+                  <td class="text-center">&mdash;</td>
+                  <td class="text-center fs15">
+                    {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+                  </td>
+                {{end}}
+
+              {{else if or (eq $txType "credit") .IsFunding}}  <!-- .IsFunding = true && txType = "all" is a credit -->
+                <td class="text-right fs15">
+                  {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+                </td>
+                {{if ne .MatchedTx ""}}
+                    <td><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
+                      data-txid="{{.MatchedTx}}"
+                      data-action="mouseover->address#hashOver mouseout->address#hashOut"
+                      >spent</a></td>
+                {{else}}
+                    <td>unspent</td>
+                {{end}}
+
+              {{else}} <!-- either "credit", or "all" with .IsFunding = false -->
+                {{if eq .SentTotal 0.0}}
+                  <td class="text-right">sstxcommitment</td>
+                {{else if ne .MatchedTx ""}}
+                  <td class="text-right"><a
+                    href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}"
+                    data-action="mouseover->address#hashOver mouseout->address#hashOut"
+                    >source</a></td>
+                {{else}}
+                  <td class="text-right">N/A</td>
+                {{end}}
+                <td class="text-right fs15">
+                  {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+                </td>
               {{end}}
-              {{if ne .SentTotal 0.0}}
-                  {{if lt 0.0 .SentTotal}}
-                  {{if eq $txType "merged_debit"}}
-                          <td class="text-right fs15">
-                          {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-                          </td>
-                      {{else}}
-                          <td class="fs15">
-                          {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-                          </td>
-                      {{end}}
-                  {{else}}
-                      <td class="text-right fs15">N/A</td>
-                  {{end}}
-              {{else}}
-                  {{if ne .MatchedTx ""}}
-                      <td><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
-                        data-txid="{{.MatchedTx}}"
-                        data-action="mouseover->address#hashOver mouseout->address#hashOut"
-                        >spent</a></td>
-                  {{else}}
-                      <td>unspent</td>
-                  {{end}}
-              {{end}}
+
               <td class="addr-tx-time">
                   {{if eq .Confirmations 0}}
                       Unconfirmed


### PR DESCRIPTION
Makes a few changes to the  `AddressInfo` type. `TxCount` is an `int` instead of a getter, and removed the `NumMergedSpent` member. Instead, merged type rows are only counted on relevant requests, instead of
every time (see `RetrieveAddressSpentUnspent` changes). For simple debit and credit views, this provides a substantial performance boost.

Changes the response from `explorer.AddressTable` to a JSON object, with a `tx_count` and `html` field. The count is needed since the merged rows are not being counted every time anymore. This is possible because if there are credits and debits available, there are merged rows available, an vice versa.

Resolves #742