### PR TITLE
api: add raw block header endpoints

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -38,7 +38,10 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/", app.getBlockSummary) // app.getLatestBlock
 			rd.Get("/height", app.currentHeight)
 			rd.Get("/hash", app.getBlockHash)
-			rd.Get("/header", app.getBlockHeader)
+			rd.Route("/header", func(rt chi.Router) {
+				rt.Get("/", app.getBlockHeader)
+				rt.Get("/raw", app.getBlockHeaderRaw)
+			})
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
@@ -54,7 +57,10 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Use(app.BlockHashPathAndIndexCtx)
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/height", app.getBlockHeight)
-			rd.Get("/header", app.getBlockHeader)
+			rd.Route("/header", func(rt chi.Router) {
+				rt.Get("/", app.getBlockHeader)
+				rt.Get("/raw", app.getBlockHeaderRaw)
+			})
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
@@ -69,7 +75,10 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 		r.Route("/{idx}", func(rd chi.Router) {
 			rd.Use(m.BlockIndexPathCtx)
 			rd.Get("/", app.getBlockSummary)
-			rd.Get("/header", app.getBlockHeader)
+			rd.Route("/header", func(rt chi.Router) {
+				rt.Get("/", app.getBlockHeader)
+				rt.Get("/raw", app.getBlockHeaderRaw)
+			})
 			rd.Get("/hash", app.getBlockHash)
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -501,6 +501,15 @@ func (db *WiredDB) GetBlockByHash(hash string) (*wire.MsgBlock, error) {
 	return db.client.GetBlock(blockHash)
 }
 
+func (db *WiredDB) GetBlockHeaderByHash(hash string) (*wire.BlockHeader, error) {
+	blockHash, err := chainhash.NewHashFromStr(hash)
+	if err != nil {
+		log.Errorf("Invalid block hash %s", hash)
+		return nil, err
+	}
+	return db.client.GetBlockHeader(blockHash)
+}
+
 func (db *WiredDB) CoinSupply() (supply *apitypes.CoinSupply) {
 	coinSupply, err := db.client.GetCoinSupply()
 	if err != nil {


### PR DESCRIPTION
This adds the following endpoints:

    - /block/best/header/raw
    - /block/{ind}/header/raw
    - /block/hash/{hash}/header/raw

Use the same api/types.BlockRaw type as used for the raw block endpoints