### PR TITLE
fix grid layout for exhange rate datum in /home

### DIFF
--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -393,16 +393,16 @@
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
                         </div>
-                    </div>
-                    {{if $.ExchangeState}}
-                    <div class="col-6 col-sm-4 col-md-6 col-lg-4 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                        <div class="fs13 text-secondary">Exchange Rate</div>
-                        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                            <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span>
-                            <span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
+                        {{if $.ExchangeState}}
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Exchange Rate</div>
+                            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span>
+                                <span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
+                            </div>
                         </div>
+                        {{end}}
                     </div>
-                    {{end}}
                 </div>
                 {{end}}
             </div> <!-- end column -->


### PR DESCRIPTION
I missed porting updating the grid classes for the exchange rate datum in https://github.com/decred/dcrdata/commit/62adc564ae51c09b41740a981797f7e3aa6de79e

This aligns the exchange rate datum like the rest of the datums.

Before:
<img width="474" alt="screen shot 2019-02-08 at 10 19 56 am" src="https://user-images.githubusercontent.com/25571523/52455487-42a3f280-2b8b-11e9-86eb-0805809360b8.png">
After:
<img width="474" alt="screen shot 2019-02-08 at 10 18 23 am" src="https://user-images.githubusercontent.com/25571523/52455454-0e303680-2b8b-11e9-8735-89c0f8ec210a.png">
