### PR TITLE
apitypes: add ScriptClass and friends

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -212,6 +212,11 @@ func (sc ScriptClass) String() string {
 	return name
 }
 
+// IsNullDataScript indicates if the script class name is a nulldata class.
+func IsNullDataScript(name string) bool {
+	return name == ScriptClassNullData.String()
+}
+
 // ScriptPubKey is the result of decodescript(ScriptPubKeyHex)
 type ScriptPubKey struct {
 	Asm       string   `json:"asm"`

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 
 	"github.com/decred/dcrd/dcrjson"
@@ -124,6 +125,91 @@ type Vout struct {
 type TxInputID struct {
 	Hash  string `json:"hash"`
 	Index uint32 `json:"vin_index"`
+}
+
+// ScriptClass represent the type of a transaction output's pkscript. The values
+// of this type are NOT compatible with dcrd's txscript.ScriptClass values! Use
+// ScriptClassFromName to get a text representation of a ScriptClass.
+type ScriptClass uint8
+
+// Classes of script payment known about in the blockchain.
+const (
+	ScriptClassNonStandard     ScriptClass = iota // None of the recognized forms.
+	ScriptClassPubKey                             // Pay pubkey.
+	ScriptClassPubkeyAlt                          // Alternative signature pubkey.
+	ScriptClassPubKeyHash                         // Pay pubkey hash.
+	ScriptClassPubkeyHashAlt                      // Alternative signature pubkey hash.
+	ScriptClassScriptHash                         // Pay to script hash.
+	ScriptClassMultiSig                           // Multi signature.
+	ScriptClassNullData                           // Empty data-only (provably prunable).
+	ScriptClassStakeSubmission                    // Stake submission.
+	ScriptClassStakeGen                           // Stake generation
+	ScriptClassStakeRevocation                    // Stake revocation.
+	ScriptClassStakeSubChange                     // Change for stake submission tx.
+	ScriptClassInvalid
+)
+
+var scriptClassToName = map[ScriptClass]string{
+	ScriptClassNonStandard:     "nonstandard",
+	ScriptClassPubKey:          "pubkey",
+	ScriptClassPubkeyAlt:       "pubkeyalt",
+	ScriptClassPubKeyHash:      "pubkeyhash",
+	ScriptClassPubkeyHashAlt:   "pubkeyhashalt",
+	ScriptClassScriptHash:      "scripthash",
+	ScriptClassMultiSig:        "multisig",
+	ScriptClassNullData:        "nulldata",
+	ScriptClassStakeSubmission: "stakesubmission",
+	ScriptClassStakeGen:        "stakegen",
+	ScriptClassStakeRevocation: "stakerevoke",
+	ScriptClassStakeSubChange:  "sstxchange",
+	ScriptClassInvalid:         "invalid",
+}
+
+var scriptNameToClass = map[string]ScriptClass{
+	"nonstandard":     ScriptClassNonStandard,
+	"pubkey":          ScriptClassPubKey,
+	"pubkeyalt":       ScriptClassPubkeyAlt,
+	"pubkeyhash":      ScriptClassPubKeyHash,
+	"pubkeyhashalt":   ScriptClassPubkeyHashAlt,
+	"scripthash":      ScriptClassScriptHash,
+	"multisig":        ScriptClassMultiSig,
+	"nulldata":        ScriptClassNullData,
+	"stakesubmission": ScriptClassStakeSubmission,
+	"stakegen":        ScriptClassStakeGen,
+	"stakerevoke":     ScriptClassStakeRevocation,
+	"sstxchange":      ScriptClassStakeSubChange,
+	// No "invalid" mapping!
+}
+
+// ScriptClassFromName attempts to identify the ScriptClass for the given script
+// class/type name. An unknown script name will return ScriptClassInvalid. This
+// may be used to map the Type field of the ScriptPubKey data type to a known
+// class. If dcrd's txscript package changes its strings, this function may be
+// unable to identify the types from dcrd.
+func ScriptClassFromName(name string) ScriptClass {
+	class, found := scriptNameToClass[strings.ToLower(name)]
+	if !found {
+		return ScriptClassInvalid // not even non-standard
+	}
+	return class
+}
+
+// IsValidScriptClass indicates the the provided string corresponds to a known
+// ScriptClass (including "nonstandard"). Note that "invalid" is not valid,
+// although a ScriptClassInvalid value mapping to "invalid" exists.
+func IsValidScriptClass(name string) (isValid bool) {
+	_, isValid = scriptNameToClass[strings.ToLower(name)]
+	return
+}
+
+// String returns the name of the ScriptClass. If the ScriptClass is
+// unrecognized it is treated as ScriptClassInvalid.
+func (sc ScriptClass) String() string {
+	name, found := scriptClassToName[sc]
+	if !found {
+		return ScriptClassInvalid.String() // better be in scriptClassToName!
+	}
+	return name
 }
 
 // ScriptPubKey is the result of decodescript(ScriptPubKeyHex)

--- a/api/types/apitypes_test.go
+++ b/api/types/apitypes_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestScriptClass_String(t *testing.T) {
+	numClasses := len(scriptClassToName)
+
+	tests := []struct {
+		testName string
+		sc       ScriptClass
+		want     string
+	}{
+		{"ScriptClassPubKey", ScriptClassPubKey, scriptClassToName[ScriptClassPubKey]},
+		{"ScriptClassNonStandard", ScriptClassNonStandard, scriptClassToName[ScriptClassNonStandard]},
+		{"ScriptClassBADBAD", ScriptClassNonStandard + ScriptClass(numClasses+1), ScriptClassInvalid.String()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := tt.sc.String(); got != tt.want {
+				t.Errorf("%s.String() = %v, want %v", tt.testName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScriptClassFromName(t *testing.T) {
+	tests := []struct {
+		testName string
+		sc       string
+		want     ScriptClass
+	}{
+		{"badName", "monkey", ScriptClassInvalid},
+		{"invalid", "invalid", ScriptClassInvalid},
+		{"OK", "pubkey", ScriptClassPubKey},
+		{"OK#2", "nulldata", ScriptClassNullData},
+		{"nonstandard is not invalid", "nonstandard", ScriptClassNonStandard},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := ScriptClassFromName(tt.sc); got != tt.want {
+				t.Errorf("ScriptClassFromName(%s) = %v, want %v", tt.sc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidScriptClass(t *testing.T) {
+	tests := []struct {
+		testName string
+		sc       string
+		want     bool
+	}{
+		{"badName", "monkey", false},
+		{"invalid is invalid", "invalid", false},
+		{"OK", "pubkey", true},
+		{"nonstandard is not invalid", "nonstandard", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := IsValidScriptClass(tt.sc); got != tt.want {
+				t.Errorf("ScriptClassFromName(%s) = %v, want %v", tt.sc, got, tt.want)
+			}
+		})
+	}
+}

--- a/api/types/apitypes_test.go
+++ b/api/types/apitypes_test.go
@@ -68,3 +68,22 @@ func TestIsValidScriptClass(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNullDataScript(t *testing.T) {
+	tests := []struct {
+		testName string
+		name     string
+		want     bool
+	}{
+		{"it is", "nulldata", true},
+		{"it is not", "blahdata", false},
+		{"it had better be", ScriptClassNullData.String(), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := IsNullDataScript(tt.name); got != tt.want {
+				t.Errorf("IsNullDataScript() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -599,6 +599,12 @@ func (db *WiredDB) GetAllTxOut(txid string) []*apitypes.TxOut {
 	for i := range txouts {
 		// dcrjson.Vout and apitypes.TxOut are the same except for N.
 		spk := &tx.Vout[i].ScriptPubKey
+		// If the script type is not recognized by apitypes, the ScriptClass
+		// types may need to be updated to match dcrd.
+		if spk.Type != "invalid" && !apitypes.IsValidScriptClass(spk.Type) {
+			log.Warnf(`The ScriptPubKey's type "%s" is not known to dcrdata! ` +
+				`Update apitypes or debug dcrd.`)
+		}
 		allTxOut = append(allTxOut, &apitypes.TxOut{
 			Value:   txouts[i].Value,
 			Version: txouts[i].Version,


### PR DESCRIPTION
This adds `ScriptClass`, which represents the type of a transaction
output's pkscript. The values of this type are NOT compatible with
dcrd's `txscript.ScriptClass` values! Use `ScriptClassFromName` to get a
text representation of a `ScriptClass`.

Also add check the type returned by dcrd when in `GetAllTxOut` as a smoke
test for changes or additions to the strings returned by dcrd.
