### PR TITLE
dcrpg: show server config at startup

### DIFF
--- a/db/dcrpg/internal/system.go
+++ b/db/dcrpg/internal/system.go
@@ -1,0 +1,52 @@
+package internal
+
+const (
+	RetrieveSysSettingsConfFile = `SELECT name, setting, unit, short_desc, source, sourcefile, sourceline
+		FROM pg_settings
+		WHERE source='configuration file';`
+
+	RetrieveSysSettingsServer = `SELECT name, setting, unit, short_desc, source, sourcefile, sourceline
+		FROM pg_settings
+		WHERE name='max_connections'
+			OR name='timezone'
+			OR name='max_files_per_process'
+			OR name='dynamic_shared_memory_type'
+			OR name='unix_socket_directories'
+			OR name='port'
+			OR name='data_directory'
+			OR name='config_file'
+			OR name='listen_address';`
+
+	RetrieveSysSettingsPerformance = `SELECT name, setting, unit, short_desc, source, sourcefile, sourceline
+		FROM pg_settings
+		WHERE name='synchronous_commit'
+			OR name='max_connections'
+			OR name='shared_buffers'
+			OR name='effective_cache_size'
+			OR name='maintenance_work_mem'
+			OR name='work_mem'
+			OR name='autovacuum_work_mem'
+			OR name='wal_buffers'
+			OR name='min_wal_size'
+			OR name='max_wal_size'
+			OR name='wal_level'
+			OR name='checkpoint_completion_target'
+			OR name='default_statistics_target'
+			OR name='random_page_cost'
+			OR name='seq_page_cost'
+			OR name='effective_io_concurrency'
+			OR name='max_worker_processes'
+			OR name='max_parallel_workers_per_gather'
+			OR name='max_parallel_workers'
+			OR name='autovacuum'
+			OR name='fsync'
+			OR name='full_page_writes'
+			OR name='huge_pages'
+			OR name='temp_buffers'
+			OR name='max_stack_depth'
+			OR name='force_parallel_mode'
+			OR name='jit'
+			OR name='jit_provider';`
+
+	RetrievePGVersion = `SELECT version();`
+)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -451,6 +451,24 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		return nil, err
 	}
 
+	pgVersion, err := RetrievePGVersion(db)
+	if err != nil {
+		return nil, err
+	}
+	log.Info(pgVersion)
+
+	perfSettings, err := RetrieveSysSettingsPerformance(db)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("postgres performance settings:\n%v", perfSettings)
+
+	servSettings, err := RetrieveSysSettingsServer(db)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("postgres server settings:\n%v", servSettings)
+
 	// Attempt to get DB best block height from tables, but if the tables are
 	// empty or not yet created, it is not an error.
 	bestHeight, bestHash, _, err := RetrieveBestBlockHeight(ctx, db)

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -23,9 +23,9 @@ func openDB() (func() error, error) {
 	dbi := DBInfo{
 		Host:   "localhost",
 		Port:   "5432",
-		User:   "dcrdata",
+		User:   "postgres",
 		Pass:   "",
-		DBName: "dcrdata_mainnet_tests",
+		DBName: "dcrdata_mainnet_xxx",
 	}
 	var err error
 	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true)

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -23,9 +23,9 @@ func openDB() (func() error, error) {
 	dbi := DBInfo{
 		Host:   "localhost",
 		Port:   "5432",
-		User:   "postgres",
+		User:   "dcrdata", // postgres for admin operations
 		Pass:   "",
-		DBName: "dcrdata_mainnet_xxx",
+		DBName: "dcrdata_mainnet_test",
 	}
 	var err error
 	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true)

--- a/db/dcrpg/system.go
+++ b/db/dcrpg/system.go
@@ -1,0 +1,177 @@
+package dcrpg
+
+import (
+	"database/sql"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
+)
+
+func parseUnit(unit string) (multiple float64, baseUnit string, err error) {
+	re := regexp.MustCompile(`([-\d\.]*)\s*(.*)`)
+	matches := re.FindStringSubmatch(unit)
+
+	if len(matches) != 3 {
+		panic("inconceivable!")
+	}
+
+	baseUnit = strings.TrimSuffix(matches[2], " ")
+
+	switch matches[1] {
+	case "":
+		multiple = 1
+	case "-":
+		multiple = -1
+	default:
+		multiple, err = strconv.ParseFloat(matches[1], 64)
+		if err != nil {
+			baseUnit = ""
+		}
+	}
+
+	return
+}
+
+type PGSetting struct {
+	Name, Setting, Unit, ShortDesc, Source, SourceFile, SourceLine string
+}
+
+type PGSettings map[string]PGSetting
+
+func (pgs PGSettings) String() string {
+	numSettings := len(pgs)
+	names := make([]string, 0, numSettings)
+	for name := range pgs {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	// Determine max width of "Setting", "Name", and "File" entries.
+	fileWidth, nameWidth, settingWidth := 4, 4, 7
+	fullSettings := make([]string, 0, numSettings)
+	for i := range names {
+		s, ok := pgs[names[i]]
+		if !ok {
+			log.Warnf("(PGSettings).String is not thread-safe!")
+			continue
+		}
+
+		// See if setting is numeric.
+		fullSetting := s.Setting
+		num1, err := strconv.ParseFloat(s.Setting, 64)
+		if err == nil {
+			// Combine with the unit if numeric.
+			num2, unit, err := parseUnit(s.Unit)
+			if err == nil {
+				if unit != "" {
+					unit = " " + unit
+				}
+				fullSetting = fmt.Sprintf("%.12g%s", num1*num2, unit)
+			}
+		}
+
+		fullSettings = append(fullSettings, fullSetting)
+
+		if len(fullSetting) > settingWidth {
+			settingWidth = len(fullSetting)
+		}
+
+		if len(s.SourceFile) > fileWidth {
+			fileWidth = len(s.SourceFile)
+		}
+		if len(s.Name) > nameWidth {
+			nameWidth = len(s.Name)
+		}
+	}
+
+	format := "%" + strconv.Itoa(nameWidth) + "s | %" + strconv.Itoa(settingWidth) +
+		"s | %10.10s | %" + strconv.Itoa(fileWidth) + "s | %5s | %-48.48s\n"
+
+	// Write the headers and a horizontal bar.
+	out := fmt.Sprintf(format, "Name", "Setting", "Source", "File", "Line", "Description")
+	hbar := strings.Repeat(string([]rune{0x2550}), nameWidth+1) + string([]rune{0x256A}) +
+		strings.Repeat(string([]rune{0x2550}), settingWidth+2) + string([]rune{0x256A}) +
+		strings.Repeat(string([]rune{0x2550}), 12) + string([]rune{0x256A}) +
+		strings.Repeat(string([]rune{0x2550}), fileWidth+2) + string([]rune{0x256A}) +
+		strings.Repeat(string([]rune{0x2550}), 7) + string([]rune{0x256A}) +
+		strings.Repeat(string([]rune{0x2550}), 50)
+	out += hbar + "\n"
+
+	// Write each row.
+	for i := range names {
+		s, ok := pgs[names[i]]
+		if !ok {
+			log.Warnf("(PGSettings).String is not thread-safe!")
+			continue
+		}
+		out += fmt.Sprintf(format, s.Name, fullSettings[i], s.Source,
+			s.SourceFile, s.SourceLine, s.ShortDesc)
+	}
+	return out
+}
+
+func RetrievePGVersion(db *sql.DB) (ver string, err error) {
+	err = db.QueryRow(internal.RetrievePGVersion).Scan(&ver)
+	return
+}
+
+func retrieveSysSettings(stmt string, db *sql.DB) (PGSettings, error) {
+	rows, err := db.Query(stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	defer closeRows(rows)
+
+	settings := make(PGSettings)
+
+	for rows.Next() {
+		var name, setting, unit, short_desc, source, sourcefile sql.NullString
+		var sourceline sql.NullInt64
+		err = rows.Scan(&name, &setting, &unit, &short_desc,
+			&source, &sourcefile, &sourceline)
+		if err != nil {
+			return nil, err
+		}
+
+		var line, file string
+		if source.String == "configuration file" {
+			source.String = "conf file"
+			if sourcefile.String == "" {
+				file = "NO PERMISION"
+			} else {
+				file = sourcefile.String
+				line = strconv.FormatInt(sourceline.Int64, 10)
+			}
+		}
+
+		settings[name.String] = PGSetting{
+			Name:       name.String,
+			Setting:    setting.String,
+			Unit:       unit.String,
+			ShortDesc:  short_desc.String,
+			Source:     source.String,
+			SourceFile: file,
+			SourceLine: line,
+		}
+	}
+
+	return settings, nil
+}
+
+func RetrieveSysSettingsConfFile(db *sql.DB) (PGSettings, error) {
+	return retrieveSysSettings(internal.RetrieveSysSettingsConfFile, db)
+}
+
+func RetrieveSysSettingsPerformance(db *sql.DB) (PGSettings, error) {
+	return retrieveSysSettings(internal.RetrieveSysSettingsPerformance, db)
+}
+
+func RetrieveSysSettingsServer(db *sql.DB) (PGSettings, error) {
+	return retrieveSysSettings(internal.RetrieveSysSettingsServer, db)
+}

--- a/db/dcrpg/system.go
+++ b/db/dcrpg/system.go
@@ -11,16 +11,25 @@ import (
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 )
 
+// parseUnit is used to separate a "unit" from pg_settings such as "8kB" into a
+// numeric component and a base unit string.
 func parseUnit(unit string) (multiple float64, baseUnit string, err error) {
+	// This regular expression is defined so that it will match any input.
 	re := regexp.MustCompile(`([-\d\.]*)\s*(.*)`)
 	matches := re.FindStringSubmatch(unit)
-
+	// One or more of the matched substrings may be "", but the base unit
+	// substring (matches[2]) will match anything.
 	if len(matches) != 3 {
 		panic("inconceivable!")
 	}
 
+	// The regexp eats leading spaces, but there may be trailing spaces
+	// remaining that should be removed.
 	baseUnit = strings.TrimSuffix(matches[2], " ")
 
+	// The numeric component is processed by strconv.ParseFloat except in the
+	// cases of an empty string or a single "-", which is interpreted as a
+	// negative sign.
 	switch matches[1] {
 	case "":
 		multiple = 1
@@ -29,6 +38,8 @@ func parseUnit(unit string) (multiple float64, baseUnit string, err error) {
 	default:
 		multiple, err = strconv.ParseFloat(matches[1], 64)
 		if err != nil {
+			// If the numeric part does not parse as a valid number (e.g.
+			// "3.2.1-"), reset the base unit and return the non-nil error.
 			baseUnit = ""
 		}
 	}
@@ -36,42 +47,52 @@ func parseUnit(unit string) (multiple float64, baseUnit string, err error) {
 	return
 }
 
+// PGSetting describes a PostgreSQL setting scanned from pg_settings.
 type PGSetting struct {
 	Name, Setting, Unit, ShortDesc, Source, SourceFile, SourceLine string
 }
 
+// PGSettings facilitates looking up a PGSetting based on a setting's Name.
 type PGSettings map[string]PGSetting
 
+// String implements the Stringer interface, generating a table of the settings
+// where the Setting and Unit fields are merged into a single column. The rows
+// of the table are sorted by the PGSettings string key (the setting's Name).
+// This function is not thread-safe, so do not modify PGSettings concurrently.
 func (pgs PGSettings) String() string {
+	// Sort the names.
 	numSettings := len(pgs)
 	names := make([]string, 0, numSettings)
 	for name := range pgs {
 		names = append(names, name)
 	}
-
 	sort.Strings(names)
 
 	// Determine max width of "Setting", "Name", and "File" entries.
 	fileWidth, nameWidth, settingWidth := 4, 4, 7
+	// Also combine Setting and Unit, in the same order as the sorted names.
 	fullSettings := make([]string, 0, numSettings)
 	for i := range names {
 		s, ok := pgs[names[i]]
 		if !ok {
-			log.Warnf("(PGSettings).String is not thread-safe!")
+			log.Errorf("(PGSettings).String is not thread-safe!")
 			continue
 		}
 
-		// See if setting is numeric.
+		// Combine Setting and Unit.
 		fullSetting := s.Setting
-		num1, err := strconv.ParseFloat(s.Setting, 64)
-		if err == nil {
+		// See if setting is numeric. Assume non-numeric settings have no Unit.
+		if num1, err := strconv.ParseFloat(s.Setting, 64); err == nil {
 			// Combine with the unit if numeric.
-			num2, unit, err := parseUnit(s.Unit)
-			if err == nil {
+			if num2, unit, err := parseUnit(s.Unit); err == nil {
 				if unit != "" {
 					unit = " " + unit
 				}
+				// Combine. e.g. 10.0, "8kB" => "80 kB"
 				fullSetting = fmt.Sprintf("%.12g%s", num1*num2, unit)
+			} else {
+				// Mystery unit.
+				fullSetting += " " + s.Unit
 			}
 		}
 
@@ -81,9 +102,11 @@ func (pgs PGSettings) String() string {
 			settingWidth = len(fullSetting)
 		}
 
+		// File column width.
 		if len(s.SourceFile) > fileWidth {
 			fileWidth = len(s.SourceFile)
 		}
+		// Name column width.
 		if len(s.Name) > nameWidth {
 			nameWidth = len(s.Name)
 		}
@@ -115,11 +138,15 @@ func (pgs PGSettings) String() string {
 	return out
 }
 
+// RetrievePGVersion retrieves the version of the connected PostgreSQL server.
 func RetrievePGVersion(db *sql.DB) (ver string, err error) {
 	err = db.QueryRow(internal.RetrievePGVersion).Scan(&ver)
 	return
 }
 
+// retrieveSysSettings retrieves the PostgreSQL settings provided a query that
+// returns the following columns from pg_setting in order: name, setting, unit,
+// short_desc, source, sourcefile, sourceline.
 func retrieveSysSettings(stmt string, db *sql.DB) (PGSettings, error) {
 	rows, err := db.Query(stmt)
 	if err != nil {
@@ -139,8 +166,11 @@ func retrieveSysSettings(stmt string, db *sql.DB) (PGSettings, error) {
 			return nil, err
 		}
 
+		// If the source is "configuration file", but the file path is empty,
+		// the connected postgres user does not have sufficient privileges.
 		var line, file string
 		if source.String == "configuration file" {
+			// Shorten the source string.
 			source.String = "conf file"
 			if sourcefile.String == "" {
 				file = "NO PERMISION"
@@ -164,14 +194,21 @@ func retrieveSysSettings(stmt string, db *sql.DB) (PGSettings, error) {
 	return settings, nil
 }
 
+// RetrieveSysSettingsConfFile retrieves settings that are set by a
+// configuration file (rather than default, environment variable, etc.).
 func RetrieveSysSettingsConfFile(db *sql.DB) (PGSettings, error) {
 	return retrieveSysSettings(internal.RetrieveSysSettingsConfFile, db)
 }
 
+// RetrieveSysSettingsPerformance a performance-related settings.
 func RetrieveSysSettingsPerformance(db *sql.DB) (PGSettings, error) {
 	return retrieveSysSettings(internal.RetrieveSysSettingsPerformance, db)
 }
 
+// RetrieveSysSettingsPerformance a key server configuration settings
+// (config_file, data_directory, max_connections, dynamic_shared_memory_type,
+// max_files_per_process, port, unix_socket_directories), which may be helpful
+// in debugging connectivity issues or other DB errors.
 func RetrieveSysSettingsServer(db *sql.DB) (PGSettings, error) {
 	return retrieveSysSettings(internal.RetrieveSysSettingsServer, db)
 }

--- a/db/dcrpg/system_online_test.go
+++ b/db/dcrpg/system_online_test.go
@@ -1,0 +1,40 @@
+// +build mainnettest
+
+package dcrpg
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestRetrieveSysSettingsConfFile(t *testing.T) {
+	ss, err := RetrieveSysSettingsConfFile(db.db)
+	if err != nil && err != sql.ErrNoRows {
+		t.Errorf("Failed to retrieve system settings: %v", err)
+	}
+	t.Logf("\n%v", ss)
+}
+
+func TestRetrieveSysSettingsPerformance(t *testing.T) {
+	ss, err := RetrieveSysSettingsPerformance(db.db)
+	if err != nil {
+		t.Errorf("Failed to retrieve system settings: %v", err)
+	}
+	t.Logf("\n%v", ss)
+}
+
+func TestRetrieveSysSettingsServer(t *testing.T) {
+	ss, err := RetrieveSysSettingsServer(db.db)
+	if err != nil {
+		t.Errorf("Failed to retrieve system server: %v", err)
+	}
+	t.Logf("\n%v", ss)
+}
+
+func TestRetrievePGVersion(t *testing.T) {
+	ver, err := RetrievePGVersion(db.db)
+	if err != nil {
+		t.Errorf("Failed to retrieve postgres version: %v", err)
+	}
+	t.Logf("\n%s", ver)
+}

--- a/db/dcrpg/system_test.go
+++ b/db/dcrpg/system_test.go
@@ -1,0 +1,49 @@
+package dcrpg
+
+import (
+	"testing"
+)
+
+func TestParseUnit(t *testing.T) {
+	tests := []struct {
+		in   string
+		mult float64
+		base string
+		fail bool
+	}{
+		{"1", 1.0, "", false},                        // no base unit
+		{" ", 1.0, "", false},                        // white space
+		{"8kB", 8.0, "kB", false},                    // basic
+		{"8 kB ", 8.0, "kB", false},                  // spaces discarded
+		{"kB", 1.0, "kB", false},                     // no numeric part
+		{".8kB", 0.8, "kB", false},                   // decimal w/ no int
+		{"122B", 122.0, "B", false},                  // different base unit
+		{"-400MB", -400.0, "MB", false},              // negative
+		{".kB", 0.0, "", true},                       // invalid
+		{"8kB63", 8.0, "kB63", false},                // number in base unit
+		{"1.21 GW", 1.21, "GW", false},               // strip space between number and base unit
+		{"J/s", 1.0, "J/s", false},                   // complex base unit
+		{"kg m^2 / s^2", 1.0, "kg m^2 / s^2", false}, // complex base unit
+		{"-v", -1.0, "v", false},                     // consider a lone dash prefix as a negation
+		{"7 dog years", 7.0, "dog years", false},     // base unit with spaces
+		{"", 1.0, "", false},                         // empty string
+	}
+
+	for i := range tests {
+		ti := &tests[i]
+		mult, base, err := parseUnit(ti.in)
+		if err != nil && !ti.fail {
+			t.Errorf("parseUnit(%s) failed: %v", ti.in, err)
+		} else if err == nil && ti.fail {
+			t.Errorf("parseUnit(%s) was supposed to fail.", ti.in)
+		}
+		if mult != ti.mult {
+			t.Errorf("parseUnit(%s) returned mult %f, expected %f", ti.in, mult, ti.mult)
+		}
+		if base != ti.base {
+			t.Errorf("parseUnit(%s) returned base %s, expected %s", ti.in, base, ti.base)
+		}
+		t.Logf("multiple=%f, base=%s", mult, base)
+	}
+
+}

--- a/db/dcrpg/system_test.go
+++ b/db/dcrpg/system_test.go
@@ -19,7 +19,8 @@ func TestParseUnit(t *testing.T) {
 		{".8kB", 0.8, "kB", false},                   // decimal w/ no int
 		{"122B", 122.0, "B", false},                  // different base unit
 		{"-400MB", -400.0, "MB", false},              // negative
-		{".kB", 0.0, "", true},                       // invalid
+		{".kB", 0.0, "", true},                       // invalid numeric part
+		{"1.1.1kB", 0.0, "", true},                   // invalid numeric part
 		{"8kB63", 8.0, "kB63", false},                // number in base unit
 		{"1.21 GW", 1.21, "GW", false},               // strip space between number and base unit
 		{"J/s", 1.0, "J/s", false},                   // complex base unit


### PR DESCRIPTION
This shows the PostgreSQL server version, performance related settings, and some server config.

e.g.:
```
[INF] PSQL: PostgreSQL 11.1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.2.1 20181127, 64-bit
[INF] PSQL: postgres performance settings:
                           Name |     Setting |     Source |         File |  Line | Description                                     
════════════════════════════════╪═════════════╪════════════╪══════════════╪═══════╪══════════════════════════════════════════════════
                     autovacuum |         off |  conf file | NO PERMISION |       | Starts the autovacuum subprocess.               
            autovacuum_work_mem |       -1 kB |    default |              |       | Sets the maximum memory to be used by each autov
   checkpoint_completion_target |         0.9 |  conf file | NO PERMISION |       | Time spent flushing dirty buffers during checkpo
      default_statistics_target |         100 |  conf file | NO PERMISION |       | Sets the default statistics target.             
           effective_cache_size | 50331648 kB |  conf file | NO PERMISION |       | Sets the planner's assumption about the total si
       effective_io_concurrency |         200 |  conf file | NO PERMISION |       | Number of simultaneous requests that can be hand
            force_parallel_mode |         off |    default |              |       | Forces use of parallel query facilities.        
                          fsync |          on |    default |              |       | Forces synchronization of updates to disk.      
               full_page_writes |          on |    default |              |       | Writes full pages to WAL when first modified aft
                     huge_pages |         try |    default |              |       | Use of huge pages on Linux or Windows.          
                            jit |          on |  conf file | NO PERMISION |       | Allow JIT compilation.                          
           maintenance_work_mem |  2097152 kB |  conf file | NO PERMISION |       | Sets the maximum memory to be used for maintenan
                max_connections |          32 |  conf file | NO PERMISION |       | Sets the maximum number of concurrent connection
           max_parallel_workers |          16 |  conf file | NO PERMISION |       | Sets the maximum number of parallel workers that
max_parallel_workers_per_gather |           8 |  conf file | NO PERMISION |       | Sets the maximum number of parallel processes pe
                max_stack_depth |     2048 kB | environmen |              |       | Sets the maximum stack depth, in kilobytes.     
                   max_wal_size |     2048 MB |  conf file | NO PERMISION |       | Sets the WAL size that triggers a checkpoint.   
           max_worker_processes |          16 |  conf file | NO PERMISION |       | Maximum number of concurrent worker processes.  
                   min_wal_size |     1024 MB |  conf file | NO PERMISION |       | Sets the minimum size to shrink the WAL to.     
               random_page_cost |         1.1 |  conf file | NO PERMISION |       | Sets the planner's estimate of the cost of a non
                  seq_page_cost |           1 |    default |              |       | Sets the planner's estimate of the cost of a seq
                 shared_buffers | 16777216 kB |  conf file | NO PERMISION |       | Sets the number of shared memory buffers used by
             synchronous_commit |         off |  conf file | NO PERMISION |       | Sets the current transaction's synchronization l
                   temp_buffers |     8192 kB |    default |              |       | Sets the maximum number of temporary buffers use
                    wal_buffers |    16384 kB |  conf file | NO PERMISION |       | Sets the number of disk-page buffers in shared m
                      wal_level |     replica |    default |              |       | Set the level of information written to the WAL.
                       work_mem |    32768 kB |  conf file | NO PERMISION |       | Sets the maximum memory to be used for query wor

[INF] PSQL: postgres server settings:
                      Name | Setting |     Source |         File |  Line | Description                                     
═══════════════════════════╪═════════╪════════════╪══════════════╪═══════╪══════════════════════════════════════════════════
dynamic_shared_memory_type |   posix |  conf file | NO PERMISION |       | Selects the dynamic shared memory implementation
           max_connections |      32 |  conf file | NO PERMISION |       | Sets the maximum number of concurrent connection
     max_files_per_process |    1000 |    default |              |       | Sets the maximum number of simultaneously open f
                      port |    5432 |    default |              |       | Sets the TCP port the server listens on.  
```

When run with as a PostgreSQL admin user, the config file and line number for settings is also shown:

![image](https://user-images.githubusercontent.com/9373513/52096560-ec342400-258c-11e9-819d-5ebe5ad204d5.png)
