### PR TITLE
semver: add ParseVersionStr and Split, use in dcrpg

### DIFF
--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -7,11 +7,10 @@ package dcrpg
 import (
 	"database/sql"
 	"fmt"
-	"regexp"
-	"strconv"
 
 	"github.com/decred/dcrdata/v4/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
+	"github.com/decred/dcrdata/v4/semver"
 )
 
 var createTableStatements = map[string]string{
@@ -289,45 +288,23 @@ func TableUpgradesRequired(versions map[string]TableVersion) []TableUpgrade {
 func TableVersions(db *sql.DB) map[string]TableVersion {
 	versions := map[string]TableVersion{}
 	for tableName := range createTableStatements {
-		Result := db.QueryRow(`select obj_description($1::regclass);`, tableName)
-		var s string
-		var v, m, p int
-		if Result != nil {
-			err := Result.Scan(&s)
-			if err != nil {
-				log.Errorf("Scan of QueryRow failed: %v", err)
-				continue
-			}
-
-			// This regex expression should detect the following versions format:
-			// v3
-			// v3.0
-			// v3.0.0
-			// v3.6.0
-			// v3.10.0
-			// v10.10.10
-			re := regexp.MustCompile(`^v(\d+)\.?(\d+)?\.?(\d+)?$`)
-			subs := re.FindStringSubmatch(s)
-			if len(subs) > 1 {
-				v, err = strconv.Atoi(subs[1])
-				if err != nil {
-					fmt.Println(err)
-				}
-				if len(subs) > 2 && len(subs[2]) > 0 {
-					m, err = strconv.Atoi(subs[2])
-					if err != nil {
-						fmt.Println(err)
-					}
-					if len(subs) > 3 && len(subs[3]) > 0 {
-						p, err = strconv.Atoi(subs[3])
-						if err != nil {
-							fmt.Println(err)
-						}
-					}
-				}
-			}
+		// Retrieve the table description.
+		var desc string
+		err := db.QueryRow(`select obj_description($1::regclass);`, tableName).Scan(&desc)
+		if err != nil {
+			log.Errorf("Query of table %s description failed: %v", tableName, err)
+			continue
 		}
-		versions[tableName] = NewTableVersion(uint32(v), uint32(m), uint32(p))
+
+		// Attempt to parse a version out of the table description.
+		sv, err := semver.ParseVersionStr(desc)
+		if err != nil {
+			log.Errorf("Failed to parse version from table description %s: %v",
+				desc, err)
+			continue
+		}
+
+		versions[tableName] = NewTableVersion(sv.Split())
 	}
 	return versions
 }

--- a/semver/semver.go
+++ b/semver/semver.go
@@ -4,7 +4,11 @@
 
 package semver
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
 
 // NewSemver returns a new Semver with the version major.minor.patch
 func NewSemver(major, minor, patch uint32) Semver {
@@ -44,4 +48,55 @@ func AnyCompatible(compatible []Semver, actual Semver) (isApiCompat bool) {
 
 func (s Semver) String() string {
 	return fmt.Sprintf("%d.%d.%d", s.major, s.minor, s.patch)
+}
+
+// Split returns the major, minor and patch version.
+func (s *Semver) Split() (uint32, uint32, uint32) {
+	return s.major, s.minor, s.patch
+}
+
+// ParseVersionStr makes a *Semver from a version string (e.g. v3.1.0, 5.3.2,
+// 7.3, etc.).  The "v" prefix is optional, as are the minor and patch versions.
+func ParseVersionStr(ver string) (*Semver, error) {
+	var v, m, p int
+	var err error
+
+	// If this matches a string, there will be 3 submatches in addition to the
+	// matched string in the result of FindStringSubmatch. Otherwise, there will
+	// result will be an empty slice.
+	re := regexp.MustCompile(`^v?(\d+)\.?(\d*)\.?(\d*)$`)
+	subs := re.FindStringSubmatch(ver)
+	if len(subs) != 4 {
+		return nil, fmt.Errorf("invalid version string")
+	}
+
+	// Matched the string and captured 3 substrings. Parse each substring, some
+	// of which may be empty. Empty substrings are treated as a 0.
+
+	// patch
+	if len(subs[3]) > 0 {
+		p, err = strconv.Atoi(subs[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// minor
+	if len(subs[2]) > 0 {
+		m, err = strconv.Atoi(subs[2])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// major
+	if len(subs[1]) > 0 {
+		v, err = strconv.Atoi(subs[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	s := NewSemver(uint32(v), uint32(m), uint32(p))
+	return &s, nil
 }

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -1,6 +1,7 @@
 package semver
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -70,5 +71,45 @@ func TestAnyCompatible(t *testing.T) {
 	if AnyCompatible(compatibleVersions, testver) {
 		t.Errorf("Versions %v and one of %v should not be compatible.",
 			testver, compatibleVersions)
+	}
+}
+
+func TestParseVersionStr(t *testing.T) {
+	tests := []struct {
+		testName string
+		ver      string
+		want     *Semver
+		wantErr  bool
+	}{
+		{"v3", "v3", &Semver{3, 0, 0}, false},
+		{"v3.0", "v3.0", &Semver{3, 0, 0}, false},
+		{"v3.0.0", "v3.0.0", &Semver{3, 0, 0}, false},
+		{"v3..0", "v3..0", &Semver{3, 0, 0}, false},
+		{"v3.6", "v3.6", &Semver{3, 6, 0}, false},
+		{"v3.6.0", "v3.6.0", &Semver{3, 6, 0}, false},
+		{"v3.10.0", "v3.10.0", &Semver{3, 10, 0}, false},
+		{"3", "3", &Semver{3, 0, 0}, false},
+		{"3.", "3.", &Semver{3, 0, 0}, false},
+		{"3.7.", "3.7.", &Semver{3, 7, 0}, false},
+		{"3.0", "3.0", &Semver{3, 0, 0}, false},
+		{"3.10.1", "3.10.1", &Semver{3, 10, 1}, false},
+		{"invalid major", "vq.10.12", nil, true},
+		{"invalid minor", "v3.x.12", nil, true},
+		{"invalid patch", "v3.10.-12", nil, true},
+		{"empty", "", nil, true},
+		{"bare v", "v", nil, true},
+		{"v10.10.10", "v10.10.10", &Semver{10, 10, 10}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			got, err := ParseVersionStr(tt.ver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVersionStr() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseVersionStr() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`semver.ParseVersionStr` parses out a version from an input string.
Add tests for `ParseVersionStr`.
Use `ParseVersionStr` in `dcrpg.TableVersions`.