### PR TITLE
cache: add cache package and AddressCache for dcrpg

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -97,10 +97,10 @@ type DataSourceLite interface {
 type DataSourceAux interface {
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
-	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
+	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
 	FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 	AddressTransactionDetails(addr string, count, skip int64,
-		txnType dbtypes.AddrTxnType) (*apitypes.Address, error)
+		txnType dbtypes.AddrTxnViewType) (*apitypes.Address, error)
 	AddressTotals(address string) (*apitypes.AddressTotals, error)
 	VotesInBlock(hash string) (int16, error)
 	TxHistoryData(address string, addrChart dbtypes.HistoryChart,

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -197,17 +197,7 @@ func (c *insightApiContext) getBlockHash(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	height, err := c.BlockData.ChainDB.HeightDB()
-	if dbtypes.IsTimeoutErr(err) {
-		apiLog.Errorf("HeightDB: %v", err)
-		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
-		return
-	}
-	if err != nil {
-		writeInsightNotFound(w, "Not found")
-		return
-	}
-
+	height := c.BlockData.ChainDB.Height()
 	if idx < 0 || idx > int(height) {
 		writeInsightError(w, "Block height out of range")
 		return
@@ -699,7 +689,7 @@ func (c *insightApiContext) getAddressBalance(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	addressInfo, err := c.BlockData.ChainDB.AddressBalance(address, 20, 0)
+	addressInfo, err := c.BlockData.ChainDB.AddressBalance(address)
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressBalance: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -1,0 +1,547 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	apitypes "github.com/decred/dcrdata/v4/api/types"
+	"github.com/decred/dcrdata/v4/db/dbtypes"
+)
+
+// CacheLock is a "try lock" for coordinating multiple accessors, while allowing
+// only a single updater. Use NewCacheLock to create a CacheLock.
+type CacheLock struct {
+	sync.Mutex
+	addrs map[string]chan struct{}
+}
+
+// NewCacheLock constructs a new CacheLock.
+func NewCacheLock() *CacheLock {
+	return &CacheLock{addrs: make(map[string]chan struct{})}
+}
+
+func (cl *CacheLock) done(addr string) {
+	cl.Lock()
+	delete(cl.addrs, addr)
+	cl.Unlock()
+}
+
+func (cl *CacheLock) hold(addr string) func() {
+	done := make(chan struct{})
+	cl.addrs[addr] = done
+	return func() {
+		cl.done(addr)
+		close(done)
+	}
+}
+
+// TryLock will attempt to obtain either an exclusive updating lock. Trylock
+// returns a bool, busy, indicating if another caller has already obtained the
+// lock. When busy is false, the caller has obtained the exclusive lock, and the
+// returned func(), done, should be called when ready to release the lock. When
+// busy is true, the returned channel, wait, should be received from to block
+// until the updater has released the lock.
+func (cl *CacheLock) TryLock(addr string) (busy bool, wait chan struct{}, done func()) {
+	cl.Lock()
+	defer cl.Unlock()
+	done = func() {}
+	wait, busy = cl.addrs[addr]
+	if !busy {
+		done = cl.hold(addr)
+	}
+	return busy, wait, done
+}
+
+func countCreditDebitRows(rows []*dbtypes.AddressRow) (numCredit, numDebit int) {
+	for _, r := range rows {
+		if r.IsFunding {
+			numCredit++
+		} else {
+			numDebit++
+		}
+	}
+	return
+}
+
+func creditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
+	if offset >= len(rows) {
+		return nil
+	}
+
+	numCreditRows, _ := countCreditDebitRows(rows)
+	if numCreditRows < N {
+		N = numCreditRows
+	}
+	if offset >= numCreditRows {
+		return nil
+	}
+
+	var skipped int
+	out := make([]*dbtypes.AddressRow, 0, N)
+	for _, r := range rows {
+		if !r.IsFunding {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		// Append this row, and break the loop if we have N rows.
+		out = append(out, r)
+		if len(out) == N {
+			break
+		}
+	}
+	return out
+}
+
+func debitAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
+	_, numDebitRows := countCreditDebitRows(rows)
+	if numDebitRows < N {
+		N = numDebitRows
+	}
+	var skipped int
+	out := make([]*dbtypes.AddressRow, 0, N)
+	for _, r := range rows {
+		if r.IsFunding {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		// Append this row, and break the loop if we have N rows.
+		out = append(out, r)
+		if len(out) == N {
+			break
+		}
+	}
+	return out
+}
+
+func allCreditAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
+	numCreditRows, _ := countCreditDebitRows(rows)
+	out := make([]*dbtypes.AddressRow, numCreditRows)
+	for i, r := range rows {
+		if r.IsFunding {
+			out[i] = r
+		}
+	}
+	return out
+}
+
+func allDebitAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
+	_, numDebitRows := countCreditDebitRows(rows)
+	out := make([]*dbtypes.AddressRow, numDebitRows)
+	for i, r := range rows {
+		if !r.IsFunding {
+			out[i] = r
+		}
+	}
+	return out
+}
+
+// AddressCacheItem is the unit of cached data pertaining to a certain address.
+// The height and hash of the best block at the time the data was obtained is
+// stored to determine validity of the cache item. Cached data for an address
+// are: balance, all non-merged address table rows, all merged address table
+// rows, all UTXOs, and address metrics.
+type AddressCacheItem struct {
+	sync.RWMutex
+	balance    *dbtypes.AddressBalance
+	rows       []*dbtypes.AddressRow // creditDebitQuery
+	rowsMerged []*dbtypes.AddressRow // mergedQuery
+	utxos      []apitypes.AddressTxnOutput
+	metrics    *dbtypes.AddressMetrics
+	height     int64
+	hash       chainhash.Hash
+}
+
+// BlockID provides basic identifying information about a block.
+type BlockID struct {
+	Hash   chainhash.Hash
+	Height int64
+}
+
+// NewBlockID constructs a new BlockID.
+func NewBlockID(hash *chainhash.Hash, height int64) *BlockID {
+	return &BlockID{
+		Hash:   *hash,
+		Height: height,
+	}
+}
+
+// blockID generates a BlockID for the AddressCacheItem.
+func (d *AddressCacheItem) blockID() *BlockID {
+	return &BlockID{d.hash, d.height}
+}
+
+// BlockHash is a thread-safe accessor for the block hash.
+func (d *AddressCacheItem) BlockHash() chainhash.Hash {
+	d.RLock()
+	defer d.RUnlock()
+	return d.hash
+}
+
+// BlockHeight is a thread-safe accessor for the block height.
+func (d *AddressCacheItem) BlockHeight() int64 {
+	d.RLock()
+	defer d.RUnlock()
+	return d.height
+}
+
+// Balance is a thread-safe accessor for the *dbtypes.AddressBalance.
+func (d *AddressCacheItem) Balance() (*dbtypes.AddressBalance, *BlockID) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.balance, d.blockID()
+}
+
+// UTXOs is a thread-safe accessor for the []apitypes.AddressTxnOutput.
+func (d *AddressCacheItem) UTXOs() ([]apitypes.AddressTxnOutput, *BlockID) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.utxos, d.blockID()
+}
+
+// Metrics is a thread-safe accessor for the *dbtypes.AddressMetrics.
+func (d *AddressCacheItem) Metrics() (*dbtypes.AddressMetrics, *BlockID) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.metrics, d.blockID()
+}
+
+// Rows is a thread-safe accessor for the []*dbtypes.AddressRow.
+func (d *AddressCacheItem) Rows() ([]*dbtypes.AddressRow, *BlockID) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.rows, d.blockID()
+}
+
+// RowsMerged is a thread-safe accessor for the []*dbtypes.AddressRow.
+func (d *AddressCacheItem) RowsMerged() ([]*dbtypes.AddressRow, *BlockID) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.rowsMerged, d.blockID()
+}
+
+// Transactions attempts to retrieve transaction data for the given view (merged
+// or not, debit/credit/all). Like the DB queries, the number of transactions to
+// retrieve, N, and the number of transactions to skip, offset, are also
+// specified.
+func (d *AddressCacheItem) Transactions(N, offset int, txnView dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *BlockID, error) {
+	if N == 0 {
+		return nil, d.blockID(), nil
+	}
+	if offset < 0 || N < 0 {
+		return nil, nil, fmt.Errorf("invalid offset (%d) or N (%d)", offset, N)
+	}
+
+	if d == nil {
+		return nil, nil, fmt.Errorf("uninitialized AddressCacheItem")
+	}
+
+	d.RLock()
+	defer d.RUnlock()
+	merged, err := txnView.IsMerged()
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid transaction view")
+	}
+	if merged && d.rowsMerged == nil {
+		return nil, nil, nil // cache miss is not an error
+	}
+	if !merged && d.rows == nil {
+		return nil, nil, nil // cache miss is not an error
+	}
+
+	endRange := func(l int) int {
+		end := offset + N
+		if end > l {
+			end = l
+		}
+		return end
+	}
+
+	var rows []*dbtypes.AddressRow
+	switch txnView {
+	case dbtypes.AddrTxnAll:
+		end := endRange(len(d.rows))
+		if offset < end {
+			rows = d.rows[offset:end]
+		}
+	case dbtypes.AddrTxnCredit:
+		rows = creditAddressRows(d.rows, N, offset)
+	case dbtypes.AddrTxnDebit:
+		rows = debitAddressRows(d.rows, N, offset)
+	case dbtypes.AddrMergedTxn:
+		end := endRange(len(d.rowsMerged))
+		if offset < end {
+			rows = d.rowsMerged[offset:end]
+		}
+	case dbtypes.AddrMergedTxnCredit:
+		rows = creditAddressRows(d.rowsMerged, N, offset)
+	case dbtypes.AddrMergedTxnDebit:
+		rows = debitAddressRows(d.rowsMerged, N, offset)
+	default:
+		return nil, nil, fmt.Errorf("unrecognized address transaction view: %v", txnView)
+	}
+
+	return rows, d.blockID(), nil
+}
+
+// setBlock ensures that the AddressCacheItem pertains to the given BlockID,
+// clearing any cached data if the previously set block is not equal to the
+// given block.
+func (d *AddressCacheItem) setBlock(block BlockID) {
+	if block.Hash == d.hash {
+		return
+	}
+	d.hash = block.Hash
+	d.height = block.Height
+	d.utxos = nil
+	d.metrics = nil
+	d.balance = nil
+	d.rows = nil
+	d.rowsMerged = nil
+}
+
+// SetRows updates the cache item for the given non-merged AddressRow slice
+// valid at the given BlockID.
+func (d *AddressCacheItem) SetRows(block BlockID, rows []*dbtypes.AddressRow) {
+	d.Lock()
+	defer d.Unlock()
+	d.setBlock(block)
+	d.rows = rows
+}
+
+// SetRowsMerged updates the cache item for the given merged AddressRow slice
+// valid at the given BlockID.
+func (d *AddressCacheItem) SetRowsMerged(block BlockID, rows []*dbtypes.AddressRow) {
+	d.Lock()
+	defer d.Unlock()
+	d.setBlock(block)
+	d.rowsMerged = rows
+}
+
+// SetUTXOs updates the cache item for the given AddressTxnOutput slice valid at
+// the given BlockID.
+func (d *AddressCacheItem) SetUTXOs(block BlockID, utxos []apitypes.AddressTxnOutput) {
+	d.Lock()
+	defer d.Unlock()
+	d.setBlock(block)
+	d.utxos = utxos
+}
+
+// SetBalance updates the cache item for the given AddressBalance valid at the
+// given BlockID.
+func (d *AddressCacheItem) SetBalance(block BlockID, balance *dbtypes.AddressBalance) {
+	d.Lock()
+	defer d.Unlock()
+	d.setBlock(block)
+	d.balance = balance
+}
+
+// AddressCache maintains a store of address data. Use NewAddressCache to create
+// a new AddressCache with initialized internal data structures.
+type AddressCache struct {
+	sync.RWMutex
+	a          map[string]*AddressCacheItem
+	cap        int
+	DevAddress string
+}
+
+// NewAddressCache constructs a AddressCache.
+func NewAddressCache(cap int) *AddressCache {
+	if cap < 2 {
+		cap = 2
+	}
+	return &AddressCache{
+		a:   make(map[string]*AddressCacheItem, cap),
+		cap: cap,
+	}
+}
+
+// addressCacheItem safely accesses any AddressCacheItem for the given address.
+func (ac *AddressCache) addressCacheItem(addr string) *AddressCacheItem {
+	ac.RLock()
+	defer ac.RUnlock()
+	return ac.a[addr]
+}
+
+// ClearAll resets AddressCache, purging all cached data.
+func (ac *AddressCache) ClearAll() {
+	ac.Lock()
+	defer ac.Unlock()
+	ac.a = make(map[string]*AddressCacheItem, ac.cap)
+}
+
+// Balance attempts to retrieve an AddressBalance for the given address. The
+// BlockID for the block at which the cached data is valid is also returned. In
+// the event of a cache miss, both returned pointers will be nil.
+func (ac *AddressCache) Balance(addr string) (*dbtypes.AddressBalance, *BlockID) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil
+	}
+	return aci.Balance()
+}
+
+// UTXOs attempts to retrieve an []AddressTxnOutput for the given address. The
+// BlockID for the block at which the cached data is valid is also returned. In
+// the event of a cache miss, the slice and the *BlockID will be nil.
+func (ac *AddressCache) UTXOs(addr string) ([]apitypes.AddressTxnOutput, *BlockID) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil
+	}
+	return aci.UTXOs()
+}
+
+// Metrics attempts to retrieve an AddressMetrics for the given address. The
+// BlockID for the block at which the cached data is valid is also returned. In
+// the event of a cache miss, both returned pointers will be nil.
+func (ac *AddressCache) Metrics(addr string) (*dbtypes.AddressMetrics, *BlockID) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil
+	}
+	return aci.Metrics()
+}
+
+// Rows attempts to retrieve an []*AddressRow for the given address. The BlockID
+// for the block at which the cached data is valid is also returned. In the
+// event of a cache miss, the slice and the *BlockID will be nil.
+func (ac *AddressCache) Rows(addr string) ([]*dbtypes.AddressRow, *BlockID) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil
+	}
+	return aci.Rows()
+}
+
+// RowsMerged attempts to retrieve an []*AddressRow for the given address. The
+// BlockID for the block at which the cached data is valid is also returned. In
+// the event of a cache miss, the slice and the *BlockID will be nil.
+func (ac *AddressCache) RowsMerged(addr string) ([]*dbtypes.AddressRow, *BlockID) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil
+	}
+	return aci.RowsMerged()
+}
+
+// Transactions attempts to retrieve transaction data for the given address and
+// view (merged or not, debit/credit/all). Like the DB queries, the number of
+// transactions to retrieve, N, and the number of transactions to skip, offset,
+// are also specified.
+func (ac *AddressCache) Transactions(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *BlockID, error) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		return nil, nil, nil /*fmt.Errorf("uninitialized address cache")*/
+	}
+	return aci.Transactions(int(N), int(offset), txnType)
+}
+
+func (ac *AddressCache) addCacheItem(addr string, aci *AddressCacheItem) {
+	for len(ac.a) >= ac.cap {
+		for a := range ac.a {
+			if a == ac.DevAddress {
+				continue
+			}
+			delete(ac.a, a)
+		}
+	}
+	ac.a[addr] = aci
+}
+
+// StoreRows stores the non-merged AddressRow slice for the given address in
+// cache. The current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreRows(addr string, rows []*dbtypes.AddressRow, block *BlockID) {
+	ac.Lock()
+	defer ac.Unlock()
+	aci := ac.a[addr]
+
+	if aci == nil || aci.BlockHash() != block.Hash {
+		ac.addCacheItem(addr, &AddressCacheItem{
+			rows:   rows,
+			height: block.Height,
+			hash:   block.Hash,
+		})
+		return
+	}
+
+	// cache is current, so just set the rows.
+	aci.Lock()
+	aci.rows = rows
+	aci.Unlock()
+}
+
+// StoreRowsMerged stores the merged AddressRow slice for the given address in
+// cache. The current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreRowsMerged(addr string, rows []*dbtypes.AddressRow, block *BlockID) {
+	ac.Lock()
+	defer ac.Unlock()
+	aci := ac.a[addr]
+
+	if aci == nil || aci.BlockHash() != block.Hash {
+		ac.addCacheItem(addr, &AddressCacheItem{
+			rowsMerged: rows,
+			height:     block.Height,
+			hash:       block.Hash,
+		})
+		return
+	}
+
+	// cache is current, so just set the rows.
+	aci.Lock()
+	aci.rowsMerged = rows
+	aci.Unlock()
+}
+
+// StoreBalance stores the AddressBalance for the given address in cache. The
+// current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalance, block *BlockID) {
+	ac.Lock()
+	defer ac.Unlock()
+	aci := ac.a[addr]
+
+	if aci == nil || aci.BlockHash() != block.Hash {
+		ac.addCacheItem(addr, &AddressCacheItem{
+			balance: balance,
+			height:  block.Height,
+			hash:    block.Hash,
+		})
+		return
+	}
+
+	// cache is current, so just set the balance.
+	aci.Lock()
+	aci.balance = balance
+	aci.Unlock()
+}
+
+// StoreUTXOs stores the AddressTxnOutput slice for the given address in cache.
+// The current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreUTXOs(addr string, utxos []apitypes.AddressTxnOutput, block *BlockID) {
+	ac.Lock()
+	defer ac.Unlock()
+	aci := ac.a[addr]
+
+	if aci == nil || aci.BlockHash() != block.Hash {
+		ac.addCacheItem(addr, &AddressCacheItem{
+			utxos:  utxos,
+			height: block.Height,
+			hash:   block.Hash,
+		})
+		return
+	}
+
+	// cache is current, so just set the utxos.
+	aci.Lock()
+	aci.utxos = utxos
+	aci.Unlock()
+}

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -1,6 +1,12 @@
 // Copyright (c) 2019, The Decred developers
 // See LICENSE for details.
 
+// package cache provides a number of types and functions for caching Decred
+// address data, and filtering AddressRow slices. The type AddressCache may
+// store the following data for an address: balance (see
+// db/types.AddressBalance), address table row data (see db/types.AddressRow),
+// merged address table row data, UTXOs (see api/types.AddressTxnOutput), and
+// "metrics" (see db/types.AddressMetrics).
 package cache
 
 import (
@@ -59,6 +65,8 @@ func (cl *CacheLock) TryLock(addr string) (busy bool, wait chan struct{}, done f
 	return busy, wait, done
 }
 
+// CountCreditDebitRows returns the numbers of credit (funding) and debit
+// (!funding) address rows.
 func CountCreditDebitRows(rows []*dbtypes.AddressRow) (numCredit, numDebit int) {
 	for _, r := range rows {
 		if r.IsFunding {
@@ -70,6 +78,8 @@ func CountCreditDebitRows(rows []*dbtypes.AddressRow) (numCredit, numDebit int) 
 	return
 }
 
+// CreditAddressRows returns up to N credit (funding) address rows from the
+// given AddressRow slice, starting after skipping offset rows.
 func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
 	if offset >= len(rows) {
 		return nil
@@ -102,6 +112,8 @@ func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Add
 	return out
 }
 
+// DebitAddressRows returns up to N debit (!funding) address rows from the given
+// AddressRow slice, starting after skipping offset rows.
 func DebitAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
 	_, numDebitRows := CountCreditDebitRows(rows)
 	if numDebitRows < N {
@@ -126,6 +138,8 @@ func DebitAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Addr
 	return out
 }
 
+// AllCreditAddressRows returns all of the credit (funding) address rows from
+// the given AddressRow slice.
 func AllCreditAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 	numCreditRows, _ := CountCreditDebitRows(rows)
 	out := make([]*dbtypes.AddressRow, 0, numCreditRows)
@@ -140,6 +154,8 @@ func AllCreditAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 	return out
 }
 
+// AllDebitAddressRows returns all of the debit (!funding) address rows from the
+// given AddressRow slice.
 func AllDebitAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 	_, numDebitRows := CountCreditDebitRows(rows)
 	out := make([]*dbtypes.AddressRow, numDebitRows)

--- a/db/cache/addresscache_test.go
+++ b/db/cache/addresscache_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheLock_TryLock(t *testing.T) {
+	cl := NewCacheLock()
+
+	addr := "blah"
+	busy, wait, done := cl.TryLock(addr)
+	if busy {
+		t.Fatal("should not be busy")
+	}
+	if wait != nil {
+		t.Fatal("wait should be a nil channel")
+	}
+
+	busy2, wait2, _ := cl.TryLock(addr)
+	if !busy2 {
+		t.Fatal("should be busy")
+	}
+	if wait2 == nil {
+		t.Fatal("wait2 should not be nil")
+	}
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		done()
+	}()
+
+	t0 := time.Now()
+	t.Log("waiting")
+	<-wait2
+	t.Log("waited for", time.Since(t0))
+}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -227,19 +227,6 @@ func (a AgendaStatusType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.String())
 }
 
-// IsMerged indicates if the address transactions view type is a merged view. If
-// the type is invalid, a non-nil error is returned.
-func (a AddrTxnType) IsMerged() (bool, error) {
-	switch a {
-	case AddrTxnAll, AddrTxnCredit, AddrTxnDebit:
-		return false, nil
-	case AddrMergedTxn, AddrMergedTxnCredit, AddrMergedTxnDebit:
-		return true, nil
-	default:
-		return false, fmt.Errorf("unrecognized address transaction view: %v", a)
-	}
-}
-
 // AgendaStatusFromStr creates an agenda status from a string.
 func AgendaStatusFromStr(status string) AgendaStatusType {
 	switch strings.ToLower(status) {

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1068,15 +1068,14 @@ func ReduceAddressHistory(addrHist []*AddressRow) *AddressInfo {
 		}
 		coin := dcrutil.Amount(addrOut.Value).ToCoin()
 		tx := AddressTx{
-			Time:      addrOut.TxBlockTime,
-			InOutID:   addrOut.TxVinVoutIndex,
-			TxID:      addrOut.TxHash,
-			TxType:    txhelpers.TxTypeToString(int(addrOut.TxType)),
-			MatchedTx: addrOut.MatchingTxHash,
-			IsFunding: addrOut.IsFunding,
+			Time:           addrOut.TxBlockTime,
+			InOutID:        addrOut.TxVinVoutIndex,
+			TxID:           addrOut.TxHash,
+			TxType:         txhelpers.TxTypeToString(int(addrOut.TxType)),
+			MatchedTx:      addrOut.MatchingTxHash,
+			IsFunding:      addrOut.IsFunding,
+			MergedTxnCount: addrOut.MergedCount,
 		}
-
-		tx.MergedTxnCount = addrOut.MergedCount
 
 		if addrOut.IsFunding {
 			// Funding transaction

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -194,7 +194,8 @@ out:
 
 			p.db.InReorg = false
 
-			_ = p.db.FreshenAddressCaches(true) // async update
+			// Freshen project fund balance and clear ALL address cache data.
+			_ = p.db.FreshenAddressCaches(true, nil) // async update
 
 			reorgData.WG.Done()
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -168,6 +168,8 @@ const (
 		JOIN vouts ON addresses.tx_vin_vout_row_id = vouts.id
 		WHERE addresses.address=$1 AND addresses.is_funding AND addresses.matching_tx_hash = '' AND valid_mainchain
 		ORDER BY addresses.block_time DESC;`
+	// Since tx_vin_vout_row_id is the vouts table primary key (id) when
+	// is_funding=true, there is no need to join vouts on tx_hash and tx_index.
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
 		WHERE address=$1 AND valid_mainchain = TRUE

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -82,7 +82,12 @@ const (
 	addrsColumnNames = `id, address, matching_tx_hash, tx_hash, tx_type, valid_mainchain,
 		tx_vin_vout_index, block_time, tx_vin_vout_row_id, value, is_funding`
 
-	SelectAddressAllByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses WHERE address=$1 ORDER BY block_time DESC;`
+	SelectAddressAllByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
+		WHERE address=$1
+		ORDER BY block_time DESC;`
+	SelectAddressAllMainchainByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
+		WHERE address=$1 AND valid_mainchain
+		ORDER BY block_time DESC;`
 
 	SelectAddressesAllTxn = `SELECT
 			transactions.tx_hash,
@@ -155,13 +160,13 @@ const (
 			addresses.value,
 			transactions.block_height,
 			addresses.block_time,
-			tx_vin_vout_index,
-			pkscript
+			addresses.tx_vin_vout_index,
+			vouts.pkscript
 		FROM addresses
 		JOIN transactions ON
 			addresses.tx_hash = transactions.tx_hash
-		JOIN vouts ON addresses.tx_hash = vouts.tx_hash AND addresses.tx_vin_vout_index=vouts.tx_index
-		WHERE addresses.address=$1 AND addresses.is_funding = TRUE AND addresses.matching_tx_hash = '' AND valid_mainchain = TRUE
+		JOIN vouts ON addresses.tx_vin_vout_row_id = vouts.id
+		WHERE addresses.address=$1 AND addresses.is_funding AND addresses.matching_tx_hash = '' AND valid_mainchain
 		ORDER BY addresses.block_time DESC;`
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
@@ -187,12 +192,14 @@ const (
 		GROUP BY (tx_hash, valid_mainchain, block_time)  -- merging common transactions in same valid mainchain block
 		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
 
-	SelectAddressMergedView = `SELECT tx_hash, valid_mainchain, block_time, sum(CASE WHEN is_funding = TRUE THEN value ELSE 0 END),
+	SelectAddressMergedViewAll = `SELECT tx_hash, valid_mainchain, block_time, sum(CASE WHEN is_funding = TRUE THEN value ELSE 0 END),
 		sum(CASE WHEN is_funding = FALSE THEN value ELSE 0 END), COUNT(*)
 		FROM addresses
 		WHERE address=$1                                 -- spending and funding transactions
 		GROUP BY (tx_hash, valid_mainchain, block_time)  -- merging common transactions in same valid mainchain block
-		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		ORDER BY block_time DESC`
+
+	SelectAddressMergedView = SelectAddressMergedViewAll + ` LIMIT $2 OFFSET $3;`
 
 	SelectAddressCsvView = "SELECT tx_hash, valid_mainchain, matching_tx_hash, value, block_time, is_funding, " +
 		"tx_vin_vout_index, tx_type FROM addresses WHERE address=$1 ORDER BY block_time DESC"

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -26,6 +26,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/v4/api/types"
 	"github.com/decred/dcrdata/v4/blockdata"
+	"github.com/decred/dcrdata/v4/db/cache"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 	"github.com/decred/dcrdata/v4/rpcutils"
@@ -44,37 +45,6 @@ var (
 // happen without making too many db accesses everytime we are updating the
 // agenda_votes table.
 var storedAgendas map[string]dbtypes.MileStone
-
-// DevFundBalance is a block-stamped wrapper for dbtypes.AddressBalance. It is
-// intended to be used for the project address.
-type DevFundBalance struct {
-	sync.RWMutex
-	*dbtypes.AddressBalance
-	updating trylock.Mutex
-	Height   int64
-	Hash     chainhash.Hash
-}
-
-// BlockHash is a thread-safe accessor for the block hash.
-func (d *DevFundBalance) BlockHash() chainhash.Hash {
-	d.RLock()
-	defer d.RUnlock()
-	return d.Hash
-}
-
-// BlockHeight is a thread-safe accessor for the block height.
-func (d *DevFundBalance) BlockHeight() int64 {
-	d.RLock()
-	defer d.RUnlock()
-	return d.Height
-}
-
-// Balance is a thread-safe accessor for the dbtypes.AddressBalance.
-func (d *DevFundBalance) Balance() *dbtypes.AddressBalance {
-	d.RLock()
-	defer d.RUnlock()
-	return d.AddressBalance
-}
 
 // ticketPoolDataCache stores the most recent ticketpool graphs information
 // fetched to minimize the possibility of making multiple queries to the db
@@ -207,6 +177,13 @@ func (u *utxoStore) Size() (sz int) {
 	return
 }
 
+type cacheLocks struct {
+	bal        *cache.CacheLock
+	rows       *cache.CacheLock
+	rowsMerged *cache.CacheLock
+	utxo       *cache.CacheLock
+}
+
 // ChainDB provides an interface for storing and manipulating extracted
 // blockchain data in a PostgreSQL database.
 type ChainDB struct {
@@ -218,10 +195,10 @@ type ChainDB struct {
 	dupChecks          bool
 	bestBlock          *BestBlock
 	lastBlock          map[chainhash.Hash]uint64
-	addressCounts      *addressCounter
 	stakeDB            *stakedb.StakeDatabase
 	unspentTicketCache *TicketTxnIDGetter
-	DevFundBalance     *DevFundBalance
+	AddressCache       *cache.AddressCache
+	CacheLocks         cacheLocks
 	devPrefetch        bool
 	InBatchSync        bool
 	InReorg            bool
@@ -372,20 +349,6 @@ func (db *ChainDBRPC) MissingSideChainBlocks() ([]dbtypes.SideChain, int, error)
 	}
 
 	return blocksToStore, nSideChainBlocks, nil
-}
-
-// addressCounter provides a cache for address balances.
-type addressCounter struct {
-	sync.RWMutex
-	validHeight int64
-	balance     map[string]dbtypes.AddressBalance
-}
-
-func makeAddressCounter() *addressCounter {
-	return &addressCounter{
-		validHeight: 0,
-		balance:     make(map[string]dbtypes.AddressBalance),
-	}
 }
 
 // TicketTxnIDGetter provides a cache for DB row IDs of tickets.
@@ -569,6 +532,9 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		hash:   bestHash,
 	}
 
+	addrCache := cache.NewAddressCache(500)
+	addrCache.DevAddress = devSubsidyAddress
+
 	return &ChainDB{
 		ctx:                ctx,
 		queryTimeout:       queryTimeout,
@@ -578,10 +544,10 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		dupChecks:          true,
 		bestBlock:          bestBlock,
 		lastBlock:          make(map[chainhash.Hash]uint64),
-		addressCounts:      makeAddressCounter(),
 		stakeDB:            stakeDB,
 		unspentTicketCache: unspentTicketCache,
-		DevFundBalance:     new(DevFundBalance),
+		AddressCache:       addrCache,
+		CacheLocks:         cacheLocks{cache.NewCacheLock(), cache.NewCacheLock(), cache.NewCacheLock(), cache.NewCacheLock()},
 		devPrefetch:        devPrefetch,
 		tpUpdatePermission: tpUpdatePermissions,
 		utxoCache:          newUtxoStore(5e4),
@@ -800,7 +766,7 @@ func (pgb *ChainDB) HeightHashDB() (uint64, string, error) {
 	return height, hash, pgb.replaceCancelError(err)
 }
 
-// Getter for ChainDB.bestBlock.height
+// Height is a getter for ChainDB.bestBlock.height.
 func (pgb *ChainDB) Height() int64 {
 	return pgb.bestBlock.Height()
 }
@@ -830,6 +796,29 @@ func (block *BestBlock) Hash() *chainhash.Hash {
 	// Caller should check hash instead of error
 	hash, _ := chainhash.NewHashFromStr(block.HashStr())
 	return hash
+}
+
+func (pgb *ChainDB) BestBlock() (*chainhash.Hash, int64) {
+	pgb.bestBlock.RLock()
+	defer pgb.bestBlock.RUnlock()
+	hash, _ := chainhash.NewHashFromStr(pgb.bestBlock.hash)
+	return hash, pgb.bestBlock.height
+}
+
+func (pgb *ChainDB) BestBlockStr() (string, int64) {
+	pgb.bestBlock.RLock()
+	defer pgb.bestBlock.RUnlock()
+	return pgb.bestBlock.hash, pgb.bestBlock.height
+}
+
+// BestBlockHash is a getter for ChainDB.bestBlock.hash.
+func (pgb *ChainDB) BestBlockHash() *chainhash.Hash {
+	return pgb.bestBlock.Hash()
+}
+
+// BestBlockHashStr is a getter for ChainDB.bestBlock.hash.
+func (pgb *ChainDB) BestBlockHashStr() string {
+	return pgb.bestBlock.HashStr()
 }
 
 // BlockHeight queries the DB for the height of the specified hash.
@@ -1025,8 +1014,7 @@ func (pgb *ChainDB) RCIStartHeight(agendaInfo dbtypes.MileStone) (int64, error) 
 
 // AgendaCumulativeVoteChoices fetches the total vote choices count for the
 // provided agenda.
-func (pgb *ChainDB) AgendaCumulativeVoteChoices(agendaID string) (yes,
-	abstain, no uint32, err error) {
+func (pgb *ChainDB) AgendaCumulativeVoteChoices(agendaID string) (yes, abstain, no uint32, err error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 
@@ -1106,7 +1094,7 @@ func (pgb *ChainDB) AddressMetrics(addr string) (*dbtypes.AddressMetrics, error)
 // the first N transactions starting from the offset element in the set of all
 // txnType transactions.
 func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
-	txnType dbtypes.AddrTxnType) (addressRows []*dbtypes.AddressRow, err error) {
+	txnType dbtypes.AddrTxnViewType) (addressRows []*dbtypes.AddressRow, err error) {
 	var addrFunc func(context.Context, *sql.DB, string, int64, int64) ([]uint64, []*dbtypes.AddressRow, error)
 	switch txnType {
 	case dbtypes.AddrTxnCredit:
@@ -1122,13 +1110,35 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 	case dbtypes.AddrMergedTxn:
 		addrFunc = RetrieveAddressMergedTxns
 	default:
-		return nil, fmt.Errorf("unknown AddrTxnType %v", txnType)
+		return nil, fmt.Errorf("unknown AddrTxnViewType %v", txnType)
 	}
 
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 
 	_, addressRows, err = addrFunc(ctx, pgb.db, address, N, offset)
+	err = pgb.replaceCancelError(err)
+	return
+}
+
+// AddressTransactionsAll retrieves all non-merged main chain addresses table
+// rows for the given address.
+func (pgb *ChainDB) AddressTransactionsAll(address string) (addressRows []*dbtypes.AddressRow, err error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+
+	_, addressRows, err = RetrieveAllMainchainAddressTxns(ctx, pgb.db, address)
+	err = pgb.replaceCancelError(err)
+	return
+}
+
+// AddressTransactionsAllMerged retrieves all merged mainchain addresses table
+// rows for the given address.
+func (pgb *ChainDB) AddressTransactionsAllMerged(address string) (addressRows []*dbtypes.AddressRow, err error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+
+	_, addressRows, err = RetrieveAllMainchainAddressMergedTxns(ctx, pgb.db, address)
 	err = pgb.replaceCancelError(err)
 	return
 }
@@ -1190,7 +1200,7 @@ func (pgb *ChainDB) TimeBasedIntervals(timeGrouping dbtypes.TimeBasedGrouping,
 func (pgb *ChainDB) TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) (*dbtypes.PoolTicketsData,
 	*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, int64, error) {
 	// Attempt to retrieve data for the current block from cache.
-	heightSeen := pgb.bestBlock.Height() // current block seen *by the ChainDB*
+	heightSeen := pgb.Height() // current block seen *by the ChainDB*
 	if heightSeen < 0 {
 		return nil, nil, nil, -1, fmt.Errorf("no charts data available")
 	}
@@ -1212,7 +1222,7 @@ func (pgb *ChainDB) TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 			pgb.tpUpdatePermission[interval].Lock()
 			defer pgb.tpUpdatePermission[interval].Unlock()
 			// Try again to pull it from cache now that the update is completed.
-			heightSeen = pgb.bestBlock.Height()
+			heightSeen = pgb.Height()
 			timeChart, priceChart, donutCharts, height, intervalFound, stale =
 				TicketPoolData(interval, heightSeen)
 			// We waited for the updater of this interval, so it should be found
@@ -1255,7 +1265,7 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 	priceChart *dbtypes.PoolTicketsData, byInputs *dbtypes.PoolTicketsData, height int64, err error) {
 	// Ensure DB height is the same before and after queries since they are not
 	// atomic. Initial height:
-	height = pgb.bestBlock.Height()
+	height = pgb.Height()
 	for {
 		// Latest block where mature tickets may have been mined.
 		maturityBlock := pgb.TicketPoolBlockMaturity()
@@ -1278,7 +1288,7 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 			return nil, nil, nil, 0, err
 		}
 
-		heightEnd := pgb.bestBlock.Height()
+		heightEnd := pgb.Height()
 		if heightEnd == height {
 			break
 		}
@@ -1289,236 +1299,270 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 	return
 }
 
-// retrieveDevBalance retrieves a new DevFundBalance without regard to the cache
-func (pgb *ChainDB) retrieveDevBalance() (*DevFundBalance, error) {
-	bb, hash, err := pgb.HeightHashDB()
+func (pgb *ChainDB) updateProjectFundCache() error {
+	// Update non-merged rows.
+	_, _, err := pgb.AddressHistory(pgb.devAddress, 1, 0, dbtypes.AddrTxnAll)
 	if err != nil {
-		return nil, err
-	}
-	blockHeight := int64(bb)
-	blockHash, err := chainhash.NewHashFromStr(hash)
-	if err != nil {
-		return nil, err
+		return err
 	}
 
-	_, devBalance, err := pgb.AddressHistoryAll(pgb.devAddress, 1, 0)
-	balance := &DevFundBalance{
-		AddressBalance: devBalance,
-		Height:         blockHeight,
-		Hash:           *blockHash,
-	}
-	return balance, err
+	// Update merged rows.
+	_, _, err = pgb.AddressHistory(pgb.devAddress, 1, 0, dbtypes.AddrMergedTxn)
+	return err
 }
 
 // FreshenAddressCaches resets the address balance cache, and prefetches the
 // project fund balance if devPrefetch is enabled and not mid-reorg.
 func (pgb *ChainDB) FreshenAddressCaches(lazyProjectFund bool) error {
-	pgb.addressCounts.Lock()
-	pgb.addressCounts.validHeight = pgb.bestBlock.Height()
-	pgb.addressCounts.balance = map[string]dbtypes.AddressBalance{}
-	pgb.addressCounts.Unlock()
+	// Clear existing cache entries.
+	pgb.AddressCache.ClearAll() // TODO: clear only addresses w/ activity
 
-	// Lazy update of DevFundBalance
-	if pgb.devPrefetch && !pgb.InReorg {
-		updateBalance := func() error {
-			log.Infof("Pre-fetching project fund balance at height %d...", pgb.bestBlock.Height())
-			if _, err := pgb.UpdateDevBalance(); err != nil {
-				err = pgb.replaceCancelError(err)
-				return fmt.Errorf("Failed to update project fund balance: %v", err)
+	// Do not initiate project fund queries if a reorg is in progress, or
+	// pre-fetch is disabled.
+	if !pgb.devPrefetch || pgb.InReorg {
+		return nil
+	}
+
+	// Update project fund data.
+	updateFundData := func() error {
+		log.Infof("Pre-fetching project fund data at height %d...", pgb.Height())
+		if err := pgb.updateProjectFundCache(); err != nil {
+			err = pgb.replaceCancelError(err)
+			return fmt.Errorf("Failed to update project fund data: %v", err)
+		}
+		return nil
+	}
+
+	if lazyProjectFund {
+		go func() {
+			runtime.Gosched()
+			if err := updateFundData(); err != nil {
+				log.Error(err)
 			}
-			return nil
-		}
-		if lazyProjectFund {
-			go func() {
-				runtime.Gosched()
-				if err := updateBalance(); err != nil {
-					log.Error(err)
-				}
-			}()
-			return nil
-		}
-		return updateBalance()
+		}()
+		return nil
 	}
-	return nil
-}
-
-// UpdateDevBalance forcibly updates the cached development/project fund balance
-// via DB queries. The bool output inidcates if the cached balance was updated
-// (if it was stale).
-func (pgb *ChainDB) UpdateDevBalance() (bool, error) {
-	// See if a DB query is already running
-	okToUpdate := pgb.DevFundBalance.updating.TryLock()
-	// Wait on readers and possibly a writer regardless so the response will not
-	// be stale even when this call doesn't call updateDevBalance.
-	pgb.DevFundBalance.Lock()
-	defer pgb.DevFundBalance.Unlock()
-	// If we got the trylock, do an actual query for the balance
-	if okToUpdate {
-		defer pgb.DevFundBalance.updating.Unlock()
-		return pgb.updateDevBalance()
-	}
-	// Otherwise the other call will have just updated the balance, and we
-	// should not waste the cycles doing it again.
-	return false, nil
-}
-
-func (pgb *ChainDB) updateDevBalance() (bool, error) {
-	// Query for current balance.
-	balance, err := pgb.retrieveDevBalance()
-	if err != nil {
-		return false, err
-	}
-
-	// If cache is stale, update it's fields.
-	if balance.Hash != pgb.DevFundBalance.Hash || pgb.DevFundBalance.AddressBalance == nil {
-		pgb.DevFundBalance.AddressBalance = balance.AddressBalance
-		pgb.DevFundBalance.Height = balance.Height
-		pgb.DevFundBalance.Hash = balance.Hash
-		return true, nil
-	}
-
-	// Cache was not stale
-	return false, nil
+	return updateFundData()
 }
 
 // DevBalance returns the current development/project fund balance, updating the
-// cached balance if it is stale.
+// cached balance if it is stale. DevBalance differs slightly from
+// addressBalance(devAddress) in that it will not initiate a DB query if a chain
+// reorganization is in progress.
 func (pgb *ChainDB) DevBalance() (*dbtypes.AddressBalance, error) {
+	// Check cache first.
+	cachedBalance, validBlock := pgb.AddressCache.Balance(pgb.devAddress)
+	bestBlockHash := pgb.BestBlockHash()
+	if cachedBalance != nil && validBlock.Hash == *bestBlockHash {
+		return cachedBalance, nil
+	}
+
 	if !pgb.InReorg {
-		hash, err := pgb.HashDB()
+		bal, err := pgb.AddressBalance(pgb.devAddress)
 		if err != nil {
 			return nil, err
 		}
-
-		// Update cache if stale
-		if pgb.DevFundBalance.BlockHash().String() != hash || pgb.DevFundBalance.Balance() == nil {
-			if _, err = pgb.UpdateDevBalance(); err != nil {
-				return nil, err
-			}
-		}
+		return bal, nil
 	}
 
-	bal := pgb.DevFundBalance.Balance()
-	if bal == nil {
-		return nil, fmt.Errorf("failed to update dev balance")
+	// In reorg and cache is stale.
+	if cachedBalance != nil {
+		return cachedBalance, nil
 	}
-
-	// return a copy of AddressBalance
-	balCopy := *bal
-	return &balCopy, nil
+	return nil, fmt.Errorf("unable to query for balance during reorg")
 }
 
-// addressBalance attempts to retrieve the dbtypes.AddressBalance from cache,
+// AddressBalance attempts to retrieve the dbtypes.AddressBalance from cache,
 // and if cache is stale or missing data for the address, a DB query is used. A
 // successful DB query will freshen the cache.
-func (pgb *ChainDB) addressBalance(address string) (*dbtypes.AddressBalance, error) {
-	bestBlock, err := pgb.HeightDB()
+func (pgb *ChainDB) AddressBalance(address string) (*dbtypes.AddressBalance, error) {
+	numSpent, numUnspent, amtSpent, amtUnspent, err :=
+		pgb.AddressSpentUnspent(address)
 	if err != nil {
 		return nil, err
 	}
+	balance := &dbtypes.AddressBalance{
+		Address:      address,
+		NumSpent:     numSpent,
+		NumUnspent:   numUnspent,
+		TotalSpent:   amtSpent,
+		TotalUnspent: amtUnspent,
+	}
 
-	totals := pgb.addressCounts
-	totals.Lock()
-	defer totals.Unlock()
+	return balance, nil
+}
 
-	var balanceInfo dbtypes.AddressBalance
-	var fresh bool
-	if totals.validHeight == bestBlock {
-		balanceInfo, fresh = totals.balance[address]
+// AddressSpentUnspent attempts to retrieve balance information for a specific
+// address from cache, and if cache is stale or missing data for the address, a
+// DB query is used. A successful DB query will freshen the cache.
+func (pgb *ChainDB) AddressSpentUnspent(address string) (int64, int64, int64, int64, error) {
+	// Check the cache first.
+	bestHash, height := pgb.BestBlock()
+	bal, validHeight := pgb.AddressCache.Balance(address)
+	if bal != nil && *bestHash == validHeight.Hash {
+		return bal.NumSpent, bal.NumUnspent, bal.TotalSpent, bal.TotalUnspent, nil
+	}
+
+	busy, wait, done := pgb.CacheLocks.bal.TryLock(address)
+	if busy {
+		// Let others get the wait channel while we wait.
+		// To return stale cache data if it is available:
+		// utxos, _ := pgb.AddressCache.UTXOs(address)
+		// if utxos != nil {
+		// 	return utxos, nil
+		// }
+		<-wait
+
+		// Try again, starting with the cache.
+		return pgb.AddressSpentUnspent(address)
 	} else {
-		// StoreBlock should do this, but the idea is to clear the old cached
-		// results when a new block is encountered.
-		log.Debugf("Address receive counter stale, at block %d when best is %d.",
-			totals.validHeight, bestBlock)
-		totals.balance = make(map[string]dbtypes.AddressBalance)
-		totals.validHeight = bestBlock
-		balanceInfo.Address = address
+		// We will run the DB query, so block others from doing the same. When
+		// query and/or cache update is completed, broadcast to any waiters that
+		// the coast is clear.
+		defer done()
 	}
 
-	if !fresh {
-		numSpent, numUnspent, amtSpent, amtUnspent, err :=
-			pgb.AddressSpentUnspent(address)
+	// Cache is empty or stale, so query the DB.
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	ns, nu, as, au, err := RetrieveAddressSpentUnspent(ctx, pgb.db, address)
+	if err != nil {
+		return 0, 0, 0, 0, pgb.replaceCancelError(err)
+	}
+
+	// Update the address cache.
+	balance := &dbtypes.AddressBalance{
+		Address:      address,
+		NumSpent:     ns,
+		NumUnspent:   nu,
+		TotalSpent:   as,
+		TotalUnspent: au,
+	}
+	pgb.AddressCache.StoreBalance(address, balance, cache.NewBlockID(bestHash, height))
+	return ns, nu, as, au, nil
+}
+
+// updateAddressRows updates the merged or non-merged address rows, or waits for
+// them to update by an ongoing query. On completion, the cache should be ready,
+// although it must be checked again.
+func (pgb *ChainDB) updateAddressRows(address string, merged bool) error {
+	cacheLock := pgb.CacheLocks.rows
+	if merged {
+		cacheLock = pgb.CacheLocks.rowsMerged
+	}
+
+	busy, wait, done := cacheLock.TryLock(address)
+	if busy {
+		// Just wait until the updater is finished.
+		<-wait
+		return nil
+	} else {
+		// We will run the DB query, so block others from doing the same. When
+		// query and/or cache update is completed, broadcast to any waiters that
+		// the coast is clear.
+		defer done()
+	}
+
+	hash, height := pgb.BestBlock()
+	blockID := cache.NewBlockID(hash, height)
+
+	if merged {
+		// Retrieve all merged address transaction rows.
+		allAddressRows, err := pgb.AddressTransactionsAllMerged(address)
 		if err != nil {
-			return nil, err
-		}
-		balanceInfo = dbtypes.AddressBalance{
-			Address:      address,
-			NumSpent:     numSpent,
-			NumUnspent:   numUnspent,
-			TotalSpent:   amtSpent,
-			TotalUnspent: amtUnspent,
+			return err
 		}
 
-		totals.balance[address] = balanceInfo
+		// Update address rows cache.
+		pgb.AddressCache.StoreRowsMerged(address, allAddressRows, blockID)
+	} else {
+		// Retrieve all non-merged address transaction rows.
+		allAddressRows, err := pgb.AddressTransactionsAll(address)
+		if err != nil {
+			return err
+		}
+
+		// Update address rows cache.
+		pgb.AddressCache.StoreRows(address, allAddressRows, blockID)
 	}
 
-	return &balanceInfo, nil
+	return nil
 }
 
 // AddressHistory queries the database for rows of the addresses table
 // containing values for a certain type of transaction (all, credits, or debits)
 // for the given address.
 func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
-	txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
-
-	bestBlock, err := pgb.HeightDB() // TODO: should be by block hash
+	txnView dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
+	// Try the address cache.
+	addressRows, _, err := pgb.AddressCache.Transactions(address, N, offset, txnView)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// See if address count cache includes a fresh count for this address.
-	totals := pgb.addressCounts
-	totals.Lock()
-	var balanceInfo dbtypes.AddressBalance
-	var fresh bool
-	if totals.validHeight == bestBlock {
-		balanceInfo, fresh = totals.balance[address]
-	} else {
-		// StoreBlock should do this, but the idea is to clear the old cached
-		// results when a new block is encountered.
-		log.Debugf("Address receive counter stale, at block %d when best is %d.",
-			totals.validHeight, bestBlock)
-		totals.balance = make(map[string]dbtypes.AddressBalance)
-		totals.validHeight = bestBlock
-		balanceInfo.Address = address
-	}
-	totals.Unlock()
-
-	// Retrieve relevant transactions
-	addressRows, err := pgb.AddressTransactions(address, N, offset, txnType)
-	if err != nil {
-		return nil, nil, err
-	}
-	if fresh || len(addressRows) == 0 {
-		return addressRows, &balanceInfo, nil
+	hash, height := pgb.BestBlock()
+	balance, validBlock := pgb.AddressCache.Balance(address)
+	cacheCurrent := validBlock != nil && validBlock.Hash == *hash
+	if cacheCurrent && balance != nil && addressRows != nil {
+		log.Debugf("Address rows (view=%s) and balance cache HIT for %s.", txnView.String(), address)
+		return addressRows, balance, nil
 	}
 
-	// If the address receive count was not cached, compute it and store it in
-	// the cache.
-	addrInfo := dbtypes.ReduceAddressHistory(addressRows)
-	if addrInfo == nil {
-		return addressRows, nil, fmt.Errorf("ReduceAddressHistory failed. len(addressRows) = %d", len(addressRows))
+	blockID := cache.NewBlockID(hash, height)
+	if !cacheCurrent || addressRows == nil {
+		log.Debugf("Address rows (view=%s) cache MISS for %s.", txnView.String(), address)
+
+		// Determine if txnView represents a merged view. Ignore the error since
+		// this txnView is already validated by AddressCache.Transactions.
+		merged, _ := txnView.IsMerged()
+		// Update or wait for an update to the cached AddressRows.
+		err := pgb.updateAddressRows(address, merged)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Try again, starting with cache.
+		return pgb.AddressHistory(address, N, offset, txnView)
 	}
+
+	log.Debugf("Address rows (view=%s) cache HIT for %s.", txnView.String(), address)
+
+	// addressRows is now current. Check if current balance is available.
+	if cacheCurrent && balance != nil {
+		log.Debugf("Address balance cache HIT for %s.", address)
+		return addressRows, balance, nil
+	}
+	log.Debugf("Address balance cache MISS for %s.", address)
 
 	// You've got all txs when the total number of fetched txs is less than the
-	// limit ,txtype is AddrTxnAll and Offset is zero.
-	if len(addressRows) < int(N) && offset == 0 && txnType == dbtypes.AddrTxnAll {
+	// limit, txtype is AddrTxnAll, and Offset is zero.
+	if len(addressRows) < int(N) && offset == 0 && txnView == dbtypes.AddrTxnAll {
 		log.Debugf("Taking balance shortcut since address rows includes all.")
-		balanceInfo = dbtypes.AddressBalance{
+		addrInfo := dbtypes.ReduceAddressHistory(addressRows)
+		if addrInfo == nil {
+			return addressRows, nil,
+				fmt.Errorf("ReduceAddressHistory failed. len(addressRows) = %d",
+					len(addressRows))
+		}
+
+		balance = &dbtypes.AddressBalance{
 			Address:      address,
 			NumSpent:     addrInfo.NumSpendingTxns,
 			NumUnspent:   addrInfo.NumFundingTxns - addrInfo.NumSpendingTxns,
 			TotalSpent:   int64(addrInfo.AmountSent),
 			TotalUnspent: int64(addrInfo.AmountUnspent),
 		}
+
+		// Update balance cache.
+		pgb.AddressCache.StoreBalance(address, balance, blockID)
 	} else {
+		// AddressSpentUnspent updates the balance cache.
 		log.Debugf("Obtaining balance via DB query.")
 		numSpent, numUnspent, amtSpent, amtUnspent, err :=
 			pgb.AddressSpentUnspent(address)
 		if err != nil {
 			return nil, nil, err
 		}
-		balanceInfo = dbtypes.AddressBalance{
+		balance = &dbtypes.AddressBalance{
 			Address:      address,
 			NumSpent:     numSpent,
 			NumUnspent:   numUnspent,
@@ -1528,21 +1572,18 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	}
 
 	log.Infof("%s: %d spent totalling %f DCR, %d unspent totalling %f DCR",
-		address, balanceInfo.NumSpent, dcrutil.Amount(balanceInfo.TotalSpent).ToCoin(),
-		balanceInfo.NumUnspent, dcrutil.Amount(balanceInfo.TotalUnspent).ToCoin())
+		address, balance.NumSpent, dcrutil.Amount(balance.TotalSpent).ToCoin(),
+		balance.NumUnspent, dcrutil.Amount(balance.TotalUnspent).ToCoin())
 	log.Infof("Caching address receive count for address %s: "+
 		"count = %d at block %d.", address,
-		balanceInfo.NumSpent+balanceInfo.NumUnspent, bestBlock)
-	totals.Lock()
-	totals.balance[address] = balanceInfo
-	totals.Unlock()
+		balance.NumSpent+balance.NumUnspent, height)
 
-	return addressRows, &balanceInfo, nil
+	return addressRows, balance, nil
 }
 
 // AddressData returns comprehensive, paginated information for an address.
 func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
-	txnType dbtypes.AddrTxnType) (addrData *dbtypes.AddressInfo, err error) {
+	txnType dbtypes.AddrTxnViewType) (addrData *dbtypes.AddressInfo, err error) {
 	merged, err := txnType.IsMerged()
 	if err != nil {
 		return nil, err
@@ -1767,7 +1808,7 @@ SPENDING_TX_DUPLICATE_CHECK:
 	addrData.Balance.TotalUnspent += (received - sent)
 
 	// Sort by date and calculate block height.
-	addrData.PostProcess(uint32(db.bestBlock.Height()))
+	addrData.PostProcess(uint32(db.Height()))
 
 	return
 }
@@ -1815,7 +1856,7 @@ func (pgb *ChainDB) FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 		txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()
 		txn.Time = dbTx.BlockTime
 		if txn.Time.UNIX() > 0 {
-			txn.Confirmations = uint64(pgb.bestBlock.Height() - dbTx.BlockHeight + 1)
+			txn.Confirmations = uint64(pgb.Height() - dbTx.BlockHeight + 1)
 		} else {
 			numUnconfirmed++
 			txn.Confirmations = 0
@@ -1865,21 +1906,18 @@ func (pgb *ChainDB) AddressTotals(address string) (*apitypes.AddressTotals, erro
 	if address == pgb.devAddress {
 		ab, err = pgb.DevBalance()
 	} else {
-		ab, err = pgb.addressBalance(address)
+		ab, err = pgb.AddressBalance(address)
 	}
 
 	if err != nil || ab == nil {
 		return nil, err
 	}
 
-	bestHeight, bestHash, err := pgb.HeightHashDB()
-	if err != nil {
-		return nil, err
-	}
+	bestHash, bestHeight := pgb.BestBlockStr()
 
 	return &apitypes.AddressTotals{
 		Address:      address,
-		BlockHeight:  bestHeight,
+		BlockHeight:  uint64(bestHeight),
 		BlockHash:    bestHash,
 		NumSpent:     ab.NumSpent,
 		NumUnspent:   ab.NumUnspent,
@@ -1902,7 +1940,7 @@ func (pgb *ChainDB) AddressTxIoCsv(address string) (rows [][]string, err error) 
 	return
 }
 
-func (pgb *ChainDB) addressInfo(addr string, count, skip int64, txnType dbtypes.AddrTxnType) (*dbtypes.AddressInfo, *dbtypes.AddressBalance, error) {
+func (pgb *ChainDB) addressInfo(addr string, count, skip int64, txnType dbtypes.AddrTxnViewType) (*dbtypes.AddressInfo, *dbtypes.AddressBalance, error) {
 	address, err := dcrutil.DecodeAddress(addr)
 	if err != nil {
 		log.Infof("Invalid address %s: %v", addr, err)
@@ -1954,7 +1992,7 @@ func (pgb *ChainDB) addressInfo(addr string, count, skip int64, txnType dbtypes.
 // starting after skip transactions. This does NOT include unconfirmed
 // transactions.
 func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
-	txnType dbtypes.AddrTxnType) (*apitypes.Address, error) {
+	txnType dbtypes.AddrTxnViewType) (*apitypes.Address, error) {
 	// Fetch address history for given transaction range and type
 	addrData, _, err := pgb.addressInfo(addr, count, skip, txnType)
 	if err != nil {
@@ -1990,7 +2028,7 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 
 // TODO: finish
 func (pgb *ChainDB) AddressTransactionRawDetails(addr string, count, skip int64,
-	txnType dbtypes.AddrTxnType) ([]*apitypes.AddressTxRaw, error) {
+	txnType dbtypes.AddrTxnViewType) ([]*apitypes.AddressTxRaw, error) {
 	addrData, _, err := pgb.addressInfo(addr, count, skip, txnType)
 	if err != nil {
 		return nil, err
@@ -2377,7 +2415,7 @@ func (pgb *ChainDB) VoutsForTx(dbTx *dbtypes.Tx) ([]dbtypes.Vout, error) {
 }
 
 func (pgb *ChainDB) TipToSideChain(mainRoot string) (string, int64, error) {
-	tipHash := pgb.bestBlock.HashStr()
+	tipHash := pgb.BestBlockHashStr()
 	var blocksMoved, txnsUpdated, vinsUpdated, votesUpdated, ticketsUpdated, addrsUpdated int64
 	for tipHash != mainRoot {
 		// 1. Block. Set is_mainchain=false on the tip block, return hash of

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1145,8 +1145,8 @@ func (pgb *ChainDB) AddressTransactionsAllMerged(address string) (addressRows []
 	return
 }
 
-// AddressHistoryAll queries the database for all rows of the addresses table
-// for the given address.
+// AddressHistoryAll retrieves N address rows of type AddrTxnAll, skipping over
+// offset rows first, in order of block time.
 func (pgb *ChainDB) AddressHistoryAll(address string, N, offset int64) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
 	return pgb.AddressHistory(address, N, offset, dbtypes.AddrTxnAll)
 }
@@ -1729,8 +1729,7 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 			return nil, err
 		}
 		if addrData.IsMerged {
-			// For merged views, either query the DB or check the process the
-			// cached merged rows.
+			// For merged views, check the cache and fall back on a DB query.
 			count, err := db.mergedTxnCount(address, txnType)
 			if err != nil {
 				return nil, err

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1629,10 +1629,8 @@ func scanAddressQueryRows(rows *sql.Rows, queryType int) (ids []uint64, addressR
 
 		switch queryType {
 		case creditQuery:
-			// addr.IsFunding == true
 			addr.AtomsCredit = addr.Value
 		case debitQuery:
-			// addr.IsFunding == false
 			addr.AtomsDebit = addr.Value
 		case creditDebitQuery:
 			if addr.IsFunding {

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -374,7 +374,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 
 	// After the last call to StoreBlock, synchronously update the project fund
 	// and clear the general address balance cache.
-	if err = db.FreshenAddressCaches(false); err != nil {
+	if err = db.FreshenAddressCaches(false, nil); err != nil {
 		log.Warnf("FreshenAddressCaches: %v", err)
 		err = nil // not an error with sync
 	}

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -83,13 +83,14 @@ type explorerDataSourceLite interface {
 // faster solution than RPC, or additional functionality.
 type explorerDataSource interface {
 	BlockHeight(hash string) (int64, error)
+	Height() int64
 	HeightDB() (int64, error)
 	BlockHash(height int64) (string, error)
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
 	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
-	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
-	AddressData(address string, N, offset int64, txnType dbtypes.AddrTxnType) (*dbtypes.AddressInfo, error)
+	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
+	AddressData(address string, N, offset int64, txnType dbtypes.AddrTxnViewType) (*dbtypes.AddressInfo, error)
 	DevBalance() (*dbtypes.AddressBalance, error)
 	FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -64,14 +64,7 @@ func (exp *explorerUI) BlockHashPathOrIndexCtx(next http.Handler) http.Handler {
 					return
 				}
 			} else {
-				maxHeight, err = exp.explorerSource.HeightDB()
-				if err != nil {
-					log.Errorf("HeightDB() failed: %v", err)
-					exp.StatusPage(w, defaultErrorCode,
-						"an unexpected error had occured while retrieving the best block",
-						"", ExpStatusError)
-					return
-				}
+				maxHeight = exp.explorerSource.Height()
 			}
 
 			if height > maxHeight {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1347,7 +1347,7 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseAddressParams is used by both /address and /addresstable.
-func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTxnType, limitN, offsetAddrOuts int64, err error) {
+func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTxnViewType, limitN, offsetAddrOuts int64, err error) {
 	// Get the address URL parameter, which should be set in the request context
 	// by the addressPathCtx middleware.
 	var parseErr error
@@ -1382,7 +1382,7 @@ func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTx
 	if txntype == "" {
 		txntype = "all"
 	}
-	txnType = dbtypes.AddrTxnTypeFromStr(txntype)
+	txnType = dbtypes.AddrTxnViewTypeFromStr(txntype)
 	if txnType == dbtypes.AddrTxnUnknown {
 		err = fmt.Errorf("unknown txntype query value")
 	}
@@ -1394,7 +1394,7 @@ func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTx
 
 // AddressListData grabs a size-limited and type-filtered set of inputs/outputs
 // for a given address.
-func (exp *explorerUI) AddressListData(address string, txnType dbtypes.AddrTxnType, limitN, offsetAddrOuts int64) (addrData *dbtypes.AddressInfo, err error) {
+func (exp *explorerUI) AddressListData(address string, txnType dbtypes.AddrTxnViewType, limitN, offsetAddrOuts int64) (addrData *dbtypes.AddressInfo, err error) {
 	if exp.liteMode {
 		addrData, _, addrErr := exp.blockData.GetExplorerAddress(address,
 			limitN, offsetAddrOuts)


### PR DESCRIPTION
Add a new `cache` package, starting with addresscache.go, which includes
`AddressCache` and `AddressCacheItem`.
Use `AddressCache` in `ChainDB`.
Remove `DevFundBalance` since it benefits from the general `AddressCache`.
Remove `addressCounts` since `AddressCache` includes balance.
To update an address' data, add `RetrieveAllMainchainAddressTxns` and
`RetrieveAllMainchainAddressMergedTxns`, which do not use `offset` or `N`.
Also cache transaction view type row counts via the new
`(*ChainDB).CountTransactions` function, which use cache or DB queries to
get the row counts for any of the supported txn view types.

Also:
- Use `vouts` table primary key in `SelectAddressUnspentWithTxn`.
- Avoid height query in `AddressUTXO`, using latest stored height instead.
- fix: `RetrieveAddressUTXOs` forgot the block time
- Rename `AddrTxnType` to `AddrTxnViewType`.
- Remove unnecessary `TimeDefs` in `scanAddressMergedRows` and
  `scanAddressQueryRows`.
- Add `Height() int64` to `explorer/explorerDataSource` interface to use the
  no-query getter. This speeds up `BlockHashPathOrIndexCtx` middleware.