### PR TITLE
Purge orphaned tip blocks on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -286,6 +286,11 @@ func _main(ctx context.Context) error {
 		}
 	}
 
+	// Give a chance to abort a purge.
+	if shutdownRequested(ctx) {
+		return nil
+	}
+
 	if blocksToPurge > 0 {
 		// The number of blocks to purge for each DB is computed so that the DBs
 		// will end on the same height.

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -5,6 +5,7 @@
 package rpcutils
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -446,6 +447,53 @@ func CommonAncestor(client *rpcclient.Client, hashA, hashB chainhash.Hash) (*cha
 
 	// hashA == hashB
 	return &hashA, chainA, chainB, nil
+}
+
+// OrphanedTipLength finds a common ancestor by iterating block heights
+// backwards until a common block hash is found. Unlike CommonAncestor, an
+// orphaned DB tip whose corresponding block is not known to dcrd will not cause
+// cause an error. The number of blocks that have been orphaned is returned.
+// Realistically, this should rarely be anything but 0 or 1, but no limits are
+// placed here on the number of blocks checked.
+func OrphanedTipLength(ctx context.Context, client *rpcclient.Client,
+	tipHeight int64, hashFunc func(int64) (string, error)) (int64, error) {
+	commonHeight := tipHeight
+	var dbHash string
+	var err error
+	var dcrdHash *chainhash.Hash
+	for {
+		// Since there are no limits on the number of blocks scanned, allow
+		// cancellation for a clean exit.
+		select {
+		case <-ctx.Done():
+			return 0, nil
+		default:
+		}
+
+		dbHash, err = hashFunc(commonHeight)
+		if err != nil {
+			return -1, fmt.Errorf("Unable to retrieve block at height %d: %v", commonHeight, err)
+		}
+		dcrdHash, err = client.GetBlockHash(commonHeight)
+		if err != nil {
+			return -1, fmt.Errorf("Unable to retrive dcrd block at height %d: %v", commonHeight, err)
+		}
+		if dcrdHash.String() == dbHash {
+			break
+		}
+
+		commonHeight--
+		if commonHeight < 0 {
+			return -1, fmt.Errorf("Unable to find a common ancestor ")
+		}
+		// Reorgs are soft-limited to depth 6 by dcrd. More than six blocks without
+		// a match probably indicates an issue.
+		if commonHeight-tipHeight == 7 {
+			log.Warnf("No common ancestor within 6 blocks. This is abnormal")
+		}
+
+	}
+	return tipHeight - commonHeight, nil
 }
 
 // GetChainwork fetches the dcrjson.BlockHeaderVerbose

--- a/rpcutils/rpcclient_test.go
+++ b/rpcutils/rpcclient_test.go
@@ -1,9 +1,12 @@
 package rpcutils
 
 import (
+	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 )
 
@@ -113,4 +116,102 @@ func TestReverseStringSlice(t *testing.T) {
 	if !reflect.DeepEqual(s2, ref2) {
 		t.Errorf("reverseStringSlice failed. Got %v, expected %v.", s2, ref2)
 	}
+}
+
+var hashMap = map[int64]string{
+	0: "0000000000000000000000000000000000000000000000000000000000000000",
+	1: "0000000000000000000000000000000000000000000000000000000000000001",
+	2: "0000000000000000000000000000000000000000000000000000000000000002",
+	3: "0000000000000000000000000000000000000000000000000000000000000003",
+	4: "0000000000000000000000000000000000000000000000000000000000000004",
+	5: "0000000000000000000000000000000000000000000000000000000000000005",
+}
+
+type hashGetterStub struct{}
+
+func (client hashGetterStub) GetBlockHash(idx int64) (*chainhash.Hash, error) {
+	if idx > 5 || idx < 0 {
+		return nil, fmt.Errorf("hashGetterStub: index out of range.")
+	}
+	return chainhash.NewHashFromStr(hashMap[idx])
+}
+
+func TestOrphanedTipLength(t *testing.T) {
+	client := hashGetterStub{}
+
+	hashes := map[int64]string{
+		5: "0000000000000000000000000000000000000000000000000000000000000005",
+		4: "something else",
+	}
+
+	hashFunc := func(idx int64) (string, error) {
+		hash, ok := hashes[idx]
+		if ok {
+			return hash, nil
+		}
+		return "", fmt.Errorf("hashFunc index not found")
+	}
+
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	uncommon, err := OrphanedTipLength(ctx, client, 5, hashFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uncommon != 0 {
+		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 1"))
+	}
+
+	hashes = map[int64]string{
+		5: "something else",
+		4: "0000000000000000000000000000000000000000000000000000000000000004",
+	}
+
+	uncommon, err = OrphanedTipLength(ctx, client, 5, hashFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uncommon != 1 {
+		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 2"))
+	}
+
+	hashes = map[int64]string{
+		5: "something else",
+		4: "side block",
+		3: "0000000000000000000000000000000000000000000000000000000000000003",
+	}
+	twoOrphans := hashes // Will use this later to test shutdown
+
+	uncommon, err = OrphanedTipLength(ctx, client, 5, hashFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uncommon != 2 {
+		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 3"))
+	}
+
+	hashes = map[int64]string{
+		5: "something else",
+		4: "side block",
+		3: "blah",
+		2: "blue",
+		1: "flu",
+		0: "fly",
+	}
+
+	uncommon, err = OrphanedTipLength(ctx, client, 5, hashFunc)
+	if err == nil || err.Error() != "Unable to find a common ancestor" {
+		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 4"))
+	}
+
+	hashes = twoOrphans
+	shutdown()
+	uncommon, err = OrphanedTipLength(ctx, client, 5, hashFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uncommon != 0 {
+		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 5"))
+	}
+
 }

--- a/rpcutils/rpcclient_test.go
+++ b/rpcutils/rpcclient_test.go
@@ -199,7 +199,7 @@ func TestOrphanedTipLength(t *testing.T) {
 		0: "fly",
 	}
 
-	uncommon, err = OrphanedTipLength(ctx, client, 5, hashFunc)
+	_, err = OrphanedTipLength(ctx, client, 5, hashFunc)
 	if err == nil || err.Error() != "Unable to find a common ancestor" {
 		t.Fatal(fmt.Errorf("Unexpected results from OrphanedTipLength test 4"))
 	}


### PR DESCRIPTION
Uses the existing purge-n-blocks loop. `rpcutils.OrphanedTipLength` compares a database to dcrd from the tip height down until a common mainchain ancestor is found, and returns the number of sidechain blocks to be purged.

Resolves #601

