### PR TITLE
home layout refinement

### DIFF
--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -39,7 +39,7 @@ $nav-link-padding-y: .55rem;
 $nav-link-padding-x: .55rem;
 
 // transaction type colors
-$regular-light: #00c903;
-$vote-light: #002ccc;
-$ticket-light: #c600c0;
-$rev-light: #d60000;
+$regular-light: #2970FF;
+$ticket-light: #2ED6A1;
+$vote-light:  #c600c0;
+$rev-light: #ED6D47;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -7,6 +7,11 @@ $body-bg: #f3f5f6;
 $border-radius: .125rem;
 
 // grid
+// Grid columns
+//
+// Set the number of columns and specify the width of the gutters.
+$grid-columns: 24;
+$grid-gutter-width: 15px;
 $container-max-widths: ();
 $container-max-widths: map-merge(
   (

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -41,5 +41,5 @@ $nav-link-padding-x: .55rem;
 // transaction type colors
 $regular-light: #2970FF;
 $ticket-light: #2ED6A1;
-$vote-light:  #c600c0;
+$vote-light: #c600c0;
 $rev-light: #ED6D47;

--- a/public/scss/home.scss
+++ b/public/scss/home.scss
@@ -9,12 +9,12 @@
 }
 
 .tx-bar.tx-vote {
-  border-right-style: solid;
+  border-left-style: solid;
   border-color: $vote-light;
 }
 
 .tx-bar.tx-ticket {
-  border-left-style: solid;
+  border-right-style: solid;
   border-color: $ticket-light;
 }
 
@@ -25,9 +25,13 @@
 
 .tx-gauge {
   height: 4px;
-  margin: 0 1px;
+  margin-right: 1px;
   width: 25%;
   transition: width 1s ease-in-out;
+
+  &:last-child {
+    margin-right: 0;
+  }
 }
 
 .tx-gauge.tx-regular {

--- a/public/scss/home.scss
+++ b/public/scss/home.scss
@@ -9,7 +9,7 @@
 }
 
 .tx-bar.tx-vote {
-  border-left-style: solid;
+  border-right-style: solid;
   border-color: $vote-light;
 }
 
@@ -19,7 +19,7 @@
 }
 
 .tx-bar.tx-rev {
-  border-right-style: solid;
+  border-left-style: solid;
   border-color: $rev-light;
 }
 

--- a/public/scss/home.scss
+++ b/public/scss/home.scss
@@ -47,17 +47,7 @@
 }
 
 .card-icon {
-  position: absolute;
-  right: 105%;
   font-size: 1.6rem;
-}
-
-.table thead tr.card-theader {
-  background: #0000001a;
-}
-
-body.darkBG .table tr.card-theader {
-  background: #ffffff1a;
 }
 
 .light-card {

--- a/public/scss/table.scss
+++ b/public/scss/table.scss
@@ -30,6 +30,7 @@ table.align-baseline-rows tr {
 .table thead th {
   border-bottom: none;
   padding: 0.36rem 0.5rem;
+  font-weight: 600;
 }
 
 .table thead tr {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -16,7 +16,7 @@
       data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"
     >
         <div class="row">
-            <div class="col-md-8 col-sm-6">
+            <div class="col-lg-16 col-sm-12">
                 <h4>Address</h4>
                 <div class="mono"
                     data-target="address.addr"
@@ -57,7 +57,7 @@
                 </div>
                 {{end}}
             </div>
-            <div class="col-md-4 col-sm-6 d-flex pb-3">
+            <div class="col-lg-8 col-sm-12 d-flex pb-3">
                 <table>
                     <tr  class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>

--- a/views/agenda.tmpl
+++ b/views/agenda.tmpl
@@ -7,13 +7,13 @@
         {{with .Ai}}
         <div class="container main">
             <div class="row justify-content-between">
-                <div class="col-md-7 col-sm-6 d-flex">
+                <div class="col-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">{{.Id}}
                     </h4>
                 </div>
             </div>
             <div class="row justify-content-between">
-                <div class="col-md-9 col-sm-6 d-flex">
+                <div class="col-lg-18 col-sm-12 d-flex">
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Description</td>
@@ -35,7 +35,7 @@
                         </tr>
                     </table>
                 </div>
-                <div class="col-md-3 col-sm-6 d-flex">
+                <div class="col-lg-6 col-sm-12 d-flex">
                     <table class="">
                         <tr>
                             <td class="text-right lh1rem pr-2 xs-w117">Status</td>

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -6,7 +6,7 @@
         {{template "navbar" .}}
         <div class="container main">
             <div class="row justify-content-between">
-                <div class="col-md-7 col-sm-6 d-flex">
+                <div class="col-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">Agendas</h4>
                 </div>
             </div>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -8,7 +8,7 @@
     {{with .Data}}
         {{$Invalidated := and (gt .Confirmations 1) (not .Valid) }}
         <div class="row justify-content-between">
-            <div class="col-md-7 col-sm-6">
+            <div class="col-lg-14 col-sm-12">
                 <h4 class="mb-2">
                     Block #{{.Height}}
                     {{ if not .MainChain }}
@@ -33,7 +33,7 @@
                     <a class="fs12" href="/api/block/{{.Height}}/verbose?indent=true" data-turbolinks="false">api</a>
                 </h4>
             </div>
-            <div class="col-md-5 col-sm-6 d-flex">
+            <div class="col-lg-10 col-sm-12 d-flex">
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117 w120">TOTAL SENT</td>
@@ -46,7 +46,7 @@
         </div>
 
         <div class="row justify-content-between">
-            <div class="col-md-7 col-sm-6 d-flex">
+            <div class="col-lg-14 col-sm-12 d-flex">
                 <table class="">
                     {{if .MainChain}}<tr>
                         <td class="text-right pr-2 lh1rem vam nowrap" title="Stakeholder (PoS) approved?">APPROVED</td>
@@ -127,7 +127,7 @@
                 </table>
             </div>
 
-            <div class="col-md-5 col-sm-6 d-flex">
+            <div class="col-lg-10 col-sm-12 d-flex">
                 <table class="">
                     <tr>
                         <td class="text-right lh1rem pr-2 xs-w117">TIME</td>
@@ -193,7 +193,7 @@
 
         <div class="row">
             <span class="anchor" id="coinbase"></span>
-            <div class="col-sm-12">
+            <div class="col-sm-24">
                 <h4><span>Block Reward</span></h4>
                 {{range .Tx}}
                     {{if eq .Coinbase true}}
@@ -230,7 +230,7 @@
 
         <div class="row">
             <span class="anchor" id="votes"></span>
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <h4><span>Votes</span></h4>
                 {{if not .Votes}}
                     <table class="table table-sm striped">
@@ -277,7 +277,7 @@
         {{if .Misses}}
         <div class="row">
             <span class="anchor" id="misses"></span>
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <h4><span>Missed Votes</span></h4>
                 <table class="table table-sm striped">
                     <thead>
@@ -302,7 +302,7 @@
 
         <div class="row">
             <span class="anchor" id="tickets"></span>
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <h4><span>Tickets</span></h4>
                 {{if not .Tickets}}
                 <table class="table table-sm striped">
@@ -342,7 +342,7 @@
         {{if .Revocations}}
         <div class="row">
             <span class="anchor" id="revokes"></span>
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <h4><span>Revokes</span></h4>
                 <table class="table table-sm striped">
                     <thead>
@@ -374,7 +374,7 @@
 
         <div class="row">
             <span class="anchor" id="transactions"></span>
-            <div class="col-sm-12">
+            <div class="col-sm-24">
                 <h4><span>Transactions</span></h4>
                 {{if not .TxAvailable}}
                 <table class="table table-sm striped">

--- a/views/disapproved.tmpl
+++ b/views/disapproved.tmpl
@@ -9,7 +9,7 @@
         <h4><span title="blocks disapproved by stakeholder voting"><img class="h30 p2tb" src="/images/pos-hammer.svg" alt="pos hammer"> Stakeholder Disapproved Blocks</span></h4>
         <h6>There are currently {{len .Data}} blocks that have been <a href="https://docs.decred.org/faq/proof-of-stake/general/#9-what-is-proof-of-stake-voting">disapproved via PoS voting.</a></h6>
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <table class="table striped table-responsive-sm" id="disapprovedblockstable">
                     <thead>
                         <tr>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -82,7 +82,7 @@
         {{end}}
 
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <table class="table striped table-responsive-sm">
                     <thead>
                         <tr>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -7,393 +7,406 @@
 <body class="{{ theme }}">
     {{ template "navbar" . }}
     <div class="container main" data-controller="time blocklist homepage">
-      <div class="text-left mx-1 pl-1 pb-1">{{.NetName}}</div>
+        <!-- <div class="text-left mx-1 pl-1 pb-1">{{.NetName}}</div> -->
 
-        <div class="row">
+            <div class="row">
 
-          <div class="col-md-6 p-0">
 
-                  <div class="pt-3 pb-1 px-4 mx-1 light-card text-center">
+                <div class="col-md-15 p-0">
+                    <div class="pt-1 pb-1 px-2 bg-white mb-1">
 
-                    <div class="d-inline-block position-relative mt-1 p-2">
-                        <span class="card-icon dcricon-twoblocks h1"></span> <a href="/blocks" class="h3">Latest Blocks</a>
-                    </div>
+                        <div class="d-inline-block position-relative mt-1 p-2">
+                            <span class="card-icon dcricon-twoblocks h1 mr-2"></span> <a href="/blocks" class="h3">Latest {{.NetName}} Blocks</a>
+                        </div>
 
-                    {{with .BestBlock}}
-                    <div class="d-flex justify-content-between align-items-center px-2 mx-auto">
-                      <div class="text-left mt-2 d-inline-block">
-                        <span class="h6 mb-0 position-relative" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
-                        <a class="d-inline-block h3 position-relative" href="/block/{{.Hash}}" data-target="homepage.blockHeight">{{.Height}}</a>
-                      </div>
-                      <div class="text-right my-2 d-inline-block">
-                        <span class="h6 position-relative" data-tooltip="total DCR sent in this block">value</span><br>
-                        <span class="h4" data-target="homepage.blockTotal">{{threeSigFigs .Total}}</span><span class="h6"> DCR</span>
-                      </div>
-                    </div>
+                        <div class="row">
+                            {{with .BestBlock}}
+                            <div class="col-6 text-center">
+                                <span class="h6 mb-0 position-relative" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
+                                <a class="d-inline-block h3 position-relative" href="/block/{{.Hash}}" data-target="homepage.blockHeight">{{.Height}}</a>
+                            </div>
+                            <div class="col-6 text-center">
+                                <span class="h6 position-relative" data-tooltip="total DCR sent in this block">value</span><br>
+                                <span class="h4" data-target="homepage.blockTotal">{{threeSigFigs .Total}}</span><span class="h6"> DCR</span>
+                            </div>
+                            <div class="col-6 text-center">
+                                <div class="d-flex align-items-baseline justify-content-center p-0 m-0">
+                                    <span class="h6 mr-2" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
+                                    {{if eq $.Consensus -1}}
+                                    <span data-target="homepage.consensusMsg" class="small text-danger">rejected</span>
+                                    {{else if eq $.Consensus 0}}
+                                    <span data-target="homepage.consensusMsg" class="small"></span>
+                                    {{else}}
+                                    <span data-target="homepage.consensusMsg" class="small text-green">approved</span>
+                                    {{end}}
+                                </div>
+                                <div class="d-inline-block p1 h4" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
+                                    {{range $index, $vote := $.BlockTally}}
+                                    <div
+                                    class="d-inline-block position-relative"
+                                    data-tooltip="{{if eq $vote -1}}the stakeholder has voted to reject this block{{else if eq $vote 1}}the stakeholder has voted to accept this block{{else}}this vote has not been received yet{{end}}"
+                                    >
+                                    <span class="dcricon-{{if eq $vote 0}}reject{{else if eq $vote 1}}affirm{{else}}missing{{end}}"></span>
+                                    </div>
+                                    {{end}}
+                                </div>
+                            </div>
 
-                    <div class="d-flex justify-content-between align-items-center px-2 mx-auto">
-                        <div class="text-left mt-2 pr-3 d-inline-block">
-                          <div class="d-flex p-0 m-0 justify-content-between">
-                            <span class="h6" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
-                            {{if eq $.Consensus -1}}
-                              <span data-target="homepage.consensusMsg" class="small text-danger">rejected</span>
-                            {{else if eq $.Consensus 0}}
-                              <span data-target="homepage.consensusMsg" class="small"></span>
-                            {{else}}
-                              <span data-target="homepage.consensusMsg" class="small text-green">approved</span>
-                            {{end}}
-                          </div>
-                          <div class="d-inline-block p1 h4" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
-                            {{range $index, $vote := $.BlockTally}}
-                            <div
-                              class="d-inline-block position-relative"
-                              data-tooltip="{{if eq $vote -1}}the stakeholder has voted to reject this block{{else if eq $vote 1}}the stakeholder has voted to accept this block{{else}}this vote has not been received yet{{end}}"
-                            >
-                              <span class="dcricon-{{if eq $vote 0}}reject{{else if eq $vote 1}}affirm{{else}}missing{{end}}"></span>
+                            <div class="col-6 text-center">
+                                <span class="h6">size</span><br>
+                                <span class="h4" data-target="homepage.blockSize">{{.FormattedBytes}}</span>
                             </div>
                             {{end}}
-                          </div>
                         </div>
-                        <div class="text-right my-2 d-inline-block">
-                          <span class="h6">size</span><br>
-                          <span class="h4" data-target="homepage.blockSize">{{.FormattedBytes}}</span>
-                        </div>
-                    </div>
-                    {{end}}
-
-                    <table class="table w-100 mt-4 mx-auto mb-0">
-                        <thead>
-                            <tr class="card-theader">
-                                <th class="text-left pl-3">Height</th>
-                                <th><div class="position-relative text-center" data-tooltip="regular transactions">R</div></th>
-                                <th><div class="position-relative text-center" data-tooltip="votes">V</div></th>
-                                <th><div class="position-relative text-center" data-tooltip="tickets">T</div></th>
-                                <th><div class="position-relative text-center" data-tooltip="revocations">X</div></th>
-                                <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
-                                <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
-                                <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
-                            </tr>
-                        </thead>
-                        <tbody data-target="blocklist.table">
-                            {{range .Blocks}}
-                            <tr data-height="{{.Height}}" data-link-class="fs18">
-                                <td class="text-left pl-2" data-type="height"><a href="/block/{{.Height}}" class="fs18">{{.Height}}</a></td>
-                                <td class="text-center" data-type="tx">{{.Transactions}}</td>
-                                <td class="text-center" data-type="votes">{{.Voters}}</td>
-                                <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
-                                <td class="text-center" data-type="revocations">{{.Revocations}}</td>
-                                <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
-                                <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
-                                <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime}}">{{.BlockTime}}</td>
-                            </tr>
-                            {{end}}
-                        </tbody>
-                    </table>
-                    <a href="/blocks" class="small">more blocks...</a>
-                  </div> <!-- end blocks card -->
-
-                  <div class="pt-3 pb-1 px-4 mx-1 mb-2 dark-card text-center">
-                    <div class="d-inline-block position-relative mt-1 p-2">
-                        <span class="card-icon dcricon-stack h1"></span> <a href="/mempool" class="h3">Mempool</a>
-                    </div>
-
-                    <div class="text-center">
-                      <span class="h2 position-relative"
-                      data-target="homepage.mempool"
-                      data-total="{{.Mempool.LikelyTotal}}"
-                      data-reg-total="{{.Mempool.RegularTotal}}"
-                      data-reg-count="{{.Mempool.NumRegular}}"
-                      data-vote-total="{{.Mempool.VoteTotal}}"
-                      data-vote-count="{{.Mempool.VotingInfo.TicketsVoted}}"
-                      data-ticket-total="{{.Mempool.TicketTotal}}"
-                      data-ticket-count="{{.Mempool.NumTickets}}"
-                      data-rev-total="{{.Mempool.RevokeTotal}}"
-                      data-rev-count="{{.Mempool.NumRevokes}}"
-                      data-tooltip="transactions ready for the next block"
-                      >{{threeSigFigs .Mempool.LikelyTotal}}</span>
-                      <span class="h5">DCR</span>
-                    </div>
-
-                    <div class="mt-2 mb-2 mb-1 w-75 mx-auto jsonly text-nowrap d-block"
-                      ><div class="tx-gauge tx-regular d-inline-block" data-target="homepage.mpRegBar"></div
-                      ><div class="tx-gauge tx-ticket d-inline-block" data-target="homepage.mpTicketBar"></div
-                      ><div class="tx-gauge tx-vote d-inline-block" data-target="homepage.mpVoteBar"></div
-                      ><div class="tx-gauge tx-rev d-inline-block" data-target="homepage.mpRevBar"></div
-                    ></div>
-
-                    <div class="d-flex justify-content-between align-items-center px-2 mx-auto">
-                        <div class="text-left my-3 pl-3 tx-bar tx-regular d-inline-block">
-                          <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
-                          <span class="h5"> regular</span>
-                          <br>
-                          <span class="h3" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
-                          <span class="h6">DCR</span>
-                        </div>
-
-                        <div class="text-right my-3 pr-3 tx-bar tx-vote d-inline-block">
-                          <span data-target="homepage.mpVoteCount"
-                          class="h4"
-                          data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
-                            {{$afterFirst := false}}
-                            {{range $hash, $tally := .Mempool.VotingInfo.VoteTallys}}
-                              {{if $afterFirst}} + {{end}}
-                              <span class="position-relative d-inline-block"
-                              data-target="homepage.voteTally"
-                              data-hash="{{$hash}}"
-                              data-affirmed="{{$tally.Affirmations}}"
-                              data-count="{{$tally.VoteCount}}"
-                              data-tooltip="for block {{$hash}}"
-                              >{{$tally.VoteCount}}</span>
-                              {{$afterFirst = true}}
-                            {{end}}
-                          </span>
-                          <span class="h5"> votes</span>
-                          <br>
-                          <span class="h3" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
-                          <span class="h6">DCR</span><br>
-                        </div>
-                    </div>
-
-                    <div class="d-flex justify-content-between align-items-center mx-auto px-2">
-                      <div class="text-left my-3 pl-3 tx-bar tx-ticket d-inline-block">
-                        <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
-                        <span class="h5"> tickets</span>
-                        <br>
-                        <span class="h3" data-target="homepage.mpTicketTotal"
-                        >{{threeSigFigs .Mempool.TicketTotal}}</span>
-                        <span class="h6">DCR</span>
-                      </div>
-
-                        <div class="text-right my-3 pr-3 tx-bar tx-rev d-inline-block">
-                          <span data-target="homepage.mpRevCount" class="h4">{{.Mempool.NumRevokes}}</span>
-                          <span class="h5"> revocations</span>
-                          <br>
-                          <span class="h3" data-target="homepage.mpRevTotal"
-                          >{{threeSigFigs .Mempool.RevokeTotal}}</span>
-                          <span class="h6">DCR</span>
-                        </div>
-                    </div>
-
-                    <div class="mx-auto my-3">
-                        <h5 class="d-inline">Latest Transactions</h5>
-                    </div>
-
-                    <table class="table w-100 mx-auto mb-0">
-                      <thead>
-                        <tr class="card-theader">
-                          <th class="text-left pl-2">Hash</th>
-                          <th>Type</th>
-                          <th>DCR</th>
-                          <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell">Size</th>
-                          <th class="text-right pr-3 jsonly">Age</th>
-                        </tr>
-                      </thead>
-                      <tbody class="homepage-mempool" data-target="homepage.transactions">
-                        {{range .Mempool.LatestTransactions}}
-                        <tr>
-                          <td class="text-left pl-1">
-                            <div class="hash-box">
-                              <div class="hash-fill">{{template "hashElide" (hashlink .Hash (print "/tx/" .Hash))}}</div>
-                            </div>
-                          </td>
-                          <td>{{.Type}}</td>
-                          <td>{{threeSigFigs .TotalOut}}</td>
-                          <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell">{{.Size}} B</td>
-                          <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
-                        </tr>
-                        {{end}}
-                    </table>
-                    <a href="/mempool" class="small">see more...</a>
-                  </div>  <!-- end mempool card -->
-          </div> <!-- end column -->
-
-          <div class="col-md-6 p-0">
-
-            {{with .Info}}
-
-            <div class="dark-card py-2 px-3 mx-1 my-0">
-                <div class="my-3 h4">
-                    <span class="dcricon-ticket d-inline-block pr-2 h3"></span>
-                    Voting
-                </div>
-                <div class="row mt-1">
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">
-                            <a class="no-underline" href="/charts?chart=ticket-price&zoom=month">Current Ticket Price</a>
-                        </div>
-                        <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                            <span data-target="homepage.blocksdiff">{{template "decimalParts" (float64AsDecimalParts .StakeDiff 8 false 2)}}</span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Next Ticket Price</div>
-                        <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
-                            <span class="fs22">~</span><span class="fs24 d-flex" data-target="homepage.nextExpectedSdiff">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}</span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
-                        <div class="d-flex lh1rem fs12 text-black-50">
-                            <span>min:&nbsp;</span>
-                            <span class="d-flex" data-target="homepage.nextExpectedMin">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}</span>
-                            <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
-                            <span class="d-flex" data-target="homepage.nextExpectedMax">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}</span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Vote Reward</div>
-                        <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                            <span data-target="homepage.bsubsidyPos">
-                                {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
-                            </span>
-                            <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
-                        </div>
-                        <div class="fs12 lh1rem text-black-50">
-                            <span data-target="homepage.ticketReward">{{template "fmtPercentage" .TicketReward}}</span> per ~{{.RewardPeriod}}
-                        </div>
-                        <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards"><span class="text-green">+{{printf "%.2f" .ASR}} %</span> per year</div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Next Ticket Price Change</div>
-                        <div class="progress mt-1 mb-1">
-                            <div
-                                class="progress-bar rounded"
-                                data-target="homepage.posBar"
-                                role="progressbar"
-                                style="width: {{ticketWindowProgress .IdxBlockInWindow}}%;"
-                                aria-valuenow="{{.IdxBlockInWindow}}"
-                                aria-valuemin="0"
-                                aria-valuemax="{{.Params.WindowSize}}"
-                            >
-                                <span class="nowrap pl-1">block <span data-target="homepage.windowIndex" >{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}}</span>
+                        <div class="row">
+                            <div class="col">
+                                <table class="table w-100 mt-2 mx-auto mb-0">
+                                    <thead>
+                                        <tr class="card-theader">
+                                            <th class="text-left pl-3">Height</th>
+                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">R</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="votes">V</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="tickets">T</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="revocations">X</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
+                                            <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
+                                            <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody data-target="blocklist.table">
+                                        {{range .Blocks}}
+                                        <tr data-height="{{.Height}}" data-link-class="fs18">
+                                            <td class="text-left pl-2" data-type="height"><a href="/block/{{.Height}}" class="fs18">{{.Height}}</a></td>
+                                            <td class="text-center" data-type="tx">{{.Transactions}}</td>
+                                            <td class="text-center" data-type="votes">{{.Voters}}</td>
+                                            <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
+                                            <td class="text-center" data-type="revocations">{{.Revocations}}</td>
+                                            <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
+                                            <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
+                                            <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime}}">{{.BlockTime}}</td>
+                                        </tr>
+                                        {{end}}
+                                    </tbody>
+                                </table>
+                                <a href="/blocks" class="small">more blocks...</a>
                             </div>
                         </div>
-                        <div class="fs12 lh1rem">
-                            <span class="text-black-50">
-                                {{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}}
-                            </span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Ticket Pool Size</div>
-                        <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                            <span data-target="homepage.poolSize">
-                                {{intComma .PoolInfo.Size}}
-                            </span>
-                        </div>
-                        <div class="fs12 lh1rem text-black-50">
-                            <span data-target="homepage.targetPct">{{printf "%.2f" .PoolInfo.PercentTarget}}</span> % of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Total Staked DCR</div>
-                        <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                            <span data-target="homepage.poolValue">
-                                {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
-                            </span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
-                        <div class="fs12 lh1rem text-black-50">
-                            <span data-target="homepage.poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of total supply
-                        </div>
-                    </div>
-                </div>
-            </div> <!-- end voting card -->
+                    </div> <!-- end blocks card -->
 
-            <div class="light-card py-2 px-3 mx-1 my-0">
-                <div class="my-3 h4">
-                    <span class="dcricon-pickaxe d-inline-block pr-2 h3"></span>
-                    <span>Mining</span>
-                </div>
-                <div class="row mt-1">
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">
-                            <a class="no-underline" href="/charts?chart=pow-difficulty">Difficulty</a>
-                        </div>
-                        <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span data-target="homepage.difficulty">{{template "decimalParts" (float64AsDecimalParts (divideFloat .Difficulty 1000000.0) 0 true)}}</span>
-                            <span class="pl-1 unit lh15rem">Mil</span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Hashrate</div>
-                        <div class="mono lh1rem pt-1 pb-1 fs14-decimal fs24 d-flex align-items-baseline">
-                            <span data-target="homepage.hashrate">{{template "decimalParts" (float64AsDecimalParts .HashRate 8 true 2)}}</span>
-                            <span class="pl-1 unit lh15rem">Ph/s</span>
-                        </div>
-                        <div class="fs12 text-black-50 lh1rem text-black-50">
-                            <span data-target="homepage.hashrateDelta">{{template "fmtPercentage" .HashRateChange}}</span> in past 24h
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">PoW Reward</div>
-                        <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span data-target="homepage.bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 true 2)}}</span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
-                    </div>
-                    <div class="col-6 col-sm-5 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Next Block Reward Reduction</div>
-                        <div class="progress mt-1 mb-1">
-                            <div
-                                class="progress-bar rounded"
-                                data-target="homepage.powBar"
-                                role="progressbar"
-                                style="width: {{rewardAdjustmentProgress .IdxInRewardWindow}}%;"
-                                aria-valuenow="{{.IdxInRewardWindow}}"
-                                aria-valuemin="0"
-                                aria-valuemax="{{.Params.RewardWindowSize}}"
-                            >
+                    <div class="pt-1 pb-1 px-2 mb-2 bg-white mb-1">
+
+                        <div class="d-flex align-items-baseline mb-2">
+                            <div class="position-relative mt-1 p-2">
+                                <span class="card-icon dcricon-stack h1 mr-2"></span> <a href="/mempool" class="h3">Mempool</a>
+                            </div>
+
+                            <div class="ml-auto">
                                 <span
-                                    id="powreward"
-                                    class="nowrap pl-1"
+                                    class="h2 position-relative"
+                                    data-target="homepage.mempool"
+                                    data-total="{{.Mempool.LikelyTotal}}"
+                                    data-reg-total="{{.Mempool.RegularTotal}}"
+                                    data-reg-count="{{.Mempool.NumRegular}}"
+                                    data-vote-total="{{.Mempool.VoteTotal}}"
+                                    data-vote-count="{{.Mempool.VotingInfo.TicketsVoted}}"
+                                    data-ticket-total="{{.Mempool.TicketTotal}}"
+                                    data-ticket-count="{{.Mempool.NumTickets}}"
+                                    data-rev-total="{{.Mempool.RevokeTotal}}"
+                                    data-rev-count="{{.Mempool.NumRevokes}}"
+                                    data-tooltip="transactions ready for the next block"
+                                >{{threeSigFigs .Mempool.LikelyTotal}}</span>
+                                <span class="h5">DCR</span>
+                            </div>
+                        </div>
+
+                        <div class="mx-2 jsonly text-nowrap d-flex">
+                            <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
+                            <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
+                            <div class="tx-gauge tx-vote" data-target="homepage.mpVoteBar"></div>
+                            <div class="tx-gauge tx-rev rounded-right" data-target="homepage.mpRevBar"></div
+                        ></div>
+
+                        <div class="row mb-2">
+                            <div class="col-md-8">
+
+                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto">
+                                    <div class="text-left my-3 pl-3 tx-bar tx-regular d-inline-block">
+                                        <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
+                                        <span class="h5"> regular</span>
+                                        <br>
+                                        <span class="h3" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
+                                        <span class="h6">DCR</span>
+                                    </div>
+
+                                    <div class="text-right my-3 pr-3 tx-bar tx-vote d-inline-block">
+                                        <span data-target="homepage.mpVoteCount"
+                                        class="h4"
+                                        data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
+                                        {{$afterFirst := false}}
+                                        {{range $hash, $tally := .Mempool.VotingInfo.VoteTallys}}
+                                            {{if $afterFirst}} + {{end}}
+                                            <span class="position-relative d-inline-block"
+                                            data-target="homepage.voteTally"
+                                            data-hash="{{$hash}}"
+                                            data-affirmed="{{$tally.Affirmations}}"
+                                            data-count="{{$tally.VoteCount}}"
+                                            data-tooltip="for block {{$hash}}"
+                                            >{{$tally.VoteCount}}</span>
+                                            {{$afterFirst = true}}
+                                        {{end}}
+                                        </span>
+                                        <span class="h5"> votes</span>
+                                        <br>
+                                        <span class="h3" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
+                                        <span class="h6">DCR</span><br>
+                                    </div>
+                                </div>
+
+                                <div class="d-flex justify-content-between align-items-center mx-auto px-2">
+                                    <div class="text-left my-3 pl-3 tx-bar tx-ticket d-inline-block">
+                                    <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
+                                    <span class="h5"> tickets</span>
+                                    <br>
+                                    <span class="h3" data-target="homepage.mpTicketTotal"
+                                    >{{threeSigFigs .Mempool.TicketTotal}}</span>
+                                    <span class="h6">DCR</span>
+                                    </div>
+
+                                    <div class="text-right my-3 pr-3 tx-bar tx-rev d-inline-block">
+                                        <span data-target="homepage.mpRevCount" class="h4">{{.Mempool.NumRevokes}}</span>
+                                        <span class="h5"> revocations</span>
+                                        <br>
+                                        <span class="h3" data-target="homepage.mpRevTotal"
+                                        >{{threeSigFigs .Mempool.RevokeTotal}}</span>
+                                        <span class="h6">DCR</span>
+                                    </div>
+                                </div>
+
+                            </div>
+
+                            <div class="col">
+
+                                <table class="table w-100 mx-auto mb-0">
+                                    <thead>
+                                    <tr class="card-theader">
+                                        <th class="text-left pl-2">Hash</th>
+                                        <th>Type</th>
+                                        <th>DCR</th>
+                                        <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell">Size</th>
+                                        <th class="text-right pr-3 jsonly">Age</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody class="homepage-mempool" data-target="homepage.transactions">
+                                    {{range .Mempool.LatestTransactions}}
+                                    <tr>
+                                        <td class="text-left pl-1">
+                                        <div class="hash-box">
+                                            <div class="hash-fill">{{template "hashElide" (hashlink .Hash (print "/tx/" .Hash))}}</div>
+                                        </div>
+                                        </td>
+                                        <td>{{.Type}}</td>
+                                        <td>{{threeSigFigs .TotalOut}}</td>
+                                        <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell">{{.Size}} B</td>
+                                        <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
+                                    </tr>
+                                    {{end}}
+                                    </tbody>
+                                </table>
+                                <a href="/mempool" class="small mb-2">see more...</a>
+                            </div>
+                        </div>
+                    </div>  <!-- end mempool card -->
+
+            </div> <!-- end column -->
+
+            <div class="col-md-9 p-0">
+
+                {{with .Info}}
+
+                <div class="bg-white mb-1 py-2 px-3 mx-1 my-0">
+                    <div class="my-3 h4">
+                        <span class="dcricon-ticket d-inline-block pr-2 h3"></span>
+                        Voting
+                    </div>
+                    <div class="row mt-1">
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">
+                                <a class="no-underline" href="/charts?chart=ticket-price&zoom=month">Current Ticket Price</a>
+                            </div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="homepage.blocksdiff">{{template "decimalParts" (float64AsDecimalParts .StakeDiff 8 false 2)}}</span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Next Ticket Price</div>
+                            <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
+                                <span class="fs22">~</span><span class="fs24 d-flex" data-target="homepage.nextExpectedSdiff">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}</span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                            <div class="d-flex lh1rem fs12 text-black-50">
+                                <span>min:&nbsp;</span>
+                                <span class="d-flex" data-target="homepage.nextExpectedMin">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}</span>
+                                <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
+                                <span class="d-flex" data-target="homepage.nextExpectedMax">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Vote Reward</div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="homepage.bsubsidyPos">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.ticketReward">{{template "fmtPercentage" .TicketReward}}</span> per ~{{.RewardPeriod}}
+                            </div>
+                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards"><span class="text-green">+{{printf "%.2f" .ASR}} %</span> per year</div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Next Ticket Price Change</div>
+                            <div class="progress mt-1 mb-1">
+                                <div
+                                    class="progress-bar rounded"
+                                    data-target="homepage.posBar"
+                                    role="progressbar"
+                                    style="width: {{ticketWindowProgress .IdxBlockInWindow}}%;"
+                                    aria-valuenow="{{.IdxBlockInWindow}}"
+                                    aria-valuemin="0"
+                                    aria-valuemax="{{.Params.WindowSize}}"
                                 >
-                                    block <span data-target="homepage.rewardIdx" >{{.IdxInRewardWindow}}</span> of {{.Params.RewardWindowSize}}
+                                    <span class="nowrap pl-1">block <span data-target="homepage.windowIndex" >{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}}</span>
+                                </div>
+                            </div>
+                            <div class="fs12 lh1rem">
+                                <span class="text-black-50">
+                                    {{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}}
                                 </span>
                             </div>
                         </div>
-                        <div class="fs12 lh1rem">
-                            <span class="text-black-50">
-                                {{remaining .IdxInRewardWindow .Params.RewardWindowSize .Params.BlockTime}}
-                            </span>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Ticket Pool Size</div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="homepage.poolSize">
+                                    {{intComma .PoolInfo.Size}}
+                                </span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.targetPct">{{printf "%.2f" .PoolInfo.PercentTarget}}</span> % of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Total Staked DCR</div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="homepage.poolValue">
+                                    {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of total supply
+                            </div>
                         </div>
                     </div>
+                </div> <!-- end voting card -->
 
-                </div>
-            </div> <!-- end mining card -->
+                <div class="bg-white mb-1 py-2 px-3 mx-1 my-0">
+                    <div class="my-3 h4">
+                        <span class="dcricon-pickaxe d-inline-block pr-2 h3"></span>
+                        <span>Mining</span>
+                    </div>
+                    <div class="row mt-1">
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">
+                                <a class="no-underline" href="/charts?chart=pow-difficulty">Difficulty</a>
+                            </div>
+                            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="homepage.difficulty">{{template "decimalParts" (float64AsDecimalParts (divideFloat .Difficulty 1000000.0) 0 true)}}</span>
+                                <span class="pl-1 unit lh15rem">Mil</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Hashrate</div>
+                            <div class="mono lh1rem pt-1 pb-1 fs14-decimal fs24 d-flex align-items-baseline">
+                                <span data-target="homepage.hashrate">{{template "decimalParts" (float64AsDecimalParts .HashRate 8 true 2)}}</span>
+                                <span class="pl-1 unit lh15rem">Ph/s</span>
+                            </div>
+                            <div class="fs12 text-black-50 lh1rem text-black-50">
+                                <span data-target="homepage.hashrateDelta">{{template "fmtPercentage" .HashRateChange}}</span> in past 24h
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">PoW Reward</div>
+                            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="homepage.bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 true 2)}}</span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Next Block Reward Reduction</div>
+                            <div class="progress mt-1 mb-1">
+                                <div
+                                    class="progress-bar rounded"
+                                    data-target="homepage.powBar"
+                                    role="progressbar"
+                                    style="width: {{rewardAdjustmentProgress .IdxInRewardWindow}}%;"
+                                    aria-valuenow="{{.IdxInRewardWindow}}"
+                                    aria-valuemin="0"
+                                    aria-valuemax="{{.Params.RewardWindowSize}}"
+                                >
+                                    <span
+                                        id="powreward"
+                                        class="nowrap pl-1"
+                                    >
+                                        block <span data-target="homepage.rewardIdx" >{{.IdxInRewardWindow}}</span> of {{.Params.RewardWindowSize}}
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="fs12 lh1rem">
+                                <span class="text-black-50">
+                                    {{remaining .IdxInRewardWindow .Params.RewardWindowSize .Params.BlockTime}}
+                                </span>
+                            </div>
+                        </div>
 
-            <div class="dark-card p-2 mb-2 px-3 mx-1">
-                <div class="my-3 h4">
-                    <span class="dcricon-tree d-inline-block pr-2 h4"></span>
-                    Distribution
-                </div>
-                <div class="row mt-1">
-                    {{if .DevFund}}
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary"><a href="/address/{{.DevAddress}}?n=20&start=0&txntype=merged">Treasury</a></div>
-                        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span data-target="homepage.devFund">
-                                {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .DevFund) 0 true)}}
-                            </span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
                     </div>
-                    {{end}}
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary lh1rem">Total Coin Supply (of 21 mil)</div>
-                        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span data-target="homepage.coinSupply">
-                                {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .CoinSupply) 0 true)}}
-                            </span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
-                        </div>
+                </div> <!-- end mining card -->
+
+                <div class="bg-white mb-1 p-2 mb-2 px-3 mx-1">
+                    <div class="my-3 h4">
+                        <span class="dcricon-tree d-inline-block pr-2 h4"></span>
+                        Distribution
                     </div>
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Treasury Block Reward</div>
-                        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span data-target="homepage.bsubsidyDev">
-                                {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.Dev) 8 true 2)}}
-                            </span>
-                            <span class="pl-1 unit lh15rem">DCR</span>
+                    <div class="row mt-1">
+                        {{if .DevFund}}
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary"><a href="/address/{{.DevAddress}}?n=20&start=0&txntype=merged">Treasury</a></div>
+                            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="homepage.devFund">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .DevFund) 0 true)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                        </div>
+                        {{end}}
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary lh1rem">Total Coin Supply (of 21 mil)</div>
+                            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="homepage.coinSupply">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .CoinSupply) 0 true)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                        </div>
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Treasury Block Reward</div>
+                            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="homepage.bsubsidyDev">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.Dev) 8 true 2)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
                         </div>
                     </div>
                     {{if $.ExchangeState}}
@@ -406,10 +419,9 @@
                     </div>
                     {{end}}
                 </div>
-            </div>
-            {{end}}
+                {{end}}
 
-          </div> <!-- end column -->
+            </div> <!-- end column -->
 
         </div>
 

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -7,221 +7,208 @@
 <body class="{{ theme }}">
     {{ template "navbar" . }}
     <div class="container main" data-controller="time blocklist homepage">
-        <!-- <div class="text-left mx-1 pl-1 pb-1">{{.NetName}}</div> -->
+        <div class="row">
+            <div class="col-md-15 p-0">
 
-            <div class="row">
-                <div class="col-md-15 p-0">
+                <div class="bg-white mb-1 py-2 px-3 my-0">
+                    <div class="d-inline-block position-relative p-2">
+                        <span class="card-icon dcricon-twoblocks h1 mr-2"></span> <a href="/blocks" class="h3 my-3">Latest {{.NetName}} Blocks</a>
+                    </div>
 
-                    <div class="bg-white mb-1 py-2 px-3 my-0">
-                        <div class="d-inline-block position-relative p-2">
-                            <span class="card-icon dcricon-twoblocks h1 mr-2"></span> <a href="/blocks" class="h3 my-3">Latest {{.NetName}} Blocks</a>
+                    <div class="row">
+                        {{with .BestBlock}}
+                        <div class="col-6 text-center">
+                            <span class="h6 mb-0 position-relative text-secondary" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
+                            <a class="d-inline-block h3 position-relative" href="/block/{{.Hash}}" data-target="homepage.blockHeight">{{.Height}}</a>
                         </div>
-
-                        <div class="row">
-                            {{with .BestBlock}}
-                            <div class="col-6 text-center">
-                                <span class="h6 mb-0 position-relative text-secondary" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
-                                <a class="d-inline-block h3 position-relative" href="/block/{{.Hash}}" data-target="homepage.blockHeight">{{.Height}}</a>
-                            </div>
-                            <div class="col-6 text-center">
-                                <span class="h6 position-relative text-secondary" data-tooltip="total DCR sent in this block">value</span><br>
-                                <span class="h4" data-target="homepage.blockTotal">{{threeSigFigs .Total}}</span><span class="h6"> DCR</span>
-                            </div>
-                            <div class="col-6 text-center">
-                                <div class="d-flex align-items-baseline justify-content-center p-0 m-0">
-                                    <span class="h6 mr-2 text-secondary" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
-                                    {{if eq $.Consensus -1}}
-                                    <span data-target="homepage.consensusMsg" class="small text-danger">rejected</span>
-                                    {{else if eq $.Consensus 0}}
-                                    <span data-target="homepage.consensusMsg" class="small"></span>
-                                    {{else}}
-                                    <span data-target="homepage.consensusMsg" class="small text-green">approved</span>
-                                    {{end}}
-                                </div>
-                                <div class="d-inline-block p1 h5" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
-                                    {{range $index, $vote := $.BlockTally}}
-                                    <div
-                                    class="d-inline-block position-relative"
-                                    data-tooltip="{{if eq $vote -1}}the stakeholder has voted to reject this block{{else if eq $vote 1}}the stakeholder has voted to accept this block{{else}}this vote has not been received yet{{end}}"
-                                    >
-                                    <span class="dcricon-{{if eq $vote 0}}reject{{else if eq $vote 1}}affirm{{else}}missing{{end}}"></span>
-                                    </div>
-                                    {{end}}
-                                </div>
-                            </div>
-
-                            <div class="col-6 text-center">
-                                <span class="h6 text-secondary">size</span><br>
-                                <span class="h4" data-target="homepage.blockSize">{{.FormattedBytes}}</span>
-                            </div>
-                            {{end}}
+                        <div class="col-6 text-center">
+                            <span class="h6 position-relative text-secondary" data-tooltip="total DCR sent in this block">value</span><br>
+                            <span class="h4" data-target="homepage.blockTotal">{{threeSigFigs .Total}}</span><span class="h6"> DCR</span>
                         </div>
-                        <div class="row">
-                            <div class="col">
-                                <table class="table w-100 mt-2 mx-auto mb-0">
-                                    <thead>
-                                        <tr class="card-theader">
-                                            <th class="text-left pl-3">Height</th>
-                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">T<span class="d-sm-none">xns</span><span class="d-none d-sm-inline">ransactions</span></div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="votes">Votes</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="tickets">Tickets</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="revocations">Revokes</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
-                                            <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
-                                            <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody data-target="blocklist.table">
-                                        {{range .Blocks}}
-                                        <tr data-height="{{.Height}}" data-link-class="fs18">
-                                            <td class="text-left pl-2" data-type="height"><a href="/block/{{.Height}}" class="fs18">{{.Height}}</a></td>
-                                            <td class="text-center" data-type="tx">{{.Transactions}}</td>
-                                            <td class="text-center" data-type="votes">{{.Voters}}</td>
-                                            <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
-                                            <td class="text-center" data-type="revocations">{{.Revocations}}</td>
-                                            <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
-                                            <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
-                                            <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime}}">{{.BlockTime}}</td>
-                                        </tr>
-                                        {{end}}
-                                    </tbody>
-                                </table>
-                                <a href="/blocks" class="small ml-2">more blocks...</a>
+                        <div class="col-6 text-center">
+                            <div class="d-flex align-items-baseline justify-content-center p-0 m-0">
+                                <span class="h6 mr-2 text-secondary" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
+                                {{if eq $.Consensus -1}}
+                                <span data-target="homepage.consensusMsg" class="small text-danger">rejected</span>
+                                {{else if eq $.Consensus 0}}
+                                <span data-target="homepage.consensusMsg" class="small"></span>
+                                {{else}}
+                                <span data-target="homepage.consensusMsg" class="small text-green">approved</span>
+                                {{end}}
+                            </div>
+                            <div class="d-inline-block p1 h5" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
+                                {{range $index, $vote := $.BlockTally}}
+                                <div
+                                class="d-inline-block position-relative"
+                                data-tooltip="{{if eq $vote -1}}the stakeholder has voted to reject this block{{else if eq $vote 1}}the stakeholder has voted to accept this block{{else}}this vote has not been received yet{{end}}"
+                                >
+                                <span class="dcricon-{{if eq $vote 0}}reject{{else if eq $vote 1}}affirm{{else}}missing{{end}}"></span>
+                                </div>
+                                {{end}}
                             </div>
                         </div>
-                    </div> <!-- end blocks card -->
-
-                    <div class="py-1 px-2 mb-1 bg-white">
-
-                        <div class="d-flex align-items-baseline my-2">
-                            <div class="position-relative col nowrap">
-                                <span class="card-icon dcricon-stack h1 mr-2"></span> <a href="/mempool" class="h3">Mempool</a>
-                            </div>
-
-                            <div class="align-right mr-3">
-                                <span
-                                    class="h2 position-relative"
-                                    data-target="homepage.mempool"
-                                    data-total="{{.Mempool.LikelyTotal}}"
-                                    data-reg-total="{{.Mempool.RegularTotal}}"
-                                    data-reg-count="{{.Mempool.NumRegular}}"
-                                    data-vote-total="{{.Mempool.VoteTotal}}"
-                                    data-vote-count="{{.Mempool.VotingInfo.TicketsVoted}}"
-                                    data-ticket-total="{{.Mempool.TicketTotal}}"
-                                    data-ticket-count="{{.Mempool.NumTickets}}"
-                                    data-rev-total="{{.Mempool.RevokeTotal}}"
-                                    data-rev-count="{{.Mempool.NumRevokes}}"
-                                    data-tooltip="transactions ready for the next block"
-                                >{{threeSigFigs .Mempool.LikelyTotal}}</span>
-                                <span class="h5">DCR</span>
-                            </div>
+                        <div class="col-6 text-center">
+                            <span class="h6 text-secondary">size</span><br>
+                            <span class="h4" data-target="homepage.blockSize">{{.FormattedBytes}}</span>
                         </div>
-
-                        <div class="row mb-2">
-
-                            <div class="col-md-9 mb-3">
-                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto mt-1 mt-lg-4 pt-1">
-                                    <div class="text-left pl-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-regular d-inline-block">
-                                        <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
-                                        <span class="h6"> regular</span>
-                                        <br>
-                                        <span class="h4" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
-                                        <span class="h6">DCR</span>
-                                    </div>
-
-                                    <div class="text-right pr-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-ticket d-inline-block">
-                                        <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
-                                        <span class="h6"> tickets</span>
-                                        <br>
-                                        <span class="h4" data-target="homepage.mpTicketTotal"
-                                        >{{threeSigFigs .Mempool.TicketTotal}}</span>
-                                        <span class="h6">DCR</span>
-                                    </div>
-                                </div>
-
-                                <div class="mx-2 jsonly text-nowrap d-flex my-3">
-                                    <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
-                                    <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
-                                    <div class="tx-gauge tx-rev" data-target="homepage.mpRevBar"></div>
-                                    <div class="tx-gauge tx-vote rounded-right" data-target="homepage.mpVoteBar"></div>
-                                </div>
-
-                                <div class="d-flex justify-content-between align-items-center mx-auto px-2">
-
-                                    <div class="text-left pl-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-rev d-inline-block">
-                                        <span data-target="homepage.mpRevCount" class="h4 lh1rem">{{.Mempool.NumRevokes}}</span>
-                                        <span class="h6"> revokes</span>
-                                        <br>
-                                        <span class="h4" data-target="homepage.mpRevTotal"
-                                        >{{threeSigFigs .Mempool.RevokeTotal}}</span>
-                                        <span class="h6">DCR</span>
-                                    </div>
-
-                                    <div class="text-right pr-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-bar tx-vote d-inline-block">
-                                        <span data-target="homepage.mpVoteCount"
-                                        class="h4 lh1rem"
-                                        data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
-                                        {{$afterFirst := false}}
-                                        {{range $hash, $tally := .Mempool.VotingInfo.VoteTallys}}
-                                            {{if $afterFirst}} + {{end}}
-                                            <span class="position-relative d-inline-block"
-                                            data-target="homepage.voteTally"
-                                            data-hash="{{$hash}}"
-                                            data-affirmed="{{$tally.Affirmations}}"
-                                            data-count="{{$tally.VoteCount}}"
-                                            data-tooltip="for block {{$hash}}"
-                                            >{{$tally.VoteCount}}</span>
-                                            {{$afterFirst = true}}
-                                        {{end}}
-                                        </span>
-                                        <span class="h6"> votes</span>
-                                        <br>
-                                        <span class="h4" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
-                                        <span class="h6">DCR</span><br>
-                                    </div>
-
-                                </div>
-                            </div>
-
-                            <div class="col mb-1">
-                                <table class="table w-100 mx-auto mb-0">
-                                    <thead>
-                                    <tr class="card-theader">
-                                        <th class="text-left pl-2">Hash</th>
-                                        <th>Type</th>
-                                        <th>DCR</th>
-                                        <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell">Size</th>
-                                        <th class="text-right pr-3 jsonly">Age</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody class="homepage-mempool" data-target="homepage.transactions">
-                                    {{range .Mempool.LatestTransactions}}
+                        {{end}}
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                            <table class="table w-100 mt-2 mx-auto mb-0">
+                                <thead>
                                     <tr>
-                                        <td class="text-left pl-1">
-                                        <div class="hash-box">
-                                            <div class="hash-fill">{{template "hashElide" (hashlink .Hash (print "/tx/" .Hash))}}</div>
-                                        </div>
-                                        </td>
-                                        <td>{{.Type}}</td>
-                                        <td>{{threeSigFigs .TotalOut}}</td>
-                                        <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell">{{.Size}} B</td>
-                                        <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
+                                        <th class="text-left pl-3">Height</th>
+                                        <th><div class="position-relative text-center" data-tooltip="regular transactions">T<span class="d-sm-none">xns</span><span class="d-none d-sm-inline">ransactions</span></div></th>
+                                        <th><div class="position-relative text-center" data-tooltip="votes">Votes</div></th>
+                                        <th><div class="position-relative text-center" data-tooltip="tickets">Tickets</div></th>
+                                        <th><div class="position-relative text-center" data-tooltip="revocations">Revokes</div></th>
+                                        <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
+                                        <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
+                                        <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
+                                    </tr>
+                                </thead>
+                                <tbody data-target="blocklist.table">
+                                    {{range .Blocks}}
+                                    <tr data-height="{{.Height}}" data-link-class="fs18">
+                                        <td class="text-left pl-2" data-type="height"><a href="/block/{{.Height}}" class="fs18">{{.Height}}</a></td>
+                                        <td class="text-center" data-type="tx">{{.Transactions}}</td>
+                                        <td class="text-center" data-type="votes">{{.Voters}}</td>
+                                        <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
+                                        <td class="text-center" data-type="revocations">{{.Revocations}}</td>
+                                        <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
+                                        <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
+                                        <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime}}">{{.BlockTime}}</td>
                                     </tr>
                                     {{end}}
-                                    </tbody>
-                                </table>
-                                <a href="/mempool" class="small ml-2">more transactions...</a>
+                                </tbody>
+                            </table>
+                            <a href="/blocks" class="small ml-2">more blocks...</a>
+                        </div>
+                    </div>
+                </div> <!-- end blocks card -->
+
+                <div class="py-1 px-2 mb-1 bg-white">
+
+                    <div class="d-flex align-items-baseline my-2">
+                        <div class="position-relative col nowrap">
+                            <span class="card-icon dcricon-stack h1 mr-2"></span> <a href="/mempool" class="h3">Mempool</a>
+                        </div>
+                        <div class="align-right mr-3">
+                            <span
+                                class="h2 position-relative"
+                                data-target="homepage.mempool"
+                                data-total="{{.Mempool.LikelyTotal}}"
+                                data-reg-total="{{.Mempool.RegularTotal}}"
+                                data-reg-count="{{.Mempool.NumRegular}}"
+                                data-vote-total="{{.Mempool.VoteTotal}}"
+                                data-vote-count="{{.Mempool.VotingInfo.TicketsVoted}}"
+                                data-ticket-total="{{.Mempool.TicketTotal}}"
+                                data-ticket-count="{{.Mempool.NumTickets}}"
+                                data-rev-total="{{.Mempool.RevokeTotal}}"
+                                data-rev-count="{{.Mempool.NumRevokes}}"
+                                data-tooltip="transactions ready for the next block"
+                            >{{threeSigFigs .Mempool.LikelyTotal}}</span>
+                            <span class="h5">DCR</span>
+                        </div>
+                    </div>
+
+                    <div class="row mb-2">
+                        <div class="col-md-9 mb-3">
+                            <div class="d-flex justify-content-between align-items-center px-2 mx-auto mt-1 mt-lg-4 pt-1">
+                                <div class="text-left pl-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-regular d-inline-block">
+                                    <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
+                                    <span class="h6"> regular</span>
+                                    <br>
+                                    <span class="h4" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
+                                    <span class="h6">DCR</span>
+                                </div>
+                                <div class="text-right pr-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-ticket d-inline-block">
+                                    <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
+                                    <span class="h6"> tickets</span>
+                                    <br>
+                                    <span class="h4" data-target="homepage.mpTicketTotal"
+                                    >{{threeSigFigs .Mempool.TicketTotal}}</span>
+                                    <span class="h6">DCR</span>
+                                </div>
                             </div>
 
-                        </div>
-                    </div>  <!-- end mempool card -->
+                            <div class="mx-2 jsonly text-nowrap d-flex my-3">
+                                <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
+                                <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
+                                <div class="tx-gauge tx-rev" data-target="homepage.mpRevBar"></div>
+                                <div class="tx-gauge tx-vote rounded-right" data-target="homepage.mpVoteBar"></div>
+                            </div>
 
+                            <div class="d-flex justify-content-between align-items-center mx-auto px-2">
+                                <div class="text-left pl-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-rev d-inline-block">
+                                    <span data-target="homepage.mpRevCount" class="h4 lh1rem">{{.Mempool.NumRevokes}}</span>
+                                    <span class="h6"> revokes</span>
+                                    <br>
+                                    <span class="h4" data-target="homepage.mpRevTotal"
+                                    >{{threeSigFigs .Mempool.RevokeTotal}}</span>
+                                    <span class="h6">DCR</span>
+                                </div>
+                                <div class="text-right pr-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-bar tx-vote d-inline-block">
+                                    <span data-target="homepage.mpVoteCount"
+                                    class="h4 lh1rem"
+                                    data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
+                                    {{$afterFirst := false}}
+                                    {{range $hash, $tally := .Mempool.VotingInfo.VoteTallys}}
+                                        {{if $afterFirst}} + {{end}}
+                                        <span class="position-relative d-inline-block"
+                                        data-target="homepage.voteTally"
+                                        data-hash="{{$hash}}"
+                                        data-affirmed="{{$tally.Affirmations}}"
+                                        data-count="{{$tally.VoteCount}}"
+                                        data-tooltip="for block {{$hash}}"
+                                        >{{$tally.VoteCount}}</span>
+                                        {{$afterFirst = true}}
+                                    {{end}}
+                                    </span>
+                                    <span class="h6"> votes</span>
+                                    <br>
+                                    <span class="h4" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
+                                    <span class="h6">DCR</span><br>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col mb-1">
+                            <table class="table w-100 mx-auto mb-0">
+                                <thead>
+                                <tr>
+                                    <th class="text-left pl-2">Hash</th>
+                                    <th>Type</th>
+                                    <th>DCR</th>
+                                    <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell">Size</th>
+                                    <th class="text-right pr-3 jsonly">Age</th>
+                                </tr>
+                                </thead>
+                                <tbody class="homepage-mempool" data-target="homepage.transactions">
+                                {{range .Mempool.LatestTransactions}}
+                                <tr>
+                                    <td class="text-left pl-1">
+                                    <div class="hash-box">
+                                        <div class="hash-fill">{{template "hashElide" (hashlink .Hash (print "/tx/" .Hash))}}</div>
+                                    </div>
+                                    </td>
+                                    <td>{{.Type}}</td>
+                                    <td>{{threeSigFigs .TotalOut}}</td>
+                                    <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell">{{.Size}} B</td>
+                                    <td class="text-right pr-3 jsonly" data-target="time.age" data-age="{{.Time}}"></td>
+                                </tr>
+                                {{end}}
+                                </tbody>
+                            </table>
+                            <a href="/mempool" class="small ml-2">more transactions...</a>
+                        </div>
+                    </div>
+                </div>  <!-- end mempool card -->
             </div> <!-- end column -->
 
             <div class="col-md-9 p-0">
-
                 {{with .Info}}
-
                 <div class="bg-white mb-1 py-2 px-3 mx-1">
                     <div class="mt-2 my-3 h4">
                         <span class="dcricon-ticket d-inline-block pr-2 h3"></span>
@@ -418,13 +405,9 @@
                     {{end}}
                 </div>
                 {{end}}
-
             </div> <!-- end column -->
-
         </div>
-
     </div>
-
     <!-- end wrapper -->
 
     {{  template "footer" . }}

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -10,8 +10,6 @@
         <!-- <div class="text-left mx-1 pl-1 pb-1">{{.NetName}}</div> -->
 
             <div class="row">
-
-
                 <div class="col-md-15 p-0">
                     <div class="pt-1 pb-1 px-2 bg-white mb-1">
 
@@ -64,10 +62,10 @@
                                     <thead>
                                         <tr class="card-theader">
                                             <th class="text-left pl-3">Height</th>
-                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">R</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="votes">V</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="tickets">T</div></th>
-                                            <th><div class="position-relative text-center" data-tooltip="revocations">X</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">Transactions</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="votes">Votes</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="tickets">Tickets</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="revocations">Revokes</div></th>
                                             <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
                                             <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
                                             <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
@@ -88,12 +86,12 @@
                                         {{end}}
                                     </tbody>
                                 </table>
-                                <a href="/blocks" class="small">more blocks...</a>
+                                <a href="/blocks" class="small ml-2">more blocks...</a>
                             </div>
                         </div>
                     </div> <!-- end blocks card -->
 
-                    <div class="pt-1 pb-1 px-2 mb-2 bg-white mb-1">
+                    <div class="py-1 px-2 mb-1 bg-white">
 
                         <div class="d-flex align-items-baseline mb-2">
                             <div class="position-relative mt-1 p-2">
@@ -119,18 +117,11 @@
                             </div>
                         </div>
 
-                        <div class="mx-2 jsonly text-nowrap d-flex">
-                            <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
-                            <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
-                            <div class="tx-gauge tx-vote" data-target="homepage.mpVoteBar"></div>
-                            <div class="tx-gauge tx-rev rounded-right" data-target="homepage.mpRevBar"></div
-                        ></div>
-
                         <div class="row mb-2">
                             <div class="col-md-8">
 
-                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto">
-                                    <div class="text-left my-3 pl-3 tx-bar tx-regular d-inline-block">
+                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto mt-4 pt-1">
+                                    <div class="text-left pl-2 tx-bar tx-regular d-inline-block">
                                         <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
                                         <span class="h5"> regular</span>
                                         <br>
@@ -138,7 +129,26 @@
                                         <span class="h6">DCR</span>
                                     </div>
 
-                                    <div class="text-right my-3 pr-3 tx-bar tx-vote d-inline-block">
+                                    <div class="text-right pr-2 tx-bar tx-ticket d-inline-block">
+                                        <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
+                                        <span class="h5"> tickets</span>
+                                        <br>
+                                        <span class="h3" data-target="homepage.mpTicketTotal"
+                                        >{{threeSigFigs .Mempool.TicketTotal}}</span>
+                                        <span class="h6">DCR</span>
+                                    </div>
+                                </div>
+
+                                <div class="mx-2 jsonly text-nowrap d-flex my-3">
+                                    <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
+                                    <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
+                                    <div class="tx-gauge tx-vote" data-target="homepage.mpVoteBar"></div>
+                                    <div class="tx-gauge tx-rev rounded-right" data-target="homepage.mpRevBar"></div
+                                ></div>
+
+                                <div class="d-flex justify-content-between align-items-center mx-auto px-2">
+
+                                    <div class="text-left pl-2 tx-bar tx-bar tx-vote d-inline-block">
                                         <span data-target="homepage.mpVoteCount"
                                         class="h4"
                                         data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
@@ -160,21 +170,10 @@
                                         <span class="h3" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
                                         <span class="h6">DCR</span><br>
                                     </div>
-                                </div>
 
-                                <div class="d-flex justify-content-between align-items-center mx-auto px-2">
-                                    <div class="text-left my-3 pl-3 tx-bar tx-ticket d-inline-block">
-                                    <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
-                                    <span class="h5"> tickets</span>
-                                    <br>
-                                    <span class="h3" data-target="homepage.mpTicketTotal"
-                                    >{{threeSigFigs .Mempool.TicketTotal}}</span>
-                                    <span class="h6">DCR</span>
-                                    </div>
-
-                                    <div class="text-right my-3 pr-3 tx-bar tx-rev d-inline-block">
+                                    <div class="text-right pr-2 tx-bar tx-rev d-inline-block">
                                         <span data-target="homepage.mpRevCount" class="h4">{{.Mempool.NumRevokes}}</span>
-                                        <span class="h5"> revocations</span>
+                                        <span class="h5"> revokes</span>
                                         <br>
                                         <span class="h3" data-target="homepage.mpRevTotal"
                                         >{{threeSigFigs .Mempool.RevokeTotal}}</span>
@@ -212,7 +211,7 @@
                                     {{end}}
                                     </tbody>
                                 </table>
-                                <a href="/mempool" class="small mb-2">see more...</a>
+                                <a href="/mempool" class="small ml-2">more transactions...</a>
                             </div>
                         </div>
                     </div>  <!-- end mempool card -->
@@ -369,7 +368,6 @@
                                 </span>
                             </div>
                         </div>
-
                     </div>
                 </div> <!-- end mining card -->
 

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -11,25 +11,25 @@
 
             <div class="row">
                 <div class="col-md-15 p-0">
-                    <div class="pt-1 pb-1 px-2 bg-white mb-1">
 
-                        <div class="d-inline-block position-relative mt-1 p-2">
-                            <span class="card-icon dcricon-twoblocks h1 mr-2"></span> <a href="/blocks" class="h3">Latest {{.NetName}} Blocks</a>
+                    <div class="bg-white mb-1 py-2 px-3 my-0">
+                        <div class="d-inline-block position-relative p-2">
+                            <span class="card-icon dcricon-twoblocks h1 mr-2"></span> <a href="/blocks" class="h3 my-3">Latest {{.NetName}} Blocks</a>
                         </div>
 
                         <div class="row">
                             {{with .BestBlock}}
                             <div class="col-6 text-center">
-                                <span class="h6 mb-0 position-relative" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
+                                <span class="h6 mb-0 position-relative text-secondary" data-tooltip="stakeholders are validating this block now.">proposed</span><br>
                                 <a class="d-inline-block h3 position-relative" href="/block/{{.Hash}}" data-target="homepage.blockHeight">{{.Height}}</a>
                             </div>
                             <div class="col-6 text-center">
-                                <span class="h6 position-relative" data-tooltip="total DCR sent in this block">value</span><br>
+                                <span class="h6 position-relative text-secondary" data-tooltip="total DCR sent in this block">value</span><br>
                                 <span class="h4" data-target="homepage.blockTotal">{{threeSigFigs .Total}}</span><span class="h6"> DCR</span>
                             </div>
                             <div class="col-6 text-center">
                                 <div class="d-flex align-items-baseline justify-content-center p-0 m-0">
-                                    <span class="h6 mr-2" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
+                                    <span class="h6 mr-2 text-secondary" data-tooltip="stakeholder's votes for the proposed block.">votes</span>
                                     {{if eq $.Consensus -1}}
                                     <span data-target="homepage.consensusMsg" class="small text-danger">rejected</span>
                                     {{else if eq $.Consensus 0}}
@@ -38,7 +38,7 @@
                                     <span data-target="homepage.consensusMsg" class="small text-green">approved</span>
                                     {{end}}
                                 </div>
-                                <div class="d-inline-block p1 h4" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
+                                <div class="d-inline-block p1 h5" data-target="homepage.blockVotes" data-hash="{{.Hash}}">
                                     {{range $index, $vote := $.BlockTally}}
                                     <div
                                     class="d-inline-block position-relative"
@@ -51,7 +51,7 @@
                             </div>
 
                             <div class="col-6 text-center">
-                                <span class="h6">size</span><br>
+                                <span class="h6 text-secondary">size</span><br>
                                 <span class="h4" data-target="homepage.blockSize">{{.FormattedBytes}}</span>
                             </div>
                             {{end}}
@@ -62,7 +62,7 @@
                                     <thead>
                                         <tr class="card-theader">
                                             <th class="text-left pl-3">Height</th>
-                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">Transactions</div></th>
+                                            <th><div class="position-relative text-center" data-tooltip="regular transactions">T<span class="d-sm-none">xns</span><span class="d-none d-sm-inline">ransactions</span></div></th>
                                             <th><div class="position-relative text-center" data-tooltip="votes">Votes</div></th>
                                             <th><div class="position-relative text-center" data-tooltip="tickets">Tickets</div></th>
                                             <th><div class="position-relative text-center" data-tooltip="revocations">Revokes</div></th>
@@ -93,12 +93,12 @@
 
                     <div class="py-1 px-2 mb-1 bg-white">
 
-                        <div class="d-flex align-items-baseline mb-2">
-                            <div class="position-relative mt-1 p-2">
+                        <div class="d-flex align-items-baseline my-2">
+                            <div class="position-relative col nowrap">
                                 <span class="card-icon dcricon-stack h1 mr-2"></span> <a href="/mempool" class="h3">Mempool</a>
                             </div>
 
-                            <div class="ml-auto">
+                            <div class="align-right mr-3">
                                 <span
                                     class="h2 position-relative"
                                     data-target="homepage.mempool"
@@ -118,22 +118,22 @@
                         </div>
 
                         <div class="row mb-2">
-                            <div class="col-md-8">
 
-                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto mt-4 pt-1">
-                                    <div class="text-left pl-2 tx-bar tx-regular d-inline-block">
+                            <div class="col-md-9 mb-3">
+                                <div class="d-flex justify-content-between align-items-center px-2 mx-auto mt-1 mt-lg-4 pt-1">
+                                    <div class="text-left pl-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-regular d-inline-block">
                                         <span data-target="homepage.mpRegCount" class="h4">{{.Mempool.NumRegular}}</span>
-                                        <span class="h5"> regular</span>
+                                        <span class="h6"> regular</span>
                                         <br>
-                                        <span class="h3" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
+                                        <span class="h4" data-target="homepage.mpRegTotal">{{threeSigFigs .Mempool.RegularTotal}}</span>
                                         <span class="h6">DCR</span>
                                     </div>
 
-                                    <div class="text-right pr-2 tx-bar tx-ticket d-inline-block">
+                                    <div class="text-right pr-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-ticket d-inline-block">
                                         <span data-target="homepage.mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
-                                        <span class="h5"> tickets</span>
+                                        <span class="h6"> tickets</span>
                                         <br>
-                                        <span class="h3" data-target="homepage.mpTicketTotal"
+                                        <span class="h4" data-target="homepage.mpTicketTotal"
                                         >{{threeSigFigs .Mempool.TicketTotal}}</span>
                                         <span class="h6">DCR</span>
                                     </div>
@@ -142,15 +142,24 @@
                                 <div class="mx-2 jsonly text-nowrap d-flex my-3">
                                     <div class="tx-gauge tx-regular rounded-left" data-target="homepage.mpRegBar"></div>
                                     <div class="tx-gauge tx-ticket" data-target="homepage.mpTicketBar"></div>
-                                    <div class="tx-gauge tx-vote" data-target="homepage.mpVoteBar"></div>
-                                    <div class="tx-gauge tx-rev rounded-right" data-target="homepage.mpRevBar"></div
-                                ></div>
+                                    <div class="tx-gauge tx-rev" data-target="homepage.mpRevBar"></div>
+                                    <div class="tx-gauge tx-vote rounded-right" data-target="homepage.mpVoteBar"></div>
+                                </div>
 
                                 <div class="d-flex justify-content-between align-items-center mx-auto px-2">
 
-                                    <div class="text-left pl-2 tx-bar tx-bar tx-vote d-inline-block">
+                                    <div class="text-left pl-3 pr-sm-3 pr-md-3 pr-lg-3 tx-bar tx-rev d-inline-block">
+                                        <span data-target="homepage.mpRevCount" class="h4 lh1rem">{{.Mempool.NumRevokes}}</span>
+                                        <span class="h6"> revokes</span>
+                                        <br>
+                                        <span class="h4" data-target="homepage.mpRevTotal"
+                                        >{{threeSigFigs .Mempool.RevokeTotal}}</span>
+                                        <span class="h6">DCR</span>
+                                    </div>
+
+                                    <div class="text-right pr-3 pl-sm-3 pl-md-3 pl-lg-3 tx-bar tx-bar tx-vote d-inline-block">
                                         <span data-target="homepage.mpVoteCount"
-                                        class="h4"
+                                        class="h4 lh1rem"
                                         data-tickets-per-block="{{.Mempool.VotingInfo.MaxVotesPerBlock}}">
                                         {{$afterFirst := false}}
                                         {{range $hash, $tally := .Mempool.VotingInfo.VoteTallys}}
@@ -165,26 +174,16 @@
                                             {{$afterFirst = true}}
                                         {{end}}
                                         </span>
-                                        <span class="h5"> votes</span>
+                                        <span class="h6"> votes</span>
                                         <br>
-                                        <span class="h3" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
+                                        <span class="h4" data-target="homepage.mpVoteTotal">{{threeSigFigs .Mempool.VoteTotal}}</span>
                                         <span class="h6">DCR</span><br>
                                     </div>
 
-                                    <div class="text-right pr-2 tx-bar tx-rev d-inline-block">
-                                        <span data-target="homepage.mpRevCount" class="h4">{{.Mempool.NumRevokes}}</span>
-                                        <span class="h5"> revokes</span>
-                                        <br>
-                                        <span class="h3" data-target="homepage.mpRevTotal"
-                                        >{{threeSigFigs .Mempool.RevokeTotal}}</span>
-                                        <span class="h6">DCR</span>
-                                    </div>
                                 </div>
-
                             </div>
 
-                            <div class="col">
-
+                            <div class="col mb-1">
                                 <table class="table w-100 mx-auto mb-0">
                                     <thead>
                                     <tr class="card-theader">
@@ -213,6 +212,7 @@
                                 </table>
                                 <a href="/mempool" class="small ml-2">more transactions...</a>
                             </div>
+
                         </div>
                     </div>  <!-- end mempool card -->
 
@@ -222,8 +222,8 @@
 
                 {{with .Info}}
 
-                <div class="bg-white mb-1 py-2 px-3 mx-1 my-0">
-                    <div class="my-3 h4">
+                <div class="bg-white mb-1 py-2 px-3 mx-1">
+                    <div class="mt-2 my-3 h4">
                         <span class="dcricon-ticket d-inline-block pr-2 h3"></span>
                         Voting
                     </div>
@@ -251,17 +251,15 @@
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                            <div class="fs13 text-secondary">Vote Reward</div>
+                            <div class="fs13 text-secondary">Ticket Pool Size</div>
                             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                                <span data-target="homepage.bsubsidyPos">
-                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
+                                <span data-target="homepage.poolSize">
+                                    {{intComma .PoolInfo.Size}}
                                 </span>
-                                <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-target="homepage.ticketReward">{{template "fmtPercentage" .TicketReward}}</span> per ~{{.RewardPeriod}}
+                                <span data-target="homepage.targetPct">{{printf "%.2f" .PoolInfo.PercentTarget}}</span> % of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>
                             </div>
-                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards"><span class="text-green">+{{printf "%.2f" .ASR}} %</span> per year</div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Next Ticket Price Change</div>
@@ -285,15 +283,17 @@
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                            <div class="fs13 text-secondary">Ticket Pool Size</div>
+                            <div class="fs13 text-secondary">Vote Reward</div>
                             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                                <span data-target="homepage.poolSize">
-                                    {{intComma .PoolInfo.Size}}
+                                <span data-target="homepage.bsubsidyPos">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
                                 </span>
+                                <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-target="homepage.targetPct">{{printf "%.2f" .PoolInfo.PercentTarget}}</span> % of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>
+                                <span data-target="homepage.ticketReward">{{template "fmtPercentage" .TicketReward}}</span> per ~{{.RewardPeriod}}
                             </div>
+                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards"><span class="text-green">+{{printf "%.2f" .ASR}} %</span> per year</div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Total Staked DCR</div>
@@ -343,7 +343,7 @@
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                            <div class="fs13 text-secondary">Next Block Reward Reduction</div>
+                            <div class="fs13 text-secondary lh1rem">Next Block Reward Reduction</div>
                             <div class="progress mt-1 mb-1">
                                 <div
                                     class="progress-bar rounded"
@@ -389,7 +389,7 @@
                         </div>
                         {{end}}
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                            <div class="fs13 text-secondary lh1rem">Total Coin Supply (of 21 mil)</div>
+                            <div class="fs13 text-secondary lh1rem">Total Coin Supply <span class="nowrap">(of 21 mil)</span></div>
                             <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
                                 <span data-target="homepage.coinSupply">
                                     {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .CoinSupply) 0 true)}}

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -7,10 +7,10 @@
         {{with .Mempool}}
         <div class="container main" data-controller="time">
             <div class="row justify-content-between">
-                <div class="col-md-7 col-sm-6 d-flex">
+                <div class="col-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">Mempool</h4>
                 </div>
-                <div class="col-md-5 col-sm-6 d-flex">
+                <div class="col-lg-10 col-sm-12 d-flex">
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117 w120">TOTAL SENT</td>
@@ -24,7 +24,7 @@
             </div>
 
             <div class="row justify-content-between">
-                <div class="col-md-5 col-sm-7 d-flex">
+                <div class="col-lg-10 col-sm-14 d-flex">
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">LAST BLOCK</td>
@@ -46,7 +46,7 @@
                         </tr>
                     </table>
                 </div>
-                <div class="col-md-5 col-sm-7 d-flex">
+                <div class="col-lg-10 col-sm-14 d-flex">
                     <table class="">
                         <tr>
                             <td class="text-right pr-2 lh1rem nowrap p03rem0">SIZE</td>
@@ -64,7 +64,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-12">
+                <div class="col-sm-24">
                 <h4><span>Votes</span></h4>
 
                     <table class="table table-sm striped">
@@ -108,7 +108,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-12">
+                <div class="col-sm-24">
                 <h4><span>Tickets</span></h4>
                     <table class="table table-sm striped">
                         <thead>
@@ -144,7 +144,7 @@
             </div>
 
             <div class="row">
-                <div class="col-sm-12">
+                <div class="col-sm-24">
                 <h4><span>Revokes</span></h4>
                     <table class="table table-sm striped">
                         <thead>
@@ -180,7 +180,7 @@
             </div>
 
             <div class="row">
-                <div class="col-sm-12">
+                <div class="col-sm-24">
                 <h4><span>Transactions</span></h4>
                     <table class="table table-sm striped">
                         <thead>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -6,7 +6,7 @@
         {{template "navbar" . }}
         <div class="container main">
             <div class="row justify-content-between">
-                <div class="col-md-7 col-sm-6 d-flex">
+                <div class="col-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">Parameters for Decred {{.ChainParams.Name}}
                       <span class="fs12" >
                         from <a href="https://github.com/decred/dcrd/blob/master/chaincfg/params.go">chaincfg/params.go</a>

--- a/views/sidechains.tmpl
+++ b/views/sidechains.tmpl
@@ -9,7 +9,7 @@
         <h4><span title="side chain blocks known to this dcrdata instance"><img class="h30 p2tb" src="/images/dcr-side-chains.svg" alt="side chain"> Side Chain Blocks</span></h4>
 
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <table class="table striped table-responsive-sm" id="sideblockstable">
                     <thead>
                         <tr>

--- a/views/statistics.tmpl
+++ b/views/statistics.tmpl
@@ -57,7 +57,7 @@
                         <div class="card-header block-rewards">Block Reward Adjustment</div>
                         <div class="card-body card-body-padding-top" style="width: 100%;">
                             <div class="row">
-                                <div style="margin: auto" class="col-12 col-lg-12">
+                                <div style="margin: auto" class="col-12 col-lg-24">
                                     <div class="progress" style="max-width: 330px">
                                         <div
                                             class="progress-bar rounded"
@@ -141,7 +141,7 @@
                         <div class="card-header proof-of-stake">Ticket Price Adjustment</div>
                         <div class="card-body card-body-padding-top" style="width: 100%;">
                             <div class="row">
-                                <div style="margin: auto" class="col-12 col-lg-12">
+                                <div style="margin: auto" class="col-12 col-lg-24">
                                     <div class="progress">
                                         <div
                                             class="progress-bar rounded"

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -83,7 +83,7 @@
 
             {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
             <div class="row">
-                <div class="col-md-12">
+                <div class="col-lg-24">
                     <table class="table striped table-responsive-sm">
                         <thead>
                             <tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -7,7 +7,7 @@
 <div class="container main" data-controller="time tx">
 {{with .Data}}
     <div class="row justify-content-between" data-pool-status="{{.TicketInfo.PoolStatus}}">
-        <div class="col-md-8 col-sm-6">
+        <div class="col-lg-16 col-sm-12">
             <h4 class="mb-2">
                 Transaction
                 <span class="fs15">
@@ -105,7 +105,7 @@
                         <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                         <td>
                             <div class="row" data-target="tx.ticketStage">
-                                <div class="col-11 col-lg-8 col-sm-12">
+                                <div class="col-11 col-lg-16 col-sm-24">
                                     <div class="progress" style="max-width: 330px">
                                         <div
                                             class="progress-bar rounded"
@@ -151,7 +151,7 @@
                         <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                         <td>
                             <div class="row" data-target="tx.ticketStage">
-                                <div class="col-11 col-lg-8 col-sm-12">
+                                <div class="col-11 col-lg-16 col-sm-24">
                                     <div class="progress" style="max-width: 330px">
                                         <div
                                             class="progress-bar rounded"
@@ -196,7 +196,7 @@
                                 <td class="text-right pr-2 h1rem p03rem0">PROBABILITY</td>
                                 <td>
                                     <div class="row">
-                                        <div class="col-11 col-lg-8 col-sm-12">
+                                        <div class="col-11 col-lg-16 col-sm-24">
                                             <div class="progress" style="max-width: 330px">
                                                 <div
                                                     class="progress-bar rounded"
@@ -220,7 +220,7 @@
                                 <td class="text-right pr-2 h1rem p03rem0">EXPIRY</td>
                                 <td>
                                     <div class="row" data-target="tx.ticketStage">
-                                        <div class="col-11 col-lg-8 col-sm-12">
+                                        <div class="col-11 col-lg-16 col-sm-24">
                                             <div class="progress" style="max-width: 330px">
                                                 <div
                                                     class="progress-bar rounded"
@@ -260,7 +260,7 @@
                 {{end}}
             </table>
         </div>
-        <div class="col-md-4 col-sm-6 d-flex">
+        <div class="col-lg-8 col-sm-12 d-flex">
 
             <table>
                 <tr class="h2rem">
@@ -305,7 +305,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-6 mb-3">
+        <div class="col-lg-12 mb-3">
             <h5>{{len .Vin}} Input{{if gt (len .Vin) 1}}s{{end}} Consumed</h5>
             <table class="table table-sm striped">
                 <thead>
@@ -364,7 +364,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-6 mb-3">
+        <div class="col-lg-12 mb-3">
             <h5>{{len .Vout}} Output{{if gt (len .Vout) 1}}s{{end}} Created</h5>
             <table class="table table-sm striped">
                 <thead>
@@ -428,7 +428,7 @@
     {{if .VoteInfo}}
     {{with .VoteInfo}}
     <div class="row mb-3">
-        <div class="col-md-12">
+        <div class="col-lg-24">
             <h4>Vote Info</h4>
             <p>Last Block Valid: <span class="mono"><strong>{{.Validation.Validity}}</strong></span><br>
             Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -80,7 +80,7 @@
         {{end}}
 
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-lg-24">
                 <table class="table striped table-responsive-sm">
                     <thead>
                         <tr>


### PR DESCRIPTION
This PR explores alternative possibilities for handling homepage layout in
https://github.com/decred/dcrdata/pull/961

Note this PR bumps up the boostrap grid to 24 cols, so would require updating the rest of the views if adopted. 

Mainly I'd like to find ways to make the layout simple, more uniform and space efficient

<img width="1280" alt="screen shot 2019-01-31 at 2 25 01 am" src="https://user-images.githubusercontent.com/25571523/52048404-286d7300-2500-11e9-9901-5df23dd89d79.png">
<img width="1274" alt="screen shot 2019-01-31 at 2 23 24 am" src="https://user-images.githubusercontent.com/25571523/52048408-2b686380-2500-11e9-9b2d-1733ccd7d64e.png">
