### PR TITLE
Add exchange rate monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,17 @@ This may make parsing more efficient for the client.
 | Detailed ticket list (fee, hash, size, age, etc.) | `/mempool/sstx/details`   | `apitypes.MempoolTicketDetails` |
 | Detailed ticket list (N highest fee rates)        | `/mempool/sstx/details/N` | `apitypes.MempoolTicketDetails` |
 
+
+| Exchanges                         | Path                | Type                         |
+| ----------------------------------| --------------------| ---------------------------- |
+| Exchange data summary             | `/exchanges`        | `exchanges.ExchangeBotState` |
+| List of available currency codes  | `/exchanges/codes`  | []string                     |
+
+Exchange monitoring is off by default. Server must be started with
+`--exchange-monitor` to enable exchange data.
+The server will set a default currency code. To use a different code, pass URL
+parameter `?code=[code]`. For example, `/exchanges?code=EUR`.
+
 | Other                           | Path      | Type               |
 | ------------------------------- | --------- | ------------------ |
 | Status                          | `/status` | `types.Status`     |

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -195,6 +195,11 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 		r.Get("/charts", app.getTicketPoolCharts)
 	})
 
+	mux.Route("/exchanges", func(r chi.Router) {
+		r.Get("/", app.getExchanges)
+		r.Get("/codes", app.getCurrencyCodes)
+	})
+
 	mux.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, r.URL.RequestURI()+" ain't no country I've ever heard of! (404)", http.StatusNotFound)
 	})

--- a/config.go
+++ b/config.go
@@ -65,6 +65,8 @@ var (
 	defaultPGDBName                     = "dcrdata"
 	defaultPGQueryTimeout time.Duration = time.Hour
 
+	defaultExchangeIndex = "USD"
+
 	maxSyncStatusLimit = 5000
 )
 
@@ -128,6 +130,11 @@ type config struct {
 	DcrdServ         string `long:"dcrdserv" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:19556)" env:"DCRDATA_DCRD_URL"`
 	DcrdCert         string `long:"dcrdcert" description:"File containing the dcrd certificate file" env:"DCRDATA_DCRD_CERT"`
 	DisableDaemonTLS bool   `long:"nodaemontls" description:"Disable TLS for the daemon RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost" env:"DCRDATA_DCRD_DISABLE_TLS"`
+
+	// ExchangeBot settings
+	DisableExchangeBot bool   `long:"no-exchange-monitor" description:"Disable the exchange monitor." env:"DCRDATA_NO_EXCHANGES"`
+	DisabledExchanges  string `long:"disable-exchange" description:"Exchanges to disable. Use a comma to separate multiple exchanges." env:"DCRDATA_DISABLE_EXCHANGES"`
+	ExchangeCurrency   string `long:"exchange-currency" description:"The default bitcoin price index. A 3-letter currency code." env:"DCRDATA_EXCHANGE_INDEX"`
 }
 
 var (
@@ -153,6 +160,7 @@ var (
 		PGPass:             defaultPGPass,
 		PGHost:             defaultPGHost,
 		PGQueryTimeout:     defaultPGQueryTimeout,
+		ExchangeCurrency:   defaultExchangeIndex,
 	}
 )
 

--- a/config.go
+++ b/config.go
@@ -65,7 +65,8 @@ var (
 	defaultPGDBName                     = "dcrdata"
 	defaultPGQueryTimeout time.Duration = time.Hour
 
-	defaultExchangeIndex = "USD"
+	defaultExchangeIndex     = "USD"
+	defaultDisabledExchanges = "huobi,dragonex"
 
 	maxSyncStatusLimit = 5000
 )
@@ -132,9 +133,9 @@ type config struct {
 	DisableDaemonTLS bool   `long:"nodaemontls" description:"Disable TLS for the daemon RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost" env:"DCRDATA_DCRD_DISABLE_TLS"`
 
 	// ExchangeBot settings
-	DisableExchangeBot bool   `long:"no-exchange-monitor" description:"Disable the exchange monitor." env:"DCRDATA_NO_EXCHANGES"`
-	DisabledExchanges  string `long:"disable-exchange" description:"Exchanges to disable. Use a comma to separate multiple exchanges." env:"DCRDATA_DISABLE_EXCHANGES"`
-	ExchangeCurrency   string `long:"exchange-currency" description:"The default bitcoin price index. A 3-letter currency code." env:"DCRDATA_EXCHANGE_INDEX"`
+	EnableExchangeBot bool   `long:"exchange-monitor" description:"Enable the exchange monitor" env:"DCRDATA_MONITOR_EXCHANGES"`
+	DisabledExchanges string `long:"disable-exchange" description:"Exchanges to disable. See /exchanges/exchanges.go for available exchanges. Use a comma to separate multiple exchanges" env:"DCRDATA_DISABLE_EXCHANGES"`
+	ExchangeCurrency  string `long:"exchange-currency" description:"The default bitcoin price index. A 3-letter currency code" env:"DCRDATA_EXCHANGE_INDEX"`
 }
 
 var (
@@ -161,6 +162,7 @@ var (
 		PGHost:             defaultPGHost,
 		PGQueryTimeout:     defaultPGQueryTimeout,
 		ExchangeCurrency:   defaultExchangeIndex,
+		DisabledExchanges:  defaultDisabledExchanges,
 	}
 )
 

--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -223,8 +223,12 @@ func NewExchangeBot(config *ExchangeBotConfig) (*ExchangeBot, error) {
 		buildExchange(token, constructor, bot.DcrBtcExchanges)
 	}
 
-	if len(bot.DcrBtcExchanges) == 0 || len(bot.IndexExchanges) == 0 {
-		return nil, fmt.Errorf("Unable to create necessary exchanges")
+	if len(bot.DcrBtcExchanges) == 0 {
+		return nil, fmt.Errorf("No DCR-BTC exchanges were intitialized")
+	}
+
+	if len(bot.IndexExchanges) == 0 {
+		return nil, fmt.Errorf("No BTC-fiat exchanges were initialized")
 	}
 
 	return bot, nil

--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -1,0 +1,541 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package exchanges
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultCurrency = "USD"
+	// New data will be sought after the data expiry. Data will still be given to
+	// a user until older than request expiry.
+	DefaultDataExpiry    = "20m"
+	DefaultRequestExpiry = "60m"
+)
+
+// ExchangeBotConfig is the configuration options for ExchangeBot.
+// DataExpiry must be less than RequestExpiry.
+// Recommend RequestExpiry > 2*DataExpiry, which will permit the exchange API
+// request to fail a couple of times before the exchange's data is discarded.
+type ExchangeBotConfig struct {
+	Disabled      []string
+	DataExpiry    string
+	RequestExpiry string
+	BtcIndex      string
+	Indent        bool
+}
+
+// ExchangeBot monitors exchanges and processes updates. When an update is
+// received from an exchange, the state is updated, and some convenient data
+// structures are prepared. Make ExchangeBot with NewExchangeBot,
+type ExchangeBot struct {
+	*sync.RWMutex
+	DcrBtcExchanges map[string]Exchange
+	IndexExchanges  map[string]Exchange
+	Exchanges       map[string]Exchange
+	// BtcIndex is the (typically fiat) currency to which the DCR price should be
+	// converted by default. Other conversions are available via a lookup in
+	// indexMap, but with slightly lower performance.
+	// 3-letter currency code, e.g. USD.
+	BtcIndex     string
+	indexMap     map[string]FiatIndices
+	currentState ExchangeBotState
+	// Both currentState and stateCopy hold the same information. currentState
+	// is updated by ExchangeBot, and a copy stored in stateCopy. After creation,
+	// stateCopy will never be updated, so can be used read-only by multiple
+	// threads.
+	stateCopy         *ExchangeBotState
+	currentStateBytes []byte
+	DataExpiry        time.Duration
+	RequestExpiry     time.Duration
+	minTick           time.Duration
+	// udpateChans and quitChans hold update and exit channels requested by the
+	// user.
+	updateChans []chan *UpdateSignal
+	quitChans   []chan struct{}
+	// exchangeChan and indexChan are passed to the individual exchanges and
+	// receive updates after a refresh is triggered.
+	exchangeChan chan *ExchangeUpdate
+	indexChan    chan *IndexUpdate
+	client       *http.Client
+	config       *ExchangeBotConfig
+	// The failed flag is set when there are either no up-to-date Bitcoin-fiat
+	// exchanges or no up-to-date Decred exchanges. IsFailed is a getter for failed.
+	failed bool
+}
+
+// ExchangeBotState is the current known state of all exchanges, in a certain
+// base currency, and a volume-averaged price and total volume in DCR.
+type ExchangeBotState struct {
+	BtcIndex    string                    `json:"btc_index"`
+	Price       float64                   `json:"price"`
+	Volume      float64                   `json:"volume"`
+	DcrBtc      map[string]*ExchangeState `json:"dcr_btc_exchanges"`
+	FiatIndices map[string]*ExchangeState `json:"btc_indices"`
+}
+
+// Copy an ExchangeState map.
+func copyStates(m map[string]*ExchangeState) map[string]*ExchangeState {
+	c := make(map[string]*ExchangeState)
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}
+
+// Creates a pointer to a copy of the ExchangeBotState.
+func (state ExchangeBotState) copy() *ExchangeBotState {
+	state.DcrBtc = copyStates(state.DcrBtc)
+	state.FiatIndices = copyStates(state.FiatIndices)
+	return &state
+}
+
+// UpdateSignal is the update sent over the update channels, and includes an
+// ExchangeBotState and a JSON-encoded byte array of the state.
+// Token is the exchange which triggered the update.
+type UpdateSignal struct {
+	Token string
+	State *ExchangeBotState
+	Bytes []byte
+}
+
+// FiatIndices maps currency codes to Bitcoin exchange rates.
+type FiatIndices map[string]float64
+
+// IndexUpdate is sent from the Exchange to the ExchangeBot indexChan when new
+// data is received.
+type IndexUpdate struct {
+	Token   string
+	Indices FiatIndices
+}
+
+// BotChannels is passed to exchanges for communication with the Start loop.
+type BotChannels struct {
+	index    chan *IndexUpdate
+	exchange chan *ExchangeUpdate
+}
+
+// UpdateChannels are requested by the user with ExchangeBot.UpdateChannels.
+type UpdateChannels struct {
+	Update chan *UpdateSignal
+	Quit   chan struct{}
+}
+
+// NewExchangeBot constructs a new ExchangeBot with the provided configuration.
+func NewExchangeBot(config *ExchangeBotConfig) (*ExchangeBot, error) {
+	// Validate configuration
+	if config.DataExpiry == "" {
+		config.DataExpiry = DefaultDataExpiry
+	}
+	if config.RequestExpiry == "" {
+		config.RequestExpiry = DefaultRequestExpiry
+	}
+	dataExpiry, err := time.ParseDuration(config.DataExpiry)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse data expiration from %s", config.DataExpiry)
+	}
+	requestExpiry, err := time.ParseDuration(config.RequestExpiry)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse request expiration from %s", config.RequestExpiry)
+	}
+	if requestExpiry < dataExpiry {
+		return nil, fmt.Errorf("Request expiration must be longer than data expiration.")
+	}
+	if dataExpiry < time.Minute {
+		return nil, fmt.Errorf("Expiration must be at least one minute.")
+	}
+	if config.BtcIndex == "" {
+		config.BtcIndex = DefaultCurrency
+	}
+	if config.Disabled == nil {
+		config.Disabled = []string{}
+	}
+
+	bot := &ExchangeBot{
+		RWMutex:         new(sync.RWMutex),
+		DcrBtcExchanges: make(map[string]Exchange),
+		IndexExchanges:  make(map[string]Exchange),
+		Exchanges:       make(map[string]Exchange),
+		BtcIndex:        config.BtcIndex,
+		indexMap:        make(map[string]FiatIndices),
+		currentState: ExchangeBotState{
+			BtcIndex:    config.BtcIndex,
+			Price:       0,
+			Volume:      0,
+			DcrBtc:      make(map[string]*ExchangeState),
+			FiatIndices: make(map[string]*ExchangeState),
+		},
+		currentStateBytes: []byte{},
+		DataExpiry:        dataExpiry,
+		RequestExpiry:     requestExpiry,
+		minTick:           5 * time.Second,
+		updateChans:       []chan *UpdateSignal{},
+		quitChans:         []chan struct{}{},
+		exchangeChan:      make(chan *ExchangeUpdate, 16),
+		indexChan:         make(chan *IndexUpdate, 16),
+		client:            new(http.Client),
+		config:            config,
+		failed:            false,
+	}
+
+	isDisabled := func(token string) bool {
+		for _, tkn := range config.Disabled {
+			if tkn == token {
+				return true
+			}
+		}
+		return false
+	}
+
+	channels := &BotChannels{
+		index:    bot.indexChan,
+		exchange: bot.exchangeChan,
+	}
+
+	buildExchange := func(token string, constructor func(*http.Client, *BotChannels) (Exchange, error), xcMap map[string]Exchange) {
+		if isDisabled(token) {
+			return
+		}
+		xc, err := constructor(bot.client, channels)
+		if err != nil {
+			return
+		}
+		xcMap[token] = xc
+		bot.Exchanges[token] = xc
+	}
+
+	for token, constructor := range BtcIndices {
+		buildExchange(token, constructor, bot.IndexExchanges)
+	}
+
+	for token, constructor := range DcrExchanges {
+		buildExchange(token, constructor, bot.DcrBtcExchanges)
+	}
+
+	if len(bot.DcrBtcExchanges) == 0 || len(bot.IndexExchanges) == 0 {
+		return nil, fmt.Errorf("Unable to create necessary exchanges.")
+	}
+
+	return bot, nil
+}
+
+// Start is the main ExchangeBot loop, reading from the exchange update channel
+// and scheduling refresh cycles.
+func (bot *ExchangeBot) Start(ctx context.Context, wg *sync.WaitGroup) {
+	tick := time.NewTimer(time.Second)
+
+	// Start refresh on all exchanges, and then change the updateTimes to
+	// de-sync the updates.
+	timeBetween := bot.DataExpiry / time.Duration(len(bot.Exchanges))
+	idx := 0
+	for _, xc := range bot.Exchanges {
+		go func(xc Exchange, d int) {
+			xc.Refresh()
+			if !xc.IsFailed() {
+				xc.Hurry(timeBetween * time.Duration(d))
+			}
+		}(xc, idx)
+		idx++
+	}
+
+out:
+	for {
+		select {
+		case update := <-bot.exchangeChan:
+			bot.updateExchange(update)
+			bot.signalUpdate(update.Token)
+		case update := <-bot.indexChan:
+			bot.updateIndices(update)
+			bot.signalUpdate(update.Token)
+		case <-tick.C:
+			bot.Cycle()
+		case <-ctx.Done():
+			break out
+		}
+		tick = bot.nextTick()
+	}
+	if wg != nil {
+		wg.Done()
+	}
+	bot.RLock()
+	defer bot.RUnlock()
+	for _, ch := range bot.quitChans {
+		close(ch)
+	}
+}
+
+// UpdateChannel returns a channel that will be sent updates.
+func (bot *ExchangeBot) UpdateChannels() *UpdateChannels {
+	update := make(chan *UpdateSignal, 16)
+	quit := make(chan struct{})
+	bot.Lock()
+	defer bot.Unlock()
+	bot.updateChans = append(bot.updateChans, update)
+	bot.quitChans = append(bot.quitChans, quit)
+	return &UpdateChannels{
+		Update: update,
+		Quit:   quit,
+	}
+}
+
+// Send an update to any channels requested with bot.UpdateChannels().
+func (bot *ExchangeBot) signalUpdate(token string) {
+	var signal *UpdateSignal
+	if bot.IsFailed() {
+		signal = &UpdateSignal{
+			Token: token,
+			State: nil,
+			Bytes: []byte{},
+		}
+	} else {
+		signal = &UpdateSignal{
+			Token: token,
+			State: bot.State(),
+			Bytes: bot.StateBytes(),
+		}
+	}
+	for _, ch := range bot.updateChans {
+		select {
+		case ch <- signal:
+		default:
+		}
+	}
+}
+
+// IsUpdated checks whether all enabled exchanges are up-to-date.
+func (bot *ExchangeBot) IsUpdated() bool {
+	oldestValid := time.Now().Add(-bot.RequestExpiry)
+	for _, xc := range bot.Exchanges {
+		lastUpdate := xc.LastUpdate()
+		if lastUpdate.Before(oldestValid) {
+			return false
+		}
+		if xc.LastFail().After(lastUpdate) {
+			return false
+		}
+	}
+	return true
+}
+
+// State is a copy of the current ExchangeBotState. A JSON-encoded byte array
+// of the current state can be accessed through StateBytes().
+func (bot *ExchangeBot) State() *ExchangeBotState {
+	bot.RLock()
+	defer bot.RUnlock()
+	return bot.stateCopy
+}
+
+// ConvertedState returns an ExchangeBotState with a base of the provided
+// currency code, if available.
+func (bot *ExchangeBot) ConvertedState(code string) (*ExchangeBotState, error) {
+	bot.RLock()
+	defer bot.RUnlock()
+	fiatIndices := make(map[string]*ExchangeState)
+	for token, indices := range bot.indexMap {
+		for symbol, price := range indices {
+			if symbol == code {
+				fiatIndices[token] = &ExchangeState{Price: price}
+			}
+		}
+	}
+
+	dcrPrice, volume := bot.processState(bot.currentState.DcrBtc, true)
+	btcPrice, _ := bot.processState(fiatIndices, false)
+	if dcrPrice == 0 || btcPrice == 0 {
+		bot.failed = true
+		return nil, fmt.Errorf("Unable to process price for currency %s.", code)
+	}
+
+	state := ExchangeBotState{
+		BtcIndex:    code,
+		Volume:      volume * btcPrice,
+		Price:       dcrPrice * btcPrice,
+		DcrBtc:      bot.currentState.DcrBtc,
+		FiatIndices: fiatIndices,
+	}
+
+	return state.copy(), nil
+}
+
+// StateBytes is a JSON-encoded byte array of the currentState.
+func (bot *ExchangeBot) StateBytes() []byte {
+	bot.RLock()
+	defer bot.RUnlock()
+	return bot.currentStateBytes
+}
+
+// ConvertedStateBytes gives a JSON-encoded byte array of the currentState
+// with a base of the provided currency code, if available.
+func (bot *ExchangeBot) ConvertedStateBytes(symbol string) ([]byte, error) {
+	state, err := bot.ConvertedState(symbol)
+	if err != nil {
+		return nil, err
+	}
+	var jsonBytes []byte
+	if bot.config.Indent {
+		jsonBytes, err = json.MarshalIndent(state, "", "    ")
+	} else {
+		jsonBytes, err = json.Marshal(state)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return jsonBytes, nil
+}
+
+// AvailableIndices creates a fresh slice of all available index currency codes.
+func (bot *ExchangeBot) AvailableIndices() []string {
+	bot.RLock()
+	defer bot.RUnlock()
+	var indices sort.StringSlice
+	add := func(index string) {
+		for _, symbol := range indices {
+			if symbol == index {
+				return
+			}
+		}
+		indices = append(indices, index)
+	}
+	for _, fiatIndices := range bot.indexMap {
+		for symbol, _ := range fiatIndices {
+			add(symbol)
+		}
+	}
+	sort.Sort(indices)
+	return indices
+}
+
+// processState is a helper function to process a slice of ExchangeState into
+// a price, and optionally a volume sum, and perform some cleanup along the way.
+// If volumeAveraged is false, all exchanges are given equal weight in the avg.
+func (bot *ExchangeBot) processState(states map[string]*ExchangeState, volumeAveraged bool) (float64, float64) {
+	var priceAccumulator, volSum float64
+	var deletions []string
+	oldestValid := time.Now().Add(-bot.RequestExpiry)
+	for token, state := range states {
+		if bot.Exchanges[token].LastUpdate().Before(oldestValid) {
+			deletions = append(deletions, token)
+		}
+		volume := 1.0
+		if volumeAveraged {
+			volume = state.Volume
+		}
+		volSum += volume
+		priceAccumulator += volume * state.Price
+	}
+	for _, token := range deletions {
+		delete(states, token)
+	}
+	if volSum == 0 {
+		return 0, 0
+	}
+	return priceAccumulator / volSum, volSum
+}
+
+// updateExchange processes an update from a Decred-BTC Exchange.
+func (bot *ExchangeBot) updateExchange(update *ExchangeUpdate) error {
+	bot.Lock()
+	defer bot.Unlock()
+	bot.currentState.DcrBtc[update.Token] = update.State
+	return bot.updateState()
+}
+
+// updateIndices processes an update from an Bitcoin index source, essentially
+// a map pairing currency codes to bitcoin prices.
+func (bot *ExchangeBot) updateIndices(update *IndexUpdate) error {
+	bot.Lock()
+	defer bot.Unlock()
+	bot.indexMap[update.Token] = update.Indices
+	price, hasCode := update.Indices[bot.config.BtcIndex]
+	if hasCode {
+		bot.currentState.FiatIndices[update.Token] = &ExchangeState{
+			Price: price,
+			Stamp: time.Now().Unix(),
+		}
+		return bot.updateState()
+	}
+	return nil
+}
+
+// Called from both updateIndices and updateExchange (under mutex lock).
+func (bot *ExchangeBot) updateState() error {
+	dcrPrice, volume := bot.processState(bot.currentState.DcrBtc, true)
+	btcPrice, _ := bot.processState(bot.currentState.FiatIndices, false)
+	if dcrPrice == 0 || btcPrice == 0 {
+		bot.failed = true
+		bot.stateCopy = nil
+		return nil
+	}
+
+	bot.failed = false
+	bot.currentState.Price = dcrPrice * btcPrice
+	bot.currentState.Volume = volume
+	var jsonBytes []byte
+	var err error
+	if bot.config.Indent {
+		jsonBytes, err = json.MarshalIndent(bot.currentState, "", "    ")
+	} else {
+		jsonBytes, err = json.Marshal(bot.currentState)
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to write bytes")
+	}
+	bot.currentStateBytes = jsonBytes
+	bot.stateCopy = bot.currentState.copy()
+	return nil
+}
+
+// IsFailed is whether the failed flag was set during the last IndexUpdate
+// or ExchangeUpdate. The failed flag is set when either no Bitcoin Index
+// sources or no Decred Exchanges are up-to-date. Individual exchanges can
+// be outdated/failed without IsFailed being false, as long as there is at least
+// one Bitcoin index and one Decred exchange.
+func (bot *ExchangeBot) IsFailed() bool {
+	bot.RLock()
+	defer bot.RUnlock()
+	return bot.failed
+}
+
+// nextTick checks the exchanges' last update and fail times, and calculates
+// when the next Cycle should run.
+func (bot *ExchangeBot) nextTick() *time.Timer {
+	tNow := time.Now()
+	tOldest := tNow
+	for _, xc := range bot.Exchanges {
+		t := xc.LastTry()
+		if t.Before(tOldest) {
+			tOldest = t
+		}
+	}
+	tSince := tNow.Sub(tOldest)
+	tilNext := bot.DataExpiry - tSince
+	if tilNext < bot.minTick {
+		tilNext = bot.minTick
+	}
+	return time.NewTimer(tilNext)
+}
+
+// Cycle refreshes all expired exchanges.
+func (bot *ExchangeBot) Cycle() {
+	tNow := time.Now()
+	for _, xc := range bot.Exchanges {
+		if tNow.Sub(xc.LastTry()) > bot.DataExpiry {
+			go xc.Refresh()
+		}
+	}
+}
+
+// Price gets the lastest Price in the default currency (BtcIndex).
+func (bot *ExchangeBot) Price() float64 {
+	bot.RLock()
+	defer bot.RUnlock()
+	return bot.currentState.Price
+}

--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -14,10 +14,13 @@ import (
 )
 
 const (
+	// DefaultCurrency is overridden by ExchangeBotConfig.BtcIndex. Data
+	// structures are cached for DefaultCurrency, so requests are a little bit
+	// faster.
 	DefaultCurrency = "USD"
-	// New data will be sought after the data expiry. Data will still be given to
-	// a user until older than request expiry.
-	DefaultDataExpiry    = "20m"
+	// DefaultDataExpiry is the amount of time between calls to the exchange API.
+	DefaultDataExpiry = "20m"
+	// DefaultRequestExpiry : Any data older than RequestExpiry will be discarded.
 	DefaultRequestExpiry = "60m"
 )
 
@@ -35,7 +38,7 @@ type ExchangeBotConfig struct {
 
 // ExchangeBot monitors exchanges and processes updates. When an update is
 // received from an exchange, the state is updated, and some convenient data
-// structures are prepared. Make ExchangeBot with NewExchangeBot,
+// structures are prepared. Make ExchangeBot with NewExchangeBot.
 type ExchangeBot struct {
 	*sync.RWMutex
 	DcrBtcExchanges map[string]Exchange
@@ -147,10 +150,10 @@ func NewExchangeBot(config *ExchangeBotConfig) (*ExchangeBot, error) {
 		return nil, fmt.Errorf("Unable to parse request expiration from %s", config.RequestExpiry)
 	}
 	if requestExpiry < dataExpiry {
-		return nil, fmt.Errorf("Request expiration must be longer than data expiration.")
+		return nil, fmt.Errorf("Request expiration must be longer than data expiration")
 	}
 	if dataExpiry < time.Minute {
-		return nil, fmt.Errorf("Expiration must be at least one minute.")
+		return nil, fmt.Errorf("Expiration must be at least one minute")
 	}
 	if config.BtcIndex == "" {
 		config.BtcIndex = DefaultCurrency
@@ -221,7 +224,7 @@ func NewExchangeBot(config *ExchangeBotConfig) (*ExchangeBot, error) {
 	}
 
 	if len(bot.DcrBtcExchanges) == 0 || len(bot.IndexExchanges) == 0 {
-		return nil, fmt.Errorf("Unable to create necessary exchanges.")
+		return nil, fmt.Errorf("Unable to create necessary exchanges")
 	}
 
 	return bot, nil
@@ -272,7 +275,8 @@ out:
 	}
 }
 
-// UpdateChannel returns a channel that will be sent updates.
+// UpdateChannels creates an UpdateChannels, which holds a channel to receive
+// exchange updates and a channel which is closed when the start loop exits.
 func (bot *ExchangeBot) UpdateChannels() *UpdateChannels {
 	update := make(chan *UpdateSignal, 16)
 	quit := make(chan struct{})
@@ -351,7 +355,7 @@ func (bot *ExchangeBot) ConvertedState(code string) (*ExchangeBotState, error) {
 	btcPrice, _ := bot.processState(fiatIndices, false)
 	if dcrPrice == 0 || btcPrice == 0 {
 		bot.failed = true
-		return nil, fmt.Errorf("Unable to process price for currency %s.", code)
+		return nil, fmt.Errorf("Unable to process price for currency %s", code)
 	}
 
 	state := ExchangeBotState{
@@ -405,7 +409,7 @@ func (bot *ExchangeBot) AvailableIndices() []string {
 		indices = append(indices, index)
 	}
 	for _, fiatIndices := range bot.indexMap {
-		for symbol, _ := range fiatIndices {
+		for symbol := range fiatIndices {
 			add(symbol)
 		}
 	}

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -1,0 +1,683 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package exchanges
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// Tokens. Used to identify the exchange.
+	Coinbase    = "coinbase"
+	CoinbaseUrl = "https://api.coinbase.com/v2/exchange-rates?currency=BTC"
+	Coindesk    = "coindesk"
+	CoindeskUrl = "https://api.coindesk.com/v1/bpi/currentprice.json"
+	Binance     = "binance"
+	BinanceUrl  = "https://api.binance.com/api/v1/ticker/24hr?symbol=DCRBTC"
+	Bittrex     = "bittrex"
+	BittrexUrl  = "https://bittrex.com/api/v1.1/public/getmarketsummary?market=btc-dcr"
+	DragonEx    = "dragonex"
+	DragonExUrl = "https://openapi.dragonex.io/api/v1/market/real/?symbol_id=1520101"
+	Huobi       = "huobi"
+	HuobiUrl    = "https://api.huobi.pro/market/detail/merged?symbol=dcrbtc"
+	Poloniex    = "poloniex"
+	PoloniexUrl = "https://poloniex.com/public?command=returnTicker"
+)
+
+var BtcIndices = map[string]func(*http.Client, *BotChannels) (Exchange, error){
+	Coinbase: NewCoinbase,
+	Coindesk: NewCoindesk,
+}
+
+var DcrExchanges = map[string]func(*http.Client, *BotChannels) (Exchange, error){
+	Binance:  NewBinance,
+	Bittrex:  NewBittrex,
+	DragonEx: NewDragonEx,
+	Huobi:    NewHuobi,
+	Poloniex: NewPoloniex,
+}
+
+// IsBtcIndex checks whether the given token is a known Bitcoin index, as
+// opposed to a Decred-to-Bitcoin Exchange.
+func IsBtcIndex(token string) bool {
+	_, ok := BtcIndices[token]
+	return ok
+}
+
+// IsDcrExchange checks whether the given token is a known Decred-BTC exchange.
+func IsDcrExchange(token string) bool {
+	_, ok := BtcIndices[token]
+	return ok
+}
+
+// Tokens is a new slice of available exchange tokens.
+func Tokens() []string {
+	var tokens []string
+	var token string
+	for token, _ = range BtcIndices {
+		tokens = append(tokens, token)
+	}
+	for token, _ = range DcrExchanges {
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+// ExchangeState is the simple template for a price. The only member that is
+// guaranteed is a price. For Decred exchanges, the volumes will also be
+// populated.
+type ExchangeState struct {
+	Price      float64 `json:"price"`
+	BaseVolume float64 `json:"base_volume,omitempty"`
+	Volume     float64 `json:"volume,omitempty"`
+	Change     float64 `json:"change,omitempty"`
+	Stamp      int64   `json:"timestamp,omitempty"`
+}
+
+// ExchangeUpdate packages the ExchangeState for the update channel.
+type ExchangeUpdate struct {
+	Token string
+	State *ExchangeState
+}
+
+// Exchange is the interface that ExchangeBot understands. Most of the methods
+// are implemented by CommonExchange, but Refresh is implemented in the
+// individual exchange types.
+type Exchange interface {
+	LastUpdate() time.Time
+	LastFail() time.Time
+	LastTry() time.Time
+	Refresh()
+	IsFailed() bool
+	Token() string
+	Hurry(time.Duration)
+}
+
+// CommonExchange is embedded in all of the exchange types and handles some
+// state tracking and token handling for ExchangeBot communications. The
+// http.Request must be created individually for each exchange.
+type CommonExchange struct {
+	*sync.RWMutex
+	token        string
+	URL          string
+	currentState *ExchangeState
+	client       *http.Client
+	lastUpdate   time.Time
+	lastFail     time.Time
+	request      *http.Request
+	channels     *BotChannels
+}
+
+// LastUpdate: the last update time.
+func (xc *CommonExchange) LastUpdate() time.Time {
+	xc.RLock()
+	defer xc.RUnlock()
+	return xc.lastUpdate
+}
+
+// Hurry can be used to subtract some amount of time from the lastUpate
+// and lastFail, and can be used to de-sync the exchange updates.
+func (xc *CommonExchange) Hurry(d time.Duration) {
+	xc.Lock()
+	defer xc.Unlock()
+	xc.lastFail = xc.lastFail.Add(-d)
+	xc.lastUpdate = xc.lastUpdate.Add(-d)
+}
+
+// LastFail: the last failure time.
+func (xc *CommonExchange) LastFail() time.Time {
+	xc.RLock()
+	defer xc.RUnlock()
+	return xc.lastFail
+}
+
+// IsFailed: true if the last failure occurred after the last success.
+func (xc *CommonExchange) IsFailed() bool {
+	xc.RLock()
+	defer xc.RUnlock()
+	return xc.lastFail.After(xc.lastUpdate)
+}
+
+// LastTry is the more recent of lastFail and LastUpdate.
+func (xc *CommonExchange) LastTry() time.Time {
+	xc.RLock()
+	defer xc.RUnlock()
+	if xc.lastFail.After(xc.lastUpdate) {
+		return xc.lastFail
+	}
+	return xc.lastUpdate
+}
+
+// Token: getter for the exchange token.
+func (xc *CommonExchange) Token() string {
+	return xc.token
+}
+
+// setLastFail sets the last failure time.
+func (xc *CommonExchange) setLastFail(t time.Time) {
+	xc.Lock()
+	defer xc.Unlock()
+	xc.lastFail = t
+}
+
+// Log the error along with the token and an additional passed identifier.
+func (xc *CommonExchange) fail(msg string, err error) {
+	log.Errorf("%s: %s: %v", xc.token, msg, err)
+	xc.setLastFail(time.Now())
+}
+
+// Sends an updated ExchangeState to the ExchangeBot.
+func (xc *CommonExchange) update(state *ExchangeState) {
+	xc.Lock()
+	defer xc.Unlock()
+	xc.lastUpdate = time.Now()
+	xc.channels.exchange <- &ExchangeUpdate{
+		Token: xc.token,
+		State: state,
+	}
+}
+
+// Sends a bitcoin index update to the ExchangeBot.
+func (xc *CommonExchange) updateIndices(indices FiatIndices) {
+	xc.Lock()
+	defer xc.Unlock()
+	xc.lastUpdate = time.Now()
+	xc.channels.index <- &IndexUpdate{
+		Token:   xc.token,
+		Indices: indices,
+	}
+}
+
+// Send the exchange request and decode the response.
+func (xc *CommonExchange) fetch(response interface{}) (err error) {
+	resp, err := xc.client.Do(xc.request)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("Request failed: %v", err))
+	}
+	defer resp.Body.Close()
+	err = json.NewDecoder(resp.Body).Decode(response)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("Failed to decode json: %v", err))
+	}
+	return
+}
+
+// Used to initialize the embedding exchanges.
+func newCommonExchange(token string, client *http.Client,
+	request *http.Request, channels *BotChannels) *CommonExchange {
+	var tZero time.Time
+	return &CommonExchange{
+		RWMutex:      new(sync.RWMutex),
+		token:        token,
+		client:       client,
+		channels:     channels,
+		currentState: new(ExchangeState),
+		lastUpdate:   tZero,
+		lastFail:     tZero,
+		request:      request,
+	}
+}
+
+// Coinbase provides 10 to 100s of bitcoin-fiat exchange pairs.
+type CoinbaseExchange struct {
+	*CommonExchange
+}
+
+func NewCoinbase(client *http.Client, channels *BotChannels) (coinbase Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, CoinbaseUrl, nil)
+	if err != nil {
+		return
+	}
+	coinbase = &CoinbaseExchange{
+		CommonExchange: newCommonExchange(Coinbase, client, request, channels),
+	}
+	return
+}
+
+type CoinbaseResponse struct {
+	Data CoinbaseResponseData `json:"data"`
+}
+
+type CoinbaseResponseData struct {
+	Currency string            `json:"currency"`
+	Rates    map[string]string `json:"rates"`
+}
+
+func (coinbase *CoinbaseExchange) Refresh() {
+	response := new(CoinbaseResponse)
+	err := coinbase.fetch(response)
+	if err != nil {
+		coinbase.fail("Fetch", err)
+		return
+	}
+
+	indices := make(FiatIndices)
+	for code, floatStr := range response.Data.Rates {
+		price, err := strconv.ParseFloat(floatStr, 64)
+		if err != nil {
+			coinbase.fail(fmt.Sprintf("Failed to parse float for index %s. Given %s", code, floatStr), err)
+			continue
+		}
+		indices[code] = price
+	}
+	coinbase.updateIndices(indices)
+}
+
+// Coindesk provides Bitcoin indices for USD, GBP, and EUR by default. Others
+// are available, but custom reqeusts would need to be implemented.
+type CoindeskExchange struct {
+	*CommonExchange
+}
+
+func NewCoindesk(client *http.Client, channels *BotChannels) (coindesk Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, CoindeskUrl, nil)
+	if err != nil {
+		return
+	}
+	coindesk = &CoindeskExchange{
+		CommonExchange: newCommonExchange(Coindesk, client, request, channels),
+	}
+	return
+}
+
+type CoindeskResponse struct {
+	Time       CoindeskResponseTime           `json:"time"`
+	Disclaimer string                         `json:"disclaimer"`
+	ChartName  string                         `json:"chartName"`
+	Bpi        map[string]CoindeskResponseBpi `json:"bpi"`
+}
+
+type CoindeskResponseTime struct {
+	Updated    string    `json:"updated"`
+	UpdatedIso time.Time `json:"updatedISO"`
+	Updateduk  string    `json:"updateduk"`
+}
+
+type CoindeskResponseBpi struct {
+	Code        string  `json:"code"`
+	Symbol      string  `json:"symbol"`
+	Rate        string  `json:"rate"`
+	Description string  `json:"description"`
+	RateFloat   float64 `json:"rate_float"`
+}
+
+func (coindesk *CoindeskExchange) Refresh() {
+	response := new(CoindeskResponse)
+	err := coindesk.fetch(response)
+	if err != nil {
+		coindesk.fail("Fetch", err)
+		return
+	}
+
+	indices := make(FiatIndices)
+	for code, bpi := range response.Bpi {
+		indices[code] = bpi.RateFloat
+	}
+	coindesk.updateIndices(indices)
+}
+
+type BinanceExchange struct {
+	*CommonExchange
+}
+
+func NewBinance(client *http.Client, channels *BotChannels) (binance Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, BinanceUrl, nil)
+	if err != nil {
+		return
+	}
+	binance = &BinanceExchange{
+		CommonExchange: newCommonExchange(Binance, client, request, channels),
+	}
+	return
+}
+
+type BinanceResponse struct {
+	Symbol             string `json:"symbol"`
+	PriceChange        string `json:"priceChange"`
+	PriceChangePercent string `json:"priceChangePercent"`
+	WeightedAvgPrice   string `json:"weightedAvgPrice"`
+	PrevClosePrice     string `json:"prevClosePrice"`
+	LastPrice          string `json:"lastPrice"`
+	LastQty            string `json:"lastQty"`
+	BidPrice           string `json:"bidPrice"`
+	BidQty             string `json:"bidQty"`
+	AskPrice           string `json:"askPrice"`
+	AskQty             string `json:"askQty"`
+	OpenPrice          string `json:"openPrice"`
+	HighPrice          string `json:"highPrice"`
+	LowPrice           string `json:"lowPrice"`
+	Volume             string `json:"volume"`
+	QuoteVolume        string `json:"quoteVolume"`
+	OpenTime           int64  `json:"openTime"`
+	CloseTime          int64  `json:"closeTime"`
+	FirstId            int64  `json:"firstId"`
+	LastId             int64  `json:"lastId"`
+	Count              int64  `json:"count"`
+}
+
+func (binance *BinanceExchange) Refresh() {
+	response := new(BinanceResponse)
+	err := binance.fetch(response)
+	if err != nil {
+		binance.fail("Fetch", err)
+		return
+	}
+	price, err := strconv.ParseFloat(response.LastPrice, 64)
+	if err != nil {
+		binance.fail(fmt.Sprintf("Failed to parse float from LastPrice=%s", response.LastPrice), err)
+		return
+	}
+	baseVolume, err := strconv.ParseFloat(response.QuoteVolume, 64)
+	if err != nil {
+		binance.fail(fmt.Sprintf("Failed to parse float from QuoteVolume=%s", response.QuoteVolume), err)
+		return
+	}
+	dcrVolume, err := strconv.ParseFloat(response.Volume, 64)
+	if err != nil {
+		binance.fail(fmt.Sprintf("Failed to parse float from Volume=%s", response.Volume), err)
+		return
+	}
+	priceChange, err := strconv.ParseFloat(response.PriceChange, 64)
+	if err != nil {
+		binance.fail(fmt.Sprintf("Failed to parse float from PriceChange=%s", response.PriceChange), err)
+		return
+	}
+	binance.update(&ExchangeState{
+		Price:      price,
+		BaseVolume: baseVolume,
+		Volume:     dcrVolume,
+		Change:     priceChange,
+		Stamp:      response.CloseTime / 1000,
+	})
+}
+
+type BittrexExchange struct {
+	*CommonExchange
+	MarketName string
+}
+
+func NewBittrex(client *http.Client, channels *BotChannels) (bittrex Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, BittrexUrl, nil)
+	if err != nil {
+		return
+	}
+	bittrex = &BittrexExchange{
+		CommonExchange: newCommonExchange(Bittrex, client, request, channels),
+		MarketName:     "BTC-DCR",
+	}
+	return
+}
+
+type BittrexResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Result  []BittrexResponseResult
+}
+
+type BittrexResponseResult struct {
+	MarketName     string  `json:"MarketName"`
+	High           float64 `json:"High"`
+	Low            float64 `json:"Low"`
+	Volume         float64 `json:"Volume"`
+	Last           float64 `json:"Last"`
+	BaseVolume     float64 `json:"BaseVolume"`
+	TimeStamp      string  `json:"TimeStamp"`
+	Bid            float64 `json:"Bid"`
+	Ask            float64 `json:"Ask"`
+	OpenBuyOrders  int     `json:"OpenBuyOrders"`
+	OpenSellOrders int     `json:"OpenSellOrders"`
+	PrevDay        float64 `json:"PrevDay"`
+	Created        string  `json:"Created"`
+}
+
+// Bittrex provides timestamps in a string format that is not quite RFC 3339.
+func (bittrex *BittrexExchange) Refresh() {
+	response := new(BittrexResponse)
+	err := bittrex.fetch(response)
+	if err != nil {
+		bittrex.fail("Fetch", err)
+		return
+	}
+	if !response.Success {
+		bittrex.fail("Unsuccessful resquest", err)
+		return
+	}
+	if len(response.Result) == 0 {
+		bittrex.fail("No result", err)
+		return
+	}
+	result := response.Result[0]
+	if result.MarketName != bittrex.MarketName {
+		bittrex.fail("Wrong market", fmt.Errorf("Expected market %s. Recieved %s.", bittrex.MarketName, result.MarketName))
+		return
+	}
+	bittrex.update(&ExchangeState{
+		Price:      result.Last,
+		BaseVolume: result.BaseVolume,
+		Volume:     result.Volume,
+		Change:     result.Last - result.PrevDay,
+	})
+}
+
+type DragonExchange struct {
+	*CommonExchange
+	SymbolId int
+}
+
+func NewDragonEx(client *http.Client, channels *BotChannels) (dragonex Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, DragonExUrl, nil)
+	if err != nil {
+		return
+	}
+	dragonex = &DragonExchange{
+		CommonExchange: newCommonExchange(DragonEx, client, request, channels),
+		SymbolId:       1520101,
+	}
+	return
+}
+
+type DragonExResponse struct {
+	Ok   bool                   `json:"ok"`
+	Code int                    `json:"code"`
+	Data []DragonExResponseData `json:"data"`
+	Msg  string                 `json:"msg"`
+}
+
+// dragonex has the current price in close_price
+type DragonExResponseData struct {
+	ClosePrice      string `json:"close_price"`
+	CurrentVolume   string `json:"current_volume"`
+	MaxPrice        string `json:"max_price"`
+	MinPrice        string `json:"min_price"`
+	OpenPrice       string `json:"open_price"`
+	PriceBase       string `json:"price_base"`
+	PriceChange     string `json:"price_change"`
+	PriceChangeRate string `json:"price_change_rate"`
+	Timestamp       int64  `json:"timestamp"`
+	TotalAmount     string `json:"total_amount"`
+	TotalVolume     string `json:"total_volume"`
+	UsdtVolume      string `json:"usdt_amount"`
+	SymbolId        int    `json:"symbol_id"`
+}
+
+func (dragonex *DragonExchange) Refresh() {
+	response := new(DragonExResponse)
+	err := dragonex.fetch(response)
+	if err != nil {
+		dragonex.fail("Fetch", err)
+		return
+	}
+	if !response.Ok {
+		dragonex.fail("Response not ok", err)
+		return
+	}
+	if len(response.Data) == 0 {
+		dragonex.fail("No data", fmt.Errorf("Response data array is empty."))
+		return
+	}
+	data := response.Data[0]
+	if data.SymbolId != dragonex.SymbolId {
+		dragonex.fail("Wrong code", fmt.Errorf("Pair id %d in response is not the expected id %d.", data.SymbolId, dragonex.SymbolId))
+		return
+	}
+	price, err := strconv.ParseFloat(data.ClosePrice, 64)
+	if err != nil {
+		dragonex.fail(fmt.Sprintf("Failed to parse float from ClosePrice=%s", data.ClosePrice), err)
+		return
+	}
+	volume, err := strconv.ParseFloat(data.TotalVolume, 64)
+	if err != nil {
+		dragonex.fail(fmt.Sprintf("Failed to parse float from TotalVolume=%s", data.TotalVolume), err)
+		return
+	}
+	btcVolume := volume * price
+	priceChange, err := strconv.ParseFloat(data.PriceChange, 64)
+	if err != nil {
+		dragonex.fail(fmt.Sprintf("Failed to parse float from PriceChange=%s", data.PriceChange), err)
+		return
+	}
+	dragonex.update(&ExchangeState{
+		Price:      price,
+		BaseVolume: btcVolume,
+		Volume:     volume,
+		Change:     priceChange,
+		Stamp:      data.Timestamp,
+	})
+}
+
+type HuobiExchange struct {
+	*CommonExchange
+	Ok string
+}
+
+func NewHuobi(client *http.Client, channels *BotChannels) (huobi Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, HuobiUrl, nil)
+	if err != nil {
+		return
+	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	huobi = &HuobiExchange{
+		CommonExchange: newCommonExchange(Huobi, client, request, channels),
+		Ok:             "ok",
+	}
+	return
+}
+
+type HuobiResponse struct {
+	Status string            `json:"status"`
+	Ch     string            `json:"ch"`
+	Ts     int64             `json:"ts"`
+	Tick   HuobiResponseTick `json:"tick"`
+}
+
+type HuobiResponseTick struct {
+	Amount  float64   `json:"amount"`
+	Open    float64   `json:"open"`
+	Close   float64   `json:"close"`
+	High    float64   `json:"high"`
+	Id      int64     `json:"id"`
+	Count   int64     `json:"count"`
+	Low     float64   `json:"low"`
+	Version int64     `json:"version"`
+	Ask     []float64 `json:"ask"`
+	Vol     float64   `json:"vol"`
+	Bid     []float64 `json:"bid"`
+}
+
+func (huobi *HuobiExchange) Refresh() {
+	response := new(HuobiResponse)
+	err := huobi.fetch(response)
+	if err != nil {
+		huobi.fail("Fetch", err)
+		return
+	}
+	if response.Status != huobi.Ok {
+		huobi.fail("Status not ok", fmt.Errorf("Expected status %s. Recieved %s.", huobi.Ok, response.Status))
+		return
+	}
+	dcrVolume := response.Tick.Vol
+	huobi.update(&ExchangeState{
+		Price:      response.Tick.Close,
+		BaseVolume: response.Tick.Vol,
+		Volume:     dcrVolume,
+		Change:     response.Tick.Close - response.Tick.Open,
+		Stamp:      response.Ts / 1000,
+	})
+}
+
+type PoloniexExchange struct {
+	*CommonExchange
+	CurrencyPair string
+}
+
+func NewPoloniex(client *http.Client, channels *BotChannels) (poloniex Exchange, err error) {
+	request, err := http.NewRequest(http.MethodGet, PoloniexUrl, nil)
+	if err != nil {
+		return
+	}
+	poloniex = &PoloniexExchange{
+		CommonExchange: newCommonExchange(Poloniex, client, request, channels),
+		CurrencyPair:   "BTC_DCR",
+	}
+	return
+}
+
+type PoloniexPair struct {
+	Id            int    `json:"id"`
+	Last          string `json:"last"`
+	LowestAsk     string `json:"lowestAsk"`
+	HighestBid    string `json:"highestBid"`
+	PercentChange string `json:"percentChange"`
+	BaseVolume    string `json:"baseVolume"`
+	QuoteVolume   string `json:"quoteVolume"`
+	IsFrozen      string `json:"isFrozen"`
+	High24hr      string `json:"high24hr"`
+	Low24hr       string `json:"low24hr"`
+}
+
+func (poloniex *PoloniexExchange) Refresh() {
+	var response map[string]*PoloniexPair
+	err := poloniex.fetch(&response)
+	if err != nil {
+		poloniex.fail("Fetch", err)
+		return
+	}
+	market, ok := response[poloniex.CurrencyPair]
+	if !ok {
+		poloniex.fail("Market not in response", fmt.Errorf("Response did not have expected CurrencyPair %s.", poloniex.CurrencyPair))
+		return
+	}
+	price, err := strconv.ParseFloat(market.Last, 64)
+	if err != nil {
+		poloniex.fail(fmt.Sprintf("Failed to parse float from Last=%s", market.Last), err)
+		return
+	}
+	baseVolume, err := strconv.ParseFloat(market.BaseVolume, 64)
+	if err != nil {
+		poloniex.fail(fmt.Sprintf("Failed to parse float from BaseVolume=%s", market.BaseVolume), err)
+		return
+	}
+	volume, err := strconv.ParseFloat(market.QuoteVolume, 64)
+	if err != nil {
+		poloniex.fail(fmt.Sprintf("Failed to parse float from QuoteVolume=%s", market.QuoteVolume), err)
+		return
+	}
+	percentChange, err := strconv.ParseFloat(market.PercentChange, 64)
+	if err != nil {
+		poloniex.fail(fmt.Sprintf("Failed to parse float from PercentChange=%s", market.PercentChange), err)
+		return
+	}
+	oldPrice := price / (1 + percentChange)
+	poloniex.update(&ExchangeState{
+		Price:      price,
+		BaseVolume: baseVolume,
+		Volume:     volume,
+		Change:     price - oldPrice,
+	})
+}

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -112,6 +112,7 @@ type CommonExchange struct {
 	client       *http.Client
 	lastUpdate   time.Time
 	lastFail     time.Time
+	lastRequest  time.Time
 	request      *http.Request
 	channels     *BotChannels
 }
@@ -146,14 +147,18 @@ func (xc *CommonExchange) IsFailed() bool {
 	return xc.lastFail.After(xc.lastUpdate)
 }
 
+// LogRequest sets the lastRequest time.Time.
+func (xc *CommonExchange) LogRequest() {
+	xc.Lock()
+	defer xc.Unlock()
+	xc.lastRequest = time.Now()
+}
+
 // LastTry is the more recent of lastFail and LastUpdate.
 func (xc *CommonExchange) LastTry() time.Time {
 	xc.RLock()
 	defer xc.RUnlock()
-	if xc.lastFail.After(xc.lastUpdate) {
-		return xc.lastFail
-	}
-	return xc.lastUpdate
+	return xc.lastRequest
 }
 
 // Token is the string associated with the exchange's token.
@@ -222,6 +227,7 @@ func newCommonExchange(token string, client *http.Client,
 		currentState: new(ExchangeState),
 		lastUpdate:   tZero,
 		lastFail:     tZero,
+		lastRequest:  tZero,
 		request:      request,
 	}
 }
@@ -256,6 +262,7 @@ type CoinbaseResponseData struct {
 
 // Refresh retrieves and parses API data from Coinbase.
 func (coinbase *CoinbaseExchange) Refresh() {
+	coinbase.LogRequest()
 	response := new(CoinbaseResponse)
 	err := coinbase.fetch(response)
 	if err != nil {
@@ -319,6 +326,7 @@ type CoindeskResponseBpi struct {
 
 // Refresh retrieves and parses API data from Coindesk.
 func (coindesk *CoindeskExchange) Refresh() {
+	coindesk.LogRequest()
 	response := new(CoindeskResponse)
 	err := coindesk.fetch(response)
 	if err != nil {
@@ -377,6 +385,7 @@ type BinanceResponse struct {
 
 // Refresh retrieves and parses API data from Binance.
 func (binance *BinanceExchange) Refresh() {
+	binance.LogRequest()
 	response := new(BinanceResponse)
 	err := binance.fetch(response)
 	if err != nil {
@@ -458,6 +467,7 @@ type BittrexResponseResult struct {
 // Refresh retrieves and parses API data from Bittrex.
 // Bittrex provides timestamps in a string format that is not quite RFC 3339.
 func (bittrex *BittrexExchange) Refresh() {
+	bittrex.LogRequest()
 	response := new(BittrexResponse)
 	err := bittrex.fetch(response)
 	if err != nil {
@@ -532,6 +542,7 @@ type DragonExResponseData struct {
 
 // Refresh retrieves and parses API data from DragonEx.
 func (dragonex *DragonExchange) Refresh() {
+	dragonex.LogRequest()
 	response := new(DragonExResponse)
 	err := dragonex.fetch(response)
 	if err != nil {
@@ -621,6 +632,7 @@ type HuobiResponseTick struct {
 
 // Refresh retrieves and parses API data from Huobi.
 func (huobi *HuobiExchange) Refresh() {
+	huobi.LogRequest()
 	response := new(HuobiResponse)
 	err := huobi.fetch(response)
 	if err != nil {
@@ -676,6 +688,7 @@ type PoloniexPair struct {
 
 // Refresh retrieves and parses API data from Poloniex.
 func (poloniex *PoloniexExchange) Refresh() {
+	poloniex.LogRequest()
 	var response map[string]*PoloniexPair
 	err := poloniex.fetch(&response)
 	if err != nil {

--- a/exchanges/exchanges_test.go
+++ b/exchanges/exchanges_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package exchanges
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/decred/slog"
+)
+
+func TestExchanges(t *testing.T) {
+	quickTest := false
+	UseLogger(slog.NewBackend(os.Stdout).Logger("EXE"))
+
+	// Skip this test during automated testing.
+	if os.Getenv("GORACE") != "" {
+		t.Skip("Skipping exchange test")
+	}
+
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	killSwitch := make(chan os.Signal, 1)
+	signal.Notify(killSwitch, os.Interrupt)
+
+	wg := new(sync.WaitGroup)
+
+	wg.Add(1)
+	go func() {
+		select {
+		case <-killSwitch:
+			shutdown()
+		case <-ctx.Done():
+		}
+		wg.Done()
+	}()
+
+	config := new(ExchangeBotConfig)
+	config.DataExpiry = "2m"
+	config.RequestExpiry = "4m"
+	config.Indent = true
+	config.Disabled = make([]string, 0)
+	bot, err := NewExchangeBot(config)
+	if err != nil {
+		t.Errorf("Error creating bot. Shutting down: %v", err)
+		shutdown()
+	}
+
+	wg.Add(1)
+	go bot.Start(ctx, wg)
+
+	quitTimer := time.NewTimer(time.Minute * 7)
+	var updated []string
+
+	ch := bot.UpdateChannels()
+
+out:
+	for {
+		select {
+		case update := <-ch.Update:
+			updated = append(updated, update.Token)
+			log.Infof("Update recieved from %s", update.Token)
+			if quickTest && bot.IsUpdated() {
+				break out
+			}
+		case <-ch.Quit:
+			t.Errorf("Exchange bot has quit.")
+			break out
+		case <-quitTimer.C:
+			break out
+		case <-ctx.Done():
+			break out
+		}
+	}
+
+	if !bot.IsFailed() {
+		log.Infof("Final state: %s", string(bot.StateBytes()))
+	}
+
+	logMissing := func(token string) {
+		for _, xc := range updated {
+			if xc == token {
+				return
+			}
+		}
+		t.Errorf("No update received for %s", token)
+	}
+
+	for _, token := range Tokens() {
+		logMissing(token)
+	}
+
+	log.Infof("%d Bitcoin indices available", len(bot.AvailableIndices()))
+	log.Infof(string(bot.StateBytes()))
+
+	shutdown()
+	wg.Wait()
+}

--- a/exchanges/log.go
+++ b/exchanges/log.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2013-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package exchanges
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrdata/v4/db/agendadb"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/txhelpers"
 	humanize "github.com/dustin/go-humanize"
@@ -138,13 +139,14 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 
 	str, err := exp.templates.execTemplateToString("home", struct {
 		*CommonPageData
-		Info       *types.HomeInfo
-		Mempool    *types.MempoolInfo
-		BestBlock  *types.BlockBasic
-		BlockTally []int
-		Consensus  int
-		Blocks     []*types.BlockBasic
-		NetName    string
+		Info          *types.HomeInfo
+		Mempool       *types.MempoolInfo
+		BestBlock     *types.BlockBasic
+		BlockTally    []int
+		Consensus     int
+		Blocks        []*types.BlockBasic
+		NetName       string
+		ExchangeState *exchanges.ExchangeBotState
 	}{
 		CommonPageData: exp.commonData(),
 		Info:           exp.pageData.HomeInfo,
@@ -154,6 +156,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		Consensus:      consensus,
 		Blocks:         blocks,
 		NetName:        exp.NetName,
+		ExchangeState:  exp.getExchangeState(),
 	})
 
 	exp.MempoolData.RUnlock()

--- a/explorer/explorerroutes_test.go
+++ b/explorer/explorerroutes_test.go
@@ -67,7 +67,7 @@ func TestStatusPageResponseCodes(t *testing.T) {
 
 	var wiredDBStub WiredDBStub
 	var chainDBStub ChainDBStub
-	exp := New(&wiredDBStub, &chainDBStub, false, "test", false, viewsPath)
+	exp := New(&wiredDBStub, &chainDBStub, false, "test", false, viewsPath, nil)
 
 	// handler := http.HandlerFunc()
 	// handler.ServeHTTP(rr, req)
@@ -104,7 +104,7 @@ func (t *testTxPageWiredDBStub) GetExplorerTx(txid string) *types.TxInfo {
 // func TestTxPageResponseCodes(t *testing.T) {
 // 	var wiredDBStub testTxPageWiredDBStub
 // 	var chainDBStub ChainDBStub
-// 	exp := New(&wiredDBStub, &chainDBStub, false, "test", false, viewsPath)
+// 	exp := New(&wiredDBStub, &chainDBStub, false, "test", false, viewsPath, nil)
 
 // 	io := []struct {
 // 		ExpStatus expStatus

--- a/log.go
+++ b/log.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrdata/v4/blockdata"
 	"github.com/decred/dcrdata/v4/db/dcrpg"
 	"github.com/decred/dcrdata/v4/db/dcrsqlite"
+	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer"
 	"github.com/decred/dcrdata/v4/mempool"
 	"github.com/decred/dcrdata/v4/middleware"
@@ -66,6 +67,7 @@ var (
 	log           = backendLog.Logger("DATD")
 	iapiLog       = backendLog.Logger("IAPI")
 	pubsubLog     = backendLog.Logger("PUBS")
+	xcBotLog      = backendLog.Logger("XBOT")
 )
 
 // Initialize package-global logger variables.
@@ -83,6 +85,7 @@ func init() {
 	middleware.UseLogger(apiLog)
 	notify.UseLogger(notifyLog)
 	pubsub.UseLogger(pubsubLog)
+	exchanges.UseLogger(xcBotLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.

--- a/log.go
+++ b/log.go
@@ -102,6 +102,7 @@ var subsystemLoggers = map[string]slog.Logger{
 	"IAPI": iapiLog,
 	"DATD": log,
 	"PUBS": pubsubLog,
+	"XBOT": xcBotLog,
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/decred/dcrdata/v4/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg"
 	"github.com/decred/dcrdata/v4/db/dcrsqlite"
+	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer"
 	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/mempool"
@@ -454,9 +455,29 @@ func _main(ctx context.Context) error {
 		return nil
 	}
 
+	// WaitGroup for monitoring goroutines
+	var wg sync.WaitGroup
+
+	// ExchangeBot
+	var xcBot *exchanges.ExchangeBot
+	if !cfg.DisableExchangeBot {
+		var botCfg exchanges.ExchangeBotConfig
+		if cfg.DisabledExchanges != "" {
+			botCfg.Disabled = strings.Split(cfg.DisabledExchanges, ",")
+		}
+		botCfg.BtcIndex = cfg.ExchangeCurrency
+		xcBot, err = exchanges.NewExchangeBot(&botCfg)
+		if err != nil {
+			log.Errorf("Could not create exchange monitor. Exchange info will be disabled.")
+		} else {
+			wg.Add(1)
+			go xcBot.Start(ctx, &wg)
+		}
+	}
+
 	// Create the explorer system.
 	explore := explorer.New(baseDB, auxDB, cfg.UseRealIP, version.Version(),
-		!cfg.NoDevPrefetch, "views") // TODO: allow views config
+		!cfg.NoDevPrefetch, "views", xcBot) // TODO: allow views config
 	if explore == nil {
 		return fmt.Errorf("failed to create new explorer (templates missing?)")
 	}
@@ -567,11 +588,8 @@ func _main(ctx context.Context) error {
 		blockDataSavers = append(blockDataSavers, insightSocketServer)
 	}
 
-	// WaitGroup for the monitor goroutines
-	var wg sync.WaitGroup
-
 	// Start dcrdata's JSON web API.
-	app := api.NewContext(dcrdClient, activeChain, baseDB, auxDB, cfg.IndentJSON)
+	app := api.NewContext(dcrdClient, activeChain, baseDB, auxDB, cfg.IndentJSON, xcBot)
 	// Start the notification hander for keeping /status up-to-date.
 	wg.Add(1)
 	go app.StatusNtfnHandler(ctx, &wg)

--- a/main.go
+++ b/main.go
@@ -468,8 +468,14 @@ func _main(ctx context.Context) error {
 		botCfg.BtcIndex = cfg.ExchangeCurrency
 		xcBot, err = exchanges.NewExchangeBot(&botCfg)
 		if err != nil {
-			log.Errorf("Could not create exchange monitor. Exchange info will be disabled.")
+			log.Errorf("Could not create exchange monitor. Exchange info will be disabled: %v", err)
 		} else {
+			var xcList, prepend string
+			for k := range xcBot.Exchanges {
+				xcList += prepend + k
+				prepend = ", "
+			}
+			log.Infof("ExchangeBot monitoring %s", xcList)
 			wg.Add(1)
 			go xcBot.Start(ctx, &wg)
 		}

--- a/main.go
+++ b/main.go
@@ -460,7 +460,7 @@ func _main(ctx context.Context) error {
 
 	// ExchangeBot
 	var xcBot *exchanges.ExchangeBot
-	if !cfg.DisableExchangeBot {
+	if cfg.EnableExchangeBot {
 		var botCfg exchanges.ExchangeBotConfig
 		if cfg.DisabledExchanges != "" {
 			botCfg.Disabled = strings.Split(cfg.DisabledExchanges, ",")

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -4,7 +4,7 @@
 ; For all logging subsystems:
 ;debuglevel=debug
 ; Set per-subsystem:
-;debuglevel=DATD=debug,SQLT=debug,MEMP=debug,RPCC=info,JAPI=debug,PSQL=debug,IAPI=debug,NTFN=debug,SKDB=debug,BLKD=debug,EXPR=debug,PUBS=debug
+;debuglevel=DATD=debug,SQLT=debug,MEMP=debug,RPCC=info,JAPI=debug,PSQL=debug,IAPI=debug,NTFN=debug,SKDB=debug,BLKD=debug,EXPR=debug,PUBS=debug,XBOT=debug
 
 ; Authentication information for dcrd RPC (must set, no default)
 ;dcrduser=duser

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -64,3 +64,9 @@
 
 ; Enable importing side chain blocks from dcrd on startup. (Default is false.)
 ;import-side-chains=true
+
+; Disable exchange monitoring.
+; no-exchange-monitor=0
+; Disable individual exchanges. Multiple exchanges can be disabled with a
+; comma-separated list, e.g. disable-exchange=dragonex,huobi
+; disable-exchange=

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -65,8 +65,9 @@
 ; Enable importing side chain blocks from dcrd on startup. (Default is false.)
 ;import-side-chains=true
 
-; Disable exchange monitoring.
-; no-exchange-monitor=0
+; Enable exchange monitoring.
+; exchange-monitor=0
 ; Disable individual exchanges. Multiple exchanges can be disabled with a
-; comma-separated list, e.g. disable-exchange=dragonex,huobi
-; disable-exchange=
+; comma-separated list. Currently available: coinbase, coindesk, binance,
+; bittrex, dragonex, huobi, poloniex
+; disable-exchange=dragonex,huobi

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -202,17 +202,6 @@
                           <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
                         </tr>
                         {{end}}
-                        {{if $.ExchangeState}}
-                        <tr class="align-baseline">
-                            <td class="text-right pr-2 lh1rem">EXCHANGE RATE</td>
-                            <td>
-                                <div class="mono lh1rem p03rem0 fs14-decimal fs18">
-                                    <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span
-                                    ><span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
-                                </div>
-                            </td>
-                        </tr>
-                        {{end}}
                     </table>
                     <a href="/mempool" class="small">see more...</a>
                   </div>  <!-- end mempool card -->
@@ -407,6 +396,15 @@
                             <span class="pl-1 unit lh15rem">DCR</span>
                         </div>
                     </div>
+                    {{if $.ExchangeState}}
+                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                        <div class="fs13 text-secondary">Exchange Rate</div>
+                        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                            <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span>
+                            <span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
+                        </div>
+                    </div>
+                    {{end}}
                 </div>
             </div>
             {{end}}

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -202,7 +202,17 @@
                           <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
                         </tr>
                         {{end}}
-                      </tbody>
+                        {{if $.ExchangeState}}
+                        <tr class="align-baseline">
+                            <td class="text-right pr-2 lh1rem">EXCHANGE RATE</td>
+                            <td>
+                                <div class="mono lh1rem p03rem0 fs14-decimal fs18">
+                                    <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span
+                                    ><span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
+                                </div>
+                            </td>
+                        </tr>
+                        {{end}}
                     </table>
                     <a href="/mempool" class="small">see more...</a>
                   </div>  <!-- end mempool card -->


### PR DESCRIPTION
The `exchanges` package contains `ExchangeBot`, which can be used to monitor DCR-BTC exchanges and BTC-fiat indices. Exchangebot can be disabled completely, or individual exchanges can be disabled.
The package currently has 5 Decred-BTC exchanges and 2 BTC-fiat index sources. The package is completely independent of other DCRData packages, but has been integrated with DCRData to demonstrate how I envision its use. 

New API endpoints added for retrieving the Decred exchange rate in one of almost 200 base currencies (indices). Results are JSON-formatted and support indenting. Try
```
http://localhost:7777/api/exchanges
http://localhost:7777/api/exchanges?indent=1&code=EUR
http://localhost:7777/api/exchanges/codes
```

On the website side, the price is simply displayed in a chosen default base on the homepage for now.

There is a test implemented which will cycle through all the exchanges about 3 times over 6 minutes. 

Resolves #711 

I think this PR is GTG, but I'm adding [WIP] for now because it's pretty big and somewhat controversial. 