### PR TITLE
pubsub/types: Add IsIOTimeoutErr and use when closing connections

### DIFF
--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -34,7 +34,8 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 		closeWS := func() {
 			err := ws.Close()
 			// Do not log error if connection is just closed.
-			if err != nil && !pstypes.IsWSClosedErr(err) {
+			if err != nil && !pstypes.IsWSClosedErr(err) &&
+				!pstypes.IsIOTimeoutErr(err) {
 				log.Errorf("Failed to close websocket: %v", err)
 			}
 		}

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -188,7 +188,7 @@ func (psh *PubSubHub) MempoolInventory() *types.MempoolInfo {
 func closeWS(ws *websocket.Conn) {
 	err := ws.Close()
 	// Do not log error if connection is just closed
-	if err != nil && !pstypes.IsWSClosedErr(err) {
+	if err != nil && !pstypes.IsWSClosedErr(err) && !pstypes.IsIOTimeoutErr(err) {
 		log.Errorf("Failed to close websocket: %v", err)
 	}
 }

--- a/pubsub/types/pubsub_types.go
+++ b/pubsub/types/pubsub_types.go
@@ -6,14 +6,28 @@ import (
 	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 )
 
-// ErrWsClosed is the error message text used websocket Conn.Close tries to
-// close an already closed connection.
-var ErrWsClosed = "use of closed network connection"
+var (
+	// ErrWsClosed is the error message text when a websocket.(*Conn).Close
+	// tries to close an already closed connection.
+	ErrWsClosed = "use of closed network connection"
+
+	// ErrWsClosed is the error message text when a websocket.(*Conn).Close
+	// fails to close a connection due to a passed write deadline.
+	ErrIOTimeout = "i/o timeout"
+)
 
 // IsWSClosedErr checks if the passed error indicates a closed websocket
 // connection.
 func IsWSClosedErr(err error) (closedErr bool) {
 	if err != nil && strings.Contains(err.Error(), ErrWsClosed) {
+		closedErr = true
+	}
+	return
+}
+
+// IsIOTimeoutErr checks if the passed error indicates an I/O timeout error.
+func IsIOTimeoutErr(err error) (closedErr bool) {
+	if err != nil && strings.Contains(err.Error(), ErrIOTimeout) {
 		closedErr = true
 	}
 	return


### PR DESCRIPTION
This avoids logging messages like the following when closing websocket connections with no listening client:

> [ERR] EXPR: Failed to close websocket: write tcp 127.0.0.1:7777->127.0.0.1:37520: i/o timeout

Closing a closed websocket connection can also result in a error with
the string "i/o timeout" since closing involves a send to the client.
When closing a websocket connection in a deferred function from the
websocket handers of explorer and pubsub, recognize such errors
and do not log the message.