### PR TITLE
db/dcrpg: Remove non-determinist VersionCheck implementation

### DIFF
--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -326,6 +326,14 @@ func (pgb *ChainDB) DeleteDuplicateMisses() (int64, error) {
 	return DeleteDuplicateMisses(pgb.db)
 }
 
+func (pgb *ChainDB) DeleteDuplicateAgendas() (int64, error) {
+	return DeleteDuplicateAgendas(pgb.db)
+}
+
+func (pgb *ChainDB) DeleteDuplicateAgendaVotes() (int64, error) {
+	return DeleteDuplicateAgendaVotes(pgb.db)
+}
+
 // Indexes checks
 
 // MissingIndexes lists missing table indexes and their descriptions.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -612,7 +612,7 @@ func (pgb *ChainDB) VersionCheck(client *rpcclient.Client) error {
 
 	for _, val := range tableUpgrades {
 		switch val.UpgradeType {
-		case Upgrade, ReIndex:
+		case Upgrade, Reindex:
 			// Select the all tables that need an upgrade or reindex.
 			needsUpgrade = append(needsUpgrade, val)
 
@@ -628,8 +628,8 @@ func (pgb *ChainDB) VersionCheck(client *rpcclient.Client) error {
 		return nil
 	}
 
-	// AddAuxPendingDBUpgrades adds the pending db upgrades and reindexes.
-	_, err := pgb.AddAuxPendingDBUpgrades(client, needsUpgrade[0].CurrentVer,
+	// UpgradeTables adds the pending db upgrades and reindexes.
+	_, err := pgb.UpgradeTables(client, needsUpgrade[0].CurrentVer,
 		needsUpgrade[0].RequiredVer)
 	if err != nil {
 		return err

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -607,7 +607,7 @@ func (pgb *ChainDB) VersionCheck(client *rpcclient.Client) error {
 		log.Debugf("Table %s: v%s", tab, ver)
 	}
 
-	needsUpgrade := make([]TableUpgrade, 0)
+	var needsUpgrade []TableUpgrade
 	tableUpgrades := TableUpgradesRequired(vers)
 
 	for _, val := range tableUpgrades {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -188,7 +188,7 @@ func DeleteDuplicateTickets(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate tickets: "
+	execErrPrefix := "failed to delete duplicate in tickets: "
 	return sqlExec(db, internal.DeleteTicketsDuplicateRows, execErrPrefix)
 }
 
@@ -200,7 +200,7 @@ func DeleteDuplicateVotes(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate votes: "
+	execErrPrefix := "failed to delete duplicate in votes: "
 	return sqlExec(db, internal.DeleteVotesDuplicateRows, execErrPrefix)
 }
 
@@ -212,8 +212,32 @@ func DeleteDuplicateMisses(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate misses: "
+	execErrPrefix := "failed to delete duplicate in misses: "
 	return sqlExec(db, internal.DeleteMissesDuplicateRows, execErrPrefix)
+}
+
+// DeleteDuplicateAgendas deletes rows in misses with duplicate names leaving
+// the one row with the lowest id.
+func DeleteDuplicateAgendas(db *sql.DB) (int64, error) {
+	if isuniq, err := IsUniqueIndex(db, "uix_agendas_name"); err != nil && err != sql.ErrNoRows {
+		return 0, err
+	} else if isuniq {
+		return 0, nil
+	}
+	execErrPrefix := "failed to delete duplicate in agendas: "
+	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
+}
+
+// DeleteDuplicateAgendaVotes deletes rows in misses with duplicate votes-row-id,
+// and agendas-row-id leaving the one row with the lowest id.
+func DeleteDuplicateAgendaVotes(db *sql.DB) (int64, error) {
+	if isuniq, err := IsUniqueIndex(db, "uix_agenda_votes"); err != nil && err != sql.ErrNoRows {
+		return 0, err
+	} else if isuniq {
+		return 0, nil
+	}
+	execErrPrefix := "failed to delete duplicate in agenda_votes: "
+	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
 }
 
 // --- stake (votes, tickets, misses) tables ---

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -188,7 +188,7 @@ func DeleteDuplicateTickets(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate in tickets: "
+	execErrPrefix := "failed to delete duplicate tickets: "
 	return sqlExec(db, internal.DeleteTicketsDuplicateRows, execErrPrefix)
 }
 
@@ -200,7 +200,7 @@ func DeleteDuplicateVotes(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate in votes: "
+	execErrPrefix := "failed to delete duplicate votes: "
 	return sqlExec(db, internal.DeleteVotesDuplicateRows, execErrPrefix)
 }
 
@@ -212,7 +212,7 @@ func DeleteDuplicateMisses(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate in misses: "
+	execErrPrefix := "failed to delete duplicate misses: "
 	return sqlExec(db, internal.DeleteMissesDuplicateRows, execErrPrefix)
 }
 
@@ -224,7 +224,7 @@ func DeleteDuplicateAgendas(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate in agendas: "
+	execErrPrefix := "failed to delete duplicate agendas: "
 	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
 }
 
@@ -236,7 +236,7 @@ func DeleteDuplicateAgendaVotes(db *sql.DB) (int64, error) {
 	} else if isuniq {
 		return 0, nil
 	}
-	execErrPrefix := "failed to delete duplicate in agenda_votes: "
+	execErrPrefix := "failed to delete duplicate agenda_votes: "
 	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
 }
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -216,7 +216,7 @@ func DeleteDuplicateMisses(db *sql.DB) (int64, error) {
 	return sqlExec(db, internal.DeleteMissesDuplicateRows, execErrPrefix)
 }
 
-// DeleteDuplicateAgendas deletes rows in misses with duplicate names leaving
+// DeleteDuplicateAgendas deletes rows in agendas with duplicate names leaving
 // the one row with the lowest id.
 func DeleteDuplicateAgendas(db *sql.DB) (int64, error) {
 	if isuniq, err := IsUniqueIndex(db, "uix_agendas_name"); err != nil && err != sql.ErrNoRows {
@@ -228,8 +228,8 @@ func DeleteDuplicateAgendas(db *sql.DB) (int64, error) {
 	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
 }
 
-// DeleteDuplicateAgendaVotes deletes rows in misses with duplicate votes-row-id,
-// and agendas-row-id leaving the one row with the lowest id.
+// DeleteDuplicateAgendaVotes deletes rows in agenda_votes with duplicate
+// votes-row-id and agendas-row-id leaving the one row with the lowest id.
 func DeleteDuplicateAgendaVotes(db *sql.DB) (int64, error) {
 	if isuniq, err := IsUniqueIndex(db, "uix_agenda_votes"); err != nil && err != sql.ErrNoRows {
 		return 0, err
@@ -237,7 +237,7 @@ func DeleteDuplicateAgendaVotes(db *sql.DB) (int64, error) {
 		return 0, nil
 	}
 	execErrPrefix := "failed to delete duplicate agenda_votes: "
-	return sqlExec(db, internal.DeleteAgendasDuplicateRows, execErrPrefix)
+	return sqlExec(db, internal.DeleteAgendaVotesDuplicateRows, execErrPrefix)
 }
 
 // --- stake (votes, tickets, misses) tables ---

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -106,7 +106,7 @@ func (s TableVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d", s.major, s.minor, s.patch)
 }
 
-// CompatibilityAction default stringer
+// String implements Stringer for CompatibilityAction.
 func (v CompatibilityAction) String() string {
 	actions := map[CompatibilityAction]string{
 		Rebuild: "rebuild",

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -81,7 +81,7 @@ type CompatibilityAction int8
 const (
 	Rebuild CompatibilityAction = iota
 	Upgrade
-	ReIndex
+	Reindex
 	OK
 	Unknown
 )
@@ -96,7 +96,7 @@ func TableVersionCompatible(required, actual TableVersion) CompatibilityAction {
 	case required.minor != actual.minor:
 		return Upgrade
 	case required.patch != actual.patch:
-		return ReIndex
+		return Reindex
 	default:
 		return OK
 	}
@@ -111,7 +111,7 @@ func (v CompatibilityAction) String() string {
 	actions := map[CompatibilityAction]string{
 		Rebuild: "rebuild",
 		Upgrade: "upgrade",
-		ReIndex: "reindex",
+		Reindex: "reindex",
 		OK:      "ok",
 	}
 	if actionStr, ok := actions[v]; ok {

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -78,20 +78,11 @@ var votingMilestones = map[string]dbtypes.MileStone{}
 // toVersion defines a table version to which the pg tables will commented to.
 var toVersion TableVersion
 
-// CheckForAuxDBUpgrade checks if an upgrade is required and currently supported.
-// A boolean value is returned to indicate if the db upgrade was
-// successfully completed.
-func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, error) {
-	var version, needVersion TableVersion
-	upgradeInfo := TableUpgradesRequired(TableVersions(pgb.db))
-
-	if len(upgradeInfo) > 0 {
-		version = upgradeInfo[0].CurrentVer
-		needVersion = upgradeInfo[0].RequiredVer
-	} else {
-		return false, nil
-	}
-
+// AddAuxPendingDBUpgrades upgrades all the tables with the pending updates from
+// the current table versions to the most recent table version supported. A
+// boolean is returned to indicate if the db upgrade was successfully completed.
+func (pgb *ChainDB) AddAuxPendingDBUpgrades(dcrdClient *rpcclient.Client,
+	version, needVersion TableVersion) (bool, error) {
 	// If the previous DB is between the 3.1/3.2 and 4.0 releases (dcrpg table
 	// versions >3.5.5 and <3.9.0), an upgrade is likely not possible IF PostgreSQL
 	// was running in a TimeZone other than UTC. Deny upgrade.
@@ -123,9 +114,6 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 
 	// Apply each upgrade in succession
 	switch {
-	case upgradeInfo[0].UpgradeType != "upgrade" && upgradeInfo[0].UpgradeType != "reindex":
-		return false, nil
-
 	// Upgrade from 3.1.0 --> 3.2.0
 	case version.major == 3 && version.minor == 1 && version.patch == 0:
 		toVersion = TableVersion{3, 2, 0}
@@ -401,8 +389,8 @@ func (pgb *ChainDB) CheckForAuxDBUpgrade(dcrdClient *rpcclient.Client) (bool, er
 	}
 
 	// Ensure the required version was reached.
-	upgradeInfo = TableUpgradesRequired(TableVersions(pgb.db))
-	if len(upgradeInfo) > 0 && upgradeInfo[0].UpgradeType != "ok" {
+	upgradeInfo := TableUpgradesRequired(TableVersions(pgb.db))
+	if len(upgradeInfo) > 0 && upgradeInfo[0].UpgradeType != OK {
 		return false, fmt.Errorf("failed to upgrade tables to required version %v", needVersion)
 	}
 


### PR DESCRIPTION
- Adds drop duplicates implementation in agendas and agenda_votes tables
- Adds a more deterministic way to check if the auxiliary db requires an upgrade, re index or rebuild.