### PR TITLE
dbtypes/dcrpg: add MergeRows

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -762,16 +762,23 @@ func MergeRows(rows []*AddressRow) ([]*AddressRow, map[string]*AddressRow, error
 		// New transactions are started with MergedCount = 1.
 		row := merged[hash]
 		if row == nil {
+			// This is the first component composing this merged row.
 			r.MergedCount = 1
+
 			// Clear the TxVinVoutIndex and VinVoutDbID since merged
 			// transactions do not refer to a single input/output.
 			r.TxVinVoutIndex = 0
 			r.VinVoutDbID = 0
+			// Merged rows are combinations of in and out transaction
+			// components, so the matching tx hash has no meaning.
+			r.MatchingTxHash = ""
+
 			if r.IsFunding {
 				r.AtomsCredit = r.Value
 			} else {
 				r.AtomsDebit = r.Value
 			}
+
 			merged[hash] = r
 			continue
 		}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -741,6 +741,65 @@ func (ar *AddressRow) IsMerged() bool {
 	return ar.MergedCount > 0
 }
 
+// MergeRows converts a slice of non-merged (regular addresses table row data)
+// into a slice of merged address rows. This involves merging rows with the same
+// transaction hash into a single entry by combining the signed values. The
+// IsFunding field of a merged transaction indicates if the net value is
+// positive or not, although the Value field is an absolute value (always
+// positive). A map of transaction hash to *AddressRow is also returned.
+// MergedRows will return a non-nil error of a merged row is detected in the
+// input since only non-merged rows are expected.
+func MergeRows(rows []*AddressRow) ([]*AddressRow, map[string]*AddressRow, error) {
+	merged := make(map[string]*AddressRow)
+	for _, r := range rows {
+		if r.MergedCount != 0 {
+			return nil, nil,
+				fmt.Errorf("merged row found in input; " +
+					"only non-merged rows may be merged")
+		}
+		hash := r.TxHash
+
+		// New transactions are started with MergedCount = 1.
+		row := merged[hash]
+		if row == nil {
+			r.MergedCount = 1
+			// Clear the TxVinVoutIndex and VinVoutDbID since merged
+			// transactions do not refer to a single input/output.
+			r.TxVinVoutIndex = 0
+			r.VinVoutDbID = 0
+			if r.IsFunding {
+				r.AtomsCredit = r.Value
+			} else {
+				r.AtomsDebit = r.Value
+			}
+			merged[hash] = r
+			continue
+		}
+
+		// Update existing transaction.
+		row.MergedCount++
+		if r.IsFunding {
+			row.AtomsCredit += r.Value
+		} else {
+			row.AtomsDebit += r.Value
+		}
+	}
+
+	// Set the Value and IsFunding fields, and build the slice.
+	mergedRows := make([]*AddressRow, 0, len(merged))
+	for _, mr := range merged {
+		value := int64(mr.AtomsCredit) - int64(mr.AtomsDebit)
+		mr.IsFunding = value >= 0
+		if !mr.IsFunding {
+			value = -value
+		}
+		mr.Value = uint64(value)
+		mergedRows = append(mergedRows, mr)
+	}
+
+	return mergedRows, merged, nil
+}
+
 // AddressMetrics defines address metrics needed to make decisions by which
 // grouping buttons on the address history page charts should be disabled or
 // enabled by default.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1144,13 +1144,15 @@ func (pgb *ChainDB) AddressTransactionsAll(address string) (addressRows []*dbtyp
 	return
 }
 
-// AddressTransactionsAllMerged retrieves all merged mainchain addresses table
-// rows for the given address.
+// AddressTransactionsAllMerged retrieves all merged (stakeholder-approved and
+// mainchain only) addresses table rows for the given address.
 func (pgb *ChainDB) AddressTransactionsAllMerged(address string) (addressRows []*dbtypes.AddressRow, err error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 
-	_, addressRows, err = RetrieveAllMainchainAddressMergedTxns(ctx, pgb.db, address)
+	onlyValidMainchain := true
+	_, addressRows, err = RetrieveAllAddressMergedTxns(ctx, pgb.db, address,
+		onlyValidMainchain)
 	err = pgb.replaceCancelError(err)
 	return
 }

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -141,10 +141,14 @@ func TestMergeRows(t *testing.T) {
 			len(mergedRows), len(mergedRows0))
 	}
 
-	for _, mr := range mergedRows0 {
-		_, ok := mrMap[mr.TxHash]
+	for _, mr0 := range mergedRows0 {
+		mr, ok := mrMap[mr0.TxHash]
 		if !ok {
-			t.Errorf("TxHash %s not found in mergedRows.", mr.TxHash)
+			t.Errorf("TxHash %s not found in mergedRows.", mr0.TxHash)
+			continue
+		}
+		if !reflect.DeepEqual(mr, mr0) {
+			t.Errorf("wanted %v, got %v", mr0, mr)
 		}
 	}
 }


### PR DESCRIPTION
Add `dbtypes.MergeRows` to converts a slice of non-merged
(regular addresses table row data) into a slice of merged
address rows. This involves merging rows with the same
transaction hash into a single entry by combining the signed
values. The `IsFunding` field of a merged transaction indicates
if the net value is positive or not, although the `Value` field is
an absolute value (always positive). A map of transaction hash
to `*AddressRow` is also returned.  `MergedRows` will return a
non-nil error of a merged row is detected in the input since
only non-merged rows are expected.

Add a test for `MergeRows` in pgblockchain_test since it is best
tested with a live DB using the project fund address.

Also change `AddressTransactionsAllMerged` so it only gets
`valid_mainchain` rows.
Change `RetrieveAllMainchainAddressMergedTxns`, which
actually got all rows including invalidated and side chain rows,
so that it can be restricted to `valid_mainchain=true` rows.
Ensure that `retrieveAddressTxns` only requests valid mainchain results
when requesting merged results to match the non-merged request.

**NEXT:** Never fetch merged rows and instead use `dbtypes.MergedRows`.