### PR TITLE
dcrsqlite: add best block queries with no is_mainchain constraints

### DIFF
--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -299,7 +299,7 @@ func NewDB(db *sql.DB) (*DB, error) {
 		}
 		// Try again without the mainchain constraint.
 		if ind+len(noSuchColPrefix) < len(errStr) {
-			log.Infof(`Block summary table missing column "%s". Table upgrade required.`,
+			log.Debugf(`Block summary table missing column "%s". Table upgrade required.`,
 				err.Error()[ind+len(noSuchColPrefix):])
 		}
 		d.dbStakeInfoHeight, err = d.getStakeInfoHeightAnyChain()


### PR DESCRIPTION
Before the sqlite table upgade is performed, it is still necessary to
query the best block height in the block and stake info tables. This
adds alternate queries that do not reference the `is_mainchain` column.
Note that the upgrade worked before 9a5780a3dd2c75570d7b3fdf6119aa3c5e82736d, which added the `is_mainchain` constraint to the queries.

Add `RetrieveHighestBlockHeight` and `RetrieveHighestStakeHeight` that
perform the query without `is_mainchain`, and add the wrappers
`getBlockSummaryHeightAnyChain` and `getStakeInfoHeightAnyChain`.

`NewDB` is modified to recognize `"no such column: is_"` errors, and
to fallback on the `"AnyChain"` functions to set the heights.

At the end of a successful table upgrade, query for the stake info best
block height using the block summary table join where `is_mainchain=true`.