### PR TITLE
Fix windows view drop down navigation bug

### DIFF
--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -3,7 +3,7 @@
 <html lang="en">
 
 {{template "html-head" "Decred Windows List"}}
-<body class="{{ theme }}" data-controller="ticketwindow">
+<body class="{{ theme }}" data-controller="ticketwindow  blocklist">
     {{template "navbar" . }}
     <div class="container main">
         <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -3,7 +3,7 @@
 <html lang="en">
 
 {{template "html-head" "Decred Windows List"}}
-<body class="{{ theme }}" data-controller="ticketwindow  blocklist">
+<body class="{{ theme }}" data-controller="ticketwindow blocklist">
     {{template "navbar" . }}
     <div class="container main">
         <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>


### PR DESCRIPTION
On `/ticketpricewindows` page the dropdown menu did not work because the blocklist `data-controller` was missing.