### PR TITLE
dcrsqlite: fast and thorough purge

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,7 +102,8 @@ type config struct {
 	DBFileName         string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)." env:"DCRDATA_SQLITE_DB_FILE_NAME"`
 	AgendaDBFileName   string `long:"agendadbfile" description:"Agenda DB file name (default is agendas.db)." env:"DCRDATA_AGENDA_DB_FILE_NAME"`
 
-	PurgeNBestBlocks int `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
+	PurgeNBestBlocks int  `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
+	FastSQLitePurge  bool `long:"fast-sqlite-purge" description:"Purge all data for the blocks above the specified height."`
 
 	FullMode       bool          `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support" env:"DCRDATA_ENABLE_FULL_MODE"`
 	PGDBName       string        `long:"pgdbname" description:"PostgreSQL DB name." env:"DCRDATA_PG_DB_NAME"`

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -371,14 +371,14 @@ type DeletionSummary struct {
 
 // String makes a pretty summary of the totals.
 func (s DeletionSummary) String() string {
-	summary := fmt.Sprintf("\t%5d Blocks purged\n", s.Blocks)
-	summary = summary + fmt.Sprintf("\t%5d Vins purged\n", s.Vins)
-	summary = summary + fmt.Sprintf("\t%5d Vouts purged\n", s.Vouts)
-	summary = summary + fmt.Sprintf("\t%5d Addresses purged\n", s.Addresses)
-	summary = summary + fmt.Sprintf("\t%5d Transactions purged\n", s.Transactions)
-	summary = summary + fmt.Sprintf("\t%5d Tickets purged\n", s.Tickets)
-	summary = summary + fmt.Sprintf("\t%5d Votes purged\n", s.Votes)
-	summary = summary + fmt.Sprintf("\t%5d Misses purged", s.Misses)
+	summary := fmt.Sprintf("%9d Blocks purged\n", s.Blocks)
+	summary = summary + fmt.Sprintf("%9d Vins purged\n", s.Vins)
+	summary = summary + fmt.Sprintf("%9d Vouts purged\n", s.Vouts)
+	summary = summary + fmt.Sprintf("%9d Addresses purged\n", s.Addresses)
+	summary = summary + fmt.Sprintf("%9d Transactions purged\n", s.Transactions)
+	summary = summary + fmt.Sprintf("%9d Tickets purged\n", s.Tickets)
+	summary = summary + fmt.Sprintf("%9d Votes purged\n", s.Votes)
+	summary = summary + fmt.Sprintf("%9d Misses purged", s.Misses)
 	return summary
 }
 


### PR DESCRIPTION
This adds the `--fast-sqlite-purge` option does not follow the main chain back by N
blocks. Rather it deletes all data for blocks above a certain height
that is computed the same way as the normal purge.

Add `(*WiredDB).PurgeBlocksAboveHeight` and the queries:
`deleteStakeInfoAboveHeightSQL` and `deleteBlocksAboveHeightSQL`.

Change `RetrieveLatestBlockSummary` to query the best block on main chain.

Fix `getHighestStakeHeight` to join with the block summary table on hash
where `is_mainchain=1`.  This ignores side chain blocks when requesting best
block data.

Add a sanity check in `PurgeBestBlock` to ensure the block summary and
stake info tables are at the same height.