### PR TITLE
Add hidepgconfig flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ modern javascript features, as well as SCSS for styling.
     - [Using Environment Variables for Configuration](#using-environment-variables-for-configuration)
     - [Indexing the Blockchain](#indexing-the-blockchain)
     - [Starting dcrdata](#starting-dcrdata)
+    - [Hide PG Config log](#hiding-the-postgreSQL-db-configuration-settings)
     - [Running the Web Interface During Synchronization](#running-the-web-interface-during-synchronization)
   - [System Hardware Requirements](#system-hardware-requirements)
     - ["lite" Mode (SQLite only)](#lite-mode-sqlite-only)
@@ -444,6 +445,11 @@ On subsequent launches, only blocks new to dcrdata are processed.
 Unlike dcrdata.conf, which must be placed in the `appdata` folder or explicitly
 set with `-C`, the "public" and "views" folders _must_ be in the same folder as
 the `dcrdata` executable.
+
+### Hiding the PostgreSQL db Configuration settings.
+
+By default postgres configuration is logged on system start up. To block the
+logging pass `--hidepgconfig` flag on on dcrdata start up command.
 
 ### Running the Web Interface During Synchronization
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ the `dcrdata` executable.
 
 ### Hiding the PostgreSQL db Configuration settings.
 
-By default postgres configuration is logged on system start up. To block the
-logging pass `--hidepgconfig` flag on on dcrdata start up command.
+By default postgres configuration settings are logged on system start up. 
+`--hidepgconfig` flag blocks the logging on dcrdata start up.
 
 ### Running the Web Interface During Synchronization
 

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -55,7 +55,7 @@ type config struct {
 	HTTPProfile  bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
 	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling."`
 	MemProfile   string `long:"memprofile" description:"File for mempry profiling."`
-	HidePGConfig bool   `long:"hidepgconfig" description:"If set to true it blocks logging of the PostgreSQL db configuration on system start up. Defaults to false."`
+	HidePGConfig bool   `long:"hidepgconfig" description:"Blocks logging of the PostgreSQL db configuration on system start up."`
 
 	// DB
 	DBHostPort             string `long:"dbhost" description:"DB host"`

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -45,16 +45,17 @@ var (
 
 type config struct {
 	// General application behavior
-	ConfigFile  string `short:"C" long:"configfile" description:"Path to configuration file"`
-	ShowVersion bool   `short:"V" long:"version" description:"Display version information and exit"`
-	TestNet     bool   `long:"testnet" description:"Use the test network (default mainnet)"`
-	SimNet      bool   `long:"simnet" description:"Use the simulation test network (default mainnet)"`
-	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
-	Quiet       bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
-	LogDir      string `long:"logdir" description:"Directory to log output"`
-	HTTPProfile bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
-	CPUProfile  string `long:"cpuprofile" description:"File for CPU profiling."`
-	MemProfile  string `long:"memprofile" description:"File for mempry profiling."`
+	ConfigFile   string `short:"C" long:"configfile" description:"Path to configuration file"`
+	ShowVersion  bool   `short:"V" long:"version" description:"Display version information and exit"`
+	TestNet      bool   `long:"testnet" description:"Use the test network (default mainnet)"`
+	SimNet       bool   `long:"simnet" description:"Use the simulation test network (default mainnet)"`
+	DebugLevel   string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
+	Quiet        bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
+	LogDir       string `long:"logdir" description:"Directory to log output"`
+	HTTPProfile  bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
+	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling."`
+	MemProfile   string `long:"memprofile" description:"File for mempry profiling."`
+	HidePGConfig bool   `long:"hidepgconfig" description:"If set to true it blocks logging of the PostgreSQL db configuration on system start up. Defaults to false."`
 
 	// DB
 	DBHostPort             string `long:"dbhost" description:"DB host"`

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -123,7 +123,7 @@ func mainCore() error {
 		DBName: cfg.DBName,
 	}
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
-	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false)
+	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig)
 	if db != nil {
 		defer db.Close()
 	}

--- a/config.go
+++ b/config.go
@@ -111,6 +111,7 @@ type config struct {
 	PGPass         string        `long:"pgpass" description:"PostgreSQL DB password." env:"DCRDATA_POSTGRES_PASS"`
 	PGHost         string        `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)." env:"DCRDATA_POSTGRES_HOST_URL"`
 	PGQueryTimeout time.Duration `short:"T" long:"pgtimeout" description:"Timeout (a time.Duration string) for most PostgreSQL queries used for user initiated queries."`
+	HidePGConfig   bool          `long:"hidepgconfig" description:"If set to true it blocks logging of the PostgreSQL db configuration on system start up. Defaults to false."`
 
 	NoDevPrefetch    bool `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
 	SyncAndQuit      bool `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`

--- a/config.go
+++ b/config.go
@@ -111,7 +111,7 @@ type config struct {
 	PGPass         string        `long:"pgpass" description:"PostgreSQL DB password." env:"DCRDATA_POSTGRES_PASS"`
 	PGHost         string        `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)." env:"DCRDATA_POSTGRES_HOST_URL"`
 	PGQueryTimeout time.Duration `short:"T" long:"pgtimeout" description:"Timeout (a time.Duration string) for most PostgreSQL queries used for user initiated queries."`
-	HidePGConfig   bool          `long:"hidepgconfig" description:"If set to true it blocks logging of the PostgreSQL db configuration on system start up. Defaults to false."`
+	HidePGConfig   bool          `long:"hidepgconfig" description:"Blocks logging of the PostgreSQL db configuration on system start up."`
 
 	NoDevPrefetch    bool `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
 	SyncAndQuit      bool `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -427,10 +427,10 @@ type DBInfo struct {
 // parameters. By default, duplicate row checks on insertion are enabled. See
 // NewChainDBWithCancel to enable context cancellation of running queries.
 func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch, isHidePGConfig bool) (*ChainDB, error) {
+	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool) (*ChainDB, error) {
 	ctx := context.Background()
 	chainDB, err := NewChainDBWithCancel(ctx, dbi, params, stakeDB,
-		devPrefetch, isHidePGConfig)
+		devPrefetch, hidePGConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
 // (context.Background()) except by the pg timeouts. If it is necessary to
 // cancel queries with CTRL+C, for example, use NewChainDBWithCancel.
 func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch, isHidePGConfig bool) (*ChainDB, error) {
+	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool) (*ChainDB, error) {
 	// Connect to the PostgreSQL daemon and return the *sql.DB.
 	db, err := Connect(dbi.Host, dbi.Port, dbi.User, dbi.Pass, dbi.DBName)
 	if err != nil {
@@ -458,9 +458,8 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	}
 	log.Info(pgVersion)
 
-	// if the hidepgconfig flag was set to true then the PostgreSQL configuration
-	// settings will not be logged by default on system start up.
-	if !isHidePGConfig {
+	// Optionally logs the PostgreSQL configuration.
+	if !hidePGConfig {
 		perfSettings, err := RetrieveSysSettingsPerformance(db)
 		if err != nil {
 			return nil, err

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -427,9 +427,10 @@ type DBInfo struct {
 // parameters. By default, duplicate row checks on insertion are enabled. See
 // NewChainDBWithCancel to enable context cancellation of running queries.
 func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch bool) (*ChainDB, error) {
+	stakeDB *stakedb.StakeDatabase, devPrefetch, isHidePGConfig bool) (*ChainDB, error) {
 	ctx := context.Background()
-	chainDB, err := NewChainDBWithCancel(ctx, dbi, params, stakeDB, devPrefetch)
+	chainDB, err := NewChainDBWithCancel(ctx, dbi, params, stakeDB,
+		devPrefetch, isHidePGConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -443,8 +444,8 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
 // behavior. NewChainDB creates context that cannot be cancelled
 // (context.Background()) except by the pg timeouts. If it is necessary to
 // cancel queries with CTRL+C, for example, use NewChainDBWithCancel.
-func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Params, stakeDB *stakedb.StakeDatabase,
-	devPrefetch bool) (*ChainDB, error) {
+func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Params,
+	stakeDB *stakedb.StakeDatabase, devPrefetch, isHidePGConfig bool) (*ChainDB, error) {
 	// Connect to the PostgreSQL daemon and return the *sql.DB.
 	db, err := Connect(dbi.Host, dbi.Port, dbi.User, dbi.Pass, dbi.DBName)
 	if err != nil {
@@ -457,17 +458,21 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	}
 	log.Info(pgVersion)
 
-	perfSettings, err := RetrieveSysSettingsPerformance(db)
-	if err != nil {
-		return nil, err
-	}
-	log.Infof("postgres performance settings:\n%v", perfSettings)
+	// if the hidepgconfig flag was set to true then the PostgreSQL configuration
+	// settings will not be logged by defualt on system start up.
+	if !isHidePGConfig {
+		perfSettings, err := RetrieveSysSettingsPerformance(db)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("postgres configuration settings:\n%v", perfSettings)
 
-	servSettings, err := RetrieveSysSettingsServer(db)
-	if err != nil {
-		return nil, err
+		servSettings, err := RetrieveSysSettingsServer(db)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("postgres server settings:\n%v", servSettings)
 	}
-	log.Infof("postgres server settings:\n%v", servSettings)
 
 	// Attempt to get DB best block height from tables, but if the tables are
 	// empty or not yet created, it is not an error.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -459,7 +459,7 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	log.Info(pgVersion)
 
 	// if the hidepgconfig flag was set to true then the PostgreSQL configuration
-	// settings will not be logged by defualt on system start up.
+	// settings will not be logged by default on system start up.
 	if !isHidePGConfig {
 		perfSettings, err := RetrieveSysSettingsPerformance(db)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func _main(ctx context.Context) error {
 		dbi.DBName = strings.Replace(dbi.DBName, "{netname}", netName(activeNet), -1)
 
 		chainDB, err := dcrpg.NewChainDBWithCancel(ctx, &dbi, activeChain,
-			baseDB.GetStakeDB(), !cfg.NoDevPrefetch)
+			baseDB.GetStakeDB(), !cfg.NoDevPrefetch, cfg.HidePGConfig)
 		if chainDB != nil {
 			defer chainDB.Close()
 		}

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -42,6 +42,10 @@
 ; syncing is done.
 ; sync-status-limit=1000
 
+; Blocks logging of the PostgreSQL db configuration on system start up. Defaults
+; to false.
+; hidepgconfig=1
+
 ; Set "Cache-Control: max-age=X" in HTTP response header for FileServer routes.
 ;cachecontrol-maxage=86400
 

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -42,8 +42,7 @@
 ; syncing is done.
 ; sync-status-limit=1000
 
-; Blocks logging of the PostgreSQL db configuration on system start up. Defaults
-; to false.
+; Blocks logging of the PostgreSQL db configuration on system start up.
 ; hidepgconfig=1
 
 ; Set "Cache-Control: max-age=X" in HTTP response header for FileServer routes.


### PR DESCRIPTION
`hidepgconfig` blocks logging of the postgresql db configuration which happens by default.

To startup dcrdata now without displaying the tabular configuration settings can be achieved by running:
```shell
go build ./ && ./v4 --hidepgconfig
```