### PR TITLE
api/insight: Add configurable insight API rate limit.

### DIFF
--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -30,8 +30,7 @@ func NewInsightApiRouter(app *insightApiContext, useRealIP bool) ApiMux {
 	mux := chi.NewRouter()
 
 	// Create a rate limiter struct.
-	reqPerSecLimit := 10.0
-	limiter := tollbooth.NewLimiter(reqPerSecLimit, nil)
+	limiter := tollbooth.NewLimiter(app.ReqPerSecLimit, nil)
 
 	if useRealIP {
 		mux.Use(middleware.RealIP)

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -35,13 +35,16 @@ type DataSourceLite interface {
 	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 }
 
+const defaultReqPerSecLimit = 20.0
+
 type insightApiContext struct {
-	nodeClient *rpcclient.Client
-	BlockData  *dcrpg.ChainDBRPC
-	params     *chaincfg.Params
-	MemPool    DataSourceLite
-	Status     apitypes.Status
-	JSONIndent string
+	nodeClient     *rpcclient.Client
+	BlockData      *dcrpg.ChainDBRPC
+	params         *chaincfg.Params
+	MemPool        DataSourceLite
+	Status         apitypes.Status
+	JSONIndent     string
+	ReqPerSecLimit float64
 }
 
 // NewInsightContext Constructor for insightApiContext
@@ -62,8 +65,15 @@ func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, pa
 			DcrdataVersion:  version.String(),
 			NetworkName:     params.Name,
 		},
+		ReqPerSecLimit: defaultReqPerSecLimit,
 	}
 	return &newContext
+}
+
+// SetReqRateLimit is used to set the requests/second/IP for the Insight API's
+// rate limiter.
+func (c *insightApiContext) SetReqRateLimit(reqPerSecLimit float64) {
+	c.ReqPerSecLimit = reqPerSecLimit
 }
 
 func (c *insightApiContext) getIndentQuery(r *http.Request) (indent string) {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/decred/slog v1.0.0
 	github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f
 	github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102 // indirect
-	github.com/didip/tollbooth v4.0.0+incompatible
+	github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible
 	github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-chi/chi v4.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
 bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi81xWQA2QIVxjWkFHptGgC547vchpUbtFo=
@@ -29,6 +30,7 @@ github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb/go.mod h1:xz
 github.com/chappjc/trylock v1.0.0 h1:WR9J1cP/+h0x9RoKsxf4I0AnYg7aONYjiwYwys8nibA=
 github.com/chappjc/trylock v1.0.0/go.mod h1:+FnHf7ZLQpdbR3H9QZUrMKF1jfyHmtpbZddoYhSTzvw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/dajohi/goemail v0.0.0-20190207191308-61faa215f94d h1:erd++vWXw2JEXelnwMBlTjOrllgTby+Oxg17Td8KUTg=
 github.com/dajohi/goemail v0.0.0-20190207191308-61faa215f94d/go.mod h1:YyX3pgj9VJX6VQYu8Cbs0GYHzgFUs8q0vX5pLmFvops=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -149,8 +151,8 @@ github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f h1:zpnMq37RjYYJ
 github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102 h1:afESQBXJEnj3fu+34X//E8Wg3nEbMJxJkwSc0tPePK0=
 github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
-github.com/didip/tollbooth v4.0.0+incompatible h1:ayQZYuF5QOxx3NdYRNuRVFLv9/2b64JtSUlewb+0TMo=
-github.com/didip/tollbooth v4.0.0+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
+github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible h1:XPOvHQZ3qQ54NtienofDf4clvH/6Kf9FbX3MqkdDsOQ=
+github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
 github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d h1:vs5Nf6IE0N/PwGJ8//zRed4gpCdcr99K2HzX7RuLOQ8=
 github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d/go.mod h1:YWyIfq3y4ArRfWZ9XksmuusP+7Mad+T0iFZ0kv0XG/M=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/main.go
+++ b/main.go
@@ -714,6 +714,7 @@ func _main(ctx context.Context) error {
 		if usePG {
 			insightApp := insight.NewInsightContext(dcrdClient, auxDB,
 				activeChain, baseDB, cfg.IndentJSON)
+			insightApp.SetReqRateLimit(cfg.InsightReqRateLimit)
 			insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP)
 			r.Mount("/insight/api", insightMux.Mux)
 

--- a/testutil/apiload/profiles.json
+++ b/testutil/apiload/profiles.json
@@ -58,6 +58,42 @@
       }
     ]
   },
+  "insight-addr": {
+    "duration": 60,
+    "attackers": [
+      {
+        "name": "first",
+        "frequency": 10,
+        "endpoints": [
+          "/insight/api/addr/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/addr/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/utxo",
+          "/insight/api/addr/DspCVzEw21aDGZ43Ax24rjFqsHimiJbF4qe",
+          "/insight/api/addr/DspCVzEw21aDGZ43Ax24rjFqsHimiJbF4qe/utxo",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSE4N",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSE4N/utxo",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSxxx",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSxxx/utxo",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/txs",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/utxo",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qexxx/txs",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qexxx/utxo",
+          "/insight/api/addrs/Dsh3RaFqAgnfnGqY9cQiJUde5cR7qwdQP8r,DsSjYHYcc7iJZaJ74CBb4dHNcukdoiLxUQ1/txs",
+          "/insight/api/addrs/Dsh3RaFqAgnfnGqY9cQiJUde5cR7qwdQP8r,DsSjYHYcc7iJZaJ74CBb4dHNcukdoiLxUQ1/utxo",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtYgP/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtYgP/utxo",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtxxx/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtxxx/utxo",
+          "/insight/api/txs?address=Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/txs?address=Dsd8i7LHGCfKWtog5kwYL5Ut7pBhMLKPVZo",
+          "/insight/api/txs?address=Dsa4zhhBhLuGKmsgHc1hHp9acW6WbpyuN7P",
+          "/insight/api/txs?address=DcpR6s7iZsPMJRorJymeYP4K9sHo35RAWZB",
+          "/insight/api/txs?address=Dsksm4jgwFJScNznBz9Rdo4R2zmUXuM71CP",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBSDL7",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBxxxx"
+        ]
+      }
+    ]
+  },
   "rotation": {
     "duration": 60,
     "attackers": [


### PR DESCRIPTION
Previously the rate limit for the Insight API was hard coded. It is now
settable via the `"insight-limit-rps"` config option.
The default is 20 req/sec per IP address.
Add `(*insightApiContext).SetReqRateLimit`.
Also update the `apiload` profiles.json with an `"insight-addr"` attack
definition, which only hits the various addr/addrs endpoints.

This also updates the go.mod/go.sum entries for github.com/didip/tollbooth
to use pseudo versions.