### PR TITLE
Fix data race

### DIFF
--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -60,7 +60,7 @@ func NewProposalsDB(politeiaURL, dbPath string) (*ProposalDB, error) {
 			IdleConnTimeout:    5 * time.Second,
 			DisableCompression: false,
 		},
-		Timeout: 30 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 
 	// politeiaURL should just be the domain part of the url without the API versioning.

--- a/main.go
+++ b/main.go
@@ -530,7 +530,7 @@ func _main(ctx context.Context) error {
 	// Proposal db update is made asynchronously to ensure that the system works
 	// even when the Politeia API endpoint set is down.
 	go func() {
-		if err = proposalsInstance.CheckProposalsUpdates(); err != nil {
+		if err := proposalsInstance.CheckProposalsUpdates(); err != nil {
 			log.Errorf("updating proposals db failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
This PR 
- masks the error returned when `proposalsInstance.CheckProposalsUpdates();` is run in a goroutine.
- Reduce the http client timeout to 10 seconds
cc #1067