### PR TITLE
This fixes the bad checksum for Sereal.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/AndreasBriese/bbloom v0.0.0-20170702084017-28f7e881ca57 h1:CVuXDbdzPW
 github.com/AndreasBriese/bbloom v0.0.0-20170702084017-28f7e881ca57/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/DataDog/zstd v1.3.4 h1:LAGHkXuvC6yky+C2CUG2tD7w8QlrUwpue8XwIh0X4AY=
 github.com/DataDog/zstd v1.3.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Sereal/Sereal v0.0.0-20180727013122-68c42fd7bfdf h1:gziqYtUl2f8Oo1/KovOJt3L+rw3TMC59rjiec32/azA=
+github.com/Sereal/Sereal v0.0.0-20180727013122-68c42fd7bfdf h1:WHiAGkqDYWg1SAc5yWsqlxd3IPLTk9jFWEH/38AL7mA=
 github.com/Sereal/Sereal v0.0.0-20180727013122-68c42fd7bfdf/go.mod h1:D0JMgToj/WdxCgd30Kc1UcA9E+WdZoJqeVOuYW7iTBM=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeFw1ejup6Kw+/88WhhLHqIJ0ngQ=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ const (
 	AppName  string = "dcrdata"
 	AppMajor uint   = 3
 	AppMinor uint   = 1
-	AppPatch uint   = 1
+	AppPatch uint   = 2
 )
 
 // go build -ldflags "-X github.com/decred/dcrdata/v3/version.appPreRelease= -X github.com/decred/dcrdata/v3/version.appBuild=`git rev-parse --short HEAD`"


### PR DESCRIPTION
The Sereal repo was affected by the symlink checksum bug of go 1.11.3.
This recomputes the checksum using go 1.11.5.

The dcrdata version is bumped to 3.1.2.