### PR TITLE
share and protect API Status struct

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -472,7 +472,7 @@ func (c *insightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 		}
 		addresses := []string{address}
 		rawTxs, recentTxs, err :=
-			c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.GetHeight()-2))
+			c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.Height-2))
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("InsightAddressTransactions: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -573,9 +573,8 @@ func (c *insightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 	// Initialize Output Structure
 	addressOutput := new(apitypes.InsightMultiAddrsTxOutput)
 	UnconfirmedTxs := []string{}
-
 	rawTxs, recentTxs, err :=
-		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.GetHeight()-2))
+		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.Height-2))
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("InsightAddressTransactions: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -786,10 +785,10 @@ func (c *insightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request
 			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", infoResult.Blocks, err))
 			return
 		}
-		lastblockhash, err := c.nodeClient.GetBlockHash(int64(c.Status.GetHeight()))
+		lastblockhash, err := c.nodeClient.GetBlockHash(int64(c.Status.Height))
 		if err != nil {
-			apiLog.Errorf("Error getting block hash %d (%s)", c.Status.GetHeight(), err)
-			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", c.Status.GetHeight(), err))
+			apiLog.Errorf("Error getting block hash %d (%s)", c.Status.Height, err)
+			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", c.Status.Height, err))
 			return
 		}
 
@@ -955,7 +954,7 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 
 	// Get confirmed transactions.
 	rawTxs, recentTxs, err :=
-		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.GetHeight()-2))
+		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.Status.Height-2))
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("InsightAddressTransactions: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -6,7 +6,6 @@ package types
 import (
 	"encoding/json"
 	"strings"
-	"sync"
 
 	"github.com/decred/dcrd/dcrjson/v2"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
@@ -374,7 +373,6 @@ type VinPrevOut struct {
 // Status indicates the state of the server, including the API version and the
 // software version.
 type Status struct {
-	sync.RWMutex    `json:"-"`
 	Ready           bool   `json:"ready"`
 	DBHeight        uint32 `json:"db_height"`
 	DBLastBlockTime int64  `json:"db_block_time"`
@@ -383,12 +381,6 @@ type Status struct {
 	APIVersion      int    `json:"api_version"`
 	DcrdataVersion  string `json:"dcrdata_version"`
 	NetworkName     string `json:"network_name"`
-}
-
-func (s *Status) GetHeight() uint32 {
-	s.RLock()
-	defer s.RUnlock()
-	return s.Height
 }
 
 // CoinSupply models the coin supply at a certain best block.


### PR DESCRIPTION
With appContext, protect with its own mutex.
With insightApiContext, no need for a mutex since it is never
modified after creation.