### PR TITLE
dcrpg: allow empty address history for merged debits too

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -227,6 +227,19 @@ func (a AgendaStatusType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.String())
 }
 
+// IsMerged indicates if the address transactions view type is a merged view. If
+// the type is invalid, a non-nil error is returned.
+func (a AddrTxnType) IsMerged() (bool, error) {
+	switch a {
+	case AddrTxnAll, AddrTxnCredit, AddrTxnDebit:
+		return false, nil
+	case AddrMergedTxn, AddrMergedTxnCredit, AddrMergedTxnDebit:
+		return true, nil
+	default:
+		return false, fmt.Errorf("unrecognized address transaction view: %v", a)
+	}
+}
+
 // AgendaStatusFromStr creates an agenda status from a string.
 func AgendaStatusFromStr(status string) AgendaStatusType {
 	switch strings.ToLower(status) {


### PR DESCRIPTION
This prevents an error when there his no txn history for either
`AddrTxnDebit` or `AddrMergedTxnDebit` views.
Also add `(AddrTxnType).IsMerged`.

Add TODO comments to handle unconfirmed transactions in merged views.