### PR TITLE
explorer: change hashrate change from daily to monthly

### DIFF
--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -361,8 +361,8 @@ type HomeInfo struct {
 	PoolInfo              TicketPoolInfo `json:"pool_info"`
 	TotalLockedDCR        float64        `json:"total_locked_dcr"`
 	HashRate              float64        `json:"hash_rate"`
-	// HashRateChange defines the hashrate change in 24hrs
-	HashRateChange float64 `json:"hash_rate_change"`
+	HashRateChangeDay     float64        `json:"hash_rate_change_day"`
+	HashRateChangeMonth   float64        `json:"hash_rate_change_month"`
 }
 
 // BlockSubsidy is an implementation of dcrjson.GetBlockSubsidyResult

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -182,7 +182,7 @@ export default class extends Controller {
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     if (this.hasDevFundTarget) this.devFundTarget.innerHTML = humanize.decimalParts(ex.dev_fund / 100000000, true, 0)
     this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)
-    this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change)
+    this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
     this.blockVotesTarget.dataset.hash = blockData.block.hash
     this.setVotes()
     let block = blockData.block

--- a/pubsub/psclient/client_test.go
+++ b/pubsub/psclient/client_test.go
@@ -674,7 +674,8 @@ var msgNewBlock312592 = &pstypes.WebSocketMessage{
 			},
 			"total_locked_dcr": 0,
 			"hash_rate": 248.56734363605156,
-			"hash_rate_change": 7.2007116787749466
+			"hash_rate_change_day": 7.2007116787749466,
+			"hash_rate_change_month": 134.0
 		}
 	}
 	`,

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -311,7 +311,7 @@
                                 <span class="pl-1 unit lh15rem">Ph/s</span>
                             </div>
                             <div class="fs12 text-black-50 lh1rem text-black-50">
-                                <span data-target="homepage.hashrateDelta">{{template "fmtPercentage" .HashRateChange}}</span> in past 24h
+                                <span data-target="homepage.hashrateDelta">{{template "fmtPercentage" .HashRateChangeMonth}}</span> in past 30 days
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">


### PR DESCRIPTION
Keep daily hashrate in a separate variable for now.
This changes the `explorer/types.HomeInfo` variable and its JSON tags. It
now has `hash_rate_change_day` and `hash_rate_change_month` instead of just
`hash_rate_change`.
Update homepage controller to set `hashrateDeltaTarget` to monthly delta.

The hash rate is very choppy on a daily basis, so show monthly like this:

![image](https://user-images.githubusercontent.com/9373513/53356733-b23b1100-38f1-11e9-85a7-86c9c557b528.png)

instead of daily:

![image](https://user-images.githubusercontent.com/9373513/53356755-c0892d00-38f1-11e9-8bdf-bd53207bd19d.png)
