### PR TITLE
dcrpg: this adds a UTXO cache refresh capability

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -684,6 +684,20 @@ type Vout struct {
 	ScriptPubKeyData ScriptPubKeyData `json:"pkScript"`
 }
 
+// UTXOData stores an address and value associated with a transaction output.
+type UTXOData struct {
+	Addresses []string
+	Value     int64
+}
+
+// UTXO represents a transaction output, but it is intended to help track
+// unspent outputs.
+type UTXO struct {
+	TxHash  string
+	TxIndex uint32
+	UTXOData
+}
+
 // AddressRow represents a row in the addresses table
 type AddressRow struct {
 	// id int64

--- a/main.go
+++ b/main.go
@@ -430,26 +430,6 @@ func _main(ctx context.Context) error {
 			return fmt.Errorf("Node is still syncing. Node height = %d, "+
 				"DB height = %d", expectedHeight, heightDB)
 		}
-		// (TODO@chappjc) The following overrides of updateAllAddresses and
-		// newPGIndexes are COMMENTED OUT until the utxoStore/utxoCache can be
-		// pre-charged. This is because without indexes and without a
-		// well-populated utxo cache, the query the value and corresponding
-		// address for a UTXO is far too slow. In an initial sync, the utxo
-		// cache is effective as it gets filled from the start of the chain, but
-		// when starting at an arbitrary block the cache is empty. But the
-		// queries to look up the data on a cache miss rely on the indexes for
-		// acceptable performance.
-		//
-		// if blocksBehind > 7500 {
-		//  log.Warnf("Setting PSQL sync to rebuild address table after large "+
-		//      "import (%d blocks).", blocksBehind)
-		//  updateAllAddresses = true
-		//  if blocksBehind > 40000 {
-		//      log.Warnf("Setting PSQL sync to drop indexes prior to bulk data "+
-		//          "import (%d blocks).", blocksBehind)
-		//      newPGIndexes = true
-		//  }
-		// }
 
 		// PG gets winning tickets out of baseDB's pool info cache, so it must
 		// be big enough to hold the needed blocks' info, and charged with the


### PR DESCRIPTION
Add a UTXO set query, `RetrieveUTXOs`.
Run `RetrieveUTXOs` in `main` when resuming sync with no indexes.
Change `dbtypes.UTXOData` to have a `[]string` addresses instead of a
single address (bare multisig is supported now).
`insertSpendingAddressRow` inserts rows for all addresses of a tx output.
Add `(*utxoStore).Reinit` and `(*ChainDB).InitUtxoCache` to populate the
UTXO cache.

Resolves https://github.com/decred/dcrdata/issues/1028