### PR TITLE
explorer/syncstatus.go: Fix barload data race

### DIFF
--- a/explorer/syncstatus.go
+++ b/explorer/syncstatus.go
@@ -67,13 +67,15 @@ func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarL
 
 	// stopTimer allows safe exit of the goroutine that triggers periodic
 	// websocket progress update.
-	var stopTimer chan bool
+	stopTimer := make(chan bool)
 
 	exp.EnableSyncStatusPage(true)
 
 	// Periodically trigger websocket hub to signal a progress update.
 	go func() {
 		timer := time.NewTicker(syncStatusInterval)
+
+	timerLoop:
 		for {
 			select {
 			case <-timer.C:
@@ -83,7 +85,7 @@ func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarL
 			case <-stopTimer:
 				log.Debug("Stopping progress bar signals.")
 				timer.Stop()
-				return
+				break timerLoop
 			}
 		}
 	}()

--- a/explorer/syncstatus.go
+++ b/explorer/syncstatus.go
@@ -67,7 +67,7 @@ func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarL
 
 	// stopTimer allows safe exit of the goroutine that triggers periodic
 	// websocket progress update.
-	stopTimer := make(chan bool)
+	stopTimer := make(chan struct{})
 
 	exp.EnableSyncStatusPage(true)
 
@@ -109,7 +109,7 @@ func (exp *explorerUI) BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarL
 	barloop:
 		for bar := range barLoad {
 			if bar == nil {
-				stopTimer <- true
+				stopTimer <- struct{}{}
 				return
 			}
 


### PR DESCRIPTION
Fixes: #1103

Adds a `stopTimer` channel shared between the goroutines launched in `BeginSyncStatusUpdates(barLoad chan *dbtypes.ProgressBarLoad) {`