### PR TITLE
view/home: display exchange rate with all big digits and two decimals

### DIFF
--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -389,7 +389,7 @@
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Exchange Rate</div>
                             <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                                <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span>
+                                <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 2 true 2)}}</span>
                                 <span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
                             </div>
                         </div>


### PR DESCRIPTION
Show exchange rate like this:

![image](https://user-images.githubusercontent.com/9373513/53368091-744be600-390d-11e9-880a-9842719f7b56.png)


instead of this (nevermind the number):

![image](https://user-images.githubusercontent.com/9373513/53368119-862d8900-390d-11e9-86f5-59a9777538c6.png)

This is based on feedback from jy-p, who raises a good point. 90 cents shouldn't be a much smaller font.  Also, fractions of cents don't have any real significance.