### PR TITLE
fix mempool webocket message keynav bug

### DIFF
--- a/public/js/services/keyboard_navigation_service.js
+++ b/public/js/services/keyboard_navigation_service.js
@@ -58,6 +58,7 @@ function toggleKeyNav () {
 }
 
 export function keyNav (event, pulsate, preserveIndex) {
+  if (!keyNavEnabled()) return
   bindElements()
   if (menuToggle.checked) {
     targets = Array.from(document.getElementById('hamburger-menu').querySelectorAll('a'))


### PR DESCRIPTION
In both the mempool and homepage controllers, `keyNav()` was being called on updates, and had no checks for whether keyboard navigation was actually enabled by the user.