### PR TITLE
confirmed and unconfirmed previous outpoint links

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1439,6 +1439,20 @@ func (db *WiredDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 		} else {
 			ValueIn, _ = dcrutil.NewAmount(vin.AmountIn)
 		}
+		if tx.BlockHeight == 0 && vin.BlockHeight == 0 {
+			// the vins in a verbose mempool tx from dcrd are always block height 0
+			vinHash, err := chainhash.NewHashFromStr(vin.Txid)
+			if err != nil {
+				log.Errorf("Failed to translate hash from string: %s", vin.Txid)
+			} else {
+				prevTx, err := db.client.GetRawTransactionVerbose(vinHash)
+				if err == nil {
+					vin.BlockHeight = uint32(prevTx.BlockHeight)
+				} else {
+					log.Errorf("Error getting data for previous outpoint of mempool transaction: %v", err)
+				}
+			}
+		}
 		inputs = append(inputs, exptypes.Vin{
 			Vin: &dcrjson.Vin{
 				Txid:        vin.Txid,

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -339,7 +339,7 @@
                                 N/A
                             {{end}}
                         </td>
-                        <td class="shrink-to-fit">
+                        <td class="shrink-to-fit"{{if eq .BlockHeight 0}} data-target="tx.mempoolTd" data-txid="{{.Txid}}"{{end}}>
                         {{if or .Coinbase .Stakebase}}
                             created
                         {{else if eq .BlockHeight 0}}


### PR DESCRIPTION
Vins in raw verbose transaction from dcrd for a mempool transaction are not given a block height, even if the previous outpoint has been confirmed. Looks them up. 

Also, a transaction can reference another mempool transaction, so in the "pending" case, stimulus checks for those txids in new blocks and add a link to the block once its included.

Resolves #906 and maybe #130 