### PR TITLE
views/controllers: stop showing vote reward rates in color

### DIFF
--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -178,7 +178,7 @@ export default class extends Controller {
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`
     this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
-    this.ticketRewardTarget.innerHTML = humanize.fmtPercentage(ex.reward)
+    this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)} %`
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     if (this.hasDevFundTarget) this.devFundTarget.innerHTML = humanize.decimalParts(ex.dev_fund / 100000000, true, 0)
     this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -178,7 +178,7 @@ export default class extends Controller {
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`
     this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
-    this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)} %`
+    this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     if (this.hasDevFundTarget) this.devFundTarget.innerHTML = humanize.decimalParts(ex.dev_fund / 100000000, true, 0)
     this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -270,9 +270,9 @@
                                 <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-target="homepage.ticketReward">{{printf "%.2f" .TicketReward}} %</span> per ~{{.RewardPeriod}}
+                                <span data-target="homepage.ticketReward">{{printf "%.2f" .TicketReward}}%</span> per ~{{.RewardPeriod}}
                             </div>
-                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}} % per year</div>
+                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}}% per year</div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Total Staked DCR</div>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -270,9 +270,9 @@
                                 <span class="pl-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-target="homepage.ticketReward">{{template "fmtPercentage" .TicketReward}}</span> per ~{{.RewardPeriod}}
+                                <span data-target="homepage.ticketReward">{{printf "%.2f" .TicketReward}} %</span> per ~{{.RewardPeriod}}
                             </div>
-                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards"><span class="text-green">+{{printf "%.2f" .ASR}} %</span> per year</div>
+                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}} % per year</div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Total Staked DCR</div>


### PR DESCRIPTION
The vote rewards (both per average reward period and yearly) need not be
shown with green for positive.

In the following section, the vote rewards do not need a color to indicate sign.

![image](https://user-images.githubusercontent.com/9373513/53350378-9715d480-38e4-11e9-9428-4be1dc9cff4b.png)

Change this to:

![image](https://user-images.githubusercontent.com/9373513/53350851-a0ec0780-38e5-11e9-9ea7-3acec1d4b581.png)

Note that this also removes the space before the percent symbol.