### PR TITLE
Order chainwork query by block height

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -198,7 +198,7 @@ const (
 	UpdateBlockNextByNextHash = `UPDATE block_chain SET next_hash = $2 WHERE next_hash = $1;`
 
 	// Grab the timestamp and chainwork.
-	SelectChainWork = `SELECT time, chainwork FROM blocks WHERE is_mainchain = true ORDER BY time;`
+	SelectChainWork = `SELECT time, chainwork FROM blocks WHERE is_mainchain = true ORDER BY height;`
 
 	// TODO: index block_chain where needed
 )


### PR DESCRIPTION
Resolves #1004. I did verify that dygraphs handles out of order timestamps without issue. 
