### PR TITLE
views/home: data-type of size column needs to be "size"

### DIFF
--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -77,7 +77,7 @@
                                         <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
                                         <td class="text-center" data-type="revocations">{{.Revocations}}</td>
                                         <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
-                                        <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="value">{{.FormattedBytes}}</td>
+                                        <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="size">{{.FormattedBytes}}</td>
                                         <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime.UNIX}}">{{.BlockTime}}</td>
                                     </tr>
                                     {{end}}


### PR DESCRIPTION
data-type of the size column on the Latest Blocks table was set to
"value" instead of "size".  This broke websocket JS updates.

Resolving https://github.com/decred/dcrdata/issues/1043