### PR TITLE
more fiat conversions

### DIFF
--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -692,3 +692,34 @@ func (bot *ExchangeBot) Price() float64 {
 	defer bot.RUnlock()
 	return bot.currentState.Price
 }
+
+// Conversion is a representation of some amount of DCR in another index.
+type Conversion struct {
+	Value float64 `json:"value"`
+	Index string  `json:"index"`
+}
+
+// TwoDecimals is a string representation of the value with two digits after
+// the decimal point, but will show more to achieve at least three significant
+// digits.
+func (c *Conversion) TwoDecimals() string {
+	if c.Value == 0.0 {
+		return "0.00"
+	} else if c.Value < 1.0 && c.Value > -1.0 {
+		return fmt.Sprintf("%3g", c.Value)
+	}
+	return fmt.Sprintf("%.2f", c.Value)
+}
+
+// Conversion attempts to multiply the supplied float with the default index.
+// Nil pointer will be returned if there is no valid exchangeState.
+func (bot *ExchangeBot) Conversion(dcrVal float64) *Conversion {
+	xcState := bot.State()
+	if xcState != nil {
+		return &Conversion{
+			Value: xcState.Price * dcrVal,
+			Index: xcState.BtcIndex,
+		}
+	}
+	return nil
+}

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -582,6 +582,11 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		exp.ChainParams.TargetTimePerBlock.Hours()/24)
 	p.HomeInfo.ASR = ASR
 
+	// If exchange monitoring is enabled, set the exchange rate.
+	if exp.xcBot != nil {
+		p.HomeInfo.ExchangeRate = exp.xcBot.Conversion(1.0)
+	}
+
 	p.Unlock()
 
 	if !exp.liteMode && exp.devPrefetch {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/dcrjson/v2"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/txhelpers"
 	humanize "github.com/dustin/go-humanize"
 )
@@ -389,26 +390,27 @@ type BlockInfo struct {
 
 // HomeInfo represents data used for the home page
 type HomeInfo struct {
-	CoinSupply            int64          `json:"coin_supply"`
-	StakeDiff             float64        `json:"sdiff"`
-	NextExpectedStakeDiff float64        `json:"next_expected_sdiff"`
-	NextExpectedBoundsMin float64        `json:"next_expected_min"`
-	NextExpectedBoundsMax float64        `json:"next_expected_max"`
-	IdxBlockInWindow      int            `json:"window_idx"`
-	IdxInRewardWindow     int            `json:"reward_idx"`
-	Difficulty            float64        `json:"difficulty"`
-	DevFund               int64          `json:"dev_fund"`
-	DevAddress            string         `json:"dev_address"`
-	TicketReward          float64        `json:"reward"`
-	RewardPeriod          string         `json:"reward_period"`
-	ASR                   float64        `json:"ASR"`
-	NBlockSubsidy         BlockSubsidy   `json:"subsidy"`
-	Params                ChainParams    `json:"params"`
-	PoolInfo              TicketPoolInfo `json:"pool_info"`
-	TotalLockedDCR        float64        `json:"total_locked_dcr"`
-	HashRate              float64        `json:"hash_rate"`
-	HashRateChangeDay     float64        `json:"hash_rate_change_day"`
-	HashRateChangeMonth   float64        `json:"hash_rate_change_month"`
+	CoinSupply            int64                 `json:"coin_supply"`
+	StakeDiff             float64               `json:"sdiff"`
+	NextExpectedStakeDiff float64               `json:"next_expected_sdiff"`
+	NextExpectedBoundsMin float64               `json:"next_expected_min"`
+	NextExpectedBoundsMax float64               `json:"next_expected_max"`
+	IdxBlockInWindow      int                   `json:"window_idx"`
+	IdxInRewardWindow     int                   `json:"reward_idx"`
+	Difficulty            float64               `json:"difficulty"`
+	DevFund               int64                 `json:"dev_fund"`
+	DevAddress            string                `json:"dev_address"`
+	TicketReward          float64               `json:"reward"`
+	RewardPeriod          string                `json:"reward_period"`
+	ASR                   float64               `json:"ASR"`
+	NBlockSubsidy         BlockSubsidy          `json:"subsidy"`
+	Params                ChainParams           `json:"params"`
+	PoolInfo              TicketPoolInfo        `json:"pool_info"`
+	TotalLockedDCR        float64               `json:"total_locked_dcr"`
+	HashRate              float64               `json:"hash_rate"`
+	HashRateChangeDay     float64               `json:"hash_rate_change_day"`
+	HashRateChangeMonth   float64               `json:"hash_rate_change_month"`
+	ExchangeRate          *exchanges.Conversion `json:"exchange_rate,omitempty"`
 }
 
 // BlockSubsidy is an implementation of dcrjson.GetBlockSubsidyResult

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -43,7 +43,8 @@ export default class extends Controller {
       'mpRegTotal', 'mpRegCount', 'mpTicketTotal', 'mpTicketCount', 'mpVoteTotal', 'mpVoteCount',
       'mpRevTotal', 'mpRevCount', 'mpRegBar', 'mpVoteBar', 'mpTicketBar',
       'mpRevBar', 'voteTally', 'blockVotes', 'blockHeight', 'blockSize',
-      'blockTotal', 'consensusMsg'
+      'blockTotal', 'consensusMsg', 'powConverted', 'convertedDev',
+      'convertedSupply', 'convertedDevSub', 'exchangeRate', 'convertedStake'
     ]
   }
 
@@ -190,5 +191,28 @@ export default class extends Controller {
     this.blockHeightTarget.href = `/block/${block.hash}`
     this.blockSizeTarget.textContent = humanize.bytes(block.size)
     this.blockTotalTarget.textContent = humanize.threeSigFigs(block.total)
+
+    if (ex.exchange_rate) {
+      let xcRate = ex.exchange_rate.value
+      let btcIndex = ex.exchange_rate.index
+      if (this.hasPowConvertedTarget) {
+        this.powConvertedTarget.textContent = `${humanize.twoDecimals(ex.subsidy.pow / 1e8 * xcRate)} ${btcIndex}`
+      }
+      if (this.hasConvertedDevTarget) {
+        this.convertedDevTarget.textContent = `${humanize.threeSigFigs(ex.dev_fund / 1e8 * xcRate)} ${btcIndex}`
+      }
+      if (this.hasConvertedSupplyTarget) {
+        this.convertedSupplyTarget.textContent = `${humanize.threeSigFigs(ex.coin_supply / 1e8 * xcRate)} ${btcIndex}`
+      }
+      if (this.hasConvertedDevSubTarget) {
+        this.convertedDevSubTarget.textContent = `${humanize.twoDecimals(ex.subsidy.dev / 1e8 * xcRate)} ${btcIndex}`
+      }
+      if (this.hasExchangeRateTarget) {
+        this.exchangeRateTarget.textContent = humanize.twoDecimals(xcRate)
+      }
+      if (this.hasConvertedStakeTarget) {
+        this.convertedStakeTarget.textContent = `${humanize.twoDecimals(ex.sdiff * xcRate)} ${btcIndex}`
+      }
+    }
   }
 }

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -86,8 +86,12 @@ var humanize = {
     if (v >= 1e-4) return `${v.toFixed(6)}`
     if (v >= 1e-5) return `${v.toFixed(7)}`
     if (v === 0) return '0'
-    console.log(`tiny v = ${v}`)
     return v.toFixed(8)
+  },
+  twoDecimals: function (v) {
+    if (v === 0.0) return '0.00'
+    if (Math.abs(v) < 1.0) return parseFloat(v).toPrecision(3)
+    return parseFloat(v).toFixed(2)
   },
   subsidyToString: function (x, y = 1) {
     return (x / 100000000 / y) + ' DCR'

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -1,4 +1,5 @@
 {{define "home"}}
+{{$conv := .Conversions}}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -215,6 +216,11 @@
                                 <span data-target="homepage.blocksdiff">{{template "decimalParts" (float64AsDecimalParts .StakeDiff 8 false 2)}}</span>
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.convertedStake">{{$conv.StakeDiff.TwoDecimals}} {{$conv.StakeDiff.Index}}</span>
+                            </div>
+                            {{end}}
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Next Ticket Price</div>
@@ -320,6 +326,11 @@
                                 <span data-target="homepage.bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 true 2)}}</span>
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.powConverted">{{$conv.PowSplit.TwoDecimals}} {{$conv.PowSplit.Index}}</span>
+                            </div>
+                            {{end}}
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary lh1rem">Next Block Reward Reduction</div>
@@ -365,6 +376,11 @@
                                 </span>
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.convertedDev">{{threeSigFigs $conv.TreasuryBalance.Value}} {{$conv.TreasuryBalance.Index}}</span>
+                            </div>
+                            {{end}}
                         </div>
                         {{end}}
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
@@ -375,6 +391,11 @@
                                 </span>
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.convertedSupply">{{threeSigFigs $conv.CoinSupply.Value}} {{$conv.CoinSupply.Index}}</span>
+                            </div>
+                            {{end}}
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Treasury Block Reward</div>
@@ -384,13 +405,18 @@
                                 </span>
                                 <span class="pl-1 unit lh15rem">DCR</span>
                             </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="homepage.convertedDevSub">{{$conv.TreasurySplit.TwoDecimals}} {{$conv.TreasurySplit.Index}}</span>
+                            </div>
+                            {{end}}
                         </div>
-                        {{if $.ExchangeState}}
+                        {{if $conv}}
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary">Exchange Rate</div>
                             <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                                <span class="d-inline-block">{{template "decimalParts" (float64AsDecimalParts $.ExchangeState.Price 4 true)}}</span>
-                                <span class="pl-1 unit lh15rem">{{$.ExchangeState.BtcIndex}}</span>
+                                <span class="d-inline-block" data-target="homepage.exchangeRate">{{$conv.ExchangeRate.TwoDecimals}}</span>
+                                <span class="pl-1 unit lh15rem">{{$conv.ExchangeRate.Index}}</span>
                             </div>
                         </div>
                         {{end}}


### PR DESCRIPTION
Adds fiat conversions to the homepage for ticket price, coin supply, miner block reward, treasury block reward, and treasury balance. 

`exchanges` package gets `Conversion` type which has the `TwoDecimal` method for displaying its value, with a minimum of two decimal places and a minimum of three significant figures.

Values are updated live with websocket `newblock` updates.