### PR TITLE
caching and query tuning for InsightAddressTransactions

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -89,20 +89,23 @@ const (
 		WHERE address=$1 AND valid_mainchain
 		ORDER BY block_time DESC;`
 
-	SelectAddressesAllTxn = `SELECT
-			transactions.tx_hash,
-			block_height
-		FROM
-			addresses
-			INNER JOIN
-				transactions
-				ON addresses.tx_hash = transactions.tx_hash
-				AND is_mainchain = TRUE AND is_valid=TRUE
+	SelectAddressesAllTxnWithHeight = `SELECT
+			addresses.tx_hash,
+			transactions.block_height
+		FROM addresses
+		INNER JOIN transactions
+			ON addresses.tx_hash = transactions.tx_hash
+				AND is_mainchain AND is_valid
 		WHERE
-			address = ANY($1) AND valid_mainchain=true
+			address = ANY($1) AND valid_mainchain
 		ORDER BY
-			time DESC,
-			transactions.tx_hash ASC;`
+			transactions.time DESC,
+			addresses.tx_hash ASC;`
+
+	SelectAddressesAllTxn = `SELECT	tx_hash, block_time
+		FROM addresses
+		WHERE address = ANY($1) AND valid_mainchain
+		ORDER BY block_time DESC, tx_hash ASC;`
 
 	// selectAddressTimeGroupingCount return the count of record groups,
 	// where grouping is done by a specified time interval, for an addresss.

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -97,6 +97,9 @@ const (
 	SelectBlockHashByHeight = `SELECT hash FROM blocks WHERE height = $1 AND is_mainchain = true;`
 	SelectBlockHeightByHash = `SELECT height FROM blocks WHERE hash = $1;`
 
+	SelectBlockTimeByHeight = `SELECT time FROM blocks
+		WHERE height = $1 AND is_mainchain = true;`
+
 	RetrieveBestBlockHeightAny = `SELECT id, hash, height FROM blocks
 		ORDER BY height DESC LIMIT 1;`
 	RetrieveBestBlockHeight = `SELECT id, hash, height FROM blocks

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -840,6 +840,15 @@ func (pgb *ChainDB) BlockHash(height int64) (string, error) {
 	return hash, pgb.replaceCancelError(err)
 }
 
+// BlockTimeByHeight queries the DB for the time of the mainchain block at the
+// given height.
+func (pgb *ChainDB) BlockTimeByHeight(height int64) (int64, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	time, err := RetrieveBlockTimeByHeight(ctx, pgb.db, height)
+	return time.UNIX(), pgb.replaceCancelError(err)
+}
+
 // VotesInBlock returns the number of votes mined in the block with the
 // specified hash.
 func (pgb *ChainDB) VotesInBlock(hash string) (int16, error) {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1312,14 +1312,20 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 }
 
 func (pgb *ChainDB) updateProjectFundCache() error {
-	// Update balance and non-merged rows.
-	_, _, err := pgb.AddressHistory(pgb.devAddress, 1, 0, dbtypes.AddrTxnAll)
+	// Update balance.
+	_, err := pgb.AddressBalance(pgb.devAddress)
 	if err != nil {
 		return err
 	}
 
-	// Update merged rows (and balance, which is already current).
-	_, _, err = pgb.AddressHistory(pgb.devAddress, 1, 0, dbtypes.AddrMergedTxn)
+	// Update non-merged rows.
+	_, err = pgb.AddressRows(pgb.devAddress, false)
+	if err != nil {
+		return err
+	}
+
+	// Update merged rows.
+	_, err = pgb.AddressRows(pgb.devAddress, true)
 	return err
 }
 


### PR DESCRIPTION
This accelerates InsightAddressTransactions, which is used for several
Insight API endpoints.

`InsightAddressTransactions` is modified to use the `rowsMerged` cache,
first checking that each address is in the cache, and then merging the
results as would be done by the DB query.

Add `(*ChainDB).AddressRows` to get the cached address rows, or query the
DB and update the cache.
Use cache-enabled `AddressRows` for `AddressTxIoCsv`.
Also add `dcrpg.MakeCsvAddressRows` to convert from `[]*dbtypes.AddressRow`
to [][]string for a CSV output.

Use AddressRows and AddressBalance in updateProjectFundCache instead
of the AddressHistory cludge.

Etc.:
- Remove the `JOIN` from `SelectAddressesAllTxn` since `block_time` is
  already in the addresses table and sufficient for getting a "recent"
  transactions slice for mempool purposes.
- Add `SelectBlockTimeByHeight` query for getting the main chain block time
  by height, which is then used in `InsightAddressTransactions`.
- Add `RetrieveBlockTimeByHeight`, using `SelectBlockTimeByHeight`.
- `RetrieveAddressTxnsOrdered` now accepts a recent block time instead of
  height.  As such, `InsightAddressTransactions` first queries for the time
  of the block at a recent block height (callers choice).