### PR TITLE
time: make a RFC3339 formatter for machines/JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ modern javascript features, as well as SCSS for styling.
     - [Using Environment Variables for Configuration](#using-environment-variables-for-configuration)
     - [Indexing the Blockchain](#indexing-the-blockchain)
     - [Starting dcrdata](#starting-dcrdata)
-    - [Hide PG Config log](#hiding-the-postgreSQL-db-configuration-settings)
+    - [Hiding the PostgreSQL db Configuration settings.](#hiding-the-postgresql-db-configuration-settings)
     - [Running the Web Interface During Synchronization](#running-the-web-interface-during-synchronization)
   - [System Hardware Requirements](#system-hardware-requirements)
     - ["lite" Mode (SQLite only)](#lite-mode-sqlite-only)
@@ -225,7 +225,7 @@ or using the Docker [container build instructions](#building-dcrdata-with-docker
 
 By default, the version string will be postfixed with "-pre+dev".  For example,
 `dcrdata version 3.1.0-pre+dev (Go version go1.11)`.  However, it may be
-desireable to set the "pre" and "dev" values to different strings, such as
+desirable to set the "pre" and "dev" values to different strings, such as
 "beta" or the actual commit hash.  To set these values, build with the
 `-ldflags` switch as follows:
 

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -198,7 +198,7 @@ out:
 
 			c.Status.Lock()
 			c.Status.DBHeight = height
-			c.Status.DBLastBlockTime = summary.Time.S.T.Unix()
+			c.Status.DBLastBlockTime = summary.Time.S.UNIX()
 
 			bdHeight, err := c.BlockData.GetHeight()
 			// Catch certain pathological conditions.

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -902,7 +902,7 @@ func (c *insightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http
 				break
 			}
 			outputBlockSummary = append(outputBlockSummary, block)
-			blockTime := block.Time.T.Unix()
+			blockTime := block.Time.UNIX()
 			if blockTime < summaryOutput.Pagination.MoreTs {
 				summaryOutput.Pagination.MoreTs = blockTime
 			}

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -26,7 +26,7 @@ func (t TimeAPI) String() string {
 
 // MarshalJSON is set as the default marshalling function for TimeAPI struct.
 func (t *TimeAPI) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.S.T.Unix())
+	return json.Marshal(t.S.UNIX())
 }
 
 // much of the time, dcrdata will be using the types in dcrjson, but others are

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -71,7 +71,7 @@ func (b *BlockData) ToStakeInfoExtendedEstimates() apitypes.StakeInfoExtendedEst
 
 // ToBlockSummary returns an apitypes.BlockDataBasic object from the blockdata
 func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
-	t := dbtypes.TimeDef{T: time.Unix(b.Header.Time, 0)}
+	t := dbtypes.NewTimeDefFromUNIX(b.Header.Time)
 	return apitypes.BlockDataBasic{
 		Height:     b.Header.Height,
 		Size:       b.Header.Size,
@@ -86,7 +86,7 @@ func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
 // ToBlockExplorerSummary returns a BlockExplorerBasic
 func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 	extra := b.ExtraInfo
-	t := dbtypes.TimeDef{T: time.Unix(b.Header.Time, 0)}
+	t := dbtypes.NewTimeDefFromUNIX(b.Header.Time)
 	return apitypes.BlockExplorerBasic{
 		Height:                 b.Header.Height,
 		Size:                   b.Header.Size,
@@ -210,7 +210,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		Hash:       hash.String(),
 		Difficulty: diff,
 		StakeDiff:  sdiff,
-		Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+		Time:       apitypes.TimeAPI{S: dbtypes.NewTimeDef(header.Timestamp)},
 		PoolInfo:   ticketPoolInfo,
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -95,7 +95,7 @@ func mainCore() int {
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+			Time:       apitypes.TimeAPI{S: dbtypes.NewTimeDef(header.Timestamp)},
 			PoolInfo: &apitypes.TicketPoolInfo{
 				Size: header.PoolSize,
 			},

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -39,7 +39,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 		Tx:           txHashStrs,
 		NumStakeTx:   uint32(len(msgBlock.STransactions)),
 		STx:          stxHashStrs,
-		Time:         TimeDef{T: blockHeader.Timestamp},
+		Time:         NewTimeDef(blockHeader.Timestamp),
 		Nonce:        uint64(blockHeader.Nonce),
 		VoteBits:     blockHeader.VoteBits,
 		Voters:       blockHeader.Voters,

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -62,7 +62,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 
 	blockHeight := msgBlock.Header.Height
 	blockHash := msgBlock.BlockHash()
-	blockTime := TimeDef{T: msgBlock.Header.Timestamp}
+	blockTime := NewTimeDef(msgBlock.Header.Timestamp)
 
 	dbTransactions := make([]*Tx, 0, len(txs))
 	dbTxVouts := make([][]*Vout, len(txs))

--- a/db/dbtypes/types_blackbox_test.go
+++ b/db/dbtypes/types_blackbox_test.go
@@ -1,0 +1,319 @@
+// +build mainnettest
+
+package dbtypes_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/v4/db/dcrpg"
+)
+
+var (
+	db *sql.DB
+)
+
+func openDB() (func() error, error) {
+	dbi := dcrpg.DBInfo{
+		Host:   "localhost",
+		Port:   "5432",
+		User:   "dcrdata", // postgres for admin operations
+		Pass:   "",
+		DBName: "dcrdata_mainnet_test",
+	}
+	var err error
+	// Connect to the PostgreSQL daemon and return the *sql.DB.
+	db, err = dcrpg.Connect(dbi.Host, dbi.Port, dbi.User, dbi.Pass, dbi.DBName)
+	if err != nil {
+		return nil, err
+	}
+	if err = dcrpg.DropTestingTable(db); err != nil {
+		return nil, err
+	}
+	if err = dcrpg.CreateTable(db, "testing"); err != nil {
+		return nil, err
+	}
+	cleanUp := func() error { return nil }
+	if db != nil {
+		cleanUp = db.Close
+	}
+	return cleanUp, err
+}
+
+func TestMain(m *testing.M) {
+	// your func
+	cleanUp, err := openDB()
+	defer cleanUp()
+	if err != nil {
+		panic(fmt.Sprintln("no db for testing:", err))
+	}
+
+	retCode := m.Run()
+
+	// call with result of m.Run()
+	os.Exit(retCode)
+}
+
+const (
+	trefUNIX int64 = 1454954400
+	trefStr        = "2016-02-08T12:00:00-06:00"
+)
+
+var (
+	// Two times in different locations for the same instant in time.
+	trefLocal = time.Unix(trefUNIX, 0).Local()
+	trefUTC   = time.Unix(trefUNIX, 0).UTC()
+)
+
+func TestTimeRoundTripCorrectTimeDef(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	// tref := time.Unix(trefUNIX, 0)               // time.Time of genesis block.
+	// timedef := &dbtypes.TimeDef{T: tref}         // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref)          // Constructor sets location to UTC.
+	timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: UTC
+
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamp) VALUES ($1) RETURNING id;`,
+		timedef).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamp FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454954400. Location set to: UTC  <== correct
+
+	if tsScanned.UNIX() != timedef.UNIX() {
+		t.Errorf("Time did not survive round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+
+	if tsScanned.T.Location() != time.UTC {
+		t.Errorf("scanned time was not UTC: %v", tsScanned.T.Location())
+	}
+}
+
+func TestTimeRoundTripCorrectValuer(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	tref := time.Unix(trefUNIX, 0)       // time.Time of genesis block.
+	timedef := &dbtypes.TimeDef{T: tref} // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref)             // Constructor sets location to UTC.
+	// timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: Local
+
+	// TimeDef.Value converts the time.Time into UTC on the fly, so the stored
+	// value will be correct regardless of the location of the TimeDef.
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamp) VALUES ($1) RETURNING id;`,
+		timedef).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamp FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454954400. Location set to: UTC  <== correct
+
+	if tsScanned.UNIX() != timedef.UNIX() {
+		t.Errorf("Time did not survive round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+
+	if tsScanned.T.Location() != time.UTC {
+		t.Errorf("scanned time was not UTC: %v", tsScanned.T.Location())
+	}
+}
+
+func TestTimeRoundTripIncorrectValuerTime(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	tref := time.Unix(trefUNIX, 0)       // time.Time of genesis block.
+	timedef := &dbtypes.TimeDef{T: tref} // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref) // Constructor sets location to UTC.
+	// timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: Local
+
+	// Using time.Time with Location as Local instead of TimeDef, where Value
+	// ensures UTC, stores the incorrect time.
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamp) VALUES ($1) RETURNING id;`,
+		timedef.T).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamp FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454932800. Location set to: UTC  <== incorrect
+
+	// Negative test. The absolute time should not survive this way (storing
+	// from time.Time in Local time).
+	if tsScanned.UNIX() == timedef.UNIX() {
+		t.Errorf("Time did not survive round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+}
+
+func TestTimeRoundTripIncorrectValuerTimeDefLocal(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	// tref := time.Unix(trefUNIX, 0)       // time.Time of genesis block.
+	// timedef := &dbtypes.TimeDef{T: tref} // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref) // Constructor sets location to UTC.
+	timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: Local
+
+	// Using dbtypes.TimeDefLocal, where Value ensures Local, stores the
+	// incorrect time.
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamp) VALUES ($1) RETURNING id;`,
+		dbtypes.TimeDefLocal(timedef)).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamp FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454932800. Location set to: UTC  <== incorrect
+
+	// Negative test. The absolute time should not survive this way (storing
+	// from time.Time in Local time).
+	if tsScanned.UNIX() == timedef.UNIX() {
+		t.Errorf("Time did unexpectedly survived the round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+}
+
+// TestTimeTZRoundTripRobust demonstrates how the TIMESTAMPTZ data type
+// does not drop a non-UTC offset when storing.  Thus, a time survives the round
+// trip regardless of what the time.Time's Location.
+func TestTimeTZRoundTripRobust(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	tref := time.Unix(trefUNIX, 0)       // time.Time of genesis block.
+	timedef := &dbtypes.TimeDef{T: tref} // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref) // Constructor sets location to UTC.
+	// timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: Local
+
+	// Using time.Time with Location as Local instead of TimeDef, where Value
+	// ensures UTC, stores the incorrect time.
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamptz) VALUES ($1) RETURNING id;`,
+		timedef.T).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamptz FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454932800. Location set to: UTC  <== incorrect
+
+	if tsScanned.UNIX() != timedef.UNIX() {
+		t.Errorf("Time did not survive round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+
+	if tsScanned.T.Location() != time.UTC {
+		t.Errorf("scanned time was not UTC: %v", tsScanned.T.Location())
+	}
+}
+
+// TestTimeTZRoundTripCorrectTimeDef ensures that the TimeDef Value and Scan
+// implementations are also compatible with TIMESTAMPTZ.
+func TestTimeTZRoundTripCorrectTimeDef(t *testing.T) {
+	// Clear the testing table.
+	if err := dcrpg.ClearTestingTable(db); err != nil {
+		t.Fatalf("Failed to clear the testing table: %v", err)
+	}
+
+	// tref := time.Unix(trefUNIX, 0)               // time.Time of genesis block.
+	// timedef := &dbtypes.TimeDef{T: tref}         // No constructor, location not changed (Local from time.Unix).
+	// timedef := dbtypes.NewTimeDef(tref)          // Constructor sets location to UTC.
+	timedef := dbtypes.NewTimeDefFromUNIX(trefUNIX) // Alt. constructor also sets location to UTC.
+
+	t.Logf("Inserting TimeDef at %d. Location set to: %v", timedef.UNIX(),
+		timedef.T.Location()) // Inserting TimeDef at 1454954400. Location set to: UTC
+
+	var id uint64
+	err := db.QueryRow(`INSERT INTO testing (timestamp) VALUES ($1) RETURNING id;`,
+		timedef).Scan(&id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var tsScanned dbtypes.TimeDef
+	err = db.QueryRow(`SELECT timestamp FROM testing;`).Scan(&tsScanned)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Scanned TimeDef at %d. Location set to: %v", tsScanned.UNIX(),
+		tsScanned.T.Location()) // Scanned TimeDef at 1454954400. Location set to: UTC  <== correct
+
+	if tsScanned.UNIX() != timedef.UNIX() {
+		t.Errorf("Time did not survive round trip: got %v, expected %v",
+			tsScanned.UNIX(), timedef.UNIX())
+	}
+
+	if tsScanned.T.Location() != time.UTC {
+		t.Errorf("scanned time was not UTC: %v", tsScanned.T.Location())
+	}
+}

--- a/db/dbtypes/types_test.go
+++ b/db/dbtypes/types_test.go
@@ -1,0 +1,157 @@
+package dbtypes
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	trefUNIX = 1454954400
+	trefStr  = "2016-02-08T12:00:00-06:00"
+)
+
+var (
+	// Two times in different locations for the same instant in time.
+	trefLocal = time.Unix(trefUNIX, 0).Local()
+	trefUTC   = time.Unix(trefUNIX, 0).UTC()
+)
+
+func TestTimeDefMarshal(t *testing.T) {
+	tref := time.Unix(trefUNIX, 0)
+	trefJSON := `"` + tref.Format(timeDefFmtJS) + `"`
+	t.Log(trefJSON)
+
+	timedef := &TimeDef{
+		T: tref,
+	}
+	jsonTime, err := timedef.MarshalJSON()
+	if err != nil {
+		t.Errorf("MarshalJSON failed: %v", err)
+	}
+
+	if string(jsonTime) != trefJSON {
+		t.Errorf("expected %s, got %s", trefJSON, string(jsonTime))
+	}
+}
+
+func TestNewTimeDef(t *testing.T) {
+	// Create a time with Local location.
+	tref, err := time.Parse(time.RFC3339, trefStr)
+	if err != nil {
+		t.Error(err)
+	}
+	tref = tref.Local()
+
+	// Create the TimeDef, and verify that the location is now UTC.
+	td := NewTimeDef(tref)
+	if td.T.Location() != time.UTC {
+		t.Errorf("NewTimeDef should return a time in UTC (not local).")
+	}
+
+	t.Log(td)
+}
+
+func TestTimeDef_Value(t *testing.T) {
+	// Create the TimeDef from a Local time.
+	td := NewTimeDef(trefLocal)
+	// Verify the Location of the time returned by Value is UTC.
+	tdSqlValue, _ := td.Value()
+	tdSqlTime, ok := tdSqlValue.(time.Time)
+	if !ok {
+		t.Error("not a time.Time")
+	}
+	t.Log(tdSqlTime)
+	if tdSqlTime.Location() != time.UTC {
+		t.Errorf("TimeDef.Value should return a UTC time.")
+	}
+
+	// Create the TimeDef from the equivalent time in UTC.
+	td2 := NewTimeDef(trefUTC)
+	// Verify the Location of the time returned by Value is UTC.
+	tdSqlValue2, _ := td2.Value()
+	tdSqlTime2, ok := tdSqlValue2.(time.Time)
+	if !ok {
+		t.Error("not a time.Time")
+	}
+	t.Log(tdSqlTime2)
+	if tdSqlTime2.Location() != time.UTC {
+		t.Errorf("TimeDef.Value should return a UTC time.")
+	}
+
+	// Verify the string formats of the time.Time are the same.
+	if tdSqlTime.String() != tdSqlTime2.String() {
+		t.Errorf("time strings do not match: %s != %s",
+			tdSqlTime.String(), tdSqlTime2.String())
+	}
+
+	// Verify the instants in time are the same.
+	if tdSqlTime.Unix() != tdSqlTime2.Unix() {
+		t.Logf("unix epoch times do not match: %d != %d",
+			tdSqlTime.Unix(), tdSqlTime2.Unix())
+	}
+
+	// Create the TimeDef from a Local time, but do not use the constructor.
+	// This shows that Value will ensure the correct time.Time in UTC for sql
+	// regardless of the location of TimeDef.T.
+	td3 := TimeDef{T: trefLocal}
+	// Verify the Location of the time returned by Value is UTC.
+	tdSqlValue3, _ := td3.Value()
+	tdSqlTime3, ok := tdSqlValue3.(time.Time)
+	if !ok {
+		t.Error("not a time.Time")
+	}
+	t.Log(tdSqlTime3)
+	if tdSqlTime3.Location() != time.UTC {
+		t.Errorf("TimeDef.Value should return a UTC time.")
+	}
+}
+
+func TestTimeDef_Scan(t *testing.T) {
+	// Scan the reference time with Local Location.
+	var td TimeDef
+	err := td.Scan(trefLocal)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TimeDef.T location should be stored as UTC.
+	if td.T.Location() != time.UTC {
+		t.Errorf("TimeDef.Value should return a UTC time.")
+	}
+
+	t.Log(td)
+
+	// Scan the reference time with UTC Location.
+	var td2 TimeDef
+	err = td2.Scan(trefUTC)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TimeDef.T location should be stored as UTC.
+	if td2.T.Location() != time.UTC {
+		t.Errorf("TimeDef.Value should return a UTC time.")
+	}
+
+	t.Log(td)
+
+	// Ensure they are the same instant in time.
+	if td.T.Unix() != td2.T.Unix() {
+		t.Logf("unix epoch times do not match: %d != %d",
+			td.T.Unix(), td2.T.Unix())
+	}
+
+	// Verify the string formats of the time.Time are the same.
+	if td.T.String() != td2.T.String() {
+		t.Errorf("time strings do not match: %s != %s",
+			td.T.String(), td2.T.String())
+	}
+
+	// Scan with an unsupported type.
+	var td3 TimeDef
+	err = td3.Scan(trefUNIX)
+	if err == nil {
+		t.Fatal("TimeDef.Scan(int64) should have failed")
+	}
+
+}

--- a/db/dcrpg/internal/common.go
+++ b/db/dcrpg/internal/common.go
@@ -4,15 +4,21 @@ import "fmt"
 
 const (
 	IndexExists = `SELECT 1
-FROM   pg_class c
-JOIN   pg_namespace n ON n.oid = c.relnamespace
-WHERE  c.relname = $1 AND n.nspname = $2;`
+		FROM   pg_class c
+		JOIN   pg_namespace n ON n.oid = c.relnamespace
+		WHERE  c.relname = $1 AND n.nspname = $2;`
 
 	IndexIsUnique = `SELECT indisunique
-FROM   pg_index i
-JOIN   pg_class c ON c.oid = i.indexrelid
-JOIN   pg_namespace n ON n.oid = c.relnamespace
-WHERE  c.relname = $1 AND n.nspname = $2`
+		FROM   pg_index i
+		JOIN   pg_class c ON c.oid = i.indexrelid
+		JOIN   pg_namespace n ON n.oid = c.relnamespace
+		WHERE  c.relname = $1 AND n.nspname = $2`
+
+	CreateTestingTable = `CREATE TABLE IF NOT EXISTS testing (
+		id SERIAL8 PRIMARY KEY,
+		timestamp TIMESTAMP,
+		timestamptz TIMESTAMPTZ
+	);`
 )
 
 func makeARRAYOfTEXT(text []string) string {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1614,7 +1614,7 @@ FUNDING_TX_DUPLICATE_CHECK:
 				TxID:          fundingTx.Hash().String(),
 				TxType:        txhelpers.DetermineTxTypeString(fundingTx.Tx),
 				InOutID:       f.Index,
-				Time:          dbtypes.TimeDef{T: time.Unix(fundingTx.MemPoolTime, 0)},
+				Time:          dbtypes.NewTimeDefFromUNIX(fundingTx.MemPoolTime),
 				FormattedSize: humanize.Bytes(uint64(fundingTx.Tx.SerializeSize())),
 				Total:         txhelpers.TotalOutFromMsgTx(fundingTx.Tx).ToCoin(),
 				ReceivedTotal: dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
@@ -1670,7 +1670,7 @@ SPENDING_TX_DUPLICATE_CHECK:
 				TxID:           spendingTx.Hash().String(),
 				TxType:         txhelpers.DetermineTxTypeString(spendingTx.Tx),
 				InOutID:        uint32(f.InputIndex),
-				Time:           dbtypes.TimeDef{T: time.Unix(spendingTx.MemPoolTime, 0)},
+				Time:           dbtypes.NewTimeDefFromUNIX(spendingTx.MemPoolTime),
 				FormattedSize:  humanize.Bytes(uint64(spendingTx.Tx.SerializeSize())),
 				Total:          txhelpers.TotalOutFromMsgTx(spendingTx.Tx).ToCoin(),
 				SentTotal:      dcrutil.Amount(valuein).ToCoin(),
@@ -1738,7 +1738,7 @@ func (pgb *ChainDB) FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 		txn.FormattedSize = humanize.Bytes(uint64(dbTx.Size))
 		txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()
 		txn.Time = dbTx.BlockTime
-		if txn.Time.T.Unix() > 0 {
+		if txn.Time.UNIX() > 0 {
 			txn.Confirmations = pgb.bestBlock.Height() - uint64(dbTx.BlockHeight) + 1
 		} else {
 			numUnconfirmed++

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1188,7 +1188,7 @@ func (pgb *ChainDB) handleAgendasTableUpgrade(msgBlock *wire.MsgBlock) (int64, e
 			}
 
 			err = pgb.db.QueryRow(internal.MakeAgendaInsertStatement(false),
-				val.ID, index, tx.TxID, tx.BlockHeight, tx.BlockTime.T,
+				val.ID, index, tx.TxID, tx.BlockHeight, tx.BlockTime,
 				progress.VotingDone == tx.BlockHeight,
 				progress.Activated == tx.BlockHeight,
 				progress.HardForked == tx.BlockHeight).Scan(&rowID)
@@ -1219,7 +1219,7 @@ func (pgb *ChainDB) handleAgendaAndAgendaVotesTablesUpgrade(msgBlock *wire.MsgBl
 		}
 
 		var voteRowID int64
-		err := pgb.db.QueryRow(query, tx.TxID, tx.BlockHash, tx.BlockTime.T).Scan(&voteRowID)
+		err := pgb.db.QueryRow(query, tx.TxID, tx.BlockHash, tx.BlockTime).Scan(&voteRowID)
 		if err != nil || voteRowID == 0 {
 			return -1, err
 		}

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -645,7 +644,7 @@ func (db *DB) StoreBlock(bd *apitypes.BlockDataBasic, isMainchain bool, isValid 
 	// Insert the block.
 	winners := strings.Join(bd.PoolInfo.Winners, ";")
 	res, err := stmt.Exec(&bd.Hash, &bd.Height, &bd.Size,
-		&bd.Difficulty, &bd.StakeDiff, bd.Time.S.T.Unix(),
+		&bd.Difficulty, &bd.StakeDiff, bd.Time.S.UNIX(),
 		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
 		&winners, &isMainchain, &isValid)
 	if err != nil {
@@ -987,7 +986,7 @@ func (db *DB) RetrieveAllPoolValAndSize() (*dbtypes.ChartsData, error) {
 			continue
 		}
 
-		chartsData.Time = append(chartsData.Time, dbtypes.TimeDef{T: time.Unix(timestamp, 0)})
+		chartsData.Time = append(chartsData.Time, dbtypes.NewTimeDefFromUNIX(timestamp))
 		chartsData.SizeF = append(chartsData.SizeF, psize)
 		chartsData.ValueF = append(chartsData.ValueF, pval)
 	}
@@ -1122,7 +1121,7 @@ func (db *DB) RetrieveBlockSummaryByTimeRange(minTime, maxTime int64, limit int)
 			&winners, &isMainchain, &isValid); err != nil {
 			log.Errorf("Unable to scan for block fields")
 		}
-		bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+		bd.Time = apitypes.TimeAPI{S: dbtypes.NewTimeDefFromUNIX(timestamp)}
 		blocks = append(blocks, *bd)
 	}
 	if err = rows.Err(); err != nil {
@@ -1161,7 +1160,7 @@ func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.NewTimeDefFromUNIX(timestamp)}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	return bd, nil
 }
@@ -1245,7 +1244,7 @@ func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic,
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.NewTimeDefFromUNIX(timestamp)}
 	bd.PoolInfo.Winners = splitToArray(winners)
 
 	if usingBlockCache {
@@ -1287,7 +1286,7 @@ func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) 
 	if err != nil {
 		return nil, err
 	}
-	bd.Time = apitypes.TimeAPI{S: dbtypes.TimeDef{T: time.Unix(timestamp, 0)}}
+	bd.Time = apitypes.TimeAPI{S: dbtypes.NewTimeDefFromUNIX(timestamp)}
 	bd.PoolInfo.Winners = splitToArray(winners)
 	// 2. Prepare + chained QueryRow/Scan
 	// stmt, err := db.Prepare(getBlockSQL)

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -387,7 +387,7 @@ func (db *WiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 			Hash:       blockhash.String(),
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
-			Time:       apitypes.TimeAPI{S: dbtypes.TimeDef{T: header.Timestamp}},
+			Time:       apitypes.TimeAPI{S: dbtypes.NewTimeDef(header.Timestamp)},
 			PoolInfo:   tpi,
 		}
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -368,7 +368,7 @@ func (exp *explorerUI) LastBlock() (lastBlockHash string, lastBlock int64, lastB
 	exp.pageData.RLock()
 	defer exp.pageData.RUnlock()
 	lastBlock = exp.pageData.BlockInfo.Height
-	lastBlockTime = exp.pageData.BlockInfo.BlockTime.T.Unix()
+	lastBlockTime = exp.pageData.BlockInfo.BlockTime.UNIX()
 	lastBlockHash = exp.pageData.BlockInfo.Hash
 	return
 }
@@ -464,7 +464,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	newBlockData := exp.blockData.GetExplorerBlock(msgBlock.BlockHash().String())
 
 	// Use the latest block's blocktime to get the last 24hr timestamp.
-	timestamp := newBlockData.BlockTime.T.Unix() - 86400
+	timestamp := newBlockData.BlockTime.UNIX() - 86400
 	targetTimePerBlock := float64(exp.ChainParams.TargetTimePerBlock)
 	// RetreiveDifficulty fetches the difficulty using the last 24hr timestamp,
 	// whereby the difficulty can have a timestamp equal to the last 24hrs

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTimeDefMarshal(t *testing.T) {
 	tref := time.Unix(1548363687, 0)
-	trefJSON := `"` + tref.Format(timeDefFmt) + `"`
+	trefJSON := `"` + tref.Format(timeDefFmtJS) + `"`
 
 	timedef := &TimeDef{
 		T: tref,
@@ -29,7 +29,7 @@ func TestTimeDefMarshal(t *testing.T) {
 
 func TestTimeDefUnmarshal(t *testing.T) {
 	tref := time.Unix(1548363687, 0).UTC()
-	trefJSON := tref.Format(timeDefFmt)
+	trefJSON := tref.Format(timeDefFmtJS)
 
 	timedef := new(TimeDef)
 	err := timedef.UnmarshalJSON([]byte(trefJSON))

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -162,7 +162,7 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					if len(inv.Tickets) > 0 {
 						mp.Price = inv.Tickets[0].TotalOut
 						mp.Count = len(inv.Tickets)
-						mp.Time = dbtypes.TimeDef{T: time.Unix(inv.Tickets[0].Time, 0)}
+						mp.Time = dbtypes.NewTimeDefFromUNIX(inv.Tickets[0].Time)
 					} else {
 						log.Debug("No tickets exists in the mempool")
 					}

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -188,6 +188,6 @@ func (c *MempoolDataCache) GetTicketPriceCountTime(feeAvgLength int) *apitypes.P
 	return &apitypes.PriceCountTime{
 		Price: c.stakeDiff + feeAvg,
 		Count: numFees,
-		Time:  dbtypes.TimeDef{T: c.timestamp},
+		Time:  dbtypes.NewTimeDef(c.timestamp),
 	}
 }

--- a/public/index.js
+++ b/public/index.js
@@ -26,9 +26,6 @@ document.addEventListener('turbolinks:load', function (e) {
   window.DCRThings = {}
   window.DCRThings.targetBlockTime = navBar.dataset.blocktime
   window.DCRThings.ticketPoolSize = navBar.dataset.poolsize
-  let clientOffset = (new Date().getTimezoneOffset() * 60)
-  let serverOffset = parseInt(navBar.dataset.timezone_offset)
-  window.DCRThings.netTimezoneOffset = clientOffset + serverOffset
 }
 
 function getSocketURI (loc) {
@@ -49,7 +46,7 @@ async function createWebSocket (loc) {
   var updateBlockData = function (event) {
     console.log('Received newblock message', event)
     var newBlock = JSON.parse(event)
-    newBlock.block.unixStamp = (new Date(newBlock.block.time).getTime() / 1000) - window.DCRThings.netTimezoneOffset
+    newBlock.block.unixStamp = new Date(newBlock.block.time).getTime() / 1000
     globalEventBus.publish('BLOCK_RECEIVED', newBlock)
   }
   ws.registerEvtHandler('newblock', updateBlockData)

--- a/public/js/controllers/time_controller.js
+++ b/public/js/controllers/time_controller.js
@@ -66,7 +66,7 @@ export default class extends Controller {
       if (isCorrectVal(el.dataset.age)) {
         el.textContent = humanize.timeSince(el.dataset.age)
       } else if (el.dataset.age !== '') {
-        el.textContent = humanize.timeSince((Date.parse(el.dataset.age) / 1000) - window.DCRThings.netTimezoneOffset)
+        el.textContent = humanize.timeSince(Date.parse(el.dataset.age) / 1000)
       }
     })
   }

--- a/pubsub/democlient/go.sum
+++ b/pubsub/democlient/go.sum
@@ -107,6 +107,7 @@ github.com/dgraph-io/badger v1.5.5-0.20190124015931-be03c12d2da2/go.mod h1:VZxzA
 github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/didip/tollbooth v4.0.0+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
 github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d/go.mod h1:YWyIfq3y4ArRfWZ9XksmuusP+7Mad+T0iFZ0kv0XG/M=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pubsub/psclient/client_test.go
+++ b/pubsub/psclient/client_test.go
@@ -278,7 +278,7 @@ var msgNewBlock312592 = &pstypes.WebSocketMessage{
 			"windowIndex": 2171,
 			"tickets": 4,
 			"revocations": 0,
-			"time": "2019-01-24 14:43:21",
+			"time": "2019-01-24T14:43:21Z",
 			"formatted_bytes": "5.6 kB",
 			"Version": 5,
 			"Confirmations": 1,
@@ -690,7 +690,7 @@ var block312592Tickets = []string{
 func TestDecodeMsgNil(t *testing.T) {
 	Msg, err := DecodeMsg(nil)
 	if err == nil {
-		t.Errorf("expected error for DecodeMsg(nil)")
+		t.Fatalf("expected error for DecodeMsg(nil)")
 	}
 	if Msg != nil {
 		t.Errorf("expected a nil return message, got: %v", Msg)
@@ -706,7 +706,7 @@ func TestDecodeMsgUnknown(t *testing.T) {
 
 	Msg, err := DecodeMsg(msg)
 	if err.Error() != expectedErr.Error() {
-		t.Errorf("incorrect error returned: got %v, expected %v", err, expectedErr)
+		t.Fatalf("incorrect error returned: got %v, expected %v", err, expectedErr)
 	}
 	if Msg != nil {
 		t.Errorf("expected a nil return message, got: %v", Msg)
@@ -716,7 +716,7 @@ func TestDecodeMsgUnknown(t *testing.T) {
 func TestDecodeMsg(t *testing.T) {
 	Msg, err := DecodeMsg(msgNewTx5)
 	if err != nil {
-		t.Errorf("failed to decode message: %v", err)
+		t.Fatalf("failed to decode message: %v", err)
 	}
 
 	txlist, ok := Msg.(*pstypes.TxList)
@@ -737,7 +737,7 @@ func TestDecodeMsg(t *testing.T) {
 func TestDecodeMsgTxList(t *testing.T) {
 	txlist, err := DecodeMsgTxList(msgNewTx5)
 	if err != nil {
-		t.Errorf("failed to decode message: %v", err)
+		t.Fatalf("failed to decode message: %v", err)
 	}
 
 	// Spot check the number of transactions.
@@ -753,7 +753,7 @@ func TestDecodeMsgTxList(t *testing.T) {
 func TestDecodeMsgMempool(t *testing.T) {
 	mpShort, err := DecodeMsgMempool(msgMempool5Latest)
 	if err != nil {
-		t.Errorf("failed to decode message: %v", err)
+		t.Fatalf("failed to decode message: %v", err)
 	}
 
 	// Spot check the number of latest transactions.
@@ -769,7 +769,7 @@ func TestDecodeMsgMempool(t *testing.T) {
 func TestDecodeMsgNewBlock(t *testing.T) {
 	newBlock, err := DecodeMsgNewBlock(msgNewBlock312592)
 	if err != nil {
-		t.Errorf("failed to decode message: %v", err)
+		t.Fatalf("failed to decode message: %v", err)
 	}
 
 	if len(newBlock.Block.Tickets) != 4 {
@@ -794,7 +794,7 @@ func TestDecodeMsgString(t *testing.T) {
 
 	str, err := DecodeMsgString(msgPing)
 	if err != nil {
-		t.Errorf("Failed to decode string: %v", err)
+		t.Fatalf("Failed to decode string: %v", err)
 	}
 	if str != expectedStr {
 		t.Errorf("Wrong string decoded: got %s, expected %s",

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -560,7 +560,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	newBlockData := psh.sourceBase.GetExplorerBlock(msgBlock.BlockHash().String())
 
 	// Use the latest block's blocktime to get the last 24hr timestamp.
-	timestamp := newBlockData.BlockTime.T.Unix() - 86400
+	timestamp := newBlockData.BlockTime.UNIX() - 86400
 	targetTimePerBlock := float64(psh.params.TargetTimePerBlock)
 	// RetreiveDifficulty fetches the difficulty using the last 24hr timestamp,
 	// whereby the difficulty can have a timestamp equal to the last 24hrs

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -132,7 +132,7 @@
                     <tr>
                         <td class="text-right lh1rem pr-2 xs-w117">TIME</td>
                         <td class="lh1rem" style="min-width: 178px;">
-                            ({{timezone}}) {{.BlockTime}}<span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.BlockTime}}"></span> ago)</span>
+                            {{.BlockTime}}<span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.BlockTime.UNIX}}"></span> ago)</span>
                         </td>
                     </tr>
                     <tr>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -99,7 +99,7 @@
                             </th>
                             <th>Size</th>
                             <th class="jsonly" >Age</th>
-                            <th>Time ({{timezone}})</th>
+                            <th>Time</th>
                         </tr>
                     </thead>
                     <tbody data-target="blocklist.table">
@@ -112,7 +112,7 @@
                             <td data-type="tickets">{{.FreshStake}}</td>
                             <td data-type="revocations">{{.Revocations}}</td>
                             <td data-type="size">{{.FormattedBytes}}</td>
-                            <td data-type="age" class="jsonly" data-target="time.age" data-age="{{.BlockTime}}"></td>
+                            <td data-type="age" class="jsonly" data-target="time.age" data-age="{{.BlockTime.UNIX}}"></td>
                             <td data-type="time">{{.BlockTime}}</td>
                         </tr>
                     {{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -29,7 +29,6 @@
 {{define "navbar"}}
 <header class="top-nav"
         id="navBar"
-        data-timezone_offset="{{timezoneOffset}}"
         data-blocktime="{{.BlockTimeUnix}}"
         data-poolsize="{{.ChainParams.TicketPoolSize}}">
     <div class="container">
@@ -224,7 +223,7 @@
               <th class="text-right">Credit DCR</th>
               <th>Debit DCR</th>
           {{end}}
-          <th>Time ({{timezone}})</th>
+          <th>Time</th>
           <th>Age</th>
           <th>Confirms</th>
           <th>Size</th>
@@ -314,7 +313,7 @@
               {{if eq (.Time.T.Unix) 0}}
                   N/A
               {{else}}
-                  <span data-controller="time" data-target="time.age" data-age="{{.Time}}"></span>
+                  <span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
               {{end}}
               </td>
 

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -65,7 +65,7 @@
                                         <th><div class="position-relative text-center" data-tooltip="revocations">Revokes</div></th>
                                         <th><div class="position-relative text-center" data-tooltip="total DCR sent">DCR</div></th>
                                         <th class="d-none d-sm-table-cell d-md-none d-lg-table-cell"><div class="position-relative text-center">Size</div></th>
-                                        <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time ({{timezone}})</th>
+                                        <th class="text-right pr-3" data-target="time.header" data-jstitle="Age">Time</th>
                                     </tr>
                                 </thead>
                                 <tbody data-target="blocklist.table">
@@ -78,7 +78,7 @@
                                         <td class="text-center" data-type="revocations">{{.Revocations}}</td>
                                         <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
                                         <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
-                                        <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime}}">{{.BlockTime}}</td>
+                                        <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime.UNIX}}">{{.BlockTime}}</td>
                                     </tr>
                                     {{end}}
                                 </tbody>

--- a/views/nexthome.tmpl
+++ b/views/nexthome.tmpl
@@ -144,7 +144,7 @@
                             <span class="unit"> DCR</span>
                         </div>
                         <span class="timespan">
-                            <span data-target="time.age" data-age="{{.Time}}"></span>&nbsp;ago
+                            <span data-target="time.age" data-age="{{.Time.UNIX}}"></span>&nbsp;ago
                         </span>
                     </div>
                     <div class="block-rows">

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -115,7 +115,7 @@
                                 <td class="text-right">{{intComma .Revocations}}</td>
                                 <td class="text-right">{{intComma .BlocksCount}}</td>
                                 <td class="text-right">{{.FormattedSize}}</td>
-                                <td id="{{toLowerCase $.TimeGrouping}}" class="text-right" data-target="time.age" data-age="{{.StartTime}}"></td>
+                                <td id="{{toLowerCase $.TimeGrouping}}" class="text-right" data-target="time.age" data-age="{{.StartTime.UNIX}}"></td>
                             </tr>
                         {{end}}
                         </tbody>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -275,7 +275,7 @@
                         {{if eq (.Time.T.Unix) 0}}
                             <span data-target="tx.formattedAge">N/A</span> <span class="op60 fs12 nowrap"><span data-target="tx.age" data-age=""></span></span>
                         {{else}}
-                            <span>({{timezone}}) {{.Time}}</span><span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.Time}}"></span> ago)</span>
+                            <span>{{.Time}}</span><span class="op60 fs12 nowrap jsonly"> (<span data-target="time.age" data-age="{{.Time.UNIX}}"></span> ago)</span>
                         {{end}}
                     </td>
                 </tr>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -94,7 +94,7 @@
                             <th class="text-right">Difficulty</th>
                             <th class="text-right">Ticket Price (DCR)</th>
                             <th class="text-right jsonly">Age</th>
-                            <th>Start Time ({{timezone}})</th>
+                            <th>Start Time</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -115,7 +115,7 @@
                             <td>{{.FormattedSize}}</td>
                             <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
                             <td class="text-right">{{printf "%.2f" (toFloat64Amount .TicketPrice)}}</td>
-                            <td class="text-right jsonly" data-controller="time" data-target="time.age" data-age="{{.StartTime}}"></td>
+                            <td class="text-right jsonly" data-controller="time" data-target="time.age" data-age="{{.StartTime.UNIX}}"></td>
                             <td>{{.StartTime}}</td>
                         </tr>
                     {{end}}


### PR DESCRIPTION
Would be a workaround for https://github.com/decred/dcrdata/issues/999, but for DBs in various states between the 3.1 and 4.0 releases, it is needed to rebuild fresh once PR https://github.com/decred/dcrdata/pull/1002 is merged.

Our time string "2006-01-02 15:04:05" was not parseable by multiple
browsers, and it lacked a time zone. This adds a second format for both
`TimeDef` types in db/dbtypes and explorer/types to format the string in
RFC3339 (`"2006-01-02T15:04:05Z07:00"`). TODO: eliminate this
duplicate type.
This format is generated with the new `(TimeDef).RFC3339()` functions.

Call `RFC3339()` from `MarshalJSON` use the `time.RFC3339` format in
`UnmarshalJSON`.  This changes the date format in all of the API endpoints
so that the times may be parsed by javascript in dumb browsers like
Safari and Epiphany.

Fix the age controller's time parsing on several pages by using the new
`RFC3339` method in the HTML templates to generate a more JS friendly
time string.

Ref. for RFC3339 and ISO8601: https://tools.ietf.org/html/rfc3339#section-5.8

This is related to https://github.com/decred/dcrdata/issues/962, but a the time columns in the DB tables should still
be changed from `TIMESTAMP` to `TIMESTAMPTZ`.