### PR TITLE
Fix bugs on the blocks listing pages' dropdown menus

### DIFF
--- a/public/js/controllers/blocklist_controller.js
+++ b/public/js/controllers/blocklist_controller.js
@@ -1,12 +1,10 @@
-/* global Turbolinks */
 import { Controller } from 'stimulus'
-import Url from 'url-parse'
 import globalEventBus from '../services/event_bus_service'
 import humanize from '../helpers/humanize_helper'
 
 export default class extends Controller {
   static get targets () {
-    return ['pagesize', 'listview', 'table']
+    return ['table']
   }
 
   connect () {
@@ -17,27 +15,6 @@ export default class extends Controller {
 
   disconnect () {
     globalEventBus.off('BLOCK_RECEIVED', this.processBlock)
-  }
-
-  setPageSize () {
-    var controller = this
-    var queryData = {}
-    queryData[controller.data.get('offsetKey')] = controller.pageOffset
-    queryData.rows = controller.pagesizeTarget.selectedOptions[0].value
-    var url = Url(window.location.href, true)
-    url.set('query', queryData)
-    Turbolinks.visit(url.href)
-  }
-
-  setListView () {
-    var url = Url(window.location.href, true)
-    var newPeriod = this.listviewTarget.selectedOptions[0].value
-    if (url.pathname !== newPeriod) {
-      delete url.query.offset
-      delete url.query.rows
-    }
-    url.set('pathname', newPeriod)
-    Turbolinks.visit(url.href)
   }
 
   _processBlock (blockData) {

--- a/public/js/controllers/pagenavigation_controller.js
+++ b/public/js/controllers/pagenavigation_controller.js
@@ -12,6 +12,9 @@ export default class extends Controller {
     var q = Url.qs.parse(url.query)
     q['offset'] = this.pagesizeTarget.dataset.offset
     q['rows'] = this.pagesizeTarget.selectedOptions[0].value
+    if (this.hasVotestatusTarget) {
+      q['byvotestatus'] = this.votestatusTarget.selectedOptions[0].value
+    }
     url.set('query', q)
     Turbolinks.visit(url.toString())
   }

--- a/public/js/controllers/pagenavigation_controller.js
+++ b/public/js/controllers/pagenavigation_controller.js
@@ -4,12 +4,12 @@ import Url from 'url-parse'
 
 export default class extends Controller {
   static get targets () {
-    return ['pagesize', 'votestatus']
+    return ['pagesize', 'votestatus', 'listview']
   }
 
   setPageSize () {
-    let url = Url(window.location.href)
-    let q = Url.qs.parse(url.query)
+    var url = Url(window.location.href)
+    var q = Url.qs.parse(url.query)
     q['offset'] = this.pagesizeTarget.dataset.offset
     q['rows'] = this.pagesizeTarget.selectedOptions[0].value
     url.set('query', q)
@@ -17,10 +17,21 @@ export default class extends Controller {
   }
 
   setFilterbyVoteStatus () {
-    let url = Url(window.location.href)
-    let q = {}
+    var url = Url(window.location.href)
+    var q = {}
     q['byvotestatus'] = this.votestatusTarget.selectedOptions[0].value
     url.set('query', q)
     Turbolinks.visit(url.toString())
+  }
+
+  setListView () {
+    var url = Url(window.location.href, true)
+    var newPeriod = this.listviewTarget.selectedOptions[0].value
+    if (url.pathname !== newPeriod) {
+      delete url.query.offset
+      delete url.query.rows
+    }
+    url.set('pathname', newPeriod)
+    Turbolinks.visit(url.href)
   }
 }

--- a/public/js/controllers/pagenavigation_controller.js
+++ b/public/js/controllers/pagenavigation_controller.js
@@ -10,7 +10,9 @@ export default class extends Controller {
   setPageSize () {
     var url = Url(window.location.href)
     var q = Url.qs.parse(url.query)
-    q['offset'] = this.pagesizeTarget.dataset.offset
+    delete q.offset
+    delete q.height
+    q[this.pagesizeTarget.dataset.offsetkey] = this.pagesizeTarget.dataset.offset
     q['rows'] = this.pagesizeTarget.selectedOptions[0].value
     if (this.hasVotestatusTarget) {
       q['byvotestatus'] = this.votestatusTarget.selectedOptions[0].value
@@ -31,8 +33,7 @@ export default class extends Controller {
     var url = Url(window.location.href, true)
     var newPeriod = this.listviewTarget.selectedOptions[0].value
     if (url.pathname !== newPeriod) {
-      delete url.query.offset
-      delete url.query.rows
+      url.set('query', {})
     }
     url.set('pathname', newPeriod)
     Turbolinks.visit(url.href)

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -5,7 +5,7 @@
 {{template "html-head" "Decred Blocks List"}}
 <body class="{{ theme }}">
     {{template "navbar" . }}
-    <div class="container main" data-controller="time blocklist">
+    <div class="container main" data-controller="time pagenavigation blocklist">
         <h4>Blocks</h4>
         {{$pendingBlocks := 0}}
         {{if gt (len $.Data) 0}}{{$pendingBlocks = ((index .Data 0).Height)}}{{end}}
@@ -24,10 +24,9 @@
                     <label class="mb-0 mr-1" for="blocksPagesize">Page Size</label>
                     <select
                         id="blocksPagesize"
-                        data-target="blocklist.pagesize"
-                        data-action="change->blocklist#setPageSize"
-                        data-blocklist-initial-offset="{{$pendingBlocks}}"
-                        data-blocklist-offset-key="height"
+                        data-target="pagenavigation.pagesize"
+                        data-action="change->pagenavigation#setPageSize"
+                        data-offset="{{$pendingBlocks}}"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $blocksCount 20}}disabled{{end}}"
                         {{if lt $blocksCount 20}}disabled="disabled"{{end}}
                     >

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -27,6 +27,7 @@
                         data-target="pagenavigation.pagesize"
                         data-action="change->pagenavigation#setPageSize"
                         data-offset="{{$pendingBlocks}}"
+                        data-offsetkey="height"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $blocksCount 20}}disabled{{end}}"
                         {{if lt $blocksCount 20}}disabled="disabled"{{end}}
                     >

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -172,8 +172,8 @@
     <div class="fs12 nowrap text-left" style="margin:auto auto auto 0px;">
         <select
           class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
-          data-target="blocklist.listview"
-          data-action="change->blocklist#setListView"
+          data-target="pagenavigation.listview"
+          data-action="change->pagenavigation#setListView"
           >
             <option {{if eq . "years"}}selected{{end}} value="years">Years</option>
             <option {{if eq . "months"}}selected{{end}} value="months">Months</option>

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -52,6 +52,7 @@
                                 data-target="pagenavigation.pagesize"
                                 data-action="change->pagenavigation#setPageSize"
                                 data-offset="{{$.Offset}}"
+                                data-offsetkey="offset"
                                 class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 10}}disabled{{end}}"
                                 {{if lt $pending 10}}disabled="disabled"{{end}}
                             >

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -4,7 +4,7 @@
     {{template "html-head" printf "Decred Vote Proposals Page"}}
     <body class="{{ theme }}">
         {{template "navbar" .}}
-        <div class="container main" data-controller="ticketwindow">
+        <div class="container main" data-controller="pagenavigation">
             <div class="row justify-content-between">
                 <div class="col-sm-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">Politeia Proposals</h4>
@@ -19,8 +19,8 @@
                             <select
                                 id="votestatus"
                                 class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
-                                data-target="ticketwindow.votestatus"
-                                data-action="change->ticketwindow#setFilterbyVoteStatus"
+                                data-target="pagenavigation.votestatus"
+                                data-action="change->pagenavigation#setFilterbyVoteStatus"
                             >
                                 <option value="all">All</option>
                                 {{range $k, $v := .VotesStatus}}
@@ -49,8 +49,8 @@
                             <label class="mb-0 mr-1" for="tbPagesize">Page Size</label>
                             <select
                                 id="tbPagesize"
-                                data-target="ticketwindow.pagesize"
-                                data-action="change->ticketwindow#setPageSize"
+                                data-target="pagenavigation.pagesize"
+                                data-action="change->pagenavigation#setPageSize"
                                 data-offset="{{$.Offset}}"
                                 class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 10}}disabled{{end}}"
                                 {{if lt $pending 10}}disabled="disabled"{{end}}
@@ -71,28 +71,28 @@
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="?offset=0&rows={{.Limit}}"
+                                        href="?offset=0&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
                                         id="next"
                                     > Newest</a>
                                 </li>
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="?offset={{subtract .Offset .Limit}}&rows={{.Limit}}"
+                                        href="?offset={{subtract .Offset .Limit}}&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
                                         id="next"
                                     > Newer</a>
                                 </li>
                                 <li class="page-item {{if ge $oldest $.TotalCount}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="?offset={{add .Offset .Limit}}&rows={{.Limit}}"
+                                        href="?offset={{add .Offset .Limit}}&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
                                         id="prev"
                                     >Older</a>
                                 </li>
                                 <li class="page-item {{if ge $oldest $.TotalCount}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="?offset={{subtract $.TotalCount .Limit}}&rows={{.Limit}}"
+                                        href="?offset={{subtract $.TotalCount .Limit}}&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
                                         id="prev"
                                     >Oldest</a>
                                 </li>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -30,6 +30,7 @@
                             data-target="pagenavigation.pagesize"
                             data-action="change->pagenavigation#setPageSize"
                             data-offset="{{$.Offset}}"
+                            data-offsetkey="offset"
                             class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 20}}disabled{{end}}"
                             {{if lt $pending 20}}disabled="disabled"{{end}}
                         >

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -18,6 +18,9 @@
                     {{$lastGrouping := (add .BestGrouping 1)}}
                     {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
                     {{$pending := (subtract $lastGrouping .Offset)}}
+                    {{$dropVal := $lastGrouping}}
+                    {{if gt $lastGrouping 200}}{{$dropVal = 200}}{{end}}
+
                     {{template "listViewRouting" $lowerCaseVal}}
 
                     <span class="fs12 nowrap text-right">
@@ -34,10 +37,8 @@
                         {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30</option>{{end}}
                         {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50</option>{{end}}
                         {{if ge $pending 100}}<option {{if eq $count 100}}selected{{end}} value="100">100</option>{{end}}
-                        {{if eq $lastGrouping $count 20 30 50 100}}{{else}}
-                            <option value="{{$lastGrouping}}">{{if gt $lastGrouping 400}}400{{else}}{{$lastGrouping}}{{end}}</option>
-                        {{end}}
-                        {{if eq $count 20 30 50 100}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
+                        {{if eq $dropVal $count 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}}</option>{{end}}
+                        {{if eq $count 20 30 50 100 200}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
                         </select>
                     </span>
                     <span class="fs12 nowrap text-right">

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -5,7 +5,7 @@
 {{template "html-head" printf "Decred %s List" .TimeGrouping}}
 <body class="{{ theme }}">
     {{template "navbar" . }}
-    <div class="container main" data-controller="time blocklist">
+    <div class="container main" data-controller="time pagenavigation">
         <div style="margin: auto auto 1rem; width: 80%; max-width: 80%;">
             <h4>{{.TimeGrouping}}</h4>
 
@@ -24,10 +24,9 @@
                         <label class="mb-0 mr-1" for="tbPagesize">Page Size</label>
                         <select
                             id="tbPagesize"
-                            data-target="blocklist.pagesize"
-                            data-action="change->blocklist#setPageSize"
-                            data-blocklist-initial-offset="{{$.Offset}}"
-                            data-blocklist-offset-key="offset"
+                            data-target="pagenavigation.pagesize"
+                            data-action="change->pagenavigation#setPageSize"
+                            data-offset="{{$.Offset}}"
                             class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 20}}disabled{{end}}"
                             {{if lt $pending 20}}disabled="disabled"{{end}}
                         >
@@ -35,7 +34,9 @@
                         {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30</option>{{end}}
                         {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50</option>{{end}}
                         {{if ge $pending 100}}<option {{if eq $count 100}}selected{{end}} value="100">100</option>{{end}}
-                        {{if eq $lastGrouping $count 20 30 50 100}}{{else}}<option value="{{$lastGrouping}}">{{$lastGrouping}}</option>{{end}}
+                        {{if eq $lastGrouping $count 20 30 50 100}}{{else}}
+                            <option value="{{$lastGrouping}}">{{if gt $lastGrouping 400}}400{{else}}{{$lastGrouping}}{{end}}</option>
+                        {{end}}
                         {{if eq $count 20 30 50 100}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
                         </select>
                     </span>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -28,6 +28,7 @@
                         data-target="pagenavigation.pagesize"
                         data-action="change->pagenavigation#setPageSize"
                         data-offset="{{$.OffsetWindow}}"
+                        data-offsetkey="offset"
                         id="windowsPagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pendingWindows 20}}disabled{{end}}"
                         {{if lt $pendingWindows 20}}disabled="disabled"{{end}}

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -16,6 +16,9 @@
             <div class="d-flex flex-wrap-reverse align-items-center justify-content-end list-display">
                 {{$oldest := (add .OffsetWindow $windowsCount)}}
                 {{$lastWindow := (add .BestWindow 1)}}
+                {{$dropVal := $lastWindow}}
+                {{if gt $lastWindow 200}}{{$dropVal = 200}}{{end}}
+
                 {{template "listViewRouting" "windows"}}
 
                 <span class="fs12 nowrap text-right">
@@ -33,10 +36,8 @@
                     {{if ge $pendingWindows 30}}<option {{if eq $windowsCount 30}}selected{{end}} value="30">30</option>{{end}}
                     {{if ge $pendingWindows 50}}<option {{if eq $windowsCount 50}}selected{{end}} value="50">50</option>{{end}}
                     {{if ge $pendingWindows 100}}<option {{if eq $windowsCount 100}}selected{{end}} value="100">100</option>{{end}}
-                    {{if eq $lastWindow $windowsCount 20 30 50 100}}{{else}}
-                        <option value="{{$lastWindow}}">{{if gt $lastWindow 400}}400{{else}}{{$lastWindow}}{{end}}</option>
-                    {{end}}
-                    {{if eq $windowsCount 20 30 50 100}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}}</option>{{end}}
+                    {{if eq $dropVal $windowsCount 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}}</option>{{end}}
+                    {{if eq $windowsCount 20 30 50 100 200}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}}</option>{{end}}
                     </select>
                 </span>
                 <span class="fs12 nowrap text-right">

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -3,7 +3,7 @@
 <html lang="en">
 
 {{template "html-head" "Decred Windows List"}}
-<body class="{{ theme }}" data-controller="ticketwindow blocklist">
+<body class="{{ theme }}" data-controller="pagenavigation">
     {{template "navbar" . }}
     <div class="container main">
         <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>
@@ -22,8 +22,8 @@
                     <label class="mb-0 mr-1" for="windowsPagesize">Page Size</label>
                     <select
                         name="windows-pagesize"
-                        data-target="ticketwindow.pagesize"
-                        data-action="change->ticketwindow#setPageSize"
+                        data-target="pagenavigation.pagesize"
+                        data-action="change->pagenavigation#setPageSize"
                         data-offset="{{$.OffsetWindow}}"
                         id="windowsPagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pendingWindows 20}}disabled{{end}}"
@@ -33,7 +33,9 @@
                     {{if ge $pendingWindows 30}}<option {{if eq $windowsCount 30}}selected{{end}} value="30">30</option>{{end}}
                     {{if ge $pendingWindows 50}}<option {{if eq $windowsCount 50}}selected{{end}} value="50">50</option>{{end}}
                     {{if ge $pendingWindows 100}}<option {{if eq $windowsCount 100}}selected{{end}} value="100">100</option>{{end}}
-                    {{if eq $lastWindow $windowsCount 20 30 50 100}}{{else}}<option value="{{$lastWindow}}">{{$lastWindow}}</option>{{end}}
+                    {{if eq $lastWindow $windowsCount 20 30 50 100}}{{else}}
+                        <option value="{{$lastWindow}}">{{if gt $lastWindow 400}}400{{else}}{{$lastWindow}}{{end}}</option>
+                    {{end}}
                     {{if eq $windowsCount 20 30 50 100}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}}</option>{{end}}
                     </select>
                 </span>


### PR DESCRIPTION
This PR fixes the following bugs on the `/ticketpricewindows` , `/blocks`, `/days`, `/weeks`, `/months` and `/years` pages drop down menus.
- #1036 - fixed by having all those pages share stimulus js controller functions

- On Changing the page size on `/blocks`, `/days`, `/weeks`, `/months` and `/years` pages, some invalid URL query parameters were set.
![screenshot from 2019-02-22 00-38-49](https://user-images.githubusercontent.com/22055953/53203483-5abf4b80-363a-11e9-90cc-6a66ab9f113f.png)

- The pagesize dropdown never had a limit to the maximum page size that can be set. The maximum page size set via the drop down has been capped at 200.

