### PR TITLE
dcrpg: upgrade all timestamp columns to timestamptz

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -10,7 +10,7 @@ const (
 		valid_mainchain BOOLEAN,
 		matching_tx_hash TEXT,
 		value INT8,
-		block_time TIMESTAMP NOT NULL,
+		block_time TIMESTAMPTZ NOT NULL,
 		is_funding BOOLEAN,
 		tx_vin_vout_index INT4,
 		tx_vin_vout_row_id INT8,

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -22,7 +22,7 @@ const (
 		num_stx INT4,
 		stx TEXT[],
 		stxDbIDs INT8[],
-		time TIMESTAMP,
+		time TIMESTAMPTZ,
 		nonce INT8,
 		vote_bits INT2,
 		voters INT2,

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -328,7 +328,7 @@ const (
 		agenda_vote_choice INT2,
 		tx_hash TEXT NOT NULL,
 		block_height INT4,
-		block_time TIMESTAMP,
+		block_time TIMESTAMPTZ,
 		locked_in BOOLEAN,
 		activated BOOLEAN,
 		hard_forked BOOLEAN

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -12,8 +12,8 @@ const (
 		/*block_db_id INT4,*/
 		block_hash TEXT,
 		block_height INT8,
-		block_time TIMESTAMP,
-		time TIMESTAMP,
+		block_time TIMESTAMPTZ,
+		time TIMESTAMPTZ,
 		tx_type INT4,
 		version INT4,
 		tree INT2,

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -18,7 +18,7 @@ const (
 		tx_tree INT2,
 		is_valid BOOLEAN,
 		is_mainchain BOOLEAN,
-		block_time TIMESTAMP,
+		block_time TIMESTAMPTZ,
 		prev_tx_hash TEXT,
 		prev_tx_index INT8,
 		prev_tx_tree INT2,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -454,8 +454,9 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 
 	// Put the PostgreSQL time zone in UTC.
 	var initTZ string
-	if err = db.QueryRow(`SHOW TIME ZONE`).Scan(&initTZ); err != nil {
-		return nil, fmt.Errorf("Unable to query current time zone: %v", err)
+	initTZ, err = CheckCurrentTimeZone(db)
+	if err != nil {
+		return nil, err
 	}
 	if initTZ != "UTC" {
 		log.Infof("Switching PostgreSQL time zone to UTC for this session.")

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -50,6 +50,31 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
+func TestCheckColumnDataType(t *testing.T) {
+	dataType, err := CheckColumnDataType(db.db, "blocks", "time")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(dataType)
+}
+
+func TestCheckCurrentTimeZone(t *testing.T) {
+	currentTZ, err := CheckCurrentTimeZone(db.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Set time zone: %v", currentTZ)
+}
+
+func TestCheckDefaultTimeZone(t *testing.T) {
+	defaultTZ, currentTZ, err := CheckDefaultTimeZone(db.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Set time zone: %v", currentTZ)
+	t.Logf("Default time zone: %v", defaultTZ)
+}
+
 func TestDeleteBestBlock(t *testing.T) {
 	ctx := context.Background()
 	res, height, hash, err := DeleteBestBlock(ctx, db.db)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
@@ -2941,7 +2941,7 @@ func RetrieveBlockSummaryByTimeRange(ctx context.Context, db *sql.DB, minTime, m
 	var rows *sql.Rows
 	var err error
 
-	// int64 -> time.Time is required to query TIMESTAMP columns.
+	// int64 -> time.Time is required to query TIMESTAMPTZ columns.
 	minT := time.Unix(minTime, 0)
 	maxT := time.Unix(maxTime, 0)
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -321,6 +321,50 @@ func TableVersions(db *sql.DB) map[string]TableVersion {
 	return versions
 }
 
+// CheckColumnDataType gets the data type of specified table column .
+func CheckColumnDataType(db *sql.DB, table, column string) (dataType string, err error) {
+	err = db.QueryRow(`SELECT data_type
+		FROM information_schema.columns
+		WHERE table_name=$1 AND column_name=$2`,
+		table, column).Scan(&dataType)
+	return
+}
+
+func CheckCurrentTimeZone(db *sql.DB) (currentTZ string, err error) {
+	if err = db.QueryRow(`SHOW TIME ZONE`).Scan(&currentTZ); err != nil {
+		err = fmt.Errorf("unable to query current time zone: %v", err)
+	}
+	return
+}
+
+func CheckDefaultTimeZone(db *sql.DB) (defaultTZ, currentTZ string, err error) {
+	// Remember the current time zone before switching to default.
+	currentTZ, err = CheckCurrentTimeZone(db)
+	if err != nil {
+		return
+	}
+
+	// Switch to DEFAULT/LOCAL.
+	_, err = db.Exec(`SET TIME ZONE DEFAULT`)
+	if err != nil {
+		err = fmt.Errorf("failed to set time zone to UTC: %v", err)
+		return
+	}
+
+	// Get the default time zone now that it is current.
+	defaultTZ, err = CheckCurrentTimeZone(db)
+	if err != nil {
+		return
+	}
+
+	// Switch back to initial time zone.
+	_, err = db.Exec(fmt.Sprintf(`SET TIME ZONE %s`, currentTZ))
+	if err != nil {
+		err = fmt.Errorf("failed to set time zone back to %s: %v", currentTZ, err)
+	}
+	return
+}
+
 func (pgb *ChainDB) DeleteDuplicates(barLoad chan *dbtypes.ProgressBarLoad) error {
 	allDuplicates := []dropDuplicatesInfo{
 		// Remove duplicate vins

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -48,7 +48,7 @@ type dropDuplicatesInfo struct {
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 8
+	tableMinor = 9
 	tablePatch = 0
 )
 

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // See LICENSE for details.
 
 package dcrpg
@@ -267,7 +267,7 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 
 	// Upgrade from 3.5.4 --> 3.5.5
 	case version.major == 3 && version.minor == 5 && version.patch == 4:
-		toVersion = TableVersion{3, 5, 5}
+		toVersion = TableVersion{3, 5, 5} // dcrdata 3.1 release
 
 		theseUpgrades := []TableUpgradeType{
 			{"addresses", addressesTableBlockTimeSortedIndex},
@@ -659,13 +659,13 @@ func (pgb *ChainDB) handleUpgrades(client *rpcutils.BlockGate,
 	switch tableUpgrade {
 	case addressesBlockTimeDataTypeUpdate, agendasBlockTimeDataTypeUpdate,
 		vinsBlockTimeDataTypeUpdate:
-		columnsUpdate = []dataTypeUpgrade{{Column: "block_time", DataType: "TIMESTAMP"}}
+		columnsUpdate = []dataTypeUpgrade{{Column: "block_time", DataType: "TIMESTAMPTZ"}}
 	case blocksBlockTimeDataTypeUpdate:
-		columnsUpdate = []dataTypeUpgrade{{Column: "time", DataType: "TIMESTAMP"}}
+		columnsUpdate = []dataTypeUpgrade{{Column: "time", DataType: "TIMESTAMPTZ"}}
 	case transactionsBlockTimeDataTypeUpdate:
 		columnsUpdate = []dataTypeUpgrade{
-			{Column: "time", DataType: "TIMESTAMP"},
-			{Column: "block_time", DataType: "TIMESTAMP"},
+			{Column: "time", DataType: "TIMESTAMPTZ"},
+			{Column: "block_time", DataType: "TIMESTAMPTZ"},
 		}
 	}
 

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -1203,25 +1203,10 @@ func handleConvertTimeStampTZ(db *sql.DB) error {
 		return fmt.Errorf("failed to set time zone to UTC: %v", err)
 	}
 
+	// Convert the affected columns of each table.
 	for i := range timestampTables {
-		tableName := timestampTables[i].TableName
-		// Remove timestamp indexes on large tables.
-		// switch tableName {
-		// case "addresses":
-		// 	err := DeindexBlockTimeOnTableAddress(db)
-		// 	if err != nil && !errIsNotExist(err) {
-		// 		log.Errorf("Failed to drop index addresses index on block_time: %v", err)
-		// 		return err
-		// 	}
-		// case "agendas":
-		// 	err := DeindexAgendasTableOnBlockTime(db)
-		// 	if err != nil && !errIsNotExist(err) {
-		// 		log.Errorf("Failed to drop index agendas index on block_time: %v", err)
-		// 		return err
-		// 	}
-		// }
-
 		// Convert the timestamp columns of this table.
+		tableName := timestampTables[i].TableName
 		for _, col := range timestampTables[i].ColumnNames {
 			log.Infof("Converting column %s.%s to TIMESTAMPTZ...", tableName, col)
 			_, err = db.Exec(fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s TYPE TIMESTAMPTZ`,
@@ -1231,19 +1216,6 @@ func handleConvertTimeStampTZ(db *sql.DB) error {
 					tableName, col, err)
 			}
 		}
-
-		// Recreate the indexes on timestamptz.
-		// switch tableName {
-		// case "addresses":
-		// 	log.Infof("Reindexing addresses table on block time...")
-		// 	err = IndexBlockTimeOnTableAddress(db)
-		// case "agendas":
-		// 	log.Infof("Reindexing agendas table on block time...")
-		// 	err = IndexAgendasTableOnBlockTime(db)
-		// }
-		// if err != nil {
-		// 	return err
-		// }
 	}
 
 	// Switch server time zone for this sesssion back to UTC to read correct


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdata/issues/999

This bumps dcrpg schema from 3.8.0 to 3.9.0.
Also set the postgres time zone to UTC in NewChainDB[WithCancel].
Maybe reindex time column of addresses and agendas table.

This *MUST* be merged prior to https://github.com/decred/dcrdata/pull/988

Tests:
 - [x] Upgrade from dcrpg 3.8.0 to 3.9.0. **upgrade denied because of timestamp issue**
 - [x] Upgrade from dcrpg 3.5.5 (dcrdata 3.1-release) to 3.9.0.  **7 minutes**
 - [x] Fresh sync