### PR TITLE
explorer: sync mempool on websocket connection

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -401,9 +401,9 @@ func (exp *explorerUI) MempoolInventory() *types.MempoolInfo {
 
 // MempoolID safely fetches the current mempool inventory ID.
 func (exp *explorerUI) MempoolID() uint64 {
-	exp.mempool.mtx.RLock()
-	defer exp.mempool.mtx.RUnlock()
-	return exp.mempool.Inv.ID()
+	exp.invsMtx.RLock()
+	defer exp.invsMtx.RUnlock()
+	return exp.invs.ID()
 }
 
 // MempoolSignals returns the mempool signal and data channels, which are to be

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -399,6 +399,13 @@ func (exp *explorerUI) MempoolInventory() *types.MempoolInfo {
 	return exp.invs
 }
 
+// MempoolID safely fetches the current mempool inventory ID.
+func (exp *explorerUI) MempoolID() uint64 {
+	exp.mempool.mtx.RLock()
+	defer exp.mempool.mtx.RUnlock()
+	return exp.mempool.Inv.ID()
+}
+
 // MempoolSignals returns the mempool signal and data channels, which are to be
 // used by the mempool package's MempoolMonitor as send only channels.
 func (exp *explorerUI) MempoolSignals() (chan<- pstypes.HubSignal, chan<- *types.MempoolTx) {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -441,6 +441,7 @@ type MempoolInfo struct {
 	Tickets      []MempoolTx `json:"tickets"`
 	Votes        []MempoolTx `json:"votes"`
 	Revocations  []MempoolTx `json:"revs"`
+	Ident        uint64      `json:"id"`
 }
 
 // DeepCopy makes a deep copy of MempoolInfo, where all the slice and map data
@@ -531,6 +532,13 @@ func (mpi *MempoolInfo) Tx(txid string) (MempoolTx, bool) {
 		return getTxFromList(txid, mpi.Revocations)
 	}
 	return MempoolTx{}, false
+}
+
+// ID can be used to track state changes.
+func (mpi *MempoolInfo) ID() uint64 {
+	mpi.RLock()
+	defer mpi.RUnlock()
+	return mpi.Ident
 }
 
 // FilterRegularTx returns a slice of all the regular (non-stake) transactions
@@ -738,8 +746,8 @@ func (vi *VotingInfo) Tally(vinfo *VoteInfo) {
 	}
 }
 
-// Tallys fetches the mempool VoteTally.VoteList if found, else a list of
-// VoteMissing.
+// BlockStatus fetches a list of votes in mempool, for the provided block hash.
+// If not found, a list of VoteMissing is returned.
 func (vi *VotingInfo) BlockStatus(hash string) ([]int, int) {
 	tally, ok := vi.VoteTallys[hash]
 	if ok {

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -102,6 +102,21 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// MempoolInfo. Used on mempool and home page.
 					inv := exp.MempoolInventory()
 
+					// Check if client supplied a mempool ID. If so, check that an update
+					// is needed before sending.
+					if msg.Message != "" {
+						clientID, err := strconv.ParseUint(msg.Message, 10, 64)
+						if err != nil {
+							// For now, just log a warning and return the mempool anyway.
+							log.Warn("Unable to parse supplied mempool ID %s", msg.Message)
+						} else {
+							if inv.ID() == clientID {
+								// Client is up-to-date. No need to send anything.
+								continue
+							}
+						}
+					}
+
 					inv.RLock()
 					msg, err := json.Marshal(inv)
 					inv.RUnlock()

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -165,6 +165,9 @@ func (p *MempoolMonitor) TxHandler(client *rpcclient.Client) {
 				continue // back to waiting for new tx signal
 			}
 
+			// Iterate the state id.
+			p.inventory.Ident++
+
 			// If this is a vote, decode vote bits.
 			var voteInfo *exptypes.VoteInfo
 			if ok := stake.IsSSGen(msgTx); ok {
@@ -344,6 +347,9 @@ func (p *MempoolMonitor) Refresh() (*StakeData, []exptypes.MempoolTx, *exptypes.
 
 	// Store the current best block info.
 	p.lastBlock = stakeData.LatestBlock
+	if p.inventory != nil {
+		inventory.Ident = p.inventory.ID() + 1
+	}
 	p.inventory = inventory
 	p.mtx.Unlock()
 

--- a/public/index.js
+++ b/public/index.js
@@ -33,7 +33,7 @@ function sleep (ms) {
 async function createWebSocket (loc) {
   // wait a bit to prevent websocket churn from drive by page loads
   var uri = getSocketURI(loc)
-  await sleep(3000)
+  await sleep(1000)
   ws.connect(uri)
 
   var updateBlockData = function (event) {

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -46,7 +46,9 @@ export default class extends Controller {
 
   connect () {
     this.ticketsPerBlock = parseInt(this.mpVoteCountTarget.dataset.ticketsPerBlock)
-    this.mempool = new Mempool(this.mempoolTarget.dataset, this.voteTallyTargets)
+    var mempoolData = this.mempoolTarget.dataset
+    ws.send('getmempooltxs', mempoolData.id)
+    this.mempool = new Mempool(mempoolData, this.voteTallyTargets)
     this.setBars(this.mempool.totals())
     ws.registerEvtHandler('newtx', (evt) => {
       var txs = JSON.parse(evt)

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -21,8 +21,8 @@ function mempoolTableRow (tx) {
     <td class="text-left pl-1">${humanize.hashElide(tx.hash, link)}</td>
     <td>${tx.Type}</td>
     <td>${humanize.threeSigFigs(tx.total || 0, false, 8)}</td>
-    <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell">${tx.size} B</td>
-    <td class="text-right pr-3 home-bl-age" data-target="time.age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
+    <td class="d-none d-sm-table-cell d-md-none d-lg-table-cell text-nowrap">${tx.size} B</td>
+    <td class="text-right pr-3 home-bl-age text-nowrap" data-target="time.age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
   </tr>`
   dompurify.sanitize(tbody, { IN_PLACE: true })
   return tbody.firstChild

--- a/public/js/controllers/mempool_controller.js
+++ b/public/js/controllers/mempool_controller.js
@@ -84,7 +84,9 @@ export default class extends Controller {
 
   connect () {
     // from txhelpers.DetermineTxTypeString
-    this.mempool = new Mempool(this.mempoolTarget.dataset, this.voteTallyTargets)
+    var mempoolData = this.mempoolTarget.dataset
+    ws.send('getmempooltxs', mempoolData.id)
+    this.mempool = new Mempool(mempoolData, this.voteTallyTargets)
     this.txTargetMap = {
       'Vote': this.voteTransactionsTarget,
       'Ticket': this.ticketTransactionsTarget,

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -336,6 +336,7 @@
 
 {{define "mempoolDump"}}
   {{$likely := .LikelyMineable}}
+  data-id="{{.Ident}}"
   data-total="{{$likely.Total}}"
   data-size="{{$likely.Size}}"
   data-count="{{$likely.Count}}"

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -78,8 +78,8 @@
                                         <td class="text-center" data-type="tickets">{{.FreshStake}}</td>
                                         <td class="text-center" data-type="revocations">{{.Revocations}}</td>
                                         <td class="text-center" data-type="value">{{threeSigFigs .Total}}</td>
-                                        <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="size">{{.FormattedBytes}}</td>
-                                        <td class="text-right pr-2" data-type="age" data-target="time.age" data-age="{{.BlockTime.UNIX}}">{{.BlockTime}}</td>
+                                        <td class="text-center d-none d-sm-table-cell d-md-none d-lg-table-cell text-nowrap" data-type="size">{{.FormattedBytes}}</td>
+                                        <td class="text-right pr-2 text-nowrap" data-type="age" data-target="time.age" data-age="{{.BlockTime.UNIX}}">{{.BlockTime}}</td>
                                     </tr>
                                     {{end}}
                                 </tbody>


### PR DESCRIPTION
Once the websocket client connects, check the clients mempool ID to see if anything has changed. If so, send a full mempool update. 

This corrects some issues when txs come in during the period after page load but before the websocket connection is made.

I still haven't pinned down how the vote icons can be missing completely, as shown in #1095. The votes for those icons are pulled from either `VotingInfo.BlockStatus` or `VoteTally.Status`, both of which pad their lists with `VoteMissing` to the correct length. 