### PR TITLE
multi: do not export the mutex

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -101,7 +101,7 @@ func (b *BlockData) ToBlockExplorerSummary() apitypes.BlockExplorerBasic {
 
 // Collector models a structure for the source of the blockdata
 type Collector struct {
-	sync.Mutex
+	mtx          sync.Mutex
 	dcrdChainSvr *rpcclient.Client
 	netParams    *chaincfg.Params
 	stakeDB      *stakedb.StakeDatabase
@@ -225,8 +225,8 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 func (t *Collector) CollectHash(hash *chainhash.Hash) (*BlockData, *wire.MsgBlock, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.Lock()
-	defer t.Unlock()
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {
@@ -280,8 +280,8 @@ func (t *Collector) CollectHash(hash *chainhash.Hash) (*BlockData, *wire.MsgBloc
 func (t *Collector) Collect() (*BlockData, *wire.MsgBlock, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.Lock()
-	defer t.Unlock()
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -44,18 +44,18 @@ func TestTimeDefUnmarshal(t *testing.T) {
 
 func TestDeepCopys(t *testing.T) {
 	tickets := []MempoolTx{
-		MempoolTx{
+		{
 			TxID:      "96e10d7ce108b1a357168b0a923d86d2744ba9777a2d81cbff71ffb982381c95",
 			Fees:      0.0001,
 			VinCount:  2,
 			VoutCount: 5,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "43f26841e744ce2f901e21400f275eda27ba2a3fa962110d52e7dd37f2193c78",
 					Index:  0,
 					Outdex: 0,
 				},
-				MempoolInput{
+				{
 					TxId:   "43f26841e744ce2f901e21400f275eda27ba2a3fa962110d52e7dd37f2193c78",
 					Index:  1,
 					Outdex: 1,
@@ -66,18 +66,18 @@ func TestDeepCopys(t *testing.T) {
 			TotalOut: 106.39717461,
 			Type:     "Ticket",
 		},
-		MempoolTx{
+		{
 			TxID:      "8eb2f6c8f3a9cdc8d6de2ef3bfca9efcffed4484dd4fde2d01dc0fc0e415c75a",
 			Fees:      0.0001,
 			VinCount:  2,
 			VoutCount: 5,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "4e9221f790916b4d891b40ef82b8a6dc89f5c0719d5d5ddcf46ac3673d8446aa",
 					Index:  0,
 					Outdex: 0,
 				},
-				MempoolInput{
+				{
 					TxId:   "4e9221f790916b4d891b40ef82b8a6dc89f5c0719d5d5ddcf46ac3673d8446aa",
 					Index:  1,
 					Outdex: 1,
@@ -91,18 +91,18 @@ func TestDeepCopys(t *testing.T) {
 	}
 
 	votes := []MempoolTx{
-		MempoolTx{
+		{
 			TxID:      "64ce0422cb6ba1aefa63c8df1d872250d181261ff3acd5a71bc1f521096207c9",
 			Fees:      0,
 			VinCount:  2,
 			VoutCount: 3,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "",
 					Index:  0,
 					Outdex: 0,
 				},
-				MempoolInput{
+				{
 					TxId:   "7884ecd8fb5934e77708f82f0aa052ad86cccc5749602be14d93745d8272538e",
 					Index:  1,
 					Outdex: 0,
@@ -113,18 +113,18 @@ func TestDeepCopys(t *testing.T) {
 			TotalOut: 102.86278351,
 			Type:     "Vote",
 		},
-		MempoolTx{
+		{
 			TxID:      "07aa38f10fe1a849a52b9d4812081854e4ac7268751a0ea661e8f499d7de91f1",
 			Fees:      0,
 			VinCount:  2,
 			VoutCount: 3,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "",
 					Index:  0,
 					Outdex: 0,
 				},
-				MempoolInput{
+				{
 					TxId:   "99045541c481e7e694598a2d77967f5e4e053cee3265d77c5b49f1eb8b282176",
 					Index:  1,
 					Outdex: 0,
@@ -135,18 +135,18 @@ func TestDeepCopys(t *testing.T) {
 			TotalOut: 105.29923146,
 			Type:     "Vote",
 		},
-		MempoolTx{
+		{
 			TxID:      "1df658e1b0de08112adcfb9b8b17dcc2b64f756b1e21f6b1f715fd2b86439955",
 			Fees:      0,
 			VinCount:  2,
 			VoutCount: 3,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "",
 					Index:  0,
 					Outdex: 0,
 				},
-				MempoolInput{
+				{
 					TxId:   "28cc0b43bf79908115323f16dbd17d0e44a5366ca5d49e2d4f5a9c5f741e5699",
 					Index:  1,
 					Outdex: 0,
@@ -160,23 +160,23 @@ func TestDeepCopys(t *testing.T) {
 	}
 
 	regular := []MempoolTx{
-		MempoolTx{
+		{
 			TxID:      "0572b2d121322d3a9b20fe5d5024c73d8bb817398948a167ddb668e52bbb21f6",
 			Fees:      0.000585,
 			VinCount:  3,
 			VoutCount: 2,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "4a9aaca49784586d3abc0dbd5d7d3dcdf70940c60bc5cbaa39379690d9ac5c6d",
 					Index:  0,
 					Outdex: 9,
 				},
-				MempoolInput{
+				{
 					TxId:   "f621d45fb440307f151c1470619e37209aca7f8c12379e82f5c2ebcf882fb884",
 					Index:  1,
 					Outdex: 1,
 				},
-				MempoolInput{
+				{
 					TxId:   "08b01afd1c252fbef8bbad933c1d7e3da1d3e3011ef3d4cdd532f5803ea173b9",
 					Index:  2,
 					Outdex: 0,
@@ -187,23 +187,23 @@ func TestDeepCopys(t *testing.T) {
 			TotalOut: 139.11389736,
 			Type:     "Regular",
 		},
-		MempoolTx{
+		{
 			TxID:      "9e11deaae5ecd1d3288468a491f820b66adfb74be70eba582c0b13a25e76bb3b",
 			Fees:      0.000585,
 			VinCount:  3,
 			VoutCount: 2,
 			Vin: []MempoolInput{
-				MempoolInput{
+				{
 					TxId:   "bf9d371a9f3fd510ec5d6b485c0fd64ca1b6dac9c3b915973ba8fc86fc788e8c",
 					Index:  0,
 					Outdex: 1,
 				},
-				MempoolInput{
+				{
 					TxId:   "a245d62d3916869f930afd80dce6f47c7291145c36fccae7ba73c0e462ff4cd5",
 					Index:  1,
 					Outdex: 1,
 				},
-				MempoolInput{
+				{
 					TxId:   "b8274d92cac36a08cc28600fec66a09e9d429486506da1c8616c93544ce0f2ee",
 					Index:  2,
 					Outdex: 2,
@@ -285,7 +285,7 @@ func TestDeepCopys(t *testing.T) {
 				"99045541c481e7e694598a2d77967f5e4e053cee3265d77c5b49f1eb8b282176": false,
 			},
 			VoteTallys: map[string]*VoteTally{
-				"de563e0f0ee0f4717c553ce456fa5ff37c784e3f52059f2e3e64ddfbcf2aaffb": &VoteTally{
+				"de563e0f0ee0f4717c553ce456fa5ff37c784e3f52059f2e3e64ddfbcf2aaffb": {
 					TicketsPerBlock: 5,
 					Marks:           []bool{true, true, true, true, true},
 				},

--- a/explorer/websocket.go
+++ b/explorer/websocket.go
@@ -56,7 +56,7 @@ type WebsocketHub struct {
 	HubRelay         chan hubSignal
 	NewTxChan        chan *types.MempoolTx
 	newTxBuffer      []*types.MempoolTx
-	bufferMtx        *sync.Mutex
+	bufferMtx        sync.Mutex
 	bufferTickerChan chan int
 	sendBufferChan   chan int
 	quitWSHandler    chan struct{}
@@ -92,7 +92,6 @@ func NewWebsocketHub() *WebsocketHub {
 		NewTxChan:        make(chan *types.MempoolTx),
 		newTxBuffer:      make([]*types.MempoolTx, 0, newTxBufferSize),
 		bufferTickerChan: make(chan int, clientSignalSize),
-		bufferMtx:        new(sync.Mutex),
 		sendBufferChan:   make(chan int, clientSignalSize),
 		quitWSHandler:    make(chan struct{}),
 	}

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -25,7 +25,7 @@ var errDef = fmt.Errorf("ProposalDB was not initialized correctly")
 
 // ProposalDB defines the common data needed to query the proposals db.
 type ProposalDB struct {
-	sync.RWMutex
+	mtx        sync.RWMutex
 	dbP        *storm.DB
 	client     *http.Client
 	APIURLpath string
@@ -134,8 +134,8 @@ func (db *ProposalDB) AllProposals(offset, rowsCount int,
 		return nil, 0, errDef
 	}
 
-	db.RLock()
-	defer db.RUnlock()
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
 
 	query := db.dbP.Select()
 	if len(filterByVoteStatus) > 0 {
@@ -169,8 +169,8 @@ func (db *ProposalDB) ProposalByID(proposalID int) (proposal *pitypes.ProposalIn
 		return nil, errDef
 	}
 
-	db.RLock()
-	defer db.RUnlock()
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
 
 	var proposals []*pitypes.ProposalInfo
 
@@ -194,8 +194,8 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 		return errDef
 	}
 
-	db.Lock()
-	defer db.Unlock()
+	db.mtx.Lock()
+	defer db.mtx.Unlock()
 
 	// Retrieve and update all current proposals whose vote statuses is either
 	// NotAuthorized, Authorized and Started

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -27,7 +27,7 @@ import (
 // server's mempool.
 type MempoolDataCollector struct {
 	// Mutex is used to prevent multiple concurrent calls to Collect.
-	sync.Mutex
+	mtx          sync.Mutex
 	dcrdChainSvr *rpcclient.Client
 	activeChain  *chaincfg.Params
 }
@@ -132,8 +132,8 @@ func (t *MempoolDataCollector) mempoolTxns() ([]exptypes.MempoolTx, error) {
 func (t *MempoolDataCollector) Collect() (*StakeData, []exptypes.MempoolTx, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
-	t.Lock()
-	defer t.Unlock()
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 
 	// Time this function
 	defer func(start time.Time) {

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -29,7 +29,7 @@ import (
 // PoolInfoCache contains a map of block hashes to ticket pool info data at that
 // block height.
 type PoolInfoCache struct {
-	sync.RWMutex
+	mtx         sync.RWMutex
 	poolInfo    map[chainhash.Hash]*apitypes.TicketPoolInfo
 	expireQueue *lane.Queue
 	maxSize     int
@@ -49,16 +49,16 @@ func NewPoolInfoCache(size int) *PoolInfoCache {
 // a *apitypes.TicketPoolInfo, and a bool indicating if the hash was found in
 // the map.
 func (c *PoolInfoCache) Get(hash chainhash.Hash) (*apitypes.TicketPoolInfo, bool) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	tpi, ok := c.poolInfo[hash]
 	return tpi, ok
 }
 
 // Set stores the ticket pool info for the given hash in the pool info cache.
 func (c *PoolInfoCache) Set(hash chainhash.Hash, p *apitypes.TicketPoolInfo) {
-	c.Lock()
-	defer c.Unlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.poolInfo[hash] = p
 	c.expireQueue.Enqueue(hash)
 	if c.expireQueue.Size() >= c.maxSize {
@@ -71,8 +71,8 @@ func (c *PoolInfoCache) Set(hash chainhash.Hash, p *apitypes.TicketPoolInfo) {
 // the new capacity is smaller than the current cache size, elements are
 // automatically evicted until the desired size is reached.
 func (c *PoolInfoCache) SetCapacity(cap int) error {
-	c.Lock()
-	defer c.Unlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.maxSize = cap
 	for c.expireQueue.Size() >= c.maxSize {
 		expireHash, ok := c.expireQueue.Dequeue().(chainhash.Hash)


### PR DESCRIPTION
It is the responsibility of the pkg to protect internal data, not the caller.