### PR TITLE
restore Coinbase txns block mining fee pseudo-input on /tx

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -967,7 +967,11 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			if data == nil {
 				log.Errorf("Unable to get block %s", tx.BlockHash)
 			} else {
-				tx.BlockMiningFee = int64(data.MiningFee)
+				// BlockInfo.MiningFee is coin (float64), while
+				// TxInfo.BlockMiningFee is int64 (atoms), so convert. If the
+				// float64 is somehow invalid, use the default zero value.
+				feeAmt, _ := dcrutil.NewAmount(data.MiningFee)
+				tx.BlockMiningFee = int64(feeAmt)
 			}
 		}
 

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -355,10 +355,9 @@
                     {{end}}
                     {{if and (eq .Type "Coinbase") (gt .BlockMiningFee 0)}}
                         <tr>
-                            <td class="mono fs13">(Transaction Fees Collected)</td>
                             <td></td>
-                            <td></td>
-                            <td class="mono fs13 text-right">{{template "decimalParts" (float64AsDecimalParts .BlockMiningFee 6 false)}}</td>
+                            <td colspan="3" class="mono fs13">(block mining fees collected)</td>
+                            <td class="mono fs13 text-right">{{template "decimalParts" (amountAsDecimalParts .BlockMiningFee false)}}</td>
                         </tr>
                     {{end}}
                 </tbody>


### PR DESCRIPTION
Coinbase transactions should show a pseudo-input on the /tx page that indicates mining fees collected.  This was accidentally broken when data types changed that resulted in the fees being zero.

Before the fix:

![image](https://user-images.githubusercontent.com/9373513/52380924-3c036700-2a35-11e9-8247-14832236d1db.png)

After the fix:

![image](https://user-images.githubusercontent.com/9373513/52380931-4291de80-2a35-11e9-90fc-83548b513974.png)

I believe this bug was unreported, but it also resolves https://github.com/decred/dcrdata/issues/651 together with dcrd's changes to utxo set semantics.