### PR TITLE
api: return decoded pkScript with /tx/{txid}/out endpoint

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -138,10 +138,9 @@ type ScriptPubKey struct {
 
 // TxOut defines a decred transaction output.
 type TxOut struct {
-	Value     float64  `json:"value"`
-	Version   uint16   `json:"version"`
-	PkScript  string   `json:"pkscript"`
-	Addresses []string `json:"addresses,omitempty"`
+	Value               float64      `json:"value"`
+	Version             uint16       `json:"version"`
+	ScriptPubKeyDecoded ScriptPubKey `json:"scriptPubKey"`
 }
 
 // TxIn defines a decred transaction input.


### PR DESCRIPTION
This changes `api/types.TxOut`, removing `PkScript` and `Addresses`, and adding
a `ScriptPubKey` struct, which include the script hex, address and more.

**/api/tx/9af946f599e09d68b4590ced2e046c3f883411e1f06e199c073efa621af18d93/out?indent=true**

Before:

```json
[
  {
    "value": 2.999738,
    "version": 0,
    "pkscript": "76a9147ac85ec3f05a103ad3f5da194ce2e7569461778a88ac",
    "addresses": [
      "DscA7xoE2FtJbkzaAkMZKMG8H6jZkpwYs5b"
    ]
  },
  {
    "value": 0,
    "version": 0,
    "pkscript": "6a20e9eb2ae23893616da16e95834f37744201fb0231f684123ab767c93fbcf8aab5"
  }
]
```

After:

```json
[
   {
      "value": 2.999738,
      "version": 0,
      "scriptPubKey": {
         "asm": "OP_DUP OP_HASH160 7ac85ec3f05a103ad3f5da194ce2e7569461778a OP_EQUALVERIFY OP_CHECKSIG",
         "hex": "76a9147ac85ec3f05a103ad3f5da194ce2e7569461778a88ac",
         "reqSigs": 1,
         "type": "pubkeyhash",
         "addresses": [
            "DscA7xoE2FtJbkzaAkMZKMG8H6jZkpwYs5b"
         ]
      }
   },
   {
      "value": 0,
      "version": 0,
      "scriptPubKey": {
         "asm": "OP_RETURN e9eb2ae23893616da16e95834f37744201fb0231f684123ab767c93fbcf8aab5",
         "hex": "6a20e9eb2ae23893616da16e95834f37744201fb0231f684123ab767c93fbcf8aab5",
         "type": "nulldata"
      }
   }
]
```