### PR TITLE
Refine mempool page layout

### DIFF
--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -9,126 +9,111 @@
         data-target="mempool.mempool"
         {{template "mempoolDump" .}}
         >
-            <div class="py-4 h4">Mempool</div>
+            <div class="pb-2 h4">Mempool</div>
 
-            <div class="row mx-1 my-2">
-                <div class="col-24 col-sm-12 col-md-24 col-lg-12 bg-white py-4 px-3 position-relative">
+            <div class="row mx-0 my-2">
+                <div class="col-24 col-sm-12 col-md-24 col-lg-12 bg-white py-3 px-3 position-relative">
                     <div class="card-pointer pointer-right d-none d-sm-block d-md-none d-lg-block"></div>
                     <div class="card-pointer pointer-bottom d-sm-none d-md-block d-lg-none"></div>
-                    <div class="pb-3 pl-1">
+                    <div class="pl-1">
                         <span class="dcricon-stack h5"></span>
                         <span class="h6 d-inline-block pl-2">Current Mempool</span>
                     </div>
                     <div class="row">
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
+                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-2 pb-sm-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
                             <div class="col-12 text-center">
                                 <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
                                     <span class="text-secondary fs13">Total Sent</span>
                                     <br>
-                                    <span class="h5" data-target="mempool.likelyTotal">{{threeSigFigs .LikelyMineable.Total}}</span> <span class="text-secondary">DCR</span>
+                                    <span class="h4" data-target="mempool.likelyTotal">{{threeSigFigs .LikelyMineable.Total}}</span> <span class="text-secondary">DCR</span>
                                 </div>
                             </div>
                             <div class="col-12 text-center">
                                 <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
                                     <span class="text-secondary fs13">Last Block</span>
                                     <br>
-                                    <span class="h5"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a></span>
+                                    <span class="h4"><a href="/block/{{.LastBlockHeight}}" data-target="mempool.bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a></span>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
+                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
                             <div class="col-12 text-center">
                                 <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
                                     <span class="text-secondary fs13" data-target="time.header" data-jstitle="Since Last Block">Last Block</span>
                                     <br>
-                                    <span class="h5" data-target="mempool.bestBlockTime  time.age" data-age="{{.LastBlockTime}}"><span class="fs13">{{.FormattedBlockTime}}</span></span>
+                                    <span class="h4" data-target="mempool.bestBlockTime time.age" data-age="{{.LastBlockTime}}"><span class="fs13">{{.FormattedBlockTime}}</span></span>
                                 </div>
                             </div>
                             <div class="col-12 text-center">
                                 <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
                                     <span class="text-secondary fs13">Size</span>
                                     <br>
-                                    <span data-target="mempool.mempoolSize" class="h5" >{{.LikelyMineable.FormattedSize}}</span>
+                                    <span class="h4" data-target="mempool.mempoolSize">{{.LikelyMineable.FormattedSize}}</span>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="col-24 col-sm-12 col-md-24 col-lg-12 secondary-card pt-3 pb-5 px-3">
-                    <div class="pb-2 pl-1">
+                <div class="col-24 col-sm-12 col-md-24 col-lg-12 secondary-card pt-3 pb-3 px-3">
+                    <div class="pl-1">
                       <!-- <span class="dcricon-stack h5"></span> -->
-                      <span class="h6 d-inline-block pl-2">Transaction Details</span>
+                      <span class="h6 d-inline-block pl-2">Transactions</span>
                     </div>
 
-                    <div class="row fs13">
-                        <div class="col-24 col-md-12">
-                            <table class="w-100">
-                                <tbody>
-                                    <tr>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle w-50 text-right">
-                                            <div class="text-right font-weight-bold pr-2">Regular:</div>
-                                        </td>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle">
-                                            <span class="fs18 align-middle" data-target="mempool.regCount">{{.NumRegular}}</span>
-                                            <span class="align-middle d-inline-block pl-1">(<span data-target="mempool.regTotal">{{threeSigFigs .LikelyMineable.RegularTotal}}</span> DCR)</span>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle w-50 text-right">
-                                            <div class="text-right font-weight-bold pr-2">Tickets:</div>
-                                        </td>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle">
-                                            <span class="fs18 align-middle" data-target="mempool.ticketCount">{{.NumTickets}}</span>
-                                            <span class="align-middle d-inline-block pl-1">(<span data-target="mempool.ticketTotal">{{threeSigFigs .LikelyMineable.TicketTotal}}</span> DCR)</span>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                    <div class="row mt-1">
+                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
+                            <div class="col-12">
+                                <div class="text-center text-secondary fs13">Regular</div>
+                                <div class="text-center h4 mb-0" data-target="mempool.regCount">{{.NumRegular}}</div>
+                                <div class="text-center fs13">
+                                    <span data-target="mempool.regTotal">{{threeSigFigs .LikelyMineable.RegularTotal}}</span> DCR
+                                </div> 
+                            </div>
+                            <div class="col-12">
+                                <div class="text-center text-secondary fs13">Tickets</div>
+                                <div class="text-center h4 mb-0" data-target="mempool.ticketCount">{{.NumTickets}}</div>
+                                <div class="text-center fs13">
+                                    <span data-target="mempool.ticketTotal">{{threeSigFigs .LikelyMineable.TicketTotal}}</span> DCR
+                                </div>
+                            </div>
                         </div>
-                        <div class="col-24 col-md-12">
-                            <table class="w-100">
-                                <tbody>
-                                    <tr>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle w-50 text-right">
-                                            <div class="text-right font-weight-bold pr-2 d-inline-block position-relative"><span data-tooltip="best block votes only">Votes:</span></div>
-                                        </td>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle">
-                                            <span class="fs18 align-middle" data-target="mempool.voteCount">
-                                              {{$afterFirst := false}}
-                                              {{range $hash, $tally := .VotingInfo.VoteTallys}}
-                                                {{if $afterFirst}} + {{end}}
-                                                <span class="position-relative d-inline-block"
-                                                data-target="mempool.voteTally"
-                                                data-hash="{{$hash}}"
-                                                data-affirmed="{{$tally.Affirmations}}"
-                                                data-count="{{$tally.VoteCount}}"
-                                                data-tooltip="for block {{$hash}}"
-                                                >{{$tally.VoteCount}}</span>
-                                                {{$afterFirst = true}}
-                                              {{end}}
-                                            </span>
-                                          <span class="align-middle d-inline-block pl-1">(<span data-target="mempool.voteTotal">{{threeSigFigs .LikelyMineable.VoteTotal}}</span> DCR)</span>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle w-50 text-right">
-                                            <div class="text-right font-weight-bold pr-2">Revocations:</div>
-                                        </td>
-                                        <td class="py-2 py-lg-4 py-xl-2 align-middle">
-                                            <span class="fs18 align-middle" data-target="mempool.revCount">{{.NumRevokes}}</span>
-                                            <span class="align-middle d-inline-block pl-1">(<span data-target="mempool.revTotal">{{threeSigFigs .LikelyMineable.RevokeTotal}}</span> DCR)</span>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
+                            <div class="col-12">
+                                <div class="text-center text-secondary fs13">Votes</div>
+                                <div class="text-center h4 mb-0" data-target="mempool.voteCount">
+                                    {{$afterFirst := false}}
+                                    {{range $hash, $tally := .VotingInfo.VoteTallys}}
+                                        {{if $afterFirst}} + {{end}}
+                                        <span class="text-center position-relative d-inline-block"
+                                        data-target="mempool.voteTally"
+                                        data-hash="{{$hash}}"
+                                        data-affirmed="{{$tally.Affirmations}}"
+                                        data-count="{{$tally.VoteCount}}"
+                                        data-tooltip="for block {{$hash}}"
+                                        >{{$tally.VoteCount}}</span>
+                                        {{$afterFirst = true}}
+                                    {{end}}
+                                </div>
+                                <div class="text-center fs13">
+                                    <span data-target="mempool.voteTotal">{{threeSigFigs .LikelyMineable.VoteTotal}}</span> DCR
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <div class="text-center text-secondary fs13">Revocations</div>
+                                <div class="text-center h4 mb-0" data-target="mempool.revCount">{{.NumRevokes}}</div>
+                                <div class="text-center fs13">
+                                    <span data-target="mempool.revTotal">{{threeSigFigs .LikelyMineable.RevokeTotal}}</span> DCR
+                                </div>
+                            </div>
                         </div>
                     </div>
+
                 </div>
             </div>
             <div class="v2-tables">
               <div class="row">
                   <div class="col-sm-24">
-                  <h4 class="pt-5 pb-3"><span>Votes</span></h4>
+                  <h4 class="pt-3 pb-2"><span>Votes</span></h4>
 
                       <table class="table striped">
                           <thead>
@@ -173,7 +158,7 @@
               </div>
               <div class="row">
                   <div class="col-sm-24">
-                  <h4 class="pt-5 pb-3"><span>Tickets</span></h4>
+                  <h4 class="pt-4 pb-2"><span>Tickets</span></h4>
                       <table class="table striped">
                           <thead>
                               <th>Transaction ID</th>
@@ -207,7 +192,7 @@
 
               <div class="row">
                   <div class="col-sm-24">
-                  <h4 class="pt-5 pb-3"><span>Revokes</span></h4>
+                  <h4 class="pt-5 pb-2"><span>Revokes</span></h4>
                       <table class="table striped">
                           <thead>
                               <th>Transaction ID</th>
@@ -241,7 +226,7 @@
 
               <div class="row">
                   <div class="col-sm-24">
-                  <h4 class="pt-5 pb-3"><span>Transactions</span></h4>
+                  <h4 class="pt-5 pb-2"><span>Transactions</span></h4>
                       <table class="table striped">
                           <thead>
                             <tr>


### PR DESCRIPTION
* Make top margin the same as other pages ( If there's interest in increasing the amount of top margin for page headings, it should be done globally, so the heading is always at the same height between the various pages )
* Increase font size of overview stat values
* Rework layout of secondary card to same labeling style as primary card
* Reduce spacing between tables

Current:
<img width="1277" alt="screen shot 2019-02-16 at 10 17 59 pm" src="https://user-images.githubusercontent.com/25571523/52901050-f74bad00-3238-11e9-8dc5-93131c8fadef.png">

Proposed Changes:
<img width="1275" alt="proposed" src="https://user-images.githubusercontent.com/25571523/52901025-a340c880-3238-11e9-9558-722a6c5b3220.png">

proposed changes (mobile):
<img width="399" alt="screen shot 2019-02-16 at 10 15 17 pm" src="https://user-images.githubusercontent.com/25571523/52901072-34b03a80-3239-11e9-8f09-39232624c524.png">
