### PR TITLE
explorer: refactor table CSS

### DIFF
--- a/public/scss/responsive.scss
+++ b/public/scss/responsive.scss
@@ -6,11 +6,6 @@
 }
 
 @media only screen and (max-width: 768px) {
-  .table {
-    margin-bottom: 0;
-    width: 100%;
-  }
-
   .sm-fullwidth {
     width: 100%;
     max-width: 100% !important;

--- a/public/scss/table.scss
+++ b/public/scss/table.scss
@@ -33,6 +33,7 @@ table.table {
   tr,
   th,
   td {
+    color: #052f4b; // Setting explicitly so bootstrap > 4.3.1 won't override.
     border-top: none;
     border-bottom: 1px solid #e4e4e4;
   }

--- a/public/scss/table.scss
+++ b/public/scss/table.scss
@@ -1,46 +1,27 @@
-.table-centered-1rem td {
-  line-height: 1rem;
-  vertical-align: middle;
-}
+table {
+  line-height: 1;
+  margin-bottom: 0;
 
-.table th {
-  font-size: 13px;
-  font-weight: 500;
-}
+  th {
+    font-size: 13px;
+    padding: 0.9em 0.6em;
+  }
 
-.table td {
-  font-size: 14px;
-  vertical-align: middle;
-}
+  td {
+    font-size: 14px;
+    padding: 0.6em;
+  }
 
-.table th,
-.table td {
-  border: none;
-  padding: 0.25rem 0.5rem;
-}
+  th,
+  td {
+    border: none;
+    padding: 0.25rem 0.5rem;
+  }
 
-.table tr {
-  border-bottom: 1px solid #e4e4e4;
-}
-
-table.align-baseline-rows tr {
-  vertical-align: baseline;
-}
-
-.table thead th {
-  border-bottom: none;
-  padding: 0.36rem 0.5rem;
-  font-weight: 600;
-}
-
-.table thead tr {
-  background: #fff;
-  border-bottom: 1px solid #e2e2e2;
-}
-
-.table-sm td {
-  padding: 0.1rem 0.5rem;
-  height: 25px;
+  thead tr {
+    background: #fff;
+    font-weight: bold;
+  }
 }
 
 .table-mono-cells td {
@@ -48,91 +29,37 @@ table.align-baseline-rows tr {
   font-size: 14px;
 }
 
-// v2 tables have a little more padding and bold headers. Will likely be a
-// default site-wide style for larger tables soon.
-.v2-tables {
-  .table {
-    line-height: 1;
-    margin-bottom: 0;
-  }
-
-  .table td {
-    padding: 0.6em;
-  }
-
-  .table th {
-    padding: 0.9em 0.6em;
-    font-weight: bold;
-  }
-
-  .elidedhash {
-    padding-top: 0.3em;
-    height: 1.3em;
-  }
-
-  .elidedhash::after,
-  .elidedhash::before {
-    padding-top: 0.3em;
+table.table {
+  tr,
+  th,
+  td {
+    border-top: none;
+    border-bottom: 1px solid #e4e4e4;
   }
 }
 
-.table tr.disabled-row {
+table.table-sm {
+  th,
+  td {
+    padding: 0.5em;
+  }
+}
+
+table.details td {
+  line-height: 1em;
+  padding: 0.5em 0;
+}
+
+table tr.disabled-row {
   background-color: #00000015;
   border-bottom: 1px solid #8885;
-}
-
-body.darkBG .table tr.disabled-row {
-  background-color: #ff00000d;
 }
 
 .blue-row {
   background: #0078ff1c;
 }
 
-.table.flush-left tr td:first-child {
-  padding-left: 0;
-}
-
-.table .address {
-  max-width: 126px;
-}
-
-.table .outpoint {
-  max-width: 222px;
-}
-
-.table-fixed {
-  table-layout: fixed;
-}
-
-.table th.addr-hash-column {
+table th.addr-hash-column {
   font-size: 14px;
   width: 20em;
-}
-
-.table div.hash-fill {
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-}
-
-/* flexboxtable */
-.flex-table .header {
-  padding: 0.36rem 0.5rem;
-  background: #fff;
-  border-bottom: 1px solid #e2e2e2;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.flex-table-row {
-  padding: 0.4rem;
-  font-size: 13px;
-  border-bottom: 1px solid #e4e4e4;
-}
-
-.table.no-border tr {
-  border-bottom: none !important;
 }

--- a/public/scss/themes.scss
+++ b/public/scss/themes.scss
@@ -95,6 +95,7 @@ body.darkBG {
     tr,
     th,
     td {
+      color: #fdfdfd; // Set this explicitly to prevent bootstrap > 4.3.1 override
       border-bottom: 1px solid #2d2d2d;
     }
   }

--- a/public/scss/themes.scss
+++ b/public/scss/themes.scss
@@ -79,19 +79,24 @@ body.darkBG {
     color: rgba(148, 255, 202, 0.75) !important;
   }
 
-  .flex-table .flex-table-row,
-  .flex-table .header,
-  .table tr {
-    border-bottom: 1px solid #2d2d2d;
-  }
-
-  .table thead th {
+  table thead th {
     vertical-align: bottom;
   }
 
-  .flex-table .header,
-  .table thead tr {
+  table thead tr {
     background: #2d2d2d;
+  }
+
+  table tr.disabled-row {
+    background-color: #ff00000d;
+  }
+
+  table.table {
+    tr,
+    th,
+    td {
+      border-bottom: 1px solid #2d2d2d;
+    }
   }
 
   .top-nav,

--- a/public/scss/typography.scss
+++ b/public/scss/typography.scss
@@ -53,7 +53,7 @@
   word-break: break-all;
   overflow: hidden;
   height: 1.2em;
-  min-width: 4em;
+  padding-top: 1px;
 }
 
 a.elidedhash {
@@ -73,7 +73,7 @@ a.elidedhash:visited {
   content: attr(data-head);
   position: absolute;
   left: 0;
-  top: 0;
+  top: 2px;
   right: 3em;
   word-break: normal;
   text-overflow: ellipsis;
@@ -96,7 +96,7 @@ div.elidedhash::after {
   content: attr(data-tail);
   position: absolute;
   right: 0;
-  top: 0;
+  top: 2px;
   width: 3em;
   z-index: 10;
   word-break: normal;

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -248,7 +248,7 @@
         </div>
         <div class="position-relative">
           <div class="loader-v2" data-target="address.listLoader"></div>
-          <div class="v2-tables position-relative" data-target="address.table">
+          <div class="position-relative" data-target="address.table">
             {{template "addressTable" .}}
           </div>
         </div>

--- a/views/agenda.tmpl
+++ b/views/agenda.tmpl
@@ -71,31 +71,31 @@
             {{$isProgress := (ne (index .Choices 0).Progress 0.0)}}
             {{$isNotDone := (or (eq .Status "started") (eq .Status "defined"))}}
             {{$showProgress := or $isProgress $isNotDone}}
-            <table class="table table-mono-cells table-sm striped">
+            <table class="table table-mono-cells table-sm my-3">
                 <thead>
                     <th>ID</th>
                     <th>Description</th>
-                    <th>Bits</th>
-                    <th>Count</th>
+                    <th class="text-right">Bits</th>
+                    <th class="text-right">Count</th>
                     {{if $showProgress}}
-                        <th>Progress</th> 
+                        <th class="text-right">Progress</th>
                    {{end}}
                 </thead>
+                <tbody>
                 {{range $i, $v := .Choices}}
                 {{with $v}}
-                <thead>
                     <tr>
                         <td class="text-left">{{.ID}}</td>
                         <td class="text-left">{{.Description}}</td>
-                        <td class="text-left">{{.Bits}}</td>
-                        <td class="text-left">{{.Count}}</td>
+                        <td class="text-right">{{.Bits}}</td>
+                        <td class="text-right">{{.Count}}</td>
                         {{if $showProgress}}
-                            <td class="text-left">{{.Progress}}</td>
+                            <td class="text-right">{{.Progress}}</td>
                         {{end}}
                     </tr>
-                </thead>
                 {{end}}
                 {{end}}
+              </tbody>
             </table>
             {{end}}
             <div data-controller="agenda" data-agenda-id="{{.ID}}" class="position-relative">

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -11,13 +11,13 @@
                 </div>
             </div>
             {{ if not .Agendas }}
-            <table class="table table-sm striped">
+            <table class="table">
                 <tr>
                     <td>No agendas found for {{ .NetName }}</td>
                 </tr>
             </table>
             {{ else }}
-            <table class="table table-mono-cells table-sm striped">
+            <table class="table table-mono-cells">
                 <thead>
                     <th>Agenda ID</th>
                     <th>Description</th>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -99,75 +99,75 @@
             </div>
             <div class="col-24 col-xl-12 secondary-card py-3 px-3 px-xl-4">
               <div class="h6 d-inline-block my-2 pl-3">Block Details</div>
-              <table class="w-100 fs14 mt-2">
+              <table class="w-100 fs14 mt-2 details">
                 <tbody>
                   <tr>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1"
+                    <td class="text-right font-weight-bold text-nowrap pr-2"
                       ><span class="d-none d-sm-inline">Ticket Price</span
                       ><span class="d-sm-none">Tkt Price</span>:
-                    <td class="text-left py-1 text-secondary">{{template "decimalParts" (float64AsDecimalParts .SBits 8 false)}}</td>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Fees: </td>
-                    <td class="text-left py-1 text-secondary">{{.MiningFee}}</td>
-                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2 py-1">Pool Size: </td>
-                    <td class="d-none d-sm-table-cell text-left py-1 text-secondary">{{.PoolSize}}</td>
+                    <td class="text-left text-secondary">{{template "decimalParts" (float64AsDecimalParts .SBits 8 false)}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Fees: </td>
+                    <td class="text-left text-secondary">{{.MiningFee}}</td>
+                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2">Pool Size: </td>
+                    <td class="d-none d-sm-table-cell text-left text-secondary">{{.PoolSize}}</td>
                   </tr>
                   <tr>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1"
+                    <td class="text-right font-weight-bold text-nowrap pr-2"
                       ><span class="d-none d-sm-inline">PoW Difficulty</span
                       ><span class="d-sm-none">PoW Diff</span>:
                     </td>
-                    <td class="text-left py-1 text-secondary">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1"
+                    <td class="text-left text-secondary">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2"
                       ><span class="d-none d-sm-inline">Block Version</span
                       ><span class="d-sm-none">Blk Ver</span>:
                     </td>
-                    <td class="text-left py-1 text-secondary">{{.Version}}</td>
-                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2 py-1">Nonce: </td>
-                    <td class="d-none d-sm-table-cell text-left py-1 text-secondary">{{.Nonce}}</td>
+                    <td class="text-left text-secondary">{{.Version}}</td>
+                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2">Nonce: </td>
+                    <td class="d-none d-sm-table-cell text-left text-secondary">{{.Nonce}}</td>
                   </tr>
                   <tr>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Final State: </td>
-                    <td class="text-left py-1 text-secondary">{{.FinalState}}</td>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1"
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Final State: </td>
+                    <td class="text-left text-secondary">{{.FinalState}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2"
                       ><span class="d-none d-sm-inline">Stake Version</span
                       ><span class="d-sm-none">Stk Ver</span>:
                     </td>
-                    <td class="text-left py-1 text-secondary">{{.StakeVersion}}</td>
-                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2 py-1">Vote Bits: </td>
-                    <td class="d-none d-sm-table-cell text-left py-1 text-secondary">{{.VoteBits}}</td>
+                    <td class="text-left text-secondary">{{.StakeVersion}}</td>
+                    <td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2">Vote Bits: </td>
+                    <td class="d-none d-sm-table-cell text-left text-secondary">{{.VoteBits}}</td>
                   </tr>
                   <tr class="d-sm-none">
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Pool Size: </td>
-                    <td class="text-left py-1 text-secondary">{{.PoolSize}}</td>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Vote Bits: </td>
-                    <td class="text-left py-1 text-secondary">{{.VoteBits}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Pool Size: </td>
+                    <td class="text-left text-secondary">{{.PoolSize}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Vote Bits: </td>
+                    <td class="text-left text-secondary">{{.VoteBits}}</td>
                   </tr>
                   <tr class="d-sm-none">
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Nonce: </td>
-                    <td class="text-left py-1 text-secondary">{{.Nonce}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Nonce: </td>
+                    <td class="text-left text-secondary">{{.Nonce}}</td>
                   </tr>
                   <tr>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Merkle Root: </td>
-                    <td colspan="5" class="text-left break-word py-1 text-secondary lh1rem"> {{.MerkleRoot}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Merkle Root: </td>
+                    <td colspan="5" class="text-left break-word text-secondary lh1rem"> {{.MerkleRoot}}</td>
                   </tr>
                   <tr>
-                    <td class="text-right font-weight-bold text-nowrap pr-2 py-1">Stake Root: </td>
-                    <td colspan="5" class="text-left break-word py-1 text-secondary lh1rem"> {{.StakeRoot}}</td>
+                    <td class="text-right font-weight-bold text-nowrap pr-2">Stake Root: </td>
+                    <td colspan="5" class="text-left break-word text-secondary lh1rem"> {{.StakeRoot}}</td>
                   </tr>
                 </tbody>
               </table>
             </div>
         </div>
 
-        <div class="v2-tables">
+        <div>
           <span class="d-inline-block pt-4 pb-1 h4">Block Reward</span>
           {{range .Tx}}
               {{if eq .Coinbase true}}
-                  <table class="table table-sm striped">
+                  <table class="table">
                       <thead>
                           <th>Transaction ID</th>
                           <th class="text-right">Total DCR</th>
-                          <th>Size</th>
+                          <th class="text-right">Size</th>
                       </thead>
                       <tbody {{if $Invalidated}}class="invalidated-tx" title="Regular transactions invalidated."{{end}}>
                           <tr>
@@ -185,7 +185,7 @@
                               <td class="mono fs15 text-right">
                                 {{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
                               </td>
-                              <td class="mono fs15">{{.FormattedSize}}</td>
+                              <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                           </tr>
                       </tbody>
                   </table>
@@ -194,7 +194,7 @@
 
           <span class="d-inline-block pt-4 pb-1 h4">Votes</span>
           {{if not .Votes}}
-              <table class="table table-sm striped">
+              <table class="table">
                   <tr>
                       <td>No votes in this block.
                           {{if lt .Height .StakeValidationHeight}}
@@ -204,11 +204,11 @@
                   </tr>
               </table>
           {{else}}
-              <table class="table table-sm striped">
+              <table class="table">
                   <thead>
                       <th>Transactions ID</th>
-                      <th>Vote Version</th>
-                      <th>Last Block</th>
+                      <th class="text-right">Vote Version</th>
+                      <th class="text-right">Last Block</th>
                       <th class="text-right">Total DCR</th>
                       <th class="text-right">Size</th>
                   </thead>
@@ -220,8 +220,8 @@
                                   <a class="hash lh1rem" href="/tx/{{.TxID}}">{{.TxID}}</a>
                               </span>
                           </td>
-                          <td class="mono fs15">{{.VoteInfo.Version}}</td>
-                          <td>{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
+                          <td class="mono fs15 text-right">{{.VoteInfo.Version}}</td>
+                          <td class="text-right">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
                           <td class="mono fs15 text-right">
                             {{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
                           </td>
@@ -235,7 +235,7 @@
         {{if ge .Height .StakeValidationHeight}}
         {{if .Misses}}
             <span class="d-inline-block pt-4 pb-1 h4">Missed Votes</span>
-            <table class="table table-sm striped">
+            <table class="table">
                 <thead>
                     <th>Ticket ID</th>
                 </thead>
@@ -256,18 +256,18 @@
 
             <span class="d-inline-block pt-4 pb-1 h4">Tickets</span>
             {{if not .Tickets}}
-            <table class="table table-sm striped">
+            <table class="table">
                 <tr>
                     <td>No tickets mined this block.</td>
                 </tr>
             </table>
             {{else}}
-                <table class="table table-sm striped">
+                <table class="table">
                     <thead>
                         <th>Transaction ID</th>
                         <th class="text-right">Total DCR</th>
                         <th class="text-right">Fee</th>
-                        <th>Size</th>
+                        <th class="text-right">Size</th>
                     </thead>
                     <tbody>
                     {{ range .Tickets}}
@@ -281,7 +281,7 @@
                               {{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
                             </td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
-                            <td class="mono fs15">{{.FormattedSize}}</td>
+                            <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                         </tr>
                     {{end}}
                     </tbody>
@@ -290,12 +290,12 @@
 
         {{if .Revocations}}
             <span class="d-inline-block pt-4 pb-1 h4">Revocations</span>
-            <table class="table table-sm striped">
+            <table class="table">
                 <thead>
                     <th>Transaction ID</th>
                     <th class="text-right">Total DCR</th>
                     <th class="text-right">Fee</th>
-                    <th>Size</th>
+                    <th class="text-right">Size</th>
                 </thead>
                 <tbody>
                     {{ range .Revs}}
@@ -309,7 +309,7 @@
                           {{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
                         </td>
                         <td class="mono fs15 text-right">{{.Fee}}</td>
-                        <td class="mono fs15">{{.FormattedSize}}</td>
+                        <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                     </tr>
                     {{end}}
                 </tbody>
@@ -317,18 +317,18 @@
         {{end}}
             <span class="d-inline-block pt-4 pb-1 h4">Transactions</span>
               {{if not .TxAvailable}}
-              <table class="table table-sm striped">
+              <table class="table">
                   <tr>
                       <td>No standard transactions mined this block.</td>
                   </tr>
               </table>
               {{else}}
-                  <table class="table table-sm striped">
+                  <table class="table">
                       <thead>
                           <th>Transaction ID</th>
                           <th class="text-right">Total DCR</th>
                           <th class="text-right">Fee</th>
-                          <th>Size</th>
+                          <th class="text-right">Size</th>
                       </thead>
                       <tbody {{if $Invalidated}}class="invalidated-tx" title="Regular transactions invalidated."{{end}}>
                           {{range .Tx}}
@@ -343,7 +343,7 @@
                                 {{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
                               </td>
                               <td class="mono fs15 text-right">{{.Fee}}</td>
-                              <td class="mono fs15">{{.FormattedSize}}</td>
+                              <td class="mono fs15 text-right">{{.FormattedSize}}</td>
                           </tr>
                           {{end}}
                           {{end}}

--- a/views/disapproved.tmpl
+++ b/views/disapproved.tmpl
@@ -10,7 +10,7 @@
         <h6>There are currently {{len .Data}} blocks that have been <a href="https://docs.decred.org/faq/proof-of-stake/general/#9-what-is-proof-of-stake-voting">disapproved via PoS voting.</a></h6>
         <div class="row">
             <div class="col-lg-24">
-                <table class="table striped table-responsive-sm" id="disapprovedblockstable">
+                <table class="table table-responsive-sm" id="disapprovedblockstable">
                     <thead>
                         <tr>
                             <th>Height</th>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -82,8 +82,8 @@
         {{end}}
 
         <div class="row">
-            <div class="col-lg-24 mt-2 v2-tables">
-                <table class="table striped">
+            <div class="col-lg-24 mt-2">
+                <table class="table">
                     <thead>
                         <tr>
                             <th>Height</th>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -324,7 +324,7 @@
       </tbody>
   </table>
   {{else}}
-  <table class="table table-mono-cells table-sm striped">
+  <table class="table table-mono-cells">
       <tr>
           <td>
               No transactions found for this address.

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -168,7 +168,7 @@
                         </div>
 
                         <div class="col mb-1">
-                            <table class="table w-100 mx-auto mb-0">
+                            <table class="table table-sm w-100 mx-auto mb-0">
                                 <thead>
                                 <tr>
                                     <th class="text-left pl-2">Hash</th>

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -67,7 +67,7 @@
                                 <div class="text-center h4 mb-0" data-target="mempool.regCount">{{.NumRegular}}</div>
                                 <div class="text-center fs13">
                                     <span data-target="mempool.regTotal">{{threeSigFigs .LikelyMineable.RegularTotal}}</span> DCR
-                                </div> 
+                                </div>
                             </div>
                             <div class="col-12">
                                 <div class="text-center text-secondary fs13">Tickets</div>
@@ -110,17 +110,17 @@
 
                 </div>
             </div>
-            <div class="v2-tables">
+            <div>
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-3 pb-2"><span>Votes</span></h4>
 
-                      <table class="table striped">
+                      <table class="table">
                           <thead>
                               <th>Transaction ID</th>
                               <th>Voting On</th>
-                              <th><div class="inline-block position-relative"><span class="d-none d-sm-inline">Validator ID</span><span class="d-inline d-sm-none" data-tooltip="Validator ID">VID</span></div></th>
-                              <th><div class="inline-block position-relative"><span class="d-none d-sm-inline">Vote Version</span><span class="d-inline d-sm-none" data-tooltip="Vote Version">Ver</span></div></th>
+                              <th class="text-right"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Validator ID</span><span class="d-inline d-sm-none" data-tooltip="Validator ID">VID</span></div></th>
+                              <th class="text-right"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Vote Version</span><span class="d-inline d-sm-none" data-tooltip="Vote Version">Ver</span></div></th>
                               <th class="text-right d-none d-sm-table-cell">Total DCR</th>
                               <th class="text-right">Size</th>
                               <th class="text-right d-none d-sm-table-cell jsonly">Time in Mempool</th>
@@ -138,8 +138,8 @@
                                   </td>
                                   <td class="mono fs15"><a href="/block/{{.VoteInfo.Validation.Hash}}">{{.VoteInfo.Validation.Height}}<span
                                     class="small">{{if .VoteInfo.ForLastBlock}} (best){{end}}</span></a></td>
-                                  <td class="mono fs15"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
-                                  <td class="mono fs15">{{.VoteInfo.Version}}</td>
+                                  <td class="mono fs15 text-right"><a href="/tx/{{.VoteInfo.TicketSpent}}">{{.VoteInfo.MempoolTicketIndex}}</a></td>
+                                  <td class="mono fs15 text-right">{{.VoteInfo.Version}}</td>
                                   <td class="mono fs15 text-right d-none d-sm-table-cell">
                                       {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
                                   </td>
@@ -159,7 +159,7 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-4 pb-2"><span>Tickets</span></h4>
-                      <table class="table striped">
+                      <table class="table">
                           <thead>
                               <th>Transaction ID</th>
                               <th class="text-right">Total DCR</th>
@@ -193,7 +193,7 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-5 pb-2"><span>Revokes</span></h4>
-                      <table class="table striped">
+                      <table class="table">
                           <thead>
                               <th>Transaction ID</th>
                               <th class="text-right">Total DCR</th>
@@ -227,7 +227,7 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-5 pb-2"><span>Transactions</span></h4>
-                      <table class="table striped">
+                      <table class="table">
                           <thead>
                             <tr>
                               <th>Transaction ID</th>

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -18,7 +18,7 @@
             <div class="row">
                 <div class="col">
                     <h4><span>Chain parameters</span></h4>
-                    <table class="table table-mono-cells table-sm striped">
+                    <table class="table table-mono-cells table-sm">
                         <thead>
                             <th width="20%">Parameter</th>
                             <th>Value</th>
@@ -103,7 +103,7 @@
                         </tbody>
                     </table>
                     <h4><span>Subsidy parameters</span></h4>
-                    <table class="table table-mono-cells table-sm striped">
+                    <table class="table table-mono-cells table-sm">
                         <thead>
                             <th width="20%">Parameter</th>
                             <th>Value</th>
@@ -151,7 +151,7 @@
                         </tbody>
                     </table>
                     <h4><span>Stake parameters</span></h4>
-                    <table class="table table-mono-cells table-sm striped">
+                    <table class="table table-mono-cells table-sm">
                         <thead>
                             <th width="20%">Parameter</th>
                             <th>Value</th>
@@ -251,7 +251,7 @@
                         </tbody>
                     </table>
                     <h4><span>Rule change parameters</span></h4>
-                    <table class="table table-mono-cells table-sm striped f15">
+                    <table class="table table-mono-cells table-sm f15">
                         <thead>
                             <th width="20%">Parameter</th>
                             <th>Value</th>
@@ -296,7 +296,7 @@
                         </tbody>
                     </table>
                     <h4><span>Address parameters</span></h4>
-                    <table class="table table-mono-cells table-sm striped">
+                    <table class="table table-mono-cells table-sm">
                         <thead>
                             <th width="20%">Address</th>
                             <th>Prefix</th>

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -30,7 +30,7 @@
                         </div>
                     {{end}}
 
-                    <table class="table table-sm striped">
+                    <table class="table">
                         <tr>
                             <td>No Proposal found for {{ .NetName }}</td>
                         </tr>
@@ -103,7 +103,7 @@
                 {{end}}
             <div>
 
-            <table class="table table-mono-cells striped">
+            <table class="table table-mono-cells">
                 <thead>
                     <tr class="d-flex">
                         <th class="col-md-9">Title</th>

--- a/views/sidechains.tmpl
+++ b/views/sidechains.tmpl
@@ -10,7 +10,7 @@
 
         <div class="row">
             <div class="col-lg-24">
-                <table class="table striped table-responsive-sm" id="sideblockstable">
+                <table class="table table-responsive-sm" id="sideblockstable">
                     <thead>
                         <tr>
                             <th>Height</th>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -85,8 +85,8 @@
 
         {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
         <div class="row">
-            <div class="col-lg-24 v2-tables">
-                <table class="table striped">
+            <div class="col-lg-24">
+                <table class="table">
                     <thead>
                         <tr>
                             <th>Start Date</th>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -278,10 +278,10 @@
           <span></span><!-- dummy for flex alignment -->
         </div>
     </div>
-    <div class="row v2-tables mb-5">
+    <div class="row mb-5">
         <div class="col-lg-12 mt-4 mb-2">
             <h5 class="pb-2">{{len .Vin}} Input{{if gt (len .Vin) 1}}s{{end}} Consumed</h5>
-            <table class="table table-sm striped">
+            <table class="table">
                 <thead>
                     <th class="shrink-to-fit">#</th>
                     <th class="text-nowrap">Previous Outpoint</th>
@@ -331,7 +331,7 @@
         </div>
         <div class="col-lg-12 mt-4">
             <h5 class="pb-2">{{len .Vout}} Output{{if gt (len .Vout) 1}}s{{end}} Created</h5>
-            <table class="table table-sm striped">
+            <table class="table">
                 <thead>
                     <th class="shrink-to-fit">#</th>
                     <th class="addr-hash-column"><div class="pl-1">Address</div></th>
@@ -395,7 +395,7 @@
             Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span>
             {{if .Choices}}
             </p>
-            <table class="table striped">
+            <table class="table">
                 <thead>
                     <th class="text-right">Issue ID</th>
                     <th>Issue Description</th>

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -85,7 +85,7 @@
 
         <div class="row">
             <div class="col-lg-24">
-                <table class="table striped v2-tables">
+                <table class="table">
                     <thead>
                         <tr>
                             <th class="text-right">Window #</th>


### PR DESCRIPTION
Finally following up on discussion from https://github.com/decred/dcrdata/pull/982#discussion_r254529952.

Removes unused CSS and migrate v2-tables styling to all tables.