### PR TITLE
dcrpg/explorer: link to the block where a missed ticket failed to vote

### DIFF
--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -334,6 +334,14 @@ const (
 
 	SelectMissesInBlock = `SELECT ticket_hash FROM misses WHERE block_hash = $1;`
 
+	SelectMissesForTicket = `SELECT height, block_hash FROM misses WHERE ticket_hash = $1;`
+
+	SelectMissesMainchainForTicket = `SELECT misses.height, misses.block_hash
+		FROM misses
+		JOIN blocks ON misses.block_hash=blocks.hash
+		WHERE ticket_hash = $1
+			AND blocks.is_mainchain = TRUE;`
+
 	// agendas table
 
 	CreateAgendasTable = `CREATE TABLE IF NOT EXISTS agendas (

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -81,6 +81,7 @@ type explorerDataSource interface {
 	DevBalance() (*dbtypes.AddressBalance, error)
 	FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)
+	TicketMiss(ticketHash string) (string, int64, error)
 	GetPgChartsData() (map[string]*dbtypes.ChartsData, error)
 	TicketsPriceByHeight() (*dbtypes.ChartsData, error)
 	SideChainBlocks() ([]*dbtypes.BlockStatus, error)
@@ -170,7 +171,7 @@ func TicketStatusText(s dbtypes.TicketSpendType, p dbtypes.TicketPoolStatus) str
 		case dbtypes.TicketUnspent:
 			return "Missed, Unrevoked"
 		case dbtypes.TicketRevoked:
-			return "Missed, Reevoked"
+			return "Missed, Revoked"
 		default:
 			return "invalid ticket state"
 		}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -180,6 +180,7 @@ type TicketInfo struct {
 	TimeTillMaturity     float64 // Time before a particular ticket reaches maturity, in hours
 	PoolStatus           string
 	SpendStatus          string
+	LotteryBlock         string  // If the ticket was chosen to vote, it was chosen to vote in this block.
 	TicketPoolSize       int64   // Total number of ticket in the pool
 	TicketExpiry         int64   // Total number of blocks before a ticket expires
 	TicketExpiryDaysLeft float64 // Approximate days left before the given ticket expires

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -86,7 +86,11 @@
                               {{if eq .Confirmations .TicketInfo.TicketMaturity}}
                                 live /
                               {{else}}
-                                {{.TicketInfo.PoolStatus}}  /
+                                {{if .TicketInfo.LotteryBlock}}
+                                  <a href="/block/{{.TicketInfo.LotteryBlock}}">{{.TicketInfo.PoolStatus}}</a> /
+                                {{else}}
+                                  {{.TicketInfo.PoolStatus}}  /
+                                {{end}}
                               {{end}}
                             {{end}}
                             {{if (index .SpendingTxns 0).Hash}}


### PR DESCRIPTION
dcrpg: Add queries to locate the block in which a ticket missed via the
misses table.  Join with the blocks table to limit to mainchain.

explorerer: Add `TicketMiss(ticketHash string) (string, int64, error)` to
the `explorerDataSource` interface.
Use `TicketMiss` in `(*explorerUI).TxPage`, to retrieve the block hash for a ticket's
missed vote.

explorer/types: Add `LotteryBlock` to `TicketInfo`. `LotteryBlock` represents
the hash of the block in which a tickets was is supposed to vote.

views: Link the "missed" text to the lottery block where it is listed as
a missed vote.

![image](https://user-images.githubusercontent.com/9373513/52907820-dc743b00-322e-11e9-9535-40909d5094b7.png)
