### PR TITLE
explorer/types: set fee and fee rate in TrimMempoolTx

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -277,9 +277,6 @@ func (exp *explorerUI) NextHome(w http.ResponseWriter, r *http.Request) {
 	inv := exp.MempoolInventory()
 	mempoolInfo := inv.Trim() // Trim internally locks the MempoolInfo.
 
-	// mempool fees appear incorrect, temporarily set to zero for now
-	mempoolInfo.Fees = 0
-
 	exp.pageData.RLock()
 	mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy
 

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -121,9 +121,6 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					inv := exp.MempoolInventory()
 					mempoolInfo := inv.Trim() // Trim internally locks the MempoolInfo.
 
-					// mempool fees appear incorrect, temporarily set to zero for now
-					mempoolInfo.Fees = 0
-
 					exp.pageData.RLock()
 					mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy
 					exp.pageData.RUnlock()

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -300,10 +300,10 @@ func (psh *PubSubHub) receiveLoop(conn *connection) {
 			// construct mempool object with properties required in template
 			inv := psh.MempoolInventory()
 			mempoolInfo := inv.Trim() // Trim locks the inventory.
-			// mempool fees appear incorrect, temporarily set to zero for now
-			mempoolInfo.Fees = 0
 
+			psh.state.RLock()
 			mempoolInfo.Subsidy = psh.state.GeneralInfo.NBlockSubsidy
+			psh.state.RUnlock()
 
 			b, err := json.Marshal(mempoolInfo)
 			if err != nil {

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -286,3 +286,31 @@ func testIsZeroHashP2PHKAddress(expectedAddress string, params *chaincfg.Params,
 			expectedTestResult)
 	}
 }
+
+func TestFeeRate(t *testing.T) {
+	// Ensure invalid fee rate is -1.
+	if FeeRate(0, 0, 0) != -1 {
+		t.Errorf("Fee rate for 0 byte size must return -1.")
+	}
+
+	// (1-2)/500*1000 = -2
+	expected := int64(-2)
+	got := FeeRate(1, 2, 500)
+	if got != expected {
+		t.Errorf("Expected fee rate of %d, got %d.", expected, got)
+	}
+
+	// (10-0)/100*1000 = 100
+	expected = int64(100)
+	got = FeeRate(10, 0, 100)
+	if got != expected {
+		t.Errorf("Expected fee rate of %d, got %d.", expected, got)
+	}
+
+	// (10-10)/1e9*1000 = 0
+	expected = int64(0)
+	got = FeeRate(10, 10, 1e9)
+	if got != expected {
+		t.Errorf("Expected fee rate of %d, got %d.", expected, got)
+	}
+}


### PR DESCRIPTION
This sets the following fields of the `TrimmedTxInfo` struct in the `TrimMempoolTx` function that were not previously being set: `FormattedSize`, `Fee`, and `FeeRate`.  It is not clear why they were left unset.

While in this area, also:
- In `FilterUniqueLastBlockVotes`, make sure duplicate votes with the same tx id are not added to the returned votes slice.
- Add `txhelpers.FeeRate`, and use it in `TxFeeRate`.  Add tests.
- Fix the docs for `TxFeeRate`.

The changes with the `TrimMempoolTx` and the `TrimmedTxInfo` struct are visible in a `getmempooltxsResp` websocket message.

Before:

```json
{
    "TxID": "c7c64fac57a404945295df4a4235617f339cbc1d2d3932f34ba54361366131f6",
    "FormattedSize": "",
    "Total": 3125.94048853,
    "Fee": 0,
    "FeeRate": 0,
    "VoteInfo": null,
    "Coinbase": false,
    "Fees": 0.007213,
    "VinCount": 31,
    "VoutCount": 57,
    "VoteValid": false
}
```

After:
```json
{
    "TxID": "c7c64fac57a404945295df4a4235617f339cbc1d2d3932f34ba54361366131f6",
    "FormattedSize": "7.2 kB",
    "Total": 3125.94048853,
    "Fee": 721300,
    "FeeRate": 100,
    "VoteInfo": null,
    "Coinbase": false,
    "Fees": 0.007213,
    "VinCount": 31,
    "VoutCount": 57,
    "VoteValid": false
}
```
