### PR TITLE
Open the barload channel always

### DIFF
--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -187,7 +187,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 	}
 
 	// Safely send sync status updates on barLoad channel, and set the channel
-	// to nil if it was closed or the buffer is full.
+	// to nil if the buffer is full.
 	sendProgressUpdate := func(p *dbtypes.ProgressBarLoad) {
 		if barLoad == nil {
 			return
@@ -201,7 +201,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 	}
 
 	// Safely send new block hash on updateExplorer channel, and set the channel
-	// to nil if it was closed or the buffer is full.
+	// to nil if the buffer is full.
 	sendPageData := func(hash *chainhash.Hash) {
 		if updateExplorer == nil {
 			return

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -245,7 +245,7 @@ func (db *WiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 	}
 
 	// Safely send sync status updates on barLoad channel, and set the channel
-	// to nil if it was closed or the buffer is full.
+	// to nil if the buffer is full.
 	sendProgressUpdate := func(p *dbtypes.ProgressBarLoad) {
 		if barLoad == nil {
 			return
@@ -259,7 +259,7 @@ func (db *WiredDB) resyncDB(ctx context.Context, blockGetter rpcutils.BlockGette
 	}
 
 	// Safely send new block hash on updateExplorer channel, and set the channel
-	// to nil if it was closed or the buffer is full.
+	// to nil if the buffer is full.
 	sendPageData := func(hash *chainhash.Hash) {
 		if updateExplorer == nil {
 			return

--- a/main.go
+++ b/main.go
@@ -951,9 +951,9 @@ func _main(ctx context.Context) error {
 	// Enable new blocks being stored into the base DB's cache.
 	baseDB.EnableCache()
 
-	// Deactivate displaying the sync status page after the db sync was completed.
+	// Block further usage of the barLoad by sending a nil value
 	if barLoad != nil {
-		close(barLoad)
+		barLoad <- nil
 	}
 
 	// Set that newly sync'd blocks should no longer be stored in the explorer.

--- a/main.go
+++ b/main.go
@@ -953,7 +953,10 @@ func _main(ctx context.Context) error {
 
 	// Block further usage of the barLoad by sending a nil value
 	if barLoad != nil {
-		barLoad <- nil
+		select {
+		case barLoad <- nil:
+		default:
+		}
 	}
 
 	// Set that newly sync'd blocks should no longer be stored in the explorer.


### PR DESCRIPTION
Premature closing of the `barLoad` channel resulted to a panic when trying to send data through a closed `barLoad` channel. 
Sending `nil` via the channel results to `barLoad` being assigned `nil` rather than closing it thereby avoiding the panic.
#1005 