### PR TITLE
explorer: correct word-break value

### DIFF
--- a/public/scss/typography.scss
+++ b/public/scss/typography.scss
@@ -50,7 +50,7 @@
   -moz-user-select: all;
   user-select: all;
   z-index: 20;
-  word-break: break-word;
+  word-break: break-all;
   overflow: hidden;
   height: 1.2em;
   min-width: 4em;


### PR DESCRIPTION
`break-word` is non-standard.