### PR TITLE
dcrsqlite/txhelpers: avoid getrawtransaction for zero hash inputs

### DIFF
--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -938,6 +938,16 @@ func IsZeroHashP2PHKAddress(checkAddressString string, params *chaincfg.Params) 
 	return checkAddressString == zeroAddress
 }
 
+// IsZeroHash checks if the Hash is the zero hash.
+func IsZeroHash(hash chainhash.Hash) bool {
+	return hash == zeroHash
+}
+
+// IsZeroHash checks if the string is the zero hash string.
+func IsZeroHashStr(hash string) bool {
+	return hash == string(zeroHashStringBytes)
+}
+
 // ValidateNetworkAddress checks if the given address is valid on the given
 // network.
 func ValidateNetworkAddress(address dcrutil.Address, p *chaincfg.Params) bool {


### PR DESCRIPTION
This avoids needless getrawtransaction RPCs for a zero hash transaction, thus eliminating:

> [ERR] SQLT: Error getting data for previous outpoint of mempool transaction: -5: No information available about transaction 0000000000000000000000000000000000000000000000000000000000000000

Add `txhelpers.IsZeroHash` and `IsZeroHashStr` with tests.