### PR TITLE
cache: rework address cache capacity

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -331,7 +331,7 @@ func (c *insightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http
 	txnOutputs := make([]apitypes.AddressTxnOutput, 0)
 
 	for _, address := range addresses {
-		confirmedTxnOutputs, err := c.BlockData.ChainDB.AddressUTXO(address)
+		confirmedTxnOutputs, _, err := c.BlockData.ChainDB.AddressUTXO(address)
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("AddressUTXO: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -701,7 +701,7 @@ func (c *insightApiContext) getAddressBalance(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	addressInfo, err := c.BlockData.ChainDB.AddressBalance(addresses[0])
+	addressInfo, _, err := c.BlockData.ChainDB.AddressBalance(addresses[0])
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressBalance: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -947,7 +947,7 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	// Get Confirmed Balances
 	var unconfirmedBalanceSat int64
 
-	balance, err := c.BlockData.ChainDB.AddressBalance(address)
+	balance, _, err := c.BlockData.ChainDB.AddressBalance(address)
 
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressSpentUnspent: %v", err)

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -123,7 +123,7 @@ func mainCore() error {
 		DBName: cfg.DBName,
 	}
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
-	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig)
+	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0)
 	if db != nil {
 		defer db.Close()
 	}

--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ var (
 	defaultPGPass                       = ""
 	defaultPGDBName                     = "dcrdata"
 	defaultPGQueryTimeout time.Duration = time.Hour
+	defaultAddrCacheCap                 = 1 << 27 // 128 MiB
 
 	defaultExchangeIndex     = "USD"
 	defaultDisabledExchanges = "huobi,dragonex"
@@ -123,6 +124,7 @@ type config struct {
 	PGHost         string        `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)." env:"DCRDATA_POSTGRES_HOST_URL"`
 	PGQueryTimeout time.Duration `short:"T" long:"pgtimeout" description:"Timeout (a time.Duration string) for most PostgreSQL queries used for user initiated queries."`
 	HidePGConfig   bool          `long:"hidepgconfig" description:"Blocks logging of the PostgreSQL db configuration on system start up."`
+	AddrCacheCap   int           `long:"addr-cache-cap" description:"Address cache capacity in bytes."`
 
 	NoDevPrefetch    bool `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
 	SyncAndQuit      bool `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`
@@ -178,6 +180,7 @@ var (
 		PGPass:              defaultPGPass,
 		PGHost:              defaultPGHost,
 		PGQueryTimeout:      defaultPGQueryTimeout,
+		AddrCacheCap:        defaultAddrCacheCap,
 		ExchangeCurrency:    defaultExchangeIndex,
 		DisabledExchanges:   defaultDisabledExchanges,
 		RateCertificate:     defaultRateCertFile,

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -12,10 +12,26 @@ package cache
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	apitypes "github.com/decred/dcrdata/v4/api/types"
 	"github.com/decred/dcrdata/v4/db/dbtypes"
+)
+
+const (
+	// addressCapacity is an absolute limit on the number of addresses that may
+	// have cached data, regardless of the number of rows.
+	addressCapacity = 1024
+
+	// The size of a AddressTxnOutput varies, but it is roughly 256 bytes.
+	approxTxnOutSize = 256
+
+	// Unlike address rows, which are counted precisely, UTXO limits are
+	// enforced per-address. maxUTXOsPerAddr is set to require at most 128 MiB
+	// given the approximate AddressTxnOutput size and full address capacity.
+	// maxUTXOsPerAddr * 256 * 1024 = 128 MiB, maxUTXOsPerAddr = 512.
+	maxUTXOsPerAddr = (1 << 27) / approxTxnOutSize / addressCapacity
 )
 
 // CacheLock is a "try lock" for coordinating multiple accessors, while allowing
@@ -66,7 +82,7 @@ func (cl *CacheLock) TryLock(addr string) (busy bool, wait chan struct{}, done f
 }
 
 // CountCreditDebitRows returns the numbers of credit (funding) and debit
-// (!funding) address rows.
+// (!funding) address rows in a []*dbtypes.AddressRow.
 func CountCreditDebitRows(rows []*dbtypes.AddressRow) (numCredit, numDebit int) {
 	for _, r := range rows {
 		if r.IsFunding {
@@ -78,14 +94,96 @@ func CountCreditDebitRows(rows []*dbtypes.AddressRow) (numCredit, numDebit int) 
 	return
 }
 
-// CreditAddressRows returns up to N credit (funding) address rows from the
-// given AddressRow slice, starting after skipping offset rows.
-func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
-	if offset >= len(rows) {
+// CountCreditDebitRowsCompact returns the numbers of credit (funding) and debit
+// (!funding) address rows in a []dbtypes.AddressRowCompact.
+func CountCreditDebitRowsCompact(rows []dbtypes.AddressRowCompact) (numCredit, numDebit int) {
+	for i := range rows {
+		if rows[i].IsFunding {
+			numCredit++
+		} else {
+			numDebit++
+		}
+	}
+	return
+}
+
+// CountCreditDebitRowsMerged returns the numbers of credit (funding) and debit
+// (!funding) address rows in a []dbtypes.AddressRowMerged.
+func CountCreditDebitRowsMerged(rows []dbtypes.AddressRowMerged) (numCredit, numDebit int) {
+	for i := range rows {
+		if rows[i].IsFunding() {
+			numCredit++
+		} else {
+			numDebit++
+		}
+	}
+	return
+}
+
+func addressRows(rows []dbtypes.AddressRowCompact, N, offset int) []dbtypes.AddressRowCompact {
+	if rows == nil {
 		return nil
 	}
+	numRows := len(rows)
+	if offset >= numRows {
+		return []dbtypes.AddressRowCompact{}
+	}
 
-	numCreditRows, _ := CountCreditDebitRows(rows)
+	end := offset + N
+	if end > numRows {
+		end = numRows
+	}
+	if offset < end {
+		return rows[offset:end]
+	}
+	return []dbtypes.AddressRowCompact{}
+}
+
+func addressRowsMerged(rows []dbtypes.AddressRowMerged, N, offset int) []dbtypes.AddressRowMerged {
+	if rows == nil {
+		return nil
+	}
+	numRows := len(rows)
+	if offset >= numRows {
+		return []dbtypes.AddressRowMerged{}
+	}
+
+	end := offset + N
+	if end > numRows {
+		end = numRows
+	}
+	if offset < end {
+		return rows[offset:end]
+	}
+	return []dbtypes.AddressRowMerged{}
+}
+
+// CreditAddressRows returns up to N credit (funding) address rows from the
+// given AddressRow slice, starting after skipping offset rows. The input rows
+// may only be of type []dbtypes.AddressRowCompact or
+// []dbtypes.AddressRowMerged. The same type is returned, unless the input type
+// is unrecognized, in which case a nil interface is returned.
+func CreditAddressRows(rows interface{}, N, offset int) interface{} {
+	switch r := rows.(type) {
+	case []dbtypes.AddressRowCompact:
+		return creditAddressRows(r, N, offset)
+	case []dbtypes.AddressRowMerged:
+		return creditAddressRowsMerged(r, N, offset)
+	default:
+		return nil
+	}
+}
+
+func creditAddressRows(rows []dbtypes.AddressRowCompact, N, offset int) []dbtypes.AddressRowCompact {
+	if rows == nil {
+		return nil
+	}
+	if offset >= len(rows) {
+		return []dbtypes.AddressRowCompact{}
+	}
+
+	// Count the number of IsFunding rows in the input slice.
+	numCreditRows, _ := CountCreditDebitRowsCompact(rows)
 	if numCreditRows < N {
 		N = numCreditRows
 	}
@@ -94,9 +192,9 @@ func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Add
 	}
 
 	var skipped int
-	out := make([]*dbtypes.AddressRow, 0, N)
-	for _, r := range rows {
-		if !r.IsFunding {
+	out := make([]dbtypes.AddressRowCompact, 0, N)
+	for i := range rows {
+		if !rows[i].IsFunding {
 			continue
 		}
 		if skipped < offset {
@@ -104,7 +202,43 @@ func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Add
 			continue
 		}
 		// Append this row, and break the loop if we have N rows.
-		out = append(out, r)
+		out = append(out, rows[i])
+		if len(out) == N {
+			break
+		}
+	}
+	return out
+}
+
+func creditAddressRowsMerged(rows []dbtypes.AddressRowMerged, N, offset int) []dbtypes.AddressRowMerged {
+	if rows == nil {
+		return nil
+	}
+	if offset >= len(rows) {
+		return []dbtypes.AddressRowMerged{}
+	}
+
+	// Count the number of IsFunding() rows in the input slice.
+	numCreditRows, _ := CountCreditDebitRowsMerged(rows)
+	if numCreditRows < N {
+		N = numCreditRows
+	}
+	if offset >= numCreditRows {
+		return nil
+	}
+
+	var skipped int
+	out := make([]dbtypes.AddressRowMerged, 0, N)
+	for i := range rows {
+		if !rows[i].IsFunding() {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		// Append this row, and break the loop if we have N rows.
+		out = append(out, rows[i])
 		if len(out) == N {
 			break
 		}
@@ -113,16 +247,38 @@ func CreditAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Add
 }
 
 // DebitAddressRows returns up to N debit (!funding) address rows from the given
-// AddressRow slice, starting after skipping offset rows.
-func DebitAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.AddressRow {
-	_, numDebitRows := CountCreditDebitRows(rows)
+// AddressRow slice, starting after skipping offset rows. The input rows may
+// only be of type []dbtypes.AddressRowCompact or []dbtypes.AddressRowMerged.
+// The same type is returned, unless the input type is unrecognized, in which
+// case a nil interface is returned.
+func DebitAddressRows(rows interface{}, N, offset int) interface{} {
+	switch r := rows.(type) {
+	case []dbtypes.AddressRowCompact:
+		return debitAddressRows(r, N, offset)
+	case []dbtypes.AddressRowMerged:
+		return debitAddressRowsMerged(r, N, offset)
+	default:
+		return nil
+	}
+}
+
+func debitAddressRows(rows []dbtypes.AddressRowCompact, N, offset int) []dbtypes.AddressRowCompact {
+	if rows == nil {
+		return nil
+	}
+	if offset >= len(rows) {
+		return []dbtypes.AddressRowCompact{}
+	}
+
+	// Count the number of !IsFunding rows in the input slice.
+	_, numDebitRows := CountCreditDebitRowsCompact(rows)
 	if numDebitRows < N {
 		N = numDebitRows
 	}
 	var skipped int
-	out := make([]*dbtypes.AddressRow, 0, N)
-	for _, r := range rows {
-		if r.IsFunding {
+	out := make([]dbtypes.AddressRowCompact, 0, N)
+	for i := range rows {
+		if rows[i].IsFunding {
 			continue
 		}
 		if skipped < offset {
@@ -130,7 +286,39 @@ func DebitAddressRows(rows []*dbtypes.AddressRow, N, offset int) []*dbtypes.Addr
 			continue
 		}
 		// Append this row, and break the loop if we have N rows.
-		out = append(out, r)
+		out = append(out, rows[i])
+		if len(out) == N {
+			break
+		}
+	}
+	return out
+}
+
+func debitAddressRowsMerged(rows []dbtypes.AddressRowMerged, N, offset int) []dbtypes.AddressRowMerged {
+	if rows == nil {
+		return nil
+	}
+	if offset >= len(rows) {
+		return []dbtypes.AddressRowMerged{}
+	}
+
+	// Count the number of !IsFunding() rows in the input slice.
+	_, numDebitRows := CountCreditDebitRowsMerged(rows)
+	if numDebitRows < N {
+		N = numDebitRows
+	}
+	var skipped int
+	out := make([]dbtypes.AddressRowMerged, 0, N)
+	for i := range rows {
+		if rows[i].IsFunding() {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		// Append this row, and break the loop if we have N rows.
+		out = append(out, rows[i])
 		if len(out) == N {
 			break
 		}
@@ -176,14 +364,13 @@ func AllDebitAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 // are: balance, all non-merged address table rows, all merged address table
 // rows, all UTXOs, and address metrics.
 type AddressCacheItem struct {
-	mtx        sync.RWMutex
-	balance    *dbtypes.AddressBalance
-	rows       []*dbtypes.AddressRow // creditDebitQuery
-	rowsMerged []*dbtypes.AddressRow // mergedQuery
-	utxos      []apitypes.AddressTxnOutput
-	metrics    *dbtypes.AddressMetrics
-	height     int64
-	hash       chainhash.Hash
+	mtx     sync.RWMutex
+	balance *dbtypes.AddressBalance
+	rows    []dbtypes.AddressRowCompact // creditDebitQuery
+	utxos   []apitypes.AddressTxnOutput
+	metrics *dbtypes.AddressMetrics
+	height  int64
+	hash    chainhash.Hash
 }
 
 // BlockID provides basic identifying information about a block.
@@ -250,23 +437,13 @@ func (d *AddressCacheItem) Metrics() (*dbtypes.AddressMetrics, *BlockID) {
 }
 
 // Rows is a thread-safe accessor for the []*dbtypes.AddressRow.
-func (d *AddressCacheItem) Rows() ([]*dbtypes.AddressRow, *BlockID) {
+func (d *AddressCacheItem) Rows() ([]dbtypes.AddressRowCompact, *BlockID) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
 	if d.rows == nil {
 		return nil, nil
 	}
 	return d.rows, d.blockID()
-}
-
-// RowsMerged is a thread-safe accessor for the []*dbtypes.AddressRow.
-func (d *AddressCacheItem) RowsMerged() ([]*dbtypes.AddressRow, *BlockID) {
-	d.mtx.RLock()
-	defer d.mtx.RUnlock()
-	if d.rowsMerged == nil {
-		return nil, nil
-	}
-	return d.rowsMerged, d.blockID()
 }
 
 // NumRows returns the number of non-merged rows. If the rows are not cached, a
@@ -280,22 +457,11 @@ func (d *AddressCacheItem) NumRows() (int, *BlockID) {
 	return len(d.rows), d.blockID()
 }
 
-// NumRowsMerged returns the number of merged rows. If the rows are not cached,
-// a count of -1 and *BlockID of nil are returned.
-func (d *AddressCacheItem) NumRowsMerged() (int, *BlockID) {
-	d.mtx.RLock()
-	defer d.mtx.RUnlock()
-	if d.rowsMerged == nil {
-		return -1, nil
-	}
-	return len(d.rowsMerged), d.blockID()
-}
-
 // Transactions attempts to retrieve transaction data for the given view (merged
 // or not, debit/credit/all). Like the DB queries, the number of transactions to
 // retrieve, N, and the number of transactions to skip, offset, are also
 // specified.
-func (d *AddressCacheItem) Transactions(N, offset int, txnView dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *BlockID, error) {
+func (d *AddressCacheItem) Transactions(N, offset int, txnView dbtypes.AddrTxnViewType) (interface{}, *BlockID, error) {
 	if offset < 0 || N < 0 {
 		return nil, nil, fmt.Errorf("invalid offset (%d) or N (%d)", offset, N)
 	}
@@ -308,54 +474,38 @@ func (d *AddressCacheItem) Transactions(N, offset int, txnView dbtypes.AddrTxnVi
 	defer d.mtx.RUnlock()
 	merged, err := txnView.IsMerged()
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid transaction view")
+		return nil, nil, fmt.Errorf("invalid transaction view: %v", txnView)
 	}
-	if merged && d.rowsMerged == nil {
-		return nil, nil, nil // cache miss is not an error
-	}
-	if !merged && d.rows == nil {
+	if d.rows == nil {
 		return nil, nil, nil // cache miss is not an error
 	}
 
-	// Cache hit, not nil.
-	rows := []*dbtypes.AddressRow{}
-	if N == 0 || len(d.rows) == 0 {
-		// Not a cache miss, just no requested or existing data.
-		return rows, d.blockID(), nil
-	}
+	blockID := d.blockID()
+	numRows := len(d.rows)
 
-	endRange := func(l int) int {
-		end := offset + N
-		if end > l {
-			end = l
+	if N == 0 || numRows == 0 || offset >= numRows {
+		// Not a cache miss, just no requested or matching data.
+		if merged {
+			return []dbtypes.AddressRowMerged{}, blockID, nil
 		}
-		return end
+		return []dbtypes.AddressRowCompact{}, blockID, nil
 	}
 
 	switch txnView {
 	case dbtypes.AddrTxnAll:
-		end := endRange(len(d.rows))
-		if offset < end {
-			rows = d.rows[offset:end]
-		}
+		// []dbtypes.AddressRowCompact
+		return addressRows(d.rows, N, offset), blockID, nil
 	case dbtypes.AddrTxnCredit:
-		rows = CreditAddressRows(d.rows, N, offset)
+		return creditAddressRows(d.rows, N, offset), blockID, nil
 	case dbtypes.AddrTxnDebit:
-		rows = DebitAddressRows(d.rows, N, offset)
-	case dbtypes.AddrMergedTxn:
-		end := endRange(len(d.rowsMerged))
-		if offset < end {
-			rows = d.rowsMerged[offset:end]
-		}
-	case dbtypes.AddrMergedTxnCredit:
-		rows = CreditAddressRows(d.rowsMerged, N, offset)
-	case dbtypes.AddrMergedTxnDebit:
-		rows = DebitAddressRows(d.rowsMerged, N, offset)
+		return debitAddressRows(d.rows, N, offset), blockID, nil
+	case dbtypes.AddrMergedTxn, dbtypes.AddrMergedTxnCredit, dbtypes.AddrMergedTxnDebit:
+		// []dbtypes.AddressRowMerged
+		return dbtypes.MergeRowsCompactRange(d.rows, N, offset, txnView), blockID, nil
 	default:
+		// This should already be caught by IsMerged err check.
 		return nil, nil, fmt.Errorf("unrecognized address transaction view: %v", txnView)
 	}
-
-	return rows, d.blockID(), nil
 }
 
 // setBlock ensures that the AddressCacheItem pertains to the given BlockID,
@@ -371,25 +521,15 @@ func (d *AddressCacheItem) setBlock(block BlockID) {
 	d.metrics = nil
 	d.balance = nil
 	d.rows = nil
-	d.rowsMerged = nil
 }
 
 // SetRows updates the cache item for the given non-merged AddressRow slice
 // valid at the given BlockID.
-func (d *AddressCacheItem) SetRows(block BlockID, rows []*dbtypes.AddressRow) {
+func (d *AddressCacheItem) SetRows(block BlockID, rows []dbtypes.AddressRowCompact) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	d.setBlock(block)
 	d.rows = rows
-}
-
-// SetRowsMerged updates the cache item for the given merged AddressRow slice
-// valid at the given BlockID.
-func (d *AddressCacheItem) SetRowsMerged(block BlockID, rows []*dbtypes.AddressRow) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-	d.setBlock(block)
-	d.rowsMerged = rows
 }
 
 // SetUTXOs updates the cache item for the given AddressTxnOutput slice valid at
@@ -410,24 +550,155 @@ func (d *AddressCacheItem) SetBalance(block BlockID, balance *dbtypes.AddressBal
 	d.balance = balance
 }
 
+type CacheCounts struct {
+	Hits, Misses int
+}
+
+type cacheCounts struct {
+	sync.Mutex
+	CacheCounts
+}
+
+type CacheMetrics struct {
+	rowMetrics     cacheCounts
+	utxoMetrics    cacheCounts
+	balanceMetrics cacheCounts
+	metricMetrics  cacheCounts
+}
+
+func (cm *CacheMetrics) RowStats() (hits, misses int) {
+	cm.rowMetrics.Lock()
+	defer cm.rowMetrics.Unlock()
+	return cm.rowMetrics.Hits, cm.rowMetrics.Misses
+}
+
+func (cm *CacheMetrics) BalanceStats() (hits, misses int) {
+	cm.balanceMetrics.Lock()
+	defer cm.balanceMetrics.Unlock()
+	return cm.balanceMetrics.Hits, cm.balanceMetrics.Misses
+}
+
+func (cm *CacheMetrics) UtxoStats() (hits, misses int) {
+	cm.utxoMetrics.Lock()
+	defer cm.utxoMetrics.Unlock()
+	return cm.utxoMetrics.Hits, cm.utxoMetrics.Misses
+}
+
+func (cm *CacheMetrics) MetricStats() (hits, misses int) {
+	cm.metricMetrics.Lock()
+	defer cm.metricMetrics.Unlock()
+	return cm.metricMetrics.Hits, cm.metricMetrics.Misses
+}
+
+func (cm *CacheMetrics) RowHit() {
+	cm.rowMetrics.Lock()
+	cm.rowMetrics.Hits++
+	cm.rowMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) RowMiss() {
+	cm.rowMetrics.Lock()
+	cm.rowMetrics.Misses++
+	cm.rowMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) UtxoHit() {
+	cm.utxoMetrics.Lock()
+	cm.utxoMetrics.Hits++
+	cm.utxoMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) UtxoMiss() {
+	cm.utxoMetrics.Lock()
+	cm.utxoMetrics.Misses++
+	cm.utxoMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) BalanceHit() {
+	cm.balanceMetrics.Lock()
+	cm.balanceMetrics.Hits++
+	cm.balanceMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) BalanceMiss() {
+	cm.balanceMetrics.Lock()
+	cm.balanceMetrics.Misses++
+	cm.balanceMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) MetricHit() {
+	cm.metricMetrics.Lock()
+	cm.metricMetrics.Hits++
+	cm.metricMetrics.Unlock()
+}
+
+func (cm *CacheMetrics) MetricMiss() {
+	cm.metricMetrics.Lock()
+	cm.metricMetrics.Misses++
+	cm.metricMetrics.Unlock()
+}
+
 // AddressCache maintains a store of address data. Use NewAddressCache to create
 // a new AddressCache with initialized internal data structures.
 type AddressCache struct {
 	mtx            sync.RWMutex
 	a              map[string]*AddressCacheItem
 	cap            int
+	capAddr        int
+	cacheMetrics   CacheMetrics
 	ProjectAddress string
 }
 
-// NewAddressCache constructs a AddressCache with capacity for the specified
-// number of addresses.
-func NewAddressCache(cap int) *AddressCache {
-	if cap < 2 {
-		cap = 2
+// NewAddressCache constructs an AddressCache with capacity for the specified
+// number of address rows.
+func NewAddressCache(rowCapacity int) *AddressCache {
+	if rowCapacity < 0 {
+		rowCapacity = 0
 	}
-	return &AddressCache{
-		a:   make(map[string]*AddressCacheItem, cap),
-		cap: cap,
+	ac := &AddressCache{
+		a:       make(map[string]*AddressCacheItem),
+		cap:     rowCapacity,
+		capAddr: addressCapacity,
+	}
+	defer func() { go ac.Reporter() }()
+	return ac
+}
+
+func (ac *AddressCache) BalanceStats() (hits, misses int) {
+	return ac.cacheMetrics.BalanceStats()
+}
+
+func (ac *AddressCache) RowStats() (hits, misses int) {
+	return ac.cacheMetrics.RowStats()
+}
+
+func (ac *AddressCache) UtxoStats() (hits, misses int) {
+	return ac.cacheMetrics.UtxoStats()
+}
+
+func (ac *AddressCache) MetricStats() (hits, misses int) {
+	return ac.cacheMetrics.MetricStats()
+}
+
+func (ac *AddressCache) Reporter() {
+	var lastBH, lastBM, lastRH, lastRM, lastUH, lastUM int
+	ticker := time.NewTicker(4 * time.Second)
+	for range ticker.C {
+		balHits, balMisses := ac.BalanceStats()
+		rowHits, rowMisses := ac.RowStats()
+		utxoHits, utxoMisses := ac.UtxoStats()
+		// Only report if a hit/miss count has changed.
+		if balHits != lastBH || balMisses != lastBM ||
+			rowHits != lastRH || rowMisses != lastRM ||
+			utxoHits != lastUH || utxoMisses != lastUM {
+			lastBH, lastBM = balHits, balMisses
+			lastRH, lastRM = rowHits, rowMisses
+			lastUH, lastUM = utxoHits, utxoMisses
+			numAddrs, numRows, numUTXOs := ac.Length()
+			log.Debugf("CACHE: addresses = %d, rows = %d, utxos = %d", numAddrs, numRows, numUTXOs)
+			log.Debugf("CACHE: row H = %d, M = %d; balance H = %d, M = %d; utxo H = %d, M = %d",
+				rowHits, rowMisses, balHits, balMisses, utxoHits, utxoMisses)
+		}
 	}
 }
 
@@ -443,7 +714,7 @@ func (ac *AddressCache) ClearAll() (numCleared int) {
 	ac.mtx.Lock()
 	defer ac.mtx.Unlock()
 	numCleared = len(ac.a)
-	ac.a = make(map[string]*AddressCacheItem, ac.cap)
+	ac.a = make(map[string]*AddressCacheItem)
 	return
 }
 
@@ -471,8 +742,10 @@ func (ac *AddressCache) Clear(addrs []string) (numCleared int) {
 func (ac *AddressCache) Balance(addr string) (*dbtypes.AddressBalance, *BlockID) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
+		ac.cacheMetrics.BalanceMiss()
 		return nil, nil
 	}
+	ac.cacheMetrics.BalanceHit()
 	return aci.Balance()
 }
 
@@ -482,8 +755,10 @@ func (ac *AddressCache) Balance(addr string) (*dbtypes.AddressBalance, *BlockID)
 func (ac *AddressCache) UTXOs(addr string) ([]apitypes.AddressTxnOutput, *BlockID) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
+		ac.cacheMetrics.UtxoMiss()
 		return nil, nil
 	}
+	ac.cacheMetrics.UtxoHit()
 	return aci.UTXOs()
 }
 
@@ -493,31 +768,24 @@ func (ac *AddressCache) UTXOs(addr string) ([]apitypes.AddressTxnOutput, *BlockI
 func (ac *AddressCache) Metrics(addr string) (*dbtypes.AddressMetrics, *BlockID) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
+		ac.cacheMetrics.MetricMiss()
 		return nil, nil
 	}
+	ac.cacheMetrics.MetricHit()
 	return aci.Metrics()
 }
 
 // Rows attempts to retrieve an []*AddressRow for the given address. The BlockID
 // for the block at which the cached data is valid is also returned. In the
 // event of a cache miss, the slice and the *BlockID will be nil.
-func (ac *AddressCache) Rows(addr string) ([]*dbtypes.AddressRow, *BlockID) {
+func (ac *AddressCache) Rows(addr string) ([]dbtypes.AddressRowCompact, *BlockID) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
+		ac.cacheMetrics.RowMiss()
 		return nil, nil
 	}
+	ac.cacheMetrics.RowHit()
 	return aci.Rows()
-}
-
-// RowsMerged attempts to retrieve an []*AddressRow for the given address. The
-// BlockID for the block at which the cached data is valid is also returned. In
-// the event of a cache miss, the slice and the *BlockID will be nil.
-func (ac *AddressCache) RowsMerged(addr string) ([]*dbtypes.AddressRow, *BlockID) {
-	aci := ac.addressCacheItem(addr)
-	if aci == nil {
-		return nil, nil
-	}
-	return aci.RowsMerged()
 }
 
 // NumRows returns the number of non-merged rows. If the rows are not cached, a
@@ -530,98 +798,235 @@ func (ac *AddressCache) NumRows(addr string) (int, *BlockID) {
 	return aci.NumRows()
 }
 
-// NumRowsMerged returns the number of merged rows. If the rows are not cached,
-// a count of -1 and *BlockID of nil are returned.
-func (ac *AddressCache) NumRowsMerged(addr string) (int, *BlockID) {
-	aci := ac.addressCacheItem(addr)
-	if aci == nil {
-		return -1, nil
-	}
-	return aci.NumRowsMerged()
-}
-
 // Transactions attempts to retrieve transaction data for the given address and
 // view (merged or not, debit/credit/all). Like the DB queries, the number of
 // transactions to retrieve, N, and the number of transactions to skip, offset,
 // are also specified.
 func (ac *AddressCache) Transactions(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *BlockID, error) {
-	aci := ac.addressCacheItem(addr)
-	if aci == nil {
-		return nil, nil, nil // cache miss is not an error; *BlockID must be nil
+	merged, err := txnType.IsMerged()
+	if err != nil {
+		return nil, nil, err
 	}
-	return aci.Transactions(int(N), int(offset), txnType)
+
+	if merged {
+		rowsMerged, blockID, err := ac.TransactionsMerged(addr, N, offset, txnType)
+		rows := dbtypes.UncompactMergedRows(rowsMerged)
+		return rows, blockID, err
+	}
+
+	rowsCompact, blockID, err := ac.TransactionsCompact(addr, N, offset, txnType)
+	rows := dbtypes.UncompactRows(rowsCompact)
+	return rows, blockID, err
 }
 
-func (ac *AddressCache) addCacheItem(addr string, aci *AddressCacheItem) {
-	// If the cache is at or above capacity, remove cache items to make room for
-	// the new item.
-	for len(ac.a) >= ac.cap {
+func (ac *AddressCache) TransactionsMerged(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]dbtypes.AddressRowMerged, *BlockID, error) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		ac.cacheMetrics.RowMiss()
+		return nil, nil, nil // cache miss is not an error; *BlockID must be nil
+	}
+	ac.cacheMetrics.RowHit()
+
+	rows, blockID, err := aci.Transactions(int(N), int(offset), txnType)
+	switch r := rows.(type) {
+	case []dbtypes.AddressRowMerged:
+		return r, blockID, err
+	default:
+		return nil, nil, fmt.Errorf("TransactionsMerged called with non-merged view %v, giving %T",
+			txnType.String(), r)
+	}
+}
+
+func (ac *AddressCache) TransactionsCompact(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]dbtypes.AddressRowCompact, *BlockID, error) {
+	aci := ac.addressCacheItem(addr)
+	if aci == nil {
+		ac.cacheMetrics.RowMiss()
+		return nil, nil, nil // cache miss is not an error; *BlockID must be nil
+	}
+	ac.cacheMetrics.RowHit()
+
+	rows, blockID, err := aci.Transactions(int(N), int(offset), txnType)
+	switch r := rows.(type) {
+	case []dbtypes.AddressRowCompact:
+		return r, blockID, err
+	default:
+		return nil, nil, fmt.Errorf("TransactionsCompact called with merged view %v, giving %T",
+			txnType.String(), r)
+	}
+}
+
+func (ac *AddressCache) length() (numAddrs, numTxns, numUTXOs int) {
+	numAddrs = len(ac.a)
+	for _, aci := range ac.a {
+		numTxns += len(aci.rows)
+		numUTXOs += len(aci.utxos)
+	}
+	return
+}
+
+// Length returns the total number of address rows and UTXOs stored in cache.
+func (ac *AddressCache) Length() (numAddrs, numTxns, numUTXOs int) {
+	ac.mtx.RLock()
+	defer ac.mtx.RUnlock()
+	return ac.length()
+}
+
+// NumAddresses returns the total number of addresses in the cache.
+func (ac *AddressCache) NumAddresses() int {
+	ac.mtx.RLock()
+	defer ac.mtx.RUnlock()
+	return len(ac.a)
+}
+
+func (ac *AddressCache) purgeRowsToFit(numRows int) (haveSpace bool) {
+	if ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
+	// First purge to meet address capacity when adding 1 new address.
+	addrsCached := len(ac.a)
+clearingaddrs:
+	for addrsCached >= ac.capAddr {
 		for a := range ac.a {
 			// Never purge the data for the project fund address.
 			if a == ac.ProjectAddress {
+				if len(ac.a) == 1 {
+					break clearingaddrs
+				}
 				continue
 			}
 			delete(ac.a, a)
+			break // recheck addrsCached
 		}
+		addrsCached = len(ac.a)
 	}
-	ac.a[addr] = aci
+
+	// If the cache is at or above row capacity, remove cache items to make room
+	// for the given number of rows.
+	addrsCached, cacheSize, _ := ac.length()
+clearing:
+	for cacheSize > 0 && cacheSize+numRows > ac.cap {
+		for a, aaci := range ac.a {
+			// nothing much to clear for this cached item
+			if len(aaci.rows) == 0 {
+				continue
+			}
+			// Never purge the data for the project fund address.
+			if a == ac.ProjectAddress {
+				if len(ac.a) == 1 {
+					break clearing
+				}
+				continue
+			}
+			delete(ac.a, a)
+			break // recheck cacheSize
+		}
+		addrsCached, cacheSize, _ = ac.length()
+	}
+
+	return cacheSize+numRows <= ac.cap && addrsCached < ac.capAddr // addrsCached+1 <= ac.capAddr
 }
 
-// StoreRows stores the non-merged AddressRow slice for the given address in
-// cache. The current best block data is required to determine cache freshness.
-func (ac *AddressCache) StoreRows(addr string, rows []*dbtypes.AddressRow, block *BlockID) {
-	ac.mtx.Lock()
-	defer ac.mtx.Unlock()
-	aci := ac.a[addr]
-
-	if block != nil && rows == nil {
-		rows = []*dbtypes.AddressRow{}
+func (ac *AddressCache) addCacheItem(addr string, aci *AddressCacheItem) (success bool) {
+	if ac.cap < 1 || ac.capAddr < 1 {
+		return false
 	}
 
+	// We will overwrite any existing AddressCacheItem, so an existing item with
+	// rows set exists, account for these rows that would be removed.
+	var alreadyStored int
+	aci0 := ac.a[addr]
+	if aci0 != nil {
+		alreadyStored = len(aci0.rows)
+	}
+	haveSpace := ac.purgeRowsToFit(len(aci.rows) - alreadyStored)
+	if haveSpace {
+		ac.a[addr] = aci
+		log.Tracef("Added new AddressCacheItem: %s", addr)
+		success = true
+	} else {
+		log.Debugf("No space in cache to add item with %d rows for %s!\n", len(aci.rows), addr)
+	}
+	return
+}
+
+func (ac *AddressCache) setCacheItemRows(addr string, rows []dbtypes.AddressRowCompact, block *BlockID) (updated bool) {
+	if ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
+	aci := ac.a[addr]
 	if aci == nil || aci.BlockHash() != block.Hash {
-		ac.addCacheItem(addr, &AddressCacheItem{
+		return ac.addCacheItem(addr, &AddressCacheItem{
 			rows:   rows,
 			height: block.Height,
 			hash:   block.Hash,
 		})
+	}
+
+	aci.mtx.Lock()
+	defer aci.mtx.Unlock()
+	// If rows is already set for this same block, there should be no need to
+	// even check the length, but confirm it is the same to be safe. If so,
+	// there is no need to save the same rows slice. This is a successful set.
+	alreadyStored := len(aci.rows)
+	if aci.rows != nil && alreadyStored == len(rows) {
+		updated = true
 		return
 	}
 
-	// cache is current, so just set the rows.
-	aci.mtx.Lock()
-	aci.rows = rows
-	aci.mtx.Unlock()
+	// Try to clear space from the cache for these rows.
+	haveSpace := ac.purgeRowsToFit(len(rows) - alreadyStored)
+	if haveSpace {
+		aci.rows = rows
+		updated = true
+	} else {
+		log.Debugf("No space in cache to set %d rows for %s!\n", len(rows), addr)
+	}
+	return
 }
 
-// StoreRowsMerged stores the merged AddressRow slice for the given address in
+// StoreRows stores the non-merged AddressRow slice for the given address in
 // cache. The current best block data is required to determine cache freshness.
-func (ac *AddressCache) StoreRowsMerged(addr string, rows []*dbtypes.AddressRow, block *BlockID) {
+func (ac *AddressCache) StoreRows(addr string, rows []*dbtypes.AddressRow, block *BlockID) bool {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
+	rowsCompact := []dbtypes.AddressRowCompact{}
+	if rows != nil {
+		rowsCompact = dbtypes.CompactRows(rows)
+	}
+
+	// respect cache capacity
+	return ac.StoreRowsCompact(addr, rowsCompact, block)
+}
+
+// StoreRows stores the non-merged AddressRow slice for the given address in
+// cache. The current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreRowsCompact(addr string, rows []dbtypes.AddressRowCompact, block *BlockID) bool {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
 	ac.mtx.Lock()
 	defer ac.mtx.Unlock()
-	aci := ac.a[addr]
 
 	if block != nil && rows == nil {
-		rows = []*dbtypes.AddressRow{}
+		rows = []dbtypes.AddressRowCompact{}
 	}
 
-	if aci == nil || aci.BlockHash() != block.Hash {
-		ac.addCacheItem(addr, &AddressCacheItem{
-			rowsMerged: rows,
-			height:     block.Height,
-			hash:       block.Hash,
-		})
-		return
-	}
-
-	// cache is current, so just set the rows.
-	aci.mtx.Lock()
-	aci.rowsMerged = rows
-	aci.mtx.Unlock()
+	// respect cache capacity
+	return ac.setCacheItemRows(addr, rows, block)
 }
 
 // StoreBalance stores the AddressBalance for the given address in cache. The
 // current best block data is required to determine cache freshness.
-func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalance, block *BlockID) {
+func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalance, block *BlockID) bool {
+	if ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
 	ac.mtx.Lock()
 	defer ac.mtx.Unlock()
 	aci := ac.a[addr]
@@ -633,23 +1038,32 @@ func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalanc
 	}
 
 	if aci == nil || aci.BlockHash() != block.Hash {
-		ac.addCacheItem(addr, &AddressCacheItem{
+		return ac.addCacheItem(addr, &AddressCacheItem{
 			balance: balance,
 			height:  block.Height,
 			hash:    block.Hash,
 		})
-		return
 	}
 
 	// cache is current, so just set the balance.
 	aci.mtx.Lock()
 	aci.balance = balance
 	aci.mtx.Unlock()
+	return true
 }
 
 // StoreUTXOs stores the AddressTxnOutput slice for the given address in cache.
 // The current best block data is required to determine cache freshness.
-func (ac *AddressCache) StoreUTXOs(addr string, utxos []apitypes.AddressTxnOutput, block *BlockID) {
+func (ac *AddressCache) StoreUTXOs(addr string, utxos []apitypes.AddressTxnOutput, block *BlockID) bool {
+	if ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
+	// Only allow storing maxUTXOsPerAddr.
+	if len(utxos) > maxUTXOsPerAddr && addr != ac.ProjectAddress {
+		return false
+	}
+
 	ac.mtx.Lock()
 	defer ac.mtx.Unlock()
 	aci := ac.a[addr]
@@ -659,16 +1073,16 @@ func (ac *AddressCache) StoreUTXOs(addr string, utxos []apitypes.AddressTxnOutpu
 	}
 
 	if aci == nil || aci.BlockHash() != block.Hash {
-		ac.addCacheItem(addr, &AddressCacheItem{
+		return ac.addCacheItem(addr, &AddressCacheItem{
 			utxos:  utxos,
 			height: block.Height,
 			hash:   block.Hash,
 		})
-		return
 	}
 
 	// cache is current, so just set the utxos.
 	aci.mtx.Lock()
 	aci.utxos = utxos
 	aci.mtx.Unlock()
+	return true
 }

--- a/db/cache/log.go
+++ b/db/cache/log.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package cache
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/db/dcrpg/insightapi_test.go
+++ b/db/dcrpg/insightapi_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package dcrpg
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+func Test_sortTxsByTimeAndHash(t *testing.T) {
+	h0, _ := chainhash.NewHashFromStr("79936a1fb658ba249443f0caf4a6a44ce73afe16d543d4f7b8dcf847dfb21a9d")
+	h1, _ := chainhash.NewHashFromStr("484e1a03f7c3795b468d7d46071e73e207aec8295917dec569a76cca981f1b95")
+	tests := []struct {
+		name string
+		txns []txSortable
+		want []txSortable
+	}{
+		{
+			name: "ok",
+			txns: []txSortable{
+				{
+					Hash: *h0,
+					Time: 16341234,
+				},
+				{
+					Hash: *h1,
+					Time: 12341234,
+				},
+				{
+					Hash: *h0,
+					Time: 12341234,
+				},
+				{
+					Hash: *h1,
+					Time: 14341234,
+				},
+			},
+			want: []txSortable{
+				{
+					Hash: *h0,
+					Time: 16341234,
+				},
+				{
+					Hash: *h1,
+					Time: 14341234,
+				},
+				{
+					Hash: *h1,
+					Time: 12341234,
+				},
+				{
+					Hash: *h0,
+					Time: 12341234,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortTxsByTimeAndHash(tt.txns)
+			if !reflect.DeepEqual(tt.txns, tt.want) {
+				t.Errorf("txsByTimeAndHash failed. Wanted %v, got %v.",
+					tt.want, tt.txns)
+			}
+		})
+	}
+}

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -84,10 +84,10 @@ const (
 
 	SelectAddressAllByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
 		WHERE address=$1
-		ORDER BY block_time DESC;`
+		ORDER BY block_time DESC, tx_hash ASC;`
 	SelectAddressAllMainchainByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
 		WHERE address=$1 AND valid_mainchain
-		ORDER BY block_time DESC;`
+		ORDER BY block_time DESC, tx_hash ASC;`
 
 	SelectAddressesAllTxnWithHeight = `SELECT
 			addresses.tx_hash,
@@ -179,7 +179,8 @@ const (
 
 	SelectAddressLimitNByAddress = `SELECT ` + addrsColumnNames + ` FROM addresses
 		WHERE address=$1 AND valid_mainchain = TRUE
-		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		ORDER BY block_time DESC, tx_hash ASC
+		LIMIT $2 OFFSET $3;`
 
 	// SelectAddressLimitNByAddressSubQry was used in certain cases prior to
 	// sorting the block_time_index.
@@ -214,11 +215,13 @@ const (
 
 	SelectAddressDebitsLimitNByAddress = `SELECT ` + addrsColumnNames + `
 		FROM addresses WHERE address=$1 AND is_funding = FALSE AND valid_mainchain
-		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		ORDER BY block_time DESC, tx_hash ASC
+		LIMIT $2 OFFSET $3;`
 
 	SelectAddressCreditsLimitNByAddress = `SELECT ` + addrsColumnNames + `
 		FROM addresses WHERE address=$1 AND is_funding AND valid_mainchain
-		ORDER BY block_time DESC LIMIT $2 OFFSET $3;`
+		ORDER BY block_time DESC, tx_hash ASC
+		LIMIT $2 OFFSET $3;`
 
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address, value
 		FROM addresses

--- a/db/dcrpg/log.go
+++ b/db/dcrpg/log.go
@@ -4,7 +4,10 @@
 
 package dcrpg
 
-import "github.com/decred/slog"
+import (
+	"github.com/decred/dcrdata/v4/db/cache"
+	"github.com/decred/slog"
+)
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -20,4 +23,5 @@ func DisableLog() {
 // UseLogger uses a specified Logger to output package logging info.
 func UseLogger(logger slog.Logger) {
 	log = logger
+	cache.UseLogger(logger)
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -422,11 +422,11 @@ type DBInfo struct {
 // NewChainDB constructs a ChainDB for the given connection and Decred network
 // parameters. By default, duplicate row checks on insertion are enabled. See
 // NewChainDBWithCancel to enable context cancellation of running queries.
-func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool) (*ChainDB, error) {
+func NewChainDB(dbi *DBInfo, params *chaincfg.Params, stakeDB *stakedb.StakeDatabase,
+	devPrefetch, hidePGConfig bool, addrCacheCap int) (*ChainDB, error) {
 	ctx := context.Background()
 	chainDB, err := NewChainDBWithCancel(ctx, dbi, params, stakeDB,
-		devPrefetch, hidePGConfig)
+		devPrefetch, hidePGConfig, addrCacheCap)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params,
 // (context.Background()) except by the pg timeouts. If it is necessary to
 // cancel queries with CTRL+C, for example, use NewChainDBWithCancel.
 func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool) (*ChainDB, error) {
+	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool, addrCacheCap int) (*ChainDB, error) {
 	// Connect to the PostgreSQL daemon and return the *sql.DB.
 	db, err := Connect(dbi.Host, dbi.Port, dbi.User, dbi.Pass, dbi.DBName)
 	if err != nil {
@@ -535,7 +535,7 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 
 	// Create the address cache with an arbitrary capacity. The project fund
 	// address is set to prevent purging its data when cache reaches capacity.
-	addrCache := cache.NewAddressCache(500)
+	addrCache := cache.NewAddressCache(addrCacheCap)
 	addrCache.ProjectAddress = devSubsidyAddress
 
 	return &ChainDB{
@@ -1315,21 +1315,16 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 }
 
 func (pgb *ChainDB) updateProjectFundCache() error {
-	// Update balance.
-	_, err := pgb.AddressBalance(pgb.devAddress)
-	if err != nil {
-		return err
-	}
-
-	// Update non-merged rows.
-	_, err = pgb.AddressRows(pgb.devAddress, false)
-	if err != nil {
-		return err
-	}
-
-	// Update merged rows.
-	_, err = pgb.AddressRows(pgb.devAddress, true)
+	_, _, err := pgb.AddressHistoryAll(pgb.devAddress, 1, 0)
 	return err
+	// Update balance.
+	// _, _, err := pgb.AddressBalance(pgb.devAddress)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// _, err = pgb.AddressRowsCompact(pgb.devAddress)
+	// return err
 }
 
 // FreshenAddressCaches resets the address balance cache by purging data for the
@@ -1338,6 +1333,7 @@ func (pgb *ChainDB) updateProjectFundCache() error {
 // asynchronously if lazyProjectFund is true.
 func (pgb *ChainDB) FreshenAddressCaches(lazyProjectFund bool, expireAddresses []string) error {
 	// Clear existing cache entries.
+	//numCleared := pgb.AddressCache.ClearAll()
 	numCleared := pgb.AddressCache.Clear(expireAddresses)
 	log.Debugf("Cleared cache for %d addresses.", numCleared)
 
@@ -1350,7 +1346,7 @@ func (pgb *ChainDB) FreshenAddressCaches(lazyProjectFund bool, expireAddresses [
 	// Update project fund data.
 	updateFundData := func() error {
 		log.Infof("Pre-fetching project fund data at height %d...", pgb.Height())
-		if err := pgb.updateProjectFundCache(); err != nil {
+		if err := pgb.updateProjectFundCache(); err != nil && err.Error() != "retry" {
 			err = pgb.replaceCancelError(err)
 			return fmt.Errorf("Failed to update project fund data: %v", err)
 		}
@@ -1382,7 +1378,7 @@ func (pgb *ChainDB) DevBalance() (*dbtypes.AddressBalance, error) {
 	}
 
 	if !pgb.InReorg {
-		bal, err := pgb.AddressBalance(pgb.devAddress)
+		bal, _, err := pgb.AddressBalance(pgb.devAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -1399,12 +1395,13 @@ func (pgb *ChainDB) DevBalance() (*dbtypes.AddressBalance, error) {
 // AddressBalance attempts to retrieve balance information for a specific
 // address from cache, and if cache is stale or missing data for the address, a
 // DB query is used. A successful DB query will freshen the cache.
-func (pgb *ChainDB) AddressBalance(address string) (*dbtypes.AddressBalance, error) {
+func (pgb *ChainDB) AddressBalance(address string) (bal *dbtypes.AddressBalance, cacheUpdated bool, err error) {
 	// Check the cache first.
 	bestHash, height := pgb.BestBlock()
-	bal, validHeight := pgb.AddressCache.Balance(address)
+	var validHeight *cache.BlockID
+	bal, validHeight = pgb.AddressCache.Balance(address)
 	if bal != nil && *bestHash == validHeight.Hash {
-		return bal, nil
+		return
 	}
 
 	busy, wait, done := pgb.CacheLocks.bal.TryLock(address)
@@ -1429,30 +1426,28 @@ func (pgb *ChainDB) AddressBalance(address string) (*dbtypes.AddressBalance, err
 	// Cache is empty or stale, so query the DB.
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
-	balance, err := RetrieveAddressBalance(ctx, pgb.db, address)
+	bal, err = RetrieveAddressBalance(ctx, pgb.db, address)
 	if err != nil {
-		return nil, pgb.replaceCancelError(err)
+		err = pgb.replaceCancelError(err)
+		return
 	}
 
 	// Update the address cache.
-	pgb.AddressCache.StoreBalance(address, balance, cache.NewBlockID(bestHash, height))
-	return balance, nil
+	cacheUpdated = pgb.AddressCache.StoreBalance(address, bal,
+		cache.NewBlockID(bestHash, height))
+	return
 }
 
-// updateAddressRows updates the merged or non-merged address rows, or waits for
-// them to update by an ongoing query. On completion, the cache should be ready,
-// although it must be checked again.
-func (pgb *ChainDB) updateAddressRows(address string, merged bool) error {
-	cacheLock := pgb.CacheLocks.rows
-	if merged {
-		cacheLock = pgb.CacheLocks.rowsMerged
-	}
-
-	busy, wait, done := cacheLock.TryLock(address)
+// updateAddressRows updates address rows, or waits for them to update by an
+// ongoing query. On completion, the cache should be ready, although it must be
+// checked again.
+func (pgb *ChainDB) updateAddressRows(address string) (rows []*dbtypes.AddressRow, cacheUpdated bool, err error) {
+	busy, wait, done := pgb.CacheLocks.rows.TryLock(address)
 	if busy {
 		// Just wait until the updater is finished.
 		<-wait
-		return nil
+		err = fmt.Errorf("retry")
+		return
 	} else {
 		// We will run the DB query, so block others from doing the same. When
 		// query and/or cache update is completed, broadcast to any waiters that
@@ -1463,56 +1458,70 @@ func (pgb *ChainDB) updateAddressRows(address string, merged bool) error {
 	hash, height := pgb.BestBlock()
 	blockID := cache.NewBlockID(hash, height)
 
-	if merged {
-		// Retrieve all merged address transaction rows.
-		allAddressRows, err := pgb.AddressTransactionsAllMerged(address)
-		if err != nil {
-			return err
-		}
-
-		// Update address rows cache.
-		pgb.AddressCache.StoreRowsMerged(address, allAddressRows, blockID)
-	} else {
-		// Retrieve all non-merged address transaction rows.
-		allAddressRows, err := pgb.AddressTransactionsAll(address)
-		if err != nil {
-			return err
-		}
-
-		// Update address rows cache.
-		pgb.AddressCache.StoreRows(address, allAddressRows, blockID)
+	// Retrieve all non-merged address transaction rows.
+	rows, err = pgb.AddressTransactionsAll(address)
+	if err != nil && err != sql.ErrNoRows {
+		return
 	}
 
-	return nil
+	// Update address rows cache.
+	cacheUpdated = pgb.AddressCache.StoreRows(address, rows, blockID)
+	return
 }
 
-// AddressRows gets the merged or non-merged address rows either from cache or
-// via DB query.
-func (pgb *ChainDB) AddressRows(address string, merged bool) ([]*dbtypes.AddressRow, error) {
+// AddressRowsMerged gets the merged address rows either from cache or via DB
+// query.
+func (pgb *ChainDB) AddressRowsMerged(address string) ([]dbtypes.AddressRowMerged, error) {
 	// Try the address cache.
-	rowCacheFn := pgb.AddressCache.Rows
-	if merged {
-		rowCacheFn = pgb.AddressCache.RowsMerged
-	}
-
 	hash := pgb.BestBlockHash()
-	addressRows, validBlock := rowCacheFn(address)
-	cacheCurrent := validBlock != nil && validBlock.Hash == *hash && addressRows != nil
+	rowsCompact, validBlock := pgb.AddressCache.Rows(address)
+	cacheCurrent := validBlock != nil && validBlock.Hash == *hash && rowsCompact != nil
 	if cacheCurrent {
-		log.Debugf("AddressRows: rows (merged=%v) cache HIT for %s.", merged, address)
-		return addressRows, nil
+		log.Tracef("AddressRows: rows cache HIT for %s.", address)
+		return dbtypes.MergeRowsCompact(rowsCompact), nil
 	}
 
-	log.Debugf("AddressRows: rows (merged=%v) cache MISS for %s.", merged, address)
+	log.Tracef("AddressRows: rows cache MISS for %s.", address)
 
 	// Update or wait for an update to the cached AddressRows.
-	err := pgb.updateAddressRows(address, merged)
+	rows, _, err := pgb.updateAddressRows(address)
 	if err != nil {
+		if err.Error() == "retry" {
+			// Try again, starting with cache.
+			return pgb.AddressRowsMerged(address)
+		}
 		return nil, err
 	}
 
-	// Try again, starting with cache.
-	return pgb.AddressRows(address, merged)
+	// We have a result.
+	return dbtypes.MergeRows(rows)
+}
+
+// AddressRows gets non-merged address rows either from cache or via DB query.
+func (pgb *ChainDB) AddressRowsCompact(address string) ([]dbtypes.AddressRowCompact, error) {
+	// Try the address cache.
+	hash := pgb.BestBlockHash()
+	rowsCompact, validBlock := pgb.AddressCache.Rows(address)
+	cacheCurrent := validBlock != nil && validBlock.Hash == *hash && rowsCompact != nil
+	if cacheCurrent {
+		log.Tracef("AddressRows: rows cache HIT for %s.", address)
+		return rowsCompact, nil
+	}
+
+	log.Tracef("AddressRows: rows cache MISS for %s.", address)
+
+	// Update or wait for an update to the cached AddressRows.
+	rows, _, err := pgb.updateAddressRows(address)
+	if err != nil {
+		if err.Error() == "retry" {
+			// Try again, starting with cache.
+			return pgb.AddressRowsCompact(address)
+		}
+		return nil, err
+	}
+
+	// We have a result.
+	return dbtypes.CompactRows(rows), err
 }
 
 // retrieveMergedTxnCount queries the DB for the merged address transaction view
@@ -1539,30 +1548,19 @@ func (pgb *ChainDB) retrieveMergedTxnCount(addr string, txnView dbtypes.AddrTxnV
 // mergedTxnCount checks cache and falls back to retrieveMergedTxnCount.
 func (pgb *ChainDB) mergedTxnCount(addr string, txnView dbtypes.AddrTxnViewType) (int, error) {
 	// Try the cache first.
-	rows, blockID := pgb.AddressCache.RowsMerged(addr)
+	rows, blockID := pgb.AddressCache.Rows(addr)
 	if blockID == nil {
 		// Query the DB.
 		return pgb.retrieveMergedTxnCount(addr, txnView)
 	}
 
-	switch txnView {
-	case dbtypes.AddrMergedTxn:
-		return len(rows), nil
-	case dbtypes.AddrMergedTxnCredit:
-		numCredit, _ := cache.CountCreditDebitRows(rows)
-		return numCredit, nil
-	case dbtypes.AddrMergedTxnDebit:
-		_, numDebit := cache.CountCreditDebitRows(rows)
-		return numDebit, nil
-	default:
-		return 0, fmt.Errorf("MergedTxnCount: requested count for non-merged view")
-	}
+	return dbtypes.CountMergedRowsCompact(rows, txnView)
 }
 
 // nonMergedTxnCount gets the non-merged address transaction view row count via
 // AddressBalance, which checks the cache and falls back to a DB query.
 func (pgb *ChainDB) nonMergedTxnCount(addr string, txnView dbtypes.AddrTxnViewType) (int, error) {
-	bal, err := pgb.AddressBalance(addr)
+	bal, _, err := pgb.AddressBalance(addr)
 	if err != nil {
 		return 0, err
 	}
@@ -1614,22 +1612,23 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 
 	cacheCurrent := validBlock != nil && validBlock.Hash == *hash
 	if !cacheCurrent {
-		log.Tracef("Address rows (view=%s) cache MISS for %s.",
+		log.Debugf("Address rows (view=%s) cache MISS for %s.",
 			txnView.String(), address)
 
-		// Determine if txnView represents a merged view. Ignore the error since
-		// this txnView is already validated by AddressCache.Transactions.
-		merged, _ := txnView.IsMerged()
 		// Update or wait for an update to the cached AddressRows.
-		err := pgb.updateAddressRows(address, merged)
-		if err != nil {
+		addressRows, _, err = pgb.updateAddressRows(address)
+		// See if another caller ran the update, in which case we were just
+		// waiting to avoid a simultaneous query. With luck the cache will be
+		// updated with this data, although it may not be. Try again.
+		if err != nil && err != sql.ErrNoRows {
+			if err.Error() == "retry" {
+				// Try again, starting with cache.
+				return pgb.AddressHistory(address, N, offset, txnView)
+			}
 			return nil, nil, err
 		}
-
-		// Try again, starting with cache.
-		return pgb.AddressHistory(address, N, offset, txnView)
 	}
-	log.Tracef("Address rows (view=%s) cache HIT for %s.",
+	log.Debugf("Address rows (view=%s) cache HIT for %s.",
 		txnView.String(), address)
 
 	// addressRows is now present and current. Proceed to get the balance.
@@ -1638,10 +1637,10 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	balance, validBlock := pgb.AddressCache.Balance(address)
 	cacheCurrent = validBlock != nil && validBlock.Hash == *hash
 	if cacheCurrent {
-		log.Tracef("Address balance cache HIT for %s.", address)
+		log.Debugf("Address balance cache HIT for %s.", address)
 		return addressRows, balance, nil
 	}
-	log.Tracef("Address balance cache MISS for %s.", address)
+	log.Debugf("Address balance cache MISS for %s.", address)
 
 	// Short cut: we have all txs when the total number of fetched txs is less
 	// than the limit, txtype is AddrTxnAll, and Offset is zero.
@@ -1669,16 +1668,15 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 				FromStake:    fromStake,
 				ToStake:      toStake,
 			}
-
-			// Update balance cache.
-			blockID := cache.NewBlockID(hash, height)
-			pgb.AddressCache.StoreBalance(address, balance, blockID)
 		}
+		// Update balance cache.
+		blockID := cache.NewBlockID(hash, height)
+		pgb.AddressCache.StoreBalance(address, balance, blockID)
 	} else {
 		// Count spent/unspent amounts and transactions.
 		log.Debugf("Obtaining balance via DB query.")
-		balance, err = pgb.AddressBalance(address)
-		if err != nil {
+		balance, _, err = pgb.AddressBalance(address)
+		if err != nil && err != sql.ErrNoRows {
 			return nil, nil, err
 		}
 	}
@@ -1713,7 +1711,7 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 		addrData.Fullmode = true
 	}
 
-	if err == sql.ErrNoRows {
+	if err == sql.ErrNoRows || (err == nil && len(addrHist) == 0) {
 		// We do not have any confirmed transactions. Prep to display ONLY
 		// unconfirmed transactions (or none at all).
 		addrData = new(dbtypes.AddressInfo)
@@ -1732,8 +1730,8 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 			// txns. i.e. Empty history is OK for debit views (merged or not).
 			if (txnType != dbtypes.AddrTxnDebit && txnType != dbtypes.AddrMergedTxnDebit) &&
 				(balance.NumSpent+balance.NumUnspent) > 0 {
-				log.Debugf("empty address history (%s): n=%d&start=%d",
-					address, limitN, offsetAddrOuts)
+				log.Debugf("empty address history (%s) for view %s: n=%d&start=%d",
+					address, txnType.String(), limitN, offsetAddrOuts)
 				return nil, fmt.Errorf("that address has no history")
 			}
 			addrData = new(dbtypes.AddressInfo)
@@ -2011,7 +2009,7 @@ func (pgb *ChainDB) AddressTotals(address string) (*apitypes.AddressTotals, erro
 	if address == pgb.devAddress {
 		ab, err = pgb.DevBalance()
 	} else {
-		ab, err = pgb.AddressBalance(address)
+		ab, _, err = pgb.AddressBalance(address)
 	}
 
 	if err != nil || ab == nil {
@@ -2067,16 +2065,49 @@ func MakeCsvAddressRows(rows []*dbtypes.AddressRow) [][]string {
 	return csvRows
 }
 
+func MakeCsvAddressRowsCompact(rows []dbtypes.AddressRowCompact) [][]string {
+	csvRows := make([][]string, 0, len(rows)+1)
+	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index",
+		"valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
+
+	for _, r := range rows {
+		var strValidMainchain string
+		if r.ValidMainChain {
+			strValidMainchain = "1"
+		} else {
+			strValidMainchain = "0"
+		}
+
+		var strDirection string
+		if r.IsFunding {
+			strDirection = "1"
+		} else {
+			strDirection = "-1"
+		}
+
+		csvRows = append(csvRows, []string{
+			r.TxHash.String(),
+			strDirection,
+			strconv.Itoa(int(r.TxVinVoutIndex)),
+			strValidMainchain,
+			strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64),
+			strconv.FormatInt(r.TxBlockTime, 10),
+			txhelpers.TxTypeToString(int(r.TxType)),
+			r.MatchingTxHash.String(),
+		})
+	}
+	return csvRows
+}
+
 // AddressTxIoCsv grabs rows of an address' transaction input/output data as a
 // 2-D array of strings to be CSV-formatted.
 func (pgb *ChainDB) AddressTxIoCsv(address string) ([][]string, error) {
-	var merged bool
-	rows, err := pgb.AddressRows(address, merged)
+	rows, err := pgb.AddressRowsCompact(address)
 	if err != nil {
 		return nil, err
 	}
 
-	return MakeCsvAddressRows(rows), nil
+	return MakeCsvAddressRowsCompact(rows), nil
 
 	// ALT implementation, without cache update:
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1272,11 +1272,10 @@ func retrieveAddressTxsCount(ctx context.Context, db *sql.DB, address, interval 
 // distinct spending transactions, and the fraction spent to and received from
 // stake-related trasnsactions.
 func RetrieveAddressBalance(ctx context.Context, db *sql.DB, address string) (balance *dbtypes.AddressBalance, err error) {
-	// The sql.Tx does not have a timeout, as the individial queries will.
-	balance = new(dbtypes.AddressBalance)
-	balance.Address = address
-	var fromStake, toStake int64
+	// Never return nil *AddressBalance.
+	balance = &dbtypes.AddressBalance{Address: address}
 
+	// The sql.Tx does not have a timeout, as the individial queries will.
 	var dbtx *sql.Tx
 	dbtx, err = db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelDefault,
@@ -1303,6 +1302,7 @@ func RetrieveAddressBalance(ctx context.Context, db *sql.DB, address string) (ba
 		}
 	}
 
+	var fromStake, toStake int64
 	for rows.Next() {
 		var count, totalValue int64
 		var noMatchingTx, isFunding, isRegular bool

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1068,7 +1068,9 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
 				return
 			} else if err == sql.ErrNoRows {
-				log.Warnf("Spend and pool status not found for ticket %s: %v", hash, err)
+				if tx.Confirmations != 0 {
+					log.Warnf("Spend and pool status not found for ticket %s: %v", hash, err)
+				}
 			} else {
 				if tx.Mature == "False" {
 					tx.TicketInfo.PoolStatus = "immature"
@@ -1377,13 +1379,19 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonBytes, err := json.Marshal(response)
-	if err != nil {
-		jsonBytes = []byte("JSON error")
-	}
+	// jsonBytes, err := json.Marshal(response)
+	// if err != nil {
+	// 	jsonBytes = []byte("JSON error")
+	// }
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(jsonBytes)
+	enc := json.NewEncoder(w)
+	//enc.SetEscapeHTML(false)
+	err = enc.Encode(response)
+	if err != nil {
+		log.Debug(err)
+	}
+	//w.Write(jsonBytes)
 }
 
 // parseAddressParams is used by both /address and /addresstable.

--- a/testutil/apiload/profiles.json
+++ b/testutil/apiload/profiles.json
@@ -94,6 +94,60 @@
       }
     ]
   },
+  "insight-addr-noutxo": {
+    "duration": 60,
+    "attackers": [
+      {
+        "name": "first",
+        "frequency": 10,
+        "endpoints": [
+          "/insight/api/addr/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/addr/DspCVzEw21aDGZ43Ax24rjFqsHimiJbF4qe",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSE4N",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSxxx",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/txs",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qexxx/txs",
+          "/insight/api/addrs/Dsh3RaFqAgnfnGqY9cQiJUde5cR7qwdQP8r,DsSjYHYcc7iJZaJ74CBb4dHNcukdoiLxUQ1/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtYgP/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtxxx/txs",
+          "/insight/api/txs?address=Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/txs?address=Dsd8i7LHGCfKWtog5kwYL5Ut7pBhMLKPVZo",
+          "/insight/api/txs?address=Dsa4zhhBhLuGKmsgHc1hHp9acW6WbpyuN7P",
+          "/insight/api/txs?address=DcpR6s7iZsPMJRorJymeYP4K9sHo35RAWZB",
+          "/insight/api/txs?address=Dsksm4jgwFJScNznBz9Rdo4R2zmUXuM71CP",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBSDL7",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBxxxx"
+        ]
+      }
+    ]
+  },
+  "insight-addr-info-only": {
+    "duration": 60,
+    "attackers": [
+      {
+        "name": "first",
+        "frequency": 10,
+        "endpoints": [
+          "/insight/api/addr/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/addr/DspCVzEw21aDGZ43Ax24rjFqsHimiJbF4qe",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSE4N",
+          "/insight/api/addr/DcfQyJ8RBPNFN8PoRBNwhJmE9PFwpNLSxxx",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx/txs",
+          "/insight/api/addrs/Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qexxx/txs",
+          "/insight/api/addrs/Dsh3RaFqAgnfnGqY9cQiJUde5cR7qwdQP8r,DsSjYHYcc7iJZaJ74CBb4dHNcukdoiLxUQ1/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtYgP/txs",
+          "/insight/api/addrs/Dsoa62CGHSupBhPNoiBGTiGmUVy9C6fLUhL,Dsj7Myj4QLyPRr5aZxoMeKeffXoueeGtxxx/txs",
+          "/insight/api/txs?address=Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
+          "/insight/api/txs?address=Dsd8i7LHGCfKWtog5kwYL5Ut7pBhMLKPVZo",
+          "/insight/api/txs?address=Dsa4zhhBhLuGKmsgHc1hHp9acW6WbpyuN7P",
+          "/insight/api/txs?address=DcpR6s7iZsPMJRorJymeYP4K9sHo35RAWZB",
+          "/insight/api/txs?address=Dsksm4jgwFJScNznBz9Rdo4R2zmUXuM71CP",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBSDL7",
+          "/insight/api/txs?address=DsZFcexJZtXXmgsbJRjLsq8btXLh7EBxxxx"
+        ]
+      }
+    ]
+  },
   "rotation": {
     "duration": 60,
     "attackers": [


### PR DESCRIPTION
This reworks the `cache` package handling.

Make capacity measure row count, not address count. Respect cache
capacity when adding new cache items and when storing rows.
The row capacity is enforced on the total number of rows across all cached
addresses.

An address limit is also set since addresses with no rows should be cached,
but not an unlimited number of addresses.

A max number of UTXOs cached is set on a per-address basis. The limit
is computed given the address limit, a rough estimate of AddressTxnOutput
size, and a desired MiB limit.  This is presently hard-coded, but may be a
config parameter in the future.

Merged rows are not cached, so the functions `MergeRows` and
`MergeRowsCompact` are added to get the data on the fly for 
(*AddressCacheItem).Transactions`.

apiload: Add two more insight address attack profiles.