### PR TITLE
wireddb/stakedb: proper synchronous ConnectBlock funcs

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -120,8 +120,8 @@ func (db *WiredDB) DisableCache() {
 }
 
 func (db *WiredDB) NewStakeDBChainMonitor(ctx context.Context, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *stakedb.ChainMonitor {
-	return db.sDB.NewChainMonitor(ctx, wg, blockChan, reorgChan)
+	reorgChan chan *txhelpers.ReorgData) *stakedb.ChainMonitor {
+	return db.sDB.NewChainMonitor(ctx, wg, reorgChan)
 }
 
 func (db *WiredDB) ChargePoolInfoCache(startHeight int64) error {

--- a/notification/ntfnchans.go
+++ b/notification/ntfnchans.go
@@ -54,13 +54,13 @@ func MakeNtfnChans(postgresEnabled bool) {
 	// as nil so that both a send (below) blocks and a receive (in
 	// blockConnectedHandler) block. default case makes non-blocking below.
 	// quit channel case manages blockConnectedHandlers.
-	NtfnChans.ConnectChan = make(chan *chainhash.Hash, blockConnChanBuffer)
+	//NtfnChans.ConnectChan = make(chan *chainhash.Hash, blockConnChanBuffer)
 
 	// WiredDB channel for connecting new blocks
 	NtfnChans.ConnectChanWiredDB = make(chan *chainhash.Hash, blockConnChanBuffer)
 
 	// Stake DB channel for connecting new blocks - BLOCKING!
-	NtfnChans.ConnectChanStakeDB = make(chan *chainhash.Hash)
+	//NtfnChans.ConnectChanStakeDB = make(chan *chainhash.Hash)
 
 	NtfnChans.ConnectChanDcrpgDB = make(chan *chainhash.Hash, blockConnChanBuffer)
 

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
@@ -17,49 +16,46 @@ import (
 
 // ChainMonitor connects blocks to the stake DB as they come in.
 type ChainMonitor struct {
-	mtx            sync.Mutex // coordinate reorg handling
-	ctx            context.Context
-	db             *StakeDatabase
-	wg             *sync.WaitGroup
-	blockChan      chan *chainhash.Hash
-	reorgChan      chan *txhelpers.ReorgData
-	syncConnect    sync.Mutex
-	ConnectingLock chan struct{}
-	DoneConnecting chan struct{}
+	mtx       sync.Mutex // coordinate reorg handling
+	ctx       context.Context
+	db        *StakeDatabase
+	wg        *sync.WaitGroup
+	blockChan chan *chainhash.Hash
+	reorgChan chan *txhelpers.ReorgData
 }
 
 // NewChainMonitor creates a new ChainMonitor
 func (db *StakeDatabase) NewChainMonitor(ctx context.Context, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash, reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
+	reorgChan chan *txhelpers.ReorgData) *ChainMonitor {
 	return &ChainMonitor{
-		ctx:            ctx,
-		db:             db,
-		wg:             wg,
-		blockChan:      blockChan,
-		reorgChan:      reorgChan,
-		ConnectingLock: make(chan struct{}, 1),
-		DoneConnecting: make(chan struct{}),
+		ctx:       ctx,
+		db:        db,
+		wg:        wg,
+		reorgChan: reorgChan,
 	}
 }
 
-// BlockConnectedSync is the synchronous (blocking call) handler for the newly
-// connected block given by the hash.
-func (p *ChainMonitor) BlockConnectedSync(hash *chainhash.Hash) (err error) {
-	// Connections go one at a time so signals cannot be mixed
-	p.syncConnect.Lock()
-	defer p.syncConnect.Unlock()
-	// lock with buffered channel, accepting handoff in BlockConnectedHandler
-	p.ConnectingLock <- struct{}{}
-	t := time.NewTimer(10 * time.Second)
-	select {
-	case <-t.C:
-		err = fmt.Errorf("block send timeout")
-	case p.blockChan <- hash:
-		// wait
-		<-p.DoneConnecting
+// ConnectBlock is a sychronous version of BlockConnectedHandler that collects
+// and stores data for a block specified by the given hash.
+func (p *ChainMonitor) ConnectBlock(hash *chainhash.Hash) (err error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	// Extend main chain
+	block, err := p.db.ConnectBlockHash(hash)
+	if err != nil {
+		return err
 	}
 
-	return
+	log.Infof("Connected block %d to stake DB.", block.Height())
+	return nil
+}
+
+// SetNewBlockChan specifies the new-block channel to be used by
+// BlockConnectedHandler. Note that BlockConnectedHandler is not required if
+// using a direct call to ConnectBlock.
+func (p *ChainMonitor) SetNewBlockChan(blockChan chan *chainhash.Hash) {
+	p.blockChan = blockChan
 }
 
 // BlockConnectedHandler handles block connected notifications, which trigger
@@ -71,43 +67,27 @@ out:
 	keepon:
 		select {
 		case hash, ok := <-p.blockChan:
-			p.mtx.Lock()
-			release := func() { p.mtx.Unlock() }
-			select {
-			case <-p.ConnectingLock:
-				// send on unbuffered channel
-				release = func() { p.mtx.Unlock(); p.DoneConnecting <- struct{}{} }
-			default:
-			}
-
 			if !ok {
 				log.Warnf("Block connected channel closed.")
-				release()
 				break out
 			}
 
-			// Extend main chain
+			// Extend main chain.
+			p.mtx.Lock()
 			block, err := p.db.ConnectBlockHash(hash)
+			p.mtx.Unlock()
 			if err != nil {
-				release()
 				log.Error(err)
 				break keepon
 			}
 
 			log.Infof("Connected block %d to stake DB.", block.Height())
 
-			release()
-
 		case <-p.ctx.Done():
 			log.Debugf("Got quit signal. Exiting block connected handler.")
 			break out
 		}
 	}
-
-	// Drain the block connected channel.
-	// for range <-p.blockChan {
-	// }
-
 }
 
 // switchToSideChain attempts to switch to a new side chain by: determining a


### PR DESCRIPTION
The synchronous `BlockConnected` functions (now named `ConnectBlock`) just
do the work without messing with the handler goroutine.
dcrdata (`main`) no longer launches the goroutines that listen on `blockChan`.
Since the goroutines no longer run, do not create the channels. Also do not
pass the channels in the chain monitor constructors.  Instead, create setters
so that other packages that want to use the monitor goroutines instead of the
synchronous functions may do so.