### PR TITLE
gov: implement live vote tracking

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1027,6 +1027,23 @@ func (pgb *ChainDB) AgendasVotesSummary(agendaID string) (summary *dbtypes.Agend
 	return
 }
 
+// AgendaVoteCounts returns the vote counts for the agenda as builtin types.
+func (pgb *ChainDB) AgendaVoteCounts(agendaID string) (yes, abstain, no uint32, err error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+
+	chainInfo := pgb.ChainInfo()
+	agendaInfo := chainInfo.AgendaMileStones[agendaID]
+
+	// Check if starttime is in the future and exit if true.
+	if time.Now().Before(agendaInfo.StartTime) {
+		return
+	}
+
+	return retrieveTotalAgendaVotesCount(ctx, pgb.db, agendaID,
+		agendaInfo.VotingStarted, agendaInfo.VotingDone)
+}
+
 // AllAgendas returns all the agendas stored currently.
 func (pgb *ChainDB) AllAgendas() (map[string]dbtypes.MileStone, error) {
 	return retrieveAllAgendas(pgb.db)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -725,8 +725,8 @@ func (db *WiredDB) GetVoteVersionInfo(ver uint32) (*dcrjson.GetVoteInfoResult, e
 // GetStakeVersions requests the output of the getstakeversions RPC, which gets
 // stake version information and individual vote version information starting at the
 // given block and for count-1 blocks prior.
-func (db *WiredDB) GetStakeVersions(txHash string, count int32) (*dcrjson.GetStakeVersionsResult, error) {
-	return db.client.GetStakeVersions(txHash, count)
+func (db *WiredDB) GetStakeVersions(blockHash string, count int32) (*dcrjson.GetStakeVersionsResult, error) {
+	return db.client.GetStakeVersions(blockHash, count)
 }
 
 // GetStakeVersionsLatest requests the output of the getstakeversions RPC for

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -248,6 +248,7 @@ type explorerUI struct {
 	blockData        explorerDataSourceLite
 	explorerSource   explorerDataSource
 	agendasSource    agendaBackend
+	voteTracker      *agendas.VoteTracker
 	proposalsSource  politeiaBackend
 	dbsSyncing       atomic.Value
 	liteMode         bool
@@ -325,6 +326,7 @@ type ExplorerConfig struct {
 	Viewsfolder       string
 	XcBot             *exchanges.ExchangeBot
 	AgendasSource     agendaBackend
+	Tracker           *agendas.VoteTracker
 	ProposalsSource   politeiaBackend
 	PoliteiaURL       string
 	MainnetLink       string
@@ -343,6 +345,7 @@ func New(cfg *ExplorerConfig) *explorerUI {
 	exp.devPrefetch = cfg.DevPrefetch
 	exp.xcBot = cfg.XcBot
 	exp.agendasSource = cfg.AgendasSource
+	exp.voteTracker = cfg.Tracker
 	exp.proposalsSource = cfg.ProposalsSource
 	exp.politeiaAPIURL = cfg.PoliteiaURL
 	explorerLinks.Mainnet = cfg.MainnetLink
@@ -551,6 +554,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		dcrutil.Amount(blockData.ExtraInfo.CoinSupply).ToCoin(),
 		float64(newBlockData.Height),
 		blockData.CurrentStakeDiff.CurrentStakeDifficulty)
+
+	// Trigger a vote info refresh
+	go exp.voteTracker.Refresh()
 
 	// Update pageData with block data and chain (home) info.
 	p := exp.pageData

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1792,10 +1792,12 @@ func (exp *explorerUI) AgendasPage(w http.ResponseWriter, r *http.Request) {
 
 	str, err := exp.templates.execTemplateToString("agendas", struct {
 		*CommonPageData
-		Agendas []*agendas.AgendaTagged
+		Agendas       []*agendas.AgendaTagged
+		VotingSummary *agendas.VoteSummary
 	}{
 		CommonPageData: exp.commonData(),
 		Agendas:        agenda,
+		VotingSummary:  exp.voteTracker.Summary(),
 	})
 
 	if err != nil {

--- a/explorer/explorerroutes_test.go
+++ b/explorer/explorerroutes_test.go
@@ -76,6 +76,7 @@ func TestStatusPageResponseCodes(t *testing.T) {
 		DevPrefetch:       false,
 		Viewsfolder:       viewsPath,
 		XcBot:             nil,
+		Tracker:           nil,
 		AgendasSource:     nil,
 		ProposalsSource:   nil,
 		PoliteiaURL:       "",

--- a/gov/agendas/go.mod
+++ b/gov/agendas/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/asdine/storm v2.2.0+incompatible
 	github.com/decred/dcrd/chaincfg v1.3.0
 	github.com/decred/dcrd/dcrjson/v2 v2.0.0
+	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/db/dbtypes v1.0.1
 	github.com/decred/dcrdata/db/dcrpg v1.0.0 // indirect
 	github.com/decred/slog v1.0.0

--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -459,7 +459,7 @@ func spoof(summary *VoteSummary) {
 	agenda := &summary.Agendas[0]
 	summary.VotingTriggered = false
 	agenda.VotingTriggered = false
-	agenda.IsVoting = false
+	agenda.IsVoting = true
 	agenda.IsDefined = false
 
 	agenda.Aye = agenda.Quorum * 9
@@ -475,9 +475,9 @@ func spoof(summary *VoteSummary) {
 	agenda.QuorumProgress = 1
 	agenda.QuorumAchieved = true
 	agenda.Approval = float32(agenda.Aye) / float32(agenda.VoteCount)
-	agenda.IsWinning = false
+	agenda.IsWinning = true
 	agenda.IsLosing = false
-	agenda.IsLocked = true
+	agenda.IsLocked = false
 	agenda.IsActive = false
 	agenda.IsFailed = false
 }

--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -1,0 +1,483 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package agendas
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/dcrjson/v2"
+	"github.com/decred/dcrd/wire"
+)
+
+const (
+	statusDefined = "defined"
+	statusStarted = "started"
+	statusLocked  = "lockedin"
+	statusActive  = "active"
+	statusFailed  = "failed"
+	choiceYes     = "yes"
+	choiceNo      = "no"
+	choiceAbstain = "abstain"
+)
+
+// VoteDataSource is satisfied by rpcclient.Client.
+type VoteDataSource interface {
+	GetStakeVersionInfo(int32) (*dcrjson.GetStakeVersionInfoResult, error)
+	GetVoteInfo(uint32) (*dcrjson.GetVoteInfoResult, error)
+	GetStakeVersions(string, int32) (*dcrjson.GetStakeVersionsResult, error)
+}
+
+// dcrd does not supply vote counts for completed votes, so the tracker will
+// need a means to get the counts from a database somewhere.
+type voteCounter func(string) (uint32, uint32, uint32, error)
+
+// AgendaSummary summarizes the current state of voting on a particular agenda.
+type AgendaSummary struct {
+	Description     string  `json:"description"`
+	ID              string  `json:"id"`
+	Quorum          uint32  `json:"quorum"`
+	QuorumProgress  float32 `json:"quorum_progress"`
+	QuorumAchieved  bool    `json:"quorum_achieved"`
+	Aye             uint32  `json:"aye"`
+	Nay             uint32  `json:"nay"`
+	Abstain         uint32  `json:"abstain"`
+	AbstainRate     float32 `json:"abstain_rate"`
+	VoteCount       uint32  `json:"vote_count"` // non-abstaining
+	PassThreshold   float32 `json:"pass_threshold"`
+	FailThreshold   float32 `json:"fail_threshold"`
+	Approval        float32 `json:"approval"`
+	LockCount       uint32  `json:"lock_count"`
+	IsWinning       bool    `json:"is_winning"`
+	IsLosing        bool    `json:"is_losing"`
+	IsVoting        bool    `json:"is_voting"`
+	IsDefined       bool    `json:"is_defined"`
+	VotingTriggered bool    `json:"voting_triggered"`
+	IsLocked        bool    `json:"is_locked"`
+	IsFailed        bool    `json:"is_failed"`
+	IsActive        bool    `json:"is_active"`
+}
+
+// VoteSummary summarizes the current state of consensus voting. VoteSummary is
+// the primary exported type produced by VoteTracker.
+type VoteSummary struct {
+	Version         uint32          `json:"version"`
+	Height          int64           `json:"height"`
+	Hash            string          `json:"hash"`
+	VoteVersion     uint32          `json:"vote_version"`
+	Agendas         []AgendaSummary `json:"agendas"`
+	OldVoters       uint32          `json:"old_voters"`
+	NewVoters       uint32          `json:"new_voters"`
+	VoterCount      uint32          `json:"voter_count"`
+	VoterThreshold  float32         `json:"voter_threshold"`
+	VoterProgress   float32         `json:"voter_progress"`
+	OldMiners       uint32          `json:"old_miners"`
+	NewMiners       uint32          `json:"new_miners"`
+	MinerCount      uint32          `json:"miner_count"`
+	MinerThreshold  float32         `json:"miner_threshold"`
+	MinerProgress   float32         `json:"miner_progress"`
+	RCIBlocks       uint32          `json:"rci_blocks"`
+	RCIMined        uint32          `json:"rci_mined"`
+	RCIProgress     float32         `json:"rci_progress"`
+	SVIBlocks       uint32          `json:"svi_blocks"`
+	SVIMined        uint32          `json:"svi_mined"`
+	SVIProgress     float32         `json:"svi_progress"`
+	TilNextRCI      int64           `json:"til_next_rci"`
+	NextRCIHeight   uint32          `json:"next_rci_height"`
+	NetworkUpgraded bool            `json:"network_upgrading"`
+	VotingTriggered bool            `json:"voting_triggered"`
+}
+
+// Store counts fetched usin the voteCounter to prevent extra database calls.
+// The counts are only required for votes that have complete, so the numbers
+// will not change.
+type voteCount struct {
+	yes     uint32
+	no      uint32
+	abstain uint32
+}
+
+// VoteTracker manages the current state of node version data and vote data on
+// the blockchain. VoteTracker refreshes its data when it is signaled by
+// a call to Refresh. A VoteSummary is created and stored for requests with the
+// Summary method.
+type VoteTracker struct {
+	mtx            sync.RWMutex
+	node           VoteDataSource
+	voteCounter    voteCounter
+	countCache     map[string]*voteCount
+	params         *chaincfg.Params
+	version        uint32
+	blockVersion   int32
+	stakeVersion   uint32
+	stakeIntervals *dcrjson.GetStakeVersionInfoResult
+	voteInfo       *dcrjson.GetVoteInfoResult
+	summary        *VoteSummary
+	ringIndex      int
+	ringHeight     int64
+	blockRing      []int32
+	minerThreshold float32
+	voterThreshold float32
+	sviBlocks      uint32
+	rciBlocks      uint32
+	blockTime      int64
+	passThreshold  float32
+	lockCount      uint32
+}
+
+// NewVoteTracker is a constructor for a VoteTracker.
+func NewVoteTracker(params *chaincfg.Params, node VoteDataSource, counter voteCounter) (*VoteTracker, error) {
+	tracker := &VoteTracker{
+		mtx:            sync.RWMutex{},
+		node:           node,
+		voteCounter:    counter,
+		countCache:     make(map[string]*voteCount),
+		params:         params,
+		version:        wire.ProtocolVersion,
+		ringIndex:      -1,
+		blockRing:      make([]int32, params.BlockUpgradeNumToCheck),
+		minerThreshold: float32(params.BlockRejectNumRequired) / float32(params.BlockUpgradeNumToCheck),
+		voterThreshold: float32(params.RuleChangeActivationMultiplier) / float32(params.RuleChangeActivationDivisor),
+		sviBlocks:      uint32(params.StakeVersionInterval),
+		rciBlocks:      params.RuleChangeActivationInterval,
+		blockTime:      int64(params.TargetTimePerBlock.Seconds()),
+		passThreshold:  float32(params.RuleChangeActivationMultiplier) / float32(params.RuleChangeActivationDivisor),
+		lockCount:      params.RuleChangeActivationInterval * uint32(params.TicketsPerBlock) * params.RuleChangeActivationMultiplier / params.RuleChangeActivationDivisor,
+	}
+
+	voteInfo, err := tracker.refreshRCI()
+	if err != nil {
+		return nil, err
+	}
+	blocksToAdd, stakeVersion, err := tracker.fetchBlocks(voteInfo)
+	if err != nil {
+		return nil, err
+	}
+	stakeInfo, err := tracker.refreshSVIs(voteInfo)
+	if err != nil {
+		return nil, err
+	}
+	tracker.update(voteInfo, blocksToAdd, stakeInfo, stakeVersion)
+	return tracker, nil
+}
+
+// Refresh refreshes node version and vote data. It can be called as a
+// goroutine. All VoteTracker updating and mutex locking is handled within
+// VoteTracker.update.
+func (tracker *VoteTracker) Refresh() {
+	voteInfo, err := tracker.refreshRCI()
+	if err != nil {
+		log.Errorf("VoteTracker.Refresh -> refreshRCI: %v")
+		return
+	}
+	blocksToAdd, stakeVersion, err := tracker.fetchBlocks(voteInfo)
+	if err != nil {
+		log.Errorf("VoteTracker.Refresh -> fetchBlocks: %v")
+		return
+	}
+	stakeInfo, err := tracker.refreshSVIs(voteInfo)
+	if err != nil {
+		log.Errorf("VoteTracker.Refresh -> refreshSVIs: %v")
+		return
+	}
+	tracker.update(voteInfo, blocksToAdd, stakeInfo, stakeVersion)
+}
+
+// Since versoion could technically be updated without turning off dcrdata,
+// the field must be protected.
+func (tracker *VoteTracker) Version() uint32 {
+	tracker.mtx.RLock()
+	defer tracker.mtx.RUnlock()
+	return tracker.version
+}
+
+// Grab the getvoteinfo data. Instead of updating the tracker's voteInfo field,
+// return, return the data. voteInfo will be updated in VoteTracker.update
+// along with other fileds under mutex lock.
+func (tracker *VoteTracker) refreshRCI() (*dcrjson.GetVoteInfoResult, error) {
+	oldVersion := tracker.Version()
+	v := oldVersion
+	var err error
+	var voteInfo *dcrjson.GetVoteInfoResult
+
+	for {
+		vinfo, err := tracker.node.GetVoteInfo(v)
+		if err != nil {
+			break
+		}
+		voteInfo = vinfo
+		v++
+	}
+
+	if voteInfo == nil {
+		return nil, fmt.Errorf("Vote information not found: %v", err)
+	}
+	if v > oldVersion+1 {
+		tracker.mtx.Lock()
+		tracker.version = v
+		tracker.mtx.Unlock()
+	}
+	return voteInfo, nil
+}
+
+// The number of blocks that have been mined in the rule change interval.
+func rciBlocks(voteInfo *dcrjson.GetVoteInfoResult) int64 {
+	return voteInfo.CurrentHeight - voteInfo.StartHeight + 1
+}
+
+// Grab the block versions for up to the last BlockUpgradeNumToCheck blocks.
+// If the current block builds upon the last block, only request a single
+// block's data. Otherwise, request all BlockUpgradeNumToCheck.
+func (tracker *VoteTracker) fetchBlocks(voteInfo *dcrjson.GetVoteInfoResult) ([]int32, uint32, error) {
+	blocksToRequest := 1
+	// If this isn't the next block, request them all again
+	if voteInfo.CurrentHeight < 0 || voteInfo.CurrentHeight != tracker.ringHeight+1 {
+		blocksToRequest = int(tracker.params.BlockUpgradeNumToCheck)
+	}
+	r, err := tracker.node.GetStakeVersions(voteInfo.Hash, int32(blocksToRequest))
+	if err != nil {
+		return nil, 0, err
+	}
+	blockCount := len(r.StakeVersions)
+	if blockCount != blocksToRequest {
+		return nil, 0, fmt.Errorf("Unexpected number of blocks returns from GetStakeVersions. Asked for %d, received %d", blockCount, blockCount)
+	}
+	blocks := make([]int32, blockCount)
+	var block dcrjson.StakeVersions
+	for i := 0; i < blockCount; i++ {
+		block = r.StakeVersions[blockCount-i-1] // iterate backwards
+		tracker.ringIndex = (tracker.ringIndex + 1) % blockCount
+		blocks[i] = block.BlockVersion
+	}
+	return blocks, block.StakeVersion, nil
+}
+
+// Get the info for the stake versions in the current rule change interval.
+func (tracker *VoteTracker) refreshSVIs(voteInfo *dcrjson.GetVoteInfoResult) (*dcrjson.GetStakeVersionInfoResult, error) {
+	blocksInCurrentRCI := rciBlocks(voteInfo)
+	svis := int32(blocksInCurrentRCI / tracker.params.StakeVersionInterval)
+	// blocksInCurrentSVI := int32(blocksInCurrentRCI % params.StakeVersionInterval)
+	if blocksInCurrentRCI%tracker.params.StakeVersionInterval > 0 {
+		svis++
+	}
+	si, err := tracker.node.GetStakeVersionInfo(svis)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving stake version info: %v", err)
+	}
+	return si, nil
+}
+
+// The cached voteCount for the given agenda, or nil if not found.
+func (tracker *VoteTracker) cachedCounts(agendaId string) *voteCount {
+	tracker.mtx.RLock()
+	defer tracker.mtx.RUnlock()
+	counts := tracker.countCache[agendaId]
+	return counts
+}
+
+// Cache the voteCount for the given agenda.
+func (tracker *VoteTracker) cacheVoteCounts(agendaId string, counts *voteCount) {
+	tracker.mtx.Lock()
+	defer tracker.mtx.Unlock()
+	tracker.countCache[agendaId] = counts
+}
+
+// Once all resources have been retrieved from dcrd, update VoteTracker fields.
+func (tracker *VoteTracker) update(voteInfo *dcrjson.GetVoteInfoResult, blocks []int32,
+	stakeInfo *dcrjson.GetStakeVersionInfoResult, stakeVersion uint32) {
+	// Check if voteCounts are needed
+	for idx := range voteInfo.Agendas {
+		agenda := &voteInfo.Agendas[idx]
+		status := agenda.Status
+		if status != statusDefined && status != statusStarted {
+			// check the cache
+			counts := tracker.countCache[agenda.ID]
+			if counts == nil {
+				counts = new(voteCount)
+				var err error
+				counts.yes, counts.abstain, counts.no, err = tracker.voteCounter(agenda.ID)
+				if err != nil {
+					log.Errorf("Error counting votes for %s", agenda.ID)
+					continue
+				}
+				tracker.cacheVoteCounts(agenda.ID, counts)
+			}
+			for idx := range agenda.Choices {
+				choice := &agenda.Choices[idx]
+				if choice.ID == choiceYes {
+					choice.Count = counts.yes
+				} else if choice.ID == choiceNo {
+					choice.Count = counts.no
+				} else {
+					choice.Count = counts.abstain
+				}
+			}
+		}
+	}
+	tracker.mtx.Lock()
+	defer tracker.mtx.Unlock()
+	tracker.voteInfo = voteInfo
+	tracker.stakeIntervals = stakeInfo
+	ringLen := int(tracker.params.BlockUpgradeNumToCheck)
+	for idx := range blocks {
+		tracker.ringIndex = (tracker.ringIndex + 1) % ringLen
+		tracker.blockRing[tracker.ringIndex] = blocks[idx]
+	}
+	tracker.blockVersion = tracker.blockRing[tracker.ringIndex]
+	tracker.stakeVersion = stakeVersion
+	tracker.ringHeight = voteInfo.CurrentHeight
+	tracker.summary = tracker.newVoteSummary()
+}
+
+// Create a new VoteSummary from the currently saved info.
+func (tracker *VoteTracker) newVoteSummary() *VoteSummary {
+	summary := &VoteSummary{
+		Version:         tracker.version,
+		Height:          tracker.voteInfo.CurrentHeight,
+		Hash:            tracker.voteInfo.Hash,
+		VoteVersion:     tracker.version,
+		MinerThreshold:  tracker.minerThreshold,
+		VoterThreshold:  tracker.voterThreshold,
+		RCIBlocks:       tracker.rciBlocks,
+		SVIBlocks:       tracker.sviBlocks,
+		NextRCIHeight:   uint32(tracker.voteInfo.EndHeight + 1),
+		NetworkUpgraded: uint32(tracker.blockVersion) == tracker.version && tracker.stakeVersion == tracker.version,
+	}
+	summary.Agendas = make([]AgendaSummary, len(tracker.voteInfo.Agendas))
+	for idx := range tracker.voteInfo.Agendas {
+		agenda := &tracker.voteInfo.Agendas[idx]
+		agendaSummary := AgendaSummary{
+			Description:   agenda.Description,
+			ID:            agenda.ID,
+			Quorum:        tracker.params.RuleChangeActivationQuorum,
+			PassThreshold: tracker.passThreshold,
+			LockCount:     tracker.lockCount,
+		}
+		status := agenda.Status
+		agendaSummary.IsLocked = status == statusLocked
+		agendaSummary.IsFailed = status == statusFailed
+		agendaSummary.IsActive = status == statusActive
+		agendaSummary.IsVoting = status == statusStarted
+		agendaSummary.IsDefined = status == statusDefined
+		for idx := range agenda.Choices {
+			choice := &agenda.Choices[idx]
+			if choice.IsNo {
+				agendaSummary.Nay = choice.Count
+			} else if choice.IsAbstain {
+				agendaSummary.Abstain = choice.Count
+			} else {
+				agendaSummary.Aye = choice.Count
+			}
+		}
+		agendaSummary.VoteCount = agendaSummary.Aye + agendaSummary.Nay
+		agendaSummary.Approval = float32(agendaSummary.Aye) / float32(agendaSummary.VoteCount)
+		agendaSummary.AbstainRate = float32(agendaSummary.Abstain) / float32(agendaSummary.VoteCount+agendaSummary.Abstain)
+		agendaSummary.QuorumProgress = float32(agendaSummary.VoteCount) / float32(agendaSummary.Quorum)
+		agendaSummary.FailThreshold = 1 - agendaSummary.PassThreshold
+		agendaSummary.QuorumAchieved = agendaSummary.VoteCount > agendaSummary.Quorum
+		if agendaSummary.QuorumProgress >= 1 {
+			agendaSummary.QuorumProgress = 1
+			agendaSummary.QuorumAchieved = true
+		}
+		if agendaSummary.Aye >= agendaSummary.LockCount {
+			agendaSummary.IsLocked = true
+		}
+		if agendaSummary.Approval >= agendaSummary.PassThreshold {
+			agendaSummary.IsWinning = true
+		}
+		if agendaSummary.Approval < agendaSummary.FailThreshold {
+			agendaSummary.IsLosing = true
+		}
+		if agendaSummary.IsDefined && summary.NetworkUpgraded {
+			agendaSummary.VotingTriggered = true
+			summary.VotingTriggered = true
+		}
+		summary.Agendas[idx] = agendaSummary
+	}
+	var sviMined uint32
+	for idx := range tracker.stakeIntervals.Intervals {
+		interval := tracker.stakeIntervals.Intervals[idx]
+		var newVoters, oldVoters uint32
+		for idy := range interval.VoteVersions {
+			version := &interval.VoteVersions[idy]
+			if version.Version == tracker.version {
+				newVoters = version.Count
+			} else {
+				oldVoters += version.Count
+			}
+		}
+		if idx == 0 {
+			sviMined = uint32(summary.Height - interval.StartHeight + 1)
+			summary.NewVoters = newVoters
+			summary.OldVoters = oldVoters
+		}
+	}
+	summary.VoterCount = summary.OldVoters + summary.NewVoters
+	summary.VoterProgress = float32(summary.NewVoters) / float32(summary.VoterCount)
+
+	// Count the miners in the rolling window.
+	currentBlockVersion := int32(tracker.version)
+	for _, blockVersion := range tracker.blockRing {
+		if blockVersion == currentBlockVersion {
+			summary.NewMiners++
+		} else {
+			summary.OldMiners++
+		}
+	}
+
+	summary.MinerCount = summary.NewMiners + summary.OldMiners
+	summary.MinerProgress = float32(summary.NewMiners) / float32(summary.MinerCount)
+
+	summary.RCIMined = uint32(tracker.voteInfo.CurrentHeight - tracker.voteInfo.StartHeight + 1)
+	summary.RCIProgress = float32(summary.RCIMined) / float32(summary.RCIBlocks)
+
+	summary.SVIMined = sviMined
+	summary.SVIProgress = float32(summary.SVIMined) / float32(summary.SVIBlocks)
+
+	summary.TilNextRCI = int64(summary.RCIBlocks-summary.RCIMined) * tracker.blockTime
+
+	return summary
+}
+
+// Summary returns VoteTracker's most recent VoteSummary. The summary returned
+// will never be modified by VoteTracker, so can be used read-only by any number
+// of threads.
+func (tracker *VoteTracker) Summary() *VoteSummary {
+	tracker.mtx.RLock()
+	defer tracker.mtx.RUnlock()
+	return tracker.summary
+}
+
+// for testing
+func spoof(summary *VoteSummary) {
+	log.Infof("Spoofing vote data for testing. Don't forget to remove this call.")
+	// summary.NetworkUpgraded = false
+	// summary.VoterProgress = 0.57
+	// summary.MinerProgress = 0.86
+	agenda := &summary.Agendas[0]
+	summary.VotingTriggered = false
+	agenda.VotingTriggered = false
+	agenda.IsVoting = false
+	agenda.IsDefined = false
+
+	agenda.Aye = agenda.Quorum * 9
+	agenda.Nay = agenda.Aye / 7
+	agenda.Abstain = agenda.Nay
+
+	// agenda.Aye = 0
+	// agenda.Nay = 0
+	// agenda.Abstain = 0
+
+	agenda.VoteCount = agenda.Aye + agenda.Nay
+	agenda.AbstainRate = float32(agenda.Abstain) / float32(agenda.VoteCount)
+	agenda.QuorumProgress = 1
+	agenda.QuorumAchieved = true
+	agenda.Approval = float32(agenda.Aye) / float32(agenda.VoteCount)
+	agenda.IsWinning = false
+	agenda.IsLosing = false
+	agenda.IsLocked = true
+	agenda.IsActive = false
+	agenda.IsFailed = false
+}

--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -187,8 +187,8 @@ func (tracker *VoteTracker) Refresh() {
 	tracker.update(voteInfo, blocksToAdd, stakeInfo, stakeVersion)
 }
 
-// Version returns the current best know vote version.
-// Since versoion could technically be updated without turning off dcrdata,
+// Version returns the current best known vote version.
+// Since version could technically be updated without turning off dcrdata,
 // the field must be protected.
 func (tracker *VoteTracker) Version() uint32 {
 	tracker.mtx.RLock()
@@ -202,10 +202,10 @@ func (tracker *VoteTracker) refreshRCI() (*dcrjson.GetVoteInfoResult, error) {
 	oldVersion := tracker.Version()
 	v := oldVersion
 	var err error
-	var voteInfo *dcrjson.GetVoteInfoResult
+	var voteInfo, vinfo *dcrjson.GetVoteInfoResult
 
 	for {
-		vinfo, err := tracker.node.GetVoteInfo(v)
+		vinfo, err = tracker.node.GetVoteInfo(v)
 		if err != nil {
 			break
 		}
@@ -364,8 +364,8 @@ func (tracker *VoteTracker) newVoteSummary() *VoteSummary {
 		agendaSummary.IsActive = status == statusActive
 		agendaSummary.IsVoting = status == statusStarted
 		agendaSummary.IsDefined = status == statusDefined
-		for idx := range agenda.Choices {
-			choice := &agenda.Choices[idx]
+		for idy := range agenda.Choices {
+			choice := &agenda.Choices[idy]
 			if choice.IsNo {
 				agendaSummary.Nay = choice.Count
 			} else if choice.IsAbstain {

--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -242,7 +242,7 @@ func (tracker *VoteTracker) fetchBlocks(voteInfo *dcrjson.GetVoteInfoResult) ([]
 	}
 	blockCount := len(r.StakeVersions)
 	if blockCount != blocksToRequest {
-		return nil, 0, fmt.Errorf("Unexpected number of blocks returns from GetStakeVersions. Asked for %d, received %d", blockCount, blockCount)
+		return nil, 0, fmt.Errorf("Unexpected number of blocks returns from GetStakeVersions. Asked for %d, received %d", blocksToRequest, blockCount)
 	}
 	blocks := make([]int32, blockCount)
 	var block dcrjson.StakeVersions

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -152,8 +152,13 @@ func counter(hash string) (uint32, uint32, uint32, error) {
 }
 
 func TestVoteTracker(t *testing.T) {
-	_, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter)
+	tracker, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter)
 	if err != nil {
 		t.Errorf("NewVoteTracker error: %v", err)
+	}
+
+	summary := tracker.Summary()
+	if summary == nil {
+		t.Errorf("nil VoteSummary error")
 	}
 }

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -135,13 +135,13 @@ func (source dataSourceStub) GetStakeVersions(hash string, count int32) (*dcrjso
 	}
 	c := int(count)
 	for i := 0; i < c; i++ {
-		result.StakeVersions = append(result.StakeVersions, dcrjson.StakeVersions{
+		result.StakeVersions[i] = dcrjson.StakeVersions{
 			Hash:         strconv.Itoa(h),
 			Height:       int64(h),
 			BlockVersion: 6,
 			StakeVersion: 6,
 			Votes:        []dcrjson.VersionBits{}, // VoteTracker does not use this
-		})
+		}
 		h--
 	}
 	return result, nil
@@ -154,6 +154,6 @@ func counter(hash string) (uint32, uint32, uint32, error) {
 func TestVoteTracker(t *testing.T) {
 	_, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter)
 	if err != nil {
-		fmt.Errorf("NewVoteTracker error: %v", err)
+		t.Errorf("NewVoteTracker error: %v", err)
 	}
 }

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -1,0 +1,159 @@
+package agendas
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/dcrjson/v2"
+)
+
+type dataSourceStub struct{}
+
+func (source dataSourceStub) GetStakeVersionInfo(version int32) (*dcrjson.GetStakeVersionInfoResult, error) {
+	if version > 6 {
+		return nil, fmt.Errorf(" ")
+	}
+	h := int64(version * 50000)
+	return &dcrjson.GetStakeVersionInfoResult{
+		CurrentHeight: h,
+		Hash:          strconv.Itoa(int(version)),
+		Intervals: []dcrjson.VersionInterval{
+			dcrjson.VersionInterval{
+				StartHeight: h - 500,
+				EndHeight:   h + 500,
+				PoSVersions: []dcrjson.VersionCount{
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   5,
+					},
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   100000,
+					},
+				},
+				VoteVersions: []dcrjson.VersionCount{
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   5,
+					},
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   100000,
+					},
+				},
+			},
+			dcrjson.VersionInterval{
+				StartHeight: h - 1500,
+				EndHeight:   h - 501,
+				PoSVersions: []dcrjson.VersionCount{
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   5,
+					},
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   100000,
+					},
+				},
+				VoteVersions: []dcrjson.VersionCount{
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   5,
+					},
+					dcrjson.VersionCount{
+						Version: uint32(version),
+						Count:   100000,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (source dataSourceStub) GetVoteInfo(version uint32) (*dcrjson.GetVoteInfoResult, error) {
+	if version > 6 {
+		return nil, fmt.Errorf(" ")
+	}
+	h := int64(version * 50000)
+	return &dcrjson.GetVoteInfoResult{
+		CurrentHeight: h,
+		StartHeight:   h - 1500,
+		EndHeight:     h + 500,
+		Hash:          strconv.Itoa(int(version)),
+		VoteVersion:   version,
+		Quorum:        4032,
+		TotalVotes:    10000,
+		Agendas: []dcrjson.Agenda{
+			dcrjson.Agenda{
+				ID:             "test agenda",
+				Description:    "agenda for testing",
+				Mask:           6,
+				StartTime:      5,
+				ExpireTime:     10,
+				Status:         "failed",
+				QuorumProgress: 0,
+				Choices: []dcrjson.Choice{
+					dcrjson.Choice{
+						ID:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0,
+						IsAbstain:   true,
+						IsNo:        false,
+						Count:       0,
+						Progress:    0,
+					},
+					dcrjson.Choice{
+						ID:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        2,
+						IsAbstain:   false,
+						IsNo:        true,
+						Count:       0,
+						Progress:    0,
+					},
+					dcrjson.Choice{
+						ID:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        4,
+						IsAbstain:   false,
+						IsNo:        false,
+						Count:       0,
+						Progress:    0,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (source dataSourceStub) GetStakeVersions(hash string, count int32) (*dcrjson.GetStakeVersionsResult, error) {
+	h, _ := strconv.Atoi(hash)
+	result := &dcrjson.GetStakeVersionsResult{
+		StakeVersions: make([]dcrjson.StakeVersions, int(count)),
+	}
+	c := int(count)
+	for i := 0; i < c; i++ {
+		result.StakeVersions = append(result.StakeVersions, dcrjson.StakeVersions{
+			Hash:         strconv.Itoa(h),
+			Height:       int64(h),
+			BlockVersion: 6,
+			StakeVersion: 6,
+			Votes:        []dcrjson.VersionBits{}, // VoteTracker does not use this
+		})
+		h--
+	}
+	return result, nil
+}
+
+func counter(hash string) (uint32, uint32, uint32, error) {
+	return 1, 2, 3, nil
+}
+
+func TestVoteTracker(t *testing.T) {
+	_, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter)
+	if err != nil {
+		fmt.Errorf("NewVoteTracker error: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -553,7 +553,7 @@ func _main(ctx context.Context) error {
 	}()
 
 	// A vote tracker tracks current block and stake versions and votes.
-	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient, auxDB.AgendaCumulativeVoteChoices)
+	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient, auxDB.AgendaVoteCounts)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize vote tracker: %v", err)
 	}

--- a/public/js/controllers/agendas_controller.js
+++ b/public/js/controllers/agendas_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus'
 import globalEventBus from '../services/event_bus_service'
 import { darkEnabled } from '../services/theme_service'
-import VoteMeter from '../helpers/vote_meter.js'
+import { VoteMeter, ProgressMeter } from '../helpers/vote_meter.js'
 
 export default class extends Controller {
   static get targets () {
@@ -17,19 +17,15 @@ export default class extends Controller {
       darkMode: darkEnabled()
     }
     if (this.hasMinerMeterTarget) {
-      this.minerMeter = new VoteMeter(this.minerMeterTarget, opts)
+      this.minerMeter = new ProgressMeter(this.minerMeterTarget, opts)
       this.meters.push(this.minerMeter)
     }
     if (this.hasVoterMeterTarget) {
-      this.voterMeter = new VoteMeter(this.voterMeterTarget, Object.assign({
-        meterColor: '#2970ff'
-      }, opts))
+      this.voterMeter = new ProgressMeter(this.voterMeterTarget, opts)
       this.meters.push(this.voterMeter)
     }
     if (this.hasQuorumMeterTarget) {
-      this.quorumMeter = new VoteMeter(this.quorumMeterTarget, Object.assign({
-        meterColor: '#2970ff'
-      }, opts))
+      this.quorumMeter = new ProgressMeter(this.quorumMeterTarget, opts)
       this.meters.push(this.quorumMeter)
     }
     if (this.hasApprovalMeterTarget) {

--- a/public/js/controllers/agendas_controller.js
+++ b/public/js/controllers/agendas_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus'
 import globalEventBus from '../services/event_bus_service'
 import { darkEnabled } from '../services/theme_service'
-import { VoteMeter, ProgressMeter } from '../helpers/vote_meter.js'
+import { VoteMeter, ProgressMeter } from '../helpers/meters.js'
 
 export default class extends Controller {
   static get targets () {

--- a/public/js/controllers/agendas_controller.js
+++ b/public/js/controllers/agendas_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from 'stimulus'
+import globalEventBus from '../services/event_bus_service'
+import { darkEnabled } from '../services/theme_service'
+import VoteMeter from '../helpers/vote_meter.js'
+
+export default class extends Controller {
+  static get targets () {
+    return [
+      'minerMeter', 'voterMeter', 'quorumMeter', 'approvalMeter'
+    ]
+  }
+
+  connect () {
+    this.minerMeter = this.voterMeter = null
+    this.meters = []
+    var opts = {
+      darkMode: darkEnabled()
+    }
+    if (this.hasMinerMeterTarget) {
+      this.minerMeter = new VoteMeter(this.minerMeterTarget, opts)
+      this.meters.push(this.minerMeter)
+    }
+    if (this.hasVoterMeterTarget) {
+      this.voterMeter = new VoteMeter(this.voterMeterTarget, Object.assign({
+        meterColor: '#2970ff'
+      }, opts))
+      this.meters.push(this.voterMeter)
+    }
+    if (this.hasQuorumMeterTarget) {
+      this.quorumMeter = new VoteMeter(this.quorumMeterTarget, Object.assign({
+        meterColor: '#2970ff'
+      }, opts))
+      this.meters.push(this.quorumMeter)
+    }
+    if (this.hasApprovalMeterTarget) {
+      this.approvalMeter = new VoteMeter(this.approvalMeterTarget, opts)
+      this.meters.push(this.approvalMeter)
+    }
+    this.setNightMode = this._setNightMode.bind(this)
+    globalEventBus.on('NIGHT_MODE', this.setNightMode)
+  }
+
+  disconnect () {
+    globalEventBus.off('NIGHT_MODE', this.setNightMode)
+  }
+
+  _setNightMode (state) {
+    this.meters.forEach((meter) => {
+      meter.setDarkMode(state.nightMode)
+    })
+  }
+}

--- a/public/js/helpers/vote_meter.js
+++ b/public/js/helpers/vote_meter.js
@@ -1,199 +1,344 @@
 const PIPI = 2 * Math.PI
 
-export default class VoteMeter {
+function makePt (x, y) {
+  return {
+    x: x,
+    y: y
+  }
+}
+
+function addOffset (pt, offset) {
+  return {
+    x: pt.x + offset.x,
+    y: pt.y + offset.y
+  }
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+class Meter {
   constructor (parent, opts) {
     opts = opts || {}
+    this.options = opts
+    this.radius = opts.radius || 0.4
     this.parent = parent
-    var d = parent.dataset
-    this.data = {
-      progress: parseFloat(d.progress),
-      type: d.type
-    }
-    this.data.thresholds = d.threshold ? [parseFloat(d.threshold)] : null
-    if (d.type === 'vote') this.data.thresholds.splice(0, 0, 1 - this.data.thresholds[0])
-    this.centralFontSize = 15
-    var l = parent.classList
-    this.meterSpace = 0.5 // radians
-    if (l.contains('large-gap')) this.meterSpace = Math.PI / 2
-    if (l.contains('arch')) this.meterSpace = Math.PI
-    this.startAngle = Math.PI / 2
-    this.meterColor = '#2dd8a3'
-    this.meterWidth = 8
-    this.approveColor = '#2dd8a3' // '#41be53'
-    this.revoteColor = '#ffe4a7'
-    this.rejectColor = '#ed6d47'
-    this.radius = 0.4
-    this.darkTheme = {
-      text: 'white',
-      tray: '#777'
-    }
-    this.lightTheme = {
-      text: 'black',
-      tray: '#999'
-    }
-    this.activeTheme = opts.darkMode ? this.darkTheme : this.lightTheme
-    this.showIndicator = true
-    for (var k in opts) {
-      this[k] = opts[k]
-    }
-    this.meterRange = {
-      start: this.startAngle + this.meterSpace / 2,
-      end: this.startAngle + PIPI - this.meterSpace / 2
-    }
-    this.meterRange.range = this.meterRange.end - this.meterRange.start
-    this.middle = {
-      x: 50,
-      y: 50
-    }
-    this.checkmark = String.fromCharCode(10004)
-    this.failmark = String.fromCharCode(10008)
     this.canvas = document.createElement('canvas')
-    this.canvas.width = 100
-    this.canvas.height = 100
+    this.offset = makePt(15, 15)
+    this.canvas.width = 130
+    this.canvas.height = 130
+    this.dimension = 100
+    this.animationEnd = {}
+    this.animationRunning = {}
+    this.animationTarget = {}
     this.ctx = this.canvas.getContext('2d')
     this.ctx.textAlign = 'center'
     this.ctx.textBaseline = 'middle'
     while (parent.firstChild) parent.removeChild(parent.firstChild)
     this.parent.appendChild(this.canvas)
-    this.draw()
+    this.middle = {
+      x: 50,
+      y: 50
+    }
+    this.offsetMiddle = addOffset(this.middle, this.offset)
+    this.startAngle = Math.PI / 2
+    var l = parent.classList
+    var meterSpace = 0.5 // radians
+    if (l.contains('large-gap')) meterSpace = Math.PI / 2
+    if (l.contains('arch')) meterSpace = Math.PI
+    this.meterSpecs = {
+      meterSpace: meterSpace,
+      startTheta: this.startAngle + meterSpace / 2,
+      endTheta: this.startAngle + PIPI - meterSpace / 2
+    }
+    this.meterSpecs.range = this.meterSpecs.endTheta - this.meterSpecs.startTheta
+    this.meterSpecs.start = this.normedPolarToCartesian(this.radius, 0)
+    this.meterSpecs.end = this.normedPolarToCartesian(this.radius, 1)
+
+    // animation options
+    opts.fps = opts.fps || 60
+    opts.animationLength = opts.animationLength || 400
+
+    // A couple unicode characters
+    this.checkmark = String.fromCharCode(10004)
+    this.failmark = String.fromCharCode(10008)
+  }
+
+  roundCap () {
+    this.ctx.lineCap = 'round'
+  }
+
+  buttCap () {
+    this.ctx.lineCap = 'butt'
   }
 
   denorm (x) {
-    return x * this.canvas.width
+    return x * this.dimension
   }
 
-  polarToCartesian (r, theta) {
+  norm (x) {
+    return x / this.dimension
+  }
+
+  normedPolarToCartesian (normed, normedTheta) {
+    // maps [0,1] to [0,width] and [0,1] to [0,2PI]
+    var r = this.denorm(normed)
+    var theta = this.denormTheta(normedTheta)
     return {
       y: this.middle.x - r * Math.cos(theta + this.startAngle),
       x: this.middle.y + r * Math.sin(theta + this.startAngle)
     }
   }
 
-  thetaRange (start, end) {
-    var range = this.meterRange
+  denormTheta (theta) {
+    return this.meterSpecs.startTheta + theta * this.meterSpecs.range
+  }
+
+  denormThetaRange (start, end) {
     return {
-      start: range.start + start / PIPI * range.range,
-      end: range.start + end / PIPI * range.range
+      start: this.denormTheta(start),
+      end: this.denormTheta(end)
     }
   }
 
-  draw () {
+  setDarkMode (nightMode) {
+    this.activeTheme = nightMode ? this.darkTheme : this.lightTheme
+    this.draw()
+  }
+
+  clear () {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
-    if (this.data.thresholds) this.drawThresholds()
-    if (this.showIndicator) this.drawIndicator()
-    this.drawCentralValue()
-    this.drawMeter()
   }
 
-  drawThresholds () {
-    this.data.thresholds.forEach((threshold) => {
-      this.drawThreshold(threshold)
-    })
-  }
-
-  drawThreshold (threshold) {
-    var angle = this.thetaRange(threshold * PIPI).start
-    var start = this.polarToCartesian(this.denorm(0.32), angle)
-    var end = this.polarToCartesian(this.denorm(0.48), angle)
+  dot (pt, color, radius) {
+    pt = addOffset(pt, this.offset)
     var ctx = this.ctx
-    ctx.lineWidth = 3.0
-    ctx.strokeStyle = this.activeTheme.tray
+    ctx.fillStyle = color
+    ctx.beginPath()
+    ctx.arc(pt.x, pt.y, radius, 0, PIPI)
+    ctx.fill()
+  }
+
+  segment (start, end, color) {
+    var ctx = this.ctx
+    ctx.strokeStyle = color
+    let range = this.denormThetaRange(start, end)
+    ctx.beginPath()
+    ctx.arc(this.offsetMiddle.x, this.offsetMiddle.y, this.denorm(this.radius), range.start, range.end)
+    ctx.stroke()
+  }
+
+  line (start, end) {
+    start = addOffset(start, this.offset)
+    end = addOffset(end, this.offset)
+    var ctx = this.ctx
     ctx.beginPath()
     ctx.moveTo(start.x, start.y)
     ctx.lineTo(end.x, end.y)
     ctx.stroke()
   }
 
-  drawIndicator () {
-    switch (this.data.type) {
-      case 'vote':
-        this.drawVoteIndicator()
-        break
-      case 'progress':
-        this.drawProgressIndicator()
-    }
+  write (text, pt, maxWidth) {
+    pt = addOffset(pt, this.offset)
+    this.ctx.fillText(text, pt.x, pt.y, maxWidth)
   }
 
-  drawProgressIndicator () {
-    var ctx = this.ctx
-    var threshold = 1
-    if (this.data.thresholds) {
-      threshold = this.data.thresholds[0]
+  async animate (key, target) {
+    var opts = this.options
+    this.animationEnd[key] = new Date().getTime() + opts.animationLength
+    this.animationTarget[key] = target
+    if (this.animationRunning[key]) return
+    this.animationRunning[key] = true
+    var frameDuration = 1000 / opts.fps
+    var now = new Date().getTime()
+    while (now < this.animationEnd[key]) {
+      let remainingTime = this.animationEnd[key] - now
+      let progress = this.data[key]
+      let toGo = this.animationTarget[key] - progress
+      let step = toGo * frameDuration / remainingTime
+      await sleep(frameDuration)
+      this.data[key] = progress + step
+      this.draw()
+      now = new Date().getTime()
     }
-    if (this.data.progress >= threshold) {
-      this.ctx.fillStyle = this.approveColor
-      ctx.font = `${this.denorm(0.2)}px sans-serif`
-      ctx.fillText(this.checkmark, this.middle.x, this.denorm(0.35))
-    } else {
-      this.ctx.fillStyle = this.activeTheme.tray
-      ctx.beginPath()
-      ctx.arc(this.middle.x, this.denorm(0.35), this.denorm(0.03), 0, PIPI)
-      ctx.fill()
-    }
-  }
-
-  drawVoteIndicator () {
-    var ctx = this.ctx
-    var fail, succeed
-    [fail, succeed] = this.data.thresholds
-    if (this.data.progress < fail) {
-      this.ctx.fillStyle = this.rejectColor
-      ctx.font = `${this.denorm(0.2)}px sans-serif`
-      ctx.fillText(this.failmark, this.middle.x, this.denorm(0.35))
-    } else if (this.data.progress >= succeed) {
-      this.ctx.fillStyle = this.approveColor
-      ctx.font = `${this.denorm(0.2)}px sans-serif`
-      ctx.fillText(this.checkmark, this.middle.x, this.denorm(0.35))
-    } else {
-      this.ctx.fillStyle = this.activeTheme.tray
-      ctx.beginPath()
-      ctx.arc(this.middle.x, this.denorm(0.35), this.denorm(0.03), 0, PIPI)
-      ctx.fill()
-    }
-  }
-
-  drawCentralValue () {
-    var ctx = this.ctx
-    var offset = this.showIndicator ? this.denorm(0.05) : 0
-    ctx.fillStyle = this.activeTheme.text
-    ctx.font = `bold ${this.centralFontSize}px sans-serif`
-    ctx.fillText(`${parseInt(this.data.progress * 100)}%`, this.middle.x, this.middle.y + offset, this.denorm(0.5))
-  }
-
-  drawMeter () {
-    var ctx = this.ctx
-    var theme = this.activeTheme
-    ctx.lineWidth = this.meterWidth
-    ctx.lineCap = 'round'
-    this.ctx.strokeStyle = theme.tray
-    var range = this.thetaRange(0, PIPI)
-    ctx.beginPath()
-    ctx.arc(this.middle.x, this.middle.y, this.denorm(this.radius), range.start, range.end)
-    ctx.stroke()
-    ctx.lineCap = 'round'
-    if (this.data.type === 'vote') {
-      let progress = this.data.progress
-      var fail, succeed
-      [fail, succeed] = this.data.thresholds
-      if (progress >= succeed) {
-        this.ctx.strokeStyle = this.approveColor
-      } else if (progress < fail) {
-        this.ctx.strokeStyle = this.rejectColor
-      } else {
-        this.ctx.strokeStyle = this.revoteColor
-      }
-    } else {
-      this.ctx.strokeStyle = this.meterColor
-    }
-
-    range = this.thetaRange(0, PIPI * this.data.progress)
-    ctx.beginPath()
-    ctx.arc(this.middle.x, this.middle.y, this.denorm(this.radius), range.start, range.end)
-    ctx.stroke()
-  }
-
-  setDarkMode (nightMode) {
-    this.activeTheme = nightMode ? this.darkTheme : this.lightTheme
+    this.data[key] = this.animationTarget[key]
     this.draw()
+    this.animationRunning[key] = false
+  }
+}
+
+export class VoteMeter extends Meter {
+  constructor (parent, opts) {
+    super(parent, opts)
+    this.buttCap()
+    opts = this.options
+    var d = parent.dataset
+    this.data = {
+      approval: parseFloat(d.approval)
+    }
+    this.approveThreshold = d.threshold
+    this.rejectThreshold = 1 - d.threshold
+
+    // Options
+    opts.centralFontSize = opts.centralFontSize || 18
+    opts.meterColor = opts.meterColor || '#2dd8a3'
+    opts.meterWidth = opts.meterWidth || 12
+    opts.approveColor = opts.approveColor || '#2dd8a3'
+    opts.revoteColor = opts.revoteColor || '#ffe4a7'
+    opts.rejectColor = opts.rejectColor || '#ed6d47'
+    opts.dotColor = opts.dotColor || '#888'
+    opts.showIndicator = opts.showIndicator || true
+    this.darkTheme = opts.darkTheme || {
+      text: 'white',
+      tray: '#999'
+    }
+    this.lightTheme = opts.lightTheme || {
+      text: 'black',
+      tray: '#555'
+    }
+    this.activeTheme = opts.darkMode ? this.darkTheme : this.lightTheme
+
+    // Set up the animation
+    var progress = this.data.approval
+    this.data.approval = 0.5
+    this.draw()
+    super.animate('approval', progress)
+  }
+
+  draw () {
+    super.clear()
+    this.drawVote()
+  }
+
+  drawVote () {
+    var ctx = this.ctx
+    var opts = this.options
+    var indicatorColor
+    var strokeColor = this.activeTheme.text
+    var trayColor = this.activeTheme.tray
+
+    // Draw the three-color tray with border
+    var borderWidth = opts.meterWidth * 1.3
+    ctx.lineWidth = borderWidth
+    this.segment(0, 1, trayColor)
+    ctx.lineWidth = opts.meterWidth
+    this.segment(0, this.rejectThreshold, opts.rejectColor)
+    this.segment(this.rejectThreshold, this.approveThreshold, opts.revoteColor)
+    this.segment(this.approveThreshold, 1, opts.approveColor)
+    ctx.strokeStyle = trayColor
+    ctx.lineWidth = 2
+    super.line(super.normedPolarToCartesian(this.radius + this.norm(borderWidth / 2), 0),
+      super.normedPolarToCartesian(this.radius - this.norm(borderWidth / 2), 0))
+    super.line(super.normedPolarToCartesian(this.radius + this.norm(borderWidth / 2), 1),
+      super.normedPolarToCartesian(this.radius - this.norm(borderWidth / 2), 1))
+
+    // Draw the indicator icon
+    if (opts.showIndicator) {
+      ctx.font = `${super.denorm(0.2)}px sans-serif`
+      if (this.data.approval < this.rejectThreshold) {
+        ctx.fillStyle = indicatorColor = opts.rejectColor
+        super.write(this.failmark, makePt(this.middle.x, super.denorm(0.35)))
+      } else if (this.data.approval >= this.approveThreshold) {
+        ctx.fillStyle = indicatorColor = opts.approveColor
+        super.write(this.checkmark, makePt(this.middle.x, super.denorm(0.35)))
+      } else {
+        indicatorColor = opts.revoteColor
+        super.dot(makePt(this.middle.x, super.denorm(0.35)), opts.dotColor, super.denorm(0.03))
+      }
+    }
+
+    // The mark
+    var halfLen = this.norm(opts.meterWidth * 0.5)
+    var start = super.normedPolarToCartesian(this.radius - halfLen * 1.2, this.data.approval)
+    var end = super.normedPolarToCartesian(this.radius + halfLen * 1.6, this.data.approval)
+    ctx.lineWidth = 2.5
+    ctx.strokeStyle = strokeColor
+    super.line(start, end)
+    super.dot(start, strokeColor, 3)
+    super.dot(end, strokeColor, 5)
+    super.dot(end, indicatorColor, 3)
+
+    // The central value
+    var offset = opts.showIndicator ? super.denorm(0.05) : 0
+    this.ctx.fillStyle = this.activeTheme.text
+    this.ctx.font = `bold ${opts.centralFontSize}px sans-serif`
+    this.write(`${parseInt(this.data.approval * 100)}%`, makePt(this.middle.x, this.middle.y + offset), super.denorm(0.5))
+  }
+}
+
+export class ProgressMeter extends Meter {
+  constructor (parent, opts) {
+    super(parent, opts)
+    this.buttCap()
+    opts = this.options
+    this.threshold = parseFloat(parent.dataset.threshold)
+    this.data = {
+      progress: parseFloat(parent.dataset.progress)
+    }
+
+    opts.meterColor = opts.meterColor || '#2970ff'
+    opts.meterWidth = opts.meterWidth || 14
+    opts.centralFontSize = opts.centralFontSize || 18
+    opts.successColor = opts.successColor = '#2dd8a3'
+    opts.showIndicator = opts.showIndicator || true
+    this.darkTheme = opts.darkTheme || {
+      tray: '#777',
+      text: 'white'
+    }
+    this.lightTheme = opts.lightTheme || {
+      tray: '#999',
+      text: 'black'
+    }
+    this.activeTheme = opts.darkMode ? this.darkTheme : this.lightTheme
+
+    var progress = this.data.progress
+    this.data.progress = 0
+    this.draw()
+    this.animate('progress', progress)
+  }
+
+  drawIndicator (value, color) {
+    var ctx = this.ctx
+    var opts = this.options
+    var theme = this.activeTheme
+    var halfLen = this.norm(opts.meterWidth) * 0.5
+    var start = super.normedPolarToCartesian(this.radius - halfLen, value)
+    var end = super.normedPolarToCartesian(this.radius + halfLen, value)
+    ctx.lineWidth = 1.5
+    ctx.strokeStyle = color
+    super.dot(start, color, 3)
+    super.dot(end, color, 3)
+    ctx.strokeStyle = theme.text
+    super.line(start, end)
+  }
+
+  draw () {
+    super.clear()
+    var ctx = this.ctx
+    var opts = this.options
+    var theme = this.activeTheme
+
+    ctx.lineWidth = opts.meterWidth
+    var c = this.data.progress >= this.threshold ? opts.successColor : theme.tray
+    super.segment(0, 1, c)
+    // super.segment(0, this.threshold, theme.tray)
+
+    this.drawIndicator(this.threshold, c)
+
+    ctx.lineWidth = opts.meterWidth
+    super.segment(0, this.data.progress, opts.meterColor)
+
+    this.drawIndicator(this.data.progress, theme.text)
+
+    if (opts.showIndicator && this.data.progress >= this.threshold) {
+      ctx.fillStyle = opts.successColor
+      super.write(this.checkmark, makePt(this.middle.x, super.denorm(0.35)))
+    }
+
+    var offset = opts.showIndicator ? super.denorm(0.05) : 0
+    this.ctx.fillStyle = this.activeTheme.text
+    this.ctx.font = `bold ${opts.centralFontSize}px sans-serif`
+    this.write(`${parseInt(this.data.progress * 100)}%`, makePt(this.middle.x, this.middle.y + offset), super.denorm(0.5))
   }
 }

--- a/public/js/helpers/vote_meter.js
+++ b/public/js/helpers/vote_meter.js
@@ -1,0 +1,199 @@
+const PIPI = 2 * Math.PI
+
+export default class VoteMeter {
+  constructor (parent, opts) {
+    opts = opts || {}
+    this.parent = parent
+    var d = parent.dataset
+    this.data = {
+      progress: parseFloat(d.progress),
+      type: d.type
+    }
+    this.data.thresholds = d.threshold ? [parseFloat(d.threshold)] : null
+    if (d.type === 'vote') this.data.thresholds.splice(0, 0, 1 - this.data.thresholds[0])
+    this.centralFontSize = 15
+    var l = parent.classList
+    this.meterSpace = 0.5 // radians
+    if (l.contains('large-gap')) this.meterSpace = Math.PI / 2
+    if (l.contains('arch')) this.meterSpace = Math.PI
+    this.startAngle = Math.PI / 2
+    this.meterColor = '#2dd8a3'
+    this.meterWidth = 8
+    this.approveColor = '#2dd8a3' // '#41be53'
+    this.revoteColor = '#ffe4a7'
+    this.rejectColor = '#ed6d47'
+    this.radius = 0.4
+    this.darkTheme = {
+      text: 'white',
+      tray: '#777'
+    }
+    this.lightTheme = {
+      text: 'black',
+      tray: '#999'
+    }
+    this.activeTheme = opts.darkMode ? this.darkTheme : this.lightTheme
+    this.showIndicator = true
+    for (var k in opts) {
+      this[k] = opts[k]
+    }
+    this.meterRange = {
+      start: this.startAngle + this.meterSpace / 2,
+      end: this.startAngle + PIPI - this.meterSpace / 2
+    }
+    this.meterRange.range = this.meterRange.end - this.meterRange.start
+    this.middle = {
+      x: 50,
+      y: 50
+    }
+    this.checkmark = String.fromCharCode(10004)
+    this.failmark = String.fromCharCode(10008)
+    this.canvas = document.createElement('canvas')
+    this.canvas.width = 100
+    this.canvas.height = 100
+    this.ctx = this.canvas.getContext('2d')
+    this.ctx.textAlign = 'center'
+    this.ctx.textBaseline = 'middle'
+    while (parent.firstChild) parent.removeChild(parent.firstChild)
+    this.parent.appendChild(this.canvas)
+    this.draw()
+  }
+
+  denorm (x) {
+    return x * this.canvas.width
+  }
+
+  polarToCartesian (r, theta) {
+    return {
+      y: this.middle.x - r * Math.cos(theta + this.startAngle),
+      x: this.middle.y + r * Math.sin(theta + this.startAngle)
+    }
+  }
+
+  thetaRange (start, end) {
+    var range = this.meterRange
+    return {
+      start: range.start + start / PIPI * range.range,
+      end: range.start + end / PIPI * range.range
+    }
+  }
+
+  draw () {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
+    if (this.data.thresholds) this.drawThresholds()
+    if (this.showIndicator) this.drawIndicator()
+    this.drawCentralValue()
+    this.drawMeter()
+  }
+
+  drawThresholds () {
+    this.data.thresholds.forEach((threshold) => {
+      this.drawThreshold(threshold)
+    })
+  }
+
+  drawThreshold (threshold) {
+    var angle = this.thetaRange(threshold * PIPI).start
+    var start = this.polarToCartesian(this.denorm(0.32), angle)
+    var end = this.polarToCartesian(this.denorm(0.48), angle)
+    var ctx = this.ctx
+    ctx.lineWidth = 3.0
+    ctx.strokeStyle = this.activeTheme.tray
+    ctx.beginPath()
+    ctx.moveTo(start.x, start.y)
+    ctx.lineTo(end.x, end.y)
+    ctx.stroke()
+  }
+
+  drawIndicator () {
+    switch (this.data.type) {
+      case 'vote':
+        this.drawVoteIndicator()
+        break
+      case 'progress':
+        this.drawProgressIndicator()
+    }
+  }
+
+  drawProgressIndicator () {
+    var ctx = this.ctx
+    var threshold = 1
+    if (this.data.thresholds) {
+      threshold = this.data.thresholds[0]
+    }
+    if (this.data.progress >= threshold) {
+      this.ctx.fillStyle = this.approveColor
+      ctx.font = `${this.denorm(0.2)}px sans-serif`
+      ctx.fillText(this.checkmark, this.middle.x, this.denorm(0.35))
+    } else {
+      this.ctx.fillStyle = this.activeTheme.tray
+      ctx.beginPath()
+      ctx.arc(this.middle.x, this.denorm(0.35), this.denorm(0.03), 0, PIPI)
+      ctx.fill()
+    }
+  }
+
+  drawVoteIndicator () {
+    var ctx = this.ctx
+    var fail, succeed
+    [fail, succeed] = this.data.thresholds
+    if (this.data.progress < fail) {
+      this.ctx.fillStyle = this.rejectColor
+      ctx.font = `${this.denorm(0.2)}px sans-serif`
+      ctx.fillText(this.failmark, this.middle.x, this.denorm(0.35))
+    } else if (this.data.progress >= succeed) {
+      this.ctx.fillStyle = this.approveColor
+      ctx.font = `${this.denorm(0.2)}px sans-serif`
+      ctx.fillText(this.checkmark, this.middle.x, this.denorm(0.35))
+    } else {
+      this.ctx.fillStyle = this.activeTheme.tray
+      ctx.beginPath()
+      ctx.arc(this.middle.x, this.denorm(0.35), this.denorm(0.03), 0, PIPI)
+      ctx.fill()
+    }
+  }
+
+  drawCentralValue () {
+    var ctx = this.ctx
+    var offset = this.showIndicator ? this.denorm(0.05) : 0
+    ctx.fillStyle = this.activeTheme.text
+    ctx.font = `bold ${this.centralFontSize}px sans-serif`
+    ctx.fillText(`${parseInt(this.data.progress * 100)}%`, this.middle.x, this.middle.y + offset, this.denorm(0.5))
+  }
+
+  drawMeter () {
+    var ctx = this.ctx
+    var theme = this.activeTheme
+    ctx.lineWidth = this.meterWidth
+    ctx.lineCap = 'round'
+    this.ctx.strokeStyle = theme.tray
+    var range = this.thetaRange(0, PIPI)
+    ctx.beginPath()
+    ctx.arc(this.middle.x, this.middle.y, this.denorm(this.radius), range.start, range.end)
+    ctx.stroke()
+    ctx.lineCap = 'round'
+    if (this.data.type === 'vote') {
+      let progress = this.data.progress
+      var fail, succeed
+      [fail, succeed] = this.data.thresholds
+      if (progress >= succeed) {
+        this.ctx.strokeStyle = this.approveColor
+      } else if (progress < fail) {
+        this.ctx.strokeStyle = this.rejectColor
+      } else {
+        this.ctx.strokeStyle = this.revoteColor
+      }
+    } else {
+      this.ctx.strokeStyle = this.meterColor
+    }
+
+    range = this.thetaRange(0, PIPI * this.data.progress)
+    ctx.beginPath()
+    ctx.arc(this.middle.x, this.middle.y, this.denorm(this.radius), range.start, range.end)
+    ctx.stroke()
+  }
+
+  setDarkMode (nightMode) {
+    this.activeTheme = nightMode ? this.darkTheme : this.lightTheme
+    this.draw()
+  }
+}

--- a/public/scss/bootstrap_overrides.scss
+++ b/public/scss/bootstrap_overrides.scss
@@ -4,3 +4,13 @@
 .progress-bar {
   text-shadow: 1px 1px 0 #00000012;
 }
+
+.v2-progress.progress {
+  height: 1rem;
+}
+
+.v2-progress {
+  .progress-bar {
+    background-color: #2dd8a3;
+  }
+}

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -476,6 +476,27 @@ input ~ .checkmark {
   margin: 2px;
 }
 
+.upgrade-meter {
+  display: inline-block;
+  width: 125px;
+  height: 125px;
+  font-size: 14px;
+  overflow: hidden;
+}
+
+.upgrade-meter.large-gap {
+  height: 105px;
+}
+
+.upgrade-meter.arch {
+  height: 80px;
+}
+
+.upgrade-meter > canvas {
+  width: 125px;
+  height: 125px;
+}
+
 body.darkBG {
   .address_chart_wrap {
     background-color: #333;

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -478,23 +478,23 @@ input ~ .checkmark {
 
 .upgrade-meter {
   display: inline-block;
-  width: 125px;
-  height: 125px;
+  width: 135px;
+  height: 135px;
   font-size: 14px;
   overflow: hidden;
 }
 
 .upgrade-meter.large-gap {
-  height: 105px;
+  height: 110px;
 }
 
 .upgrade-meter.arch {
-  height: 80px;
+  height: 90px;
 }
 
 .upgrade-meter > canvas {
-  width: 125px;
-  height: 125px;
+  width: 135px;
+  height: 135px;
 }
 
 body.darkBG {

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -476,7 +476,7 @@ input ~ .checkmark {
   margin: 2px;
 }
 
-.upgrade-meter {
+.meter {
   display: inline-block;
   width: 135px;
   height: 135px;
@@ -484,15 +484,15 @@ input ~ .checkmark {
   overflow: hidden;
 }
 
-.upgrade-meter.large-gap {
+.meter.large-gap {
   height: 110px;
 }
 
-.upgrade-meter.arch {
+.meter.arch {
   height: 90px;
 }
 
-.upgrade-meter > canvas {
+.meter > canvas {
   width: 135px;
   height: 135px;
 }

--- a/public/scss/typography.scss
+++ b/public/scss/typography.scss
@@ -29,8 +29,8 @@
   transition: 0.133s transform;
 }
 
-.truncate-hash {
-  flex: 1 1 auto;
+.truncate {
+  max-width: 350px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -1,10 +1,235 @@
+{{define "voteTable"}}
+  <table class="w-100 fs14 mt-2">
+    <tbody>
+      <tr>
+        <td class="text-right font-weight-bold">Ayes: &nbsp;</td>
+        <td class="text-left"> &nbsp;{{.Aye}}</td>
+        <td class="text-right font-weight-bold">Approved: &nbsp;</td>
+        <td class="text-left"> &nbsp;{{printf "%.1f" (f32x100 .Approval)}}%</td>
+      </tr>
+      <tr>
+        <td class="text-right font-weight-bold">Nays: &nbsp;</td>
+        <td class="text-left"> &nbsp;{{.Nay}}</td>
+        <td class="text-right font-weight-bold">Abstain: &nbsp;</td>
+        <td class="text-left"> &nbsp;{{.Abstain}} ({{printf "%.1f" (f32x100 .AbstainRate)}}%)</td>
+      </tr>
+    </tbody>
+  </table>
+{{end}}{{/* END VOTE TABLE DEFINITION */}}
 {{define "agendas"}}
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decred Vote Agendas Page"}}
     <body class="{{ theme }}">
         {{template "navbar" .}}
-        <div class="container main">
+        <div class="container main pb-5" data-controller="agendas">
+
+
+
+
+            {{- /* PRIMARY INFO CARD. LISTS AGENDAS AND SHOWS RCI/SVI PROGRESS BARS */}}
+            {{if .VotingSummary}}
+            {{with .VotingSummary}}
+            <div class="row px-3">
+                <div class="bg-white py-3 px-4 px-lg-5 text-left col-24 col-lg-12 my-4">
+                  {{range .Agendas}}
+                    <div class="fs16 w-100 text-left hash-box rounded mb-3 p-3">
+                      {{if .IsDefined}}
+                        {{if .VotingTriggered}}
+                            <span class="fs18 font-weight-bold lh1rem">{{.ID}} vote scheduled</span><br />
+                            <span class="fs14 d-inline-block lh1rem mb-2">voting begins at block {{$.VotingSummary.NextRCIHeight}} (about <span class="font-weight-bold">{{secondsToShortDurationString $.VotingSummary.TilNextRCI}}</span>)</span><br />
+                            {{.Description}}
+                        {{else}}
+                            <span class="fs18 font-weight-bold mr-2">{{.ID}}</span><br>
+                            {{.Description}}
+                        {{end}}
+                      {{else if .IsVoting}}
+                          <span class="fs18 font-weight-bold lh1rem">Now voting on {{.ID}}</span><br>
+                          <span class="fs14 d-inline-block lh1rem mb-2">voting ends at block {{$.VotingSummary.NextRCIHeight}} (about <span class="font-weight-bold">{{secondsToShortDurationString $.VotingSummary.TilNextRCI}}</span>)</span><br>
+                          {{.Description}}
+                          {{template "voteTable" .}}
+                      {{else if .IsLocked}}
+                          <div class="d-flex justify-content-start align-items-center mb-2">
+                              <span class="fs22 text-green dcricon-affirm mr-2 pt-1"></span>
+                              <div class="d-inline-block">
+                                <span class="fs18 font-weight-bold mr-2">{{.ID}} approved</span>
+                                <span class="fs14">active at block {{$.VotingSummary.NextRCIHeight}} (about {{secondsToShortDurationString $.VotingSummary.TilNextRCI}})</span>
+                              </div>
+                          </div>
+                          {{.Description}}
+                          {{template "voteTable" .}}
+                      {{else if .IsFailed}}
+                          <div class="d-flex justify-content-start align-items-center mb-2">
+                              <span class="fs22 text-danger dcricon-reject mr-2 pt-1"></span> <span class="fs18 font-weight-bold">{{.ID}} rejected</span>
+                          </div>
+                          {{.Description}}
+                          {{template "voteTable" .}}
+                      {{else if .IsActive}}
+                          <div class="d-flex justify-content-start align-items-center mb-2">
+                              <span class="fs22 text-green dcricon-affirm mr-2 pt-1"></span> <span class="fs18 font-weight-bold">{{.ID}} passed (active)</span>
+                          </div>
+                          {{.Description}}
+                          {{template "voteTable" .}}
+                      {{end}}
+                    </div>
+                  {{end}}{{/* END AGENDA ITERATION, START RCI/SVI PROGRESS BARS */}}
+                    <div class="row justify-content-between">
+                        <div class="col-24 col-sm-12 text-left mb-3">
+                            <span class="text-secondary fs14">Rule Change Interval</span>
+                            <div class="progress v2-progress col-24 col-sm-18 px-0">
+                                <div
+                                    class="progress-bar rounded text-left"
+                                    role="progressbar"
+                                    style="width: {{f32x100 .RCIProgress}}%;"
+                                    aria-valuenow="{{.RCIMined}}"
+                                    aria-valuemin="0"
+                                    aria-valuemax="{{.RCIBlocks}}"
+                                ><span class="font-weight-bold ml-2">{{printf "%.0f" (f32x100 .RCIProgress)}} %</span>
+                                </div>
+                            </div>
+                            <span class="fs14">{{.RCIMined}} of {{.RCIBlocks}} blocks</span>
+                        </div>
+                        <div class="col-24 col-sm-12 text-left mb-3">
+                            <span class="text-secondary fs14">Stake Version Interval</span>
+                            <div class="progress v2-progress col-24 col-sm-18 px-0">
+                                <div
+                                    class="progress-bar rounded text-left"
+                                    role="progressbar"
+                                    style="width: {{f32x100 .SVIProgress}}%;"
+                                    aria-valuenow="{{.SVIMined}}"
+                                    aria-valuemin="0"
+                                    aria-valuemax="{{.SVIBlocks}}"
+                                ><span class="font-weight-bold ml-2">{{printf "%.0f" (f32x100 .SVIProgress)}} %</span>
+                                </div>
+                            </div>
+                            <span class="fs14">{{.SVIMined}} of {{.SVIBlocks}} blocks</span>
+                        </div>
+                    </div>{{/* END OF SVI/RCI INTERVAL PROGRESS BARS */}}
+                </div>{{/* END OF PRMARY INFO CARD */ -}}
+
+
+                {{/* PRE-VOTING */}}
+                {{if or (not .NetworkUpgraded) .VotingTriggered}}
+                    <div class="col-24 col-lg-12 pt-4 px-1 text-center">
+                      {{if .VotingTriggered}}
+                        <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Upgrade complete. A vote has been triggered</div>
+                      {{else}}
+                        <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Upgrade threshold not met</div>
+                      {{end}}
+                      <div class="col-24 d-flex justify-content-around align-items-center">
+                        <div class="d-inline-block text-center p-2">
+                          <span class="fs16 font-weight-bold">v{{.Version}} Miners</span><br>
+                          <div
+                            class="upgrade-meter text-center js-only large-gap"
+                            data-target="agendas.minerMeter"
+                            data-progress="{{.MinerProgress}}"
+                            data-threshold="{{.MinerThreshold}}"
+                            data-type="progress"
+                            >
+                            {{printf "%.1f" (f32x100 .MinerProgress)}}%
+                          </div><br>
+                          <span class="text-secondary fs14 lh1rem">threshold <span class="font-weight-bold">{{printf "%.0f" (f32x100 .MinerThreshold)}} %<span></span>
+                        </div>
+                        <div class="d-inline-block text-center p-4">
+                          <span class="fs16 font-weight-bold">v{{.Version}} Voters</span><br>
+                          <div
+                            class="upgrade-meter text-center js-only large-gap"
+                            data-target="agendas.voterMeter"
+                            data-progress="{{.VoterProgress}}"
+                            data-threshold="{{.VoterThreshold}}"
+                            data-type="progress"
+                            >
+                            {{printf "%.1f" (f32x100 .VoterProgress)}}%
+                          </div><br>
+                          <span class="text-secondary fs14">threshold <span class="font-weight-bold">{{printf "%.0f" (f32x100 .VoterThreshold)}} %</span></span>
+                        </div>
+                      </div>
+                    </div>
+                {{end}}{{/* END PRE-VOTING */ -}}
+
+
+
+                {{/* FOR CURRENT OR COMPLETED VOTES, SHOW THE TALLIES */}}
+                {{range .Agendas}}
+                    {{if .IsVoting}}
+                      <div class="col-24 col-lg-12 d-flex flex-column justify-content-between pt-4 px-1 text-center">
+                          <div>
+                            {{if not .QuorumAchieved}}
+                              <span class="bg-white p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> has not achieved quorum yet</span>
+                            {{else if .IsLocked}}
+                              <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> has passed</div>
+                            {{else if .IsWinning}}
+                              <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> is winning, but not a lock yet</div>
+                            {{else if .IsLosing}}
+                              <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> is losing, but hasn't been rejected yet</div>
+                            {{else}}
+                              <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Voting on <span class="font-weight-bold">{{.ID}}</span></div>
+                            {{end}}
+                          </div>
+                          <div class="d-flex justify-content-around align-items-start flex-wrap">
+                            <div class="d-inline-block text-center p-2">
+                              <span class="fs16 font-weight-bold">Quorum</span><br>
+                              <div
+                                class="upgrade-meter text-center js-only large-gap"
+                                data-target="agendas.quorumMeter"
+                                data-progress="{{.QuorumProgress}}"
+                                data-type="progress"
+                                >
+                                {{printf "%.1f" (f32x100 .QuorumProgress)}}%
+                              </div><br>
+                              {{if .QuorumAchieved}}
+                                <span class="text-secondary fs14">quorum achieved</span>
+                              {{else}}
+                                <span class="text-secondary fs14"><span class="font-weight-bold">{{.VoteCount}} of {{.Quorum}}</span> votes cast</span>
+                              {{end}}
+                            </div>
+                            <div class="d-inline-block text-center p-2">
+                              <span class="fs16 font-weight-bold">Approval</span><br>
+                              <div
+                                class="upgrade-meter text-center js-only large-gap"
+                                data-target="agendas.approvalMeter"
+                                data-progress="{{.Approval}}"
+                                data-threshold="{{.PassThreshold}}"
+                                data-type="vote"
+                                >
+                                {{printf "%.1f" (f32x100 .Approval)}}%
+                              </div><br>
+                              <span class="text-secondary fs14">{{printf "%.0f" (f32x100 .PassThreshold)}}% passes,
+                                &lt; {{printf "%.0f" (f32x100 .FailThreshold)}}% rejects, <br>
+                                otherwise vote again
+                              </span>
+                            </div>
+                          </div>
+                          <span></span>{{/* FLEX SPACER */}}
+                      </div>
+                    {{else if or .IsFailed .IsLocked .IsActive}}{{/* VOTING COMPLETE */}}
+                        <div class="col-24 col-lg-12 py-3 px-1 row flex-column justify-content-center align-items-center">
+                            <div class="d-inline-block text-center p-2">
+                              <span class="fs16 font-weight-bold">{{.ID}} Results</span><br>
+                              <div
+                                class="upgrade-meter text-center js-only large-gap"
+                                data-target="agendas.approvalMeter"
+                                data-progress="{{.Approval}}"
+                                data-threshold="{{.PassThreshold}}"
+                                data-type="vote"
+                                >
+                                {{printf "%.1f" (f32x100 .Approval)}}%
+                              </div><br>
+                              {{if or .IsLocked .IsActive}}
+                                <span class="text-secondary fs14">passed</span>
+                              {{else}}
+                                <span class="text-secondary fs14">rejected</span>
+                              {{end}}
+                            </div>
+                        </div>
+                    {{end}}{{/* END VOTE METER CARDS */}}
+                {{end}}{{/* END ITERATING AGENDAS */}}
+            </div>
+            {{- end}}{{/* END WITH VOTESUMMARY */}}
+            {{end}}{{/* END TOP CURRENT VOTE SUMMARY SECTION */ -}}
+
+
+            {{/* AGENDA TABLE */}}
             <div class="row justify-content-between">
                 <div class="col-lg-14 col-sm-12 d-flex">
                     <h4 class="mb-2">Agendas</h4>
@@ -20,32 +245,28 @@
             <table class="table table-mono-cells">
                 <thead>
                     <th>Agenda ID</th>
-                    <th>Description</th>
-                    <th>Mask</th>
-                    <th>Status</th>
-                    <th>Quorum Progress</th>
-                    <th>Vote Version</th>
-                    <th>Start Time</th>
-                    <th>Expire Time</th>
+                    <th class="d-none d-md-table-cell">Description</th>
+                    <th class="text-right">Status</th>
+                    <th class="text-right">Vote Version</th>
+                    <th class="text-right d-none d-sm-table-cell">Start Time</th>
+                    <th class="text-right d-none d-sm-table-cell">Expire Time</th>
                 </thead>
                 {{range $i, $v := .Agendas}}
                 {{with $v}}
                 <tbody>
                     <td><a href="/agenda/{{.ID}}">{{.ID}}</a></td>
-                    <td>{{.Description}}</td>
-                    <td>{{.Mask}}</td>
-                    <td>{{toTitleCase .Status.String}}</td>
-                    <td>{{printf "%.2f" (x100 .QuorumProgress)}}</td>
-                    <td>{{.VoteVersion}}</td>
-                    <td>{{TimeConversion .StartTime}}</td>
-                    <td>{{TimeConversion .ExpireTime}}</td>
+                    <td class="d-none d-md-table-cell truncate">{{.Description}}</td>
+                    <td class="text-right">{{.Status}}</td>
+                    <td class="text-right">{{.VoteVersion}}</td>
+                    <td class="text-right d-none d-sm-table-cell">{{TimeConversion .StartTime}}</td>
+                    <td class="text-right d-none d-sm-table-cell">{{TimeConversion .ExpireTime}}</td>
                 </tbody>
                 {{end}}
                 {{end}}
             </table>
-            {{end}}
+            {{end}}{{/* END TOP CURRENT VOTE SUMMARY SECTION */}}
         </div>
         {{template "footer" . }}
     </body>
 </html>
-{{end}}
+{{end}}{{/* END AGENDAS DEFINITION */}}

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -120,7 +120,7 @@
                         <div class="d-inline-block text-center p-2">
                           <span class="fs16 font-weight-bold">v{{.Version}} Miners</span><br>
                           <div
-                            class="upgrade-meter text-center js-only large-gap"
+                            class="meter text-center js-only large-gap"
                             data-target="agendas.minerMeter"
                             data-progress="{{.MinerProgress}}"
                             data-threshold="{{.MinerThreshold}}"
@@ -132,7 +132,7 @@
                         <div class="d-inline-block text-center p-4">
                           <span class="fs16 font-weight-bold">v{{.Version}} Voters</span><br>
                           <div
-                            class="upgrade-meter text-center js-only large-gap"
+                            class="meter text-center js-only large-gap"
                             data-target="agendas.voterMeter"
                             data-progress="{{.VoterProgress}}"
                             data-threshold="{{.VoterThreshold}}"
@@ -168,7 +168,7 @@
                             <div class="d-inline-block text-center p-2">
                               <span class="fs16 font-weight-bold">Quorum</span><br>
                               <div
-                                class="upgrade-meter text-center js-only large-gap"
+                                class="meter text-center js-only large-gap"
                                 data-target="agendas.quorumMeter"
                                 data-progress="{{.QuorumProgress}}"
                                 data-threshold="1.0"
@@ -184,7 +184,7 @@
                             <div class="d-inline-block text-center p-2">
                               <span class="fs16 font-weight-bold">Approval</span><br>
                               <div
-                                class="upgrade-meter text-center js-only large-gap"
+                                class="meter text-center js-only large-gap"
                                 data-target="agendas.approvalMeter"
                                 data-approval="{{.Approval}}"
                                 data-threshold="{{.PassThreshold}}"
@@ -204,7 +204,7 @@
                             <div class="d-inline-block text-center p-2">
                               <span class="fs16 font-weight-bold">{{.ID}} Results</span><br>
                               <div
-                                class="upgrade-meter text-center js-only large-gap"
+                                class="meter text-center js-only large-gap"
                                 data-target="agendas.approvalMeter"
                                 data-approval="{{.Approval}}"
                                 data-threshold="{{.PassThreshold}}"

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -124,7 +124,6 @@
                             data-target="agendas.minerMeter"
                             data-progress="{{.MinerProgress}}"
                             data-threshold="{{.MinerThreshold}}"
-                            data-type="progress"
                             >
                             {{printf "%.1f" (f32x100 .MinerProgress)}}%
                           </div><br>
@@ -137,7 +136,6 @@
                             data-target="agendas.voterMeter"
                             data-progress="{{.VoterProgress}}"
                             data-threshold="{{.VoterThreshold}}"
-                            data-type="progress"
                             >
                             {{printf "%.1f" (f32x100 .VoterProgress)}}%
                           </div><br>
@@ -173,7 +171,7 @@
                                 class="upgrade-meter text-center js-only large-gap"
                                 data-target="agendas.quorumMeter"
                                 data-progress="{{.QuorumProgress}}"
-                                data-type="progress"
+                                data-threshold="1.0"
                                 >
                                 {{printf "%.1f" (f32x100 .QuorumProgress)}}%
                               </div><br>
@@ -188,9 +186,8 @@
                               <div
                                 class="upgrade-meter text-center js-only large-gap"
                                 data-target="agendas.approvalMeter"
-                                data-progress="{{.Approval}}"
+                                data-approval="{{.Approval}}"
                                 data-threshold="{{.PassThreshold}}"
-                                data-type="vote"
                                 >
                                 {{printf "%.1f" (f32x100 .Approval)}}%
                               </div><br>
@@ -209,9 +206,8 @@
                               <div
                                 class="upgrade-meter text-center js-only large-gap"
                                 data-target="agendas.approvalMeter"
-                                data-progress="{{.Approval}}"
+                                data-approval="{{.Approval}}"
                                 data-threshold="{{.PassThreshold}}"
-                                data-type="vote"
                                 >
                                 {{printf "%.1f" (f32x100 .Approval)}}%
                               </div><br>

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -30,10 +30,10 @@
             {{- /* PRIMARY INFO CARD. LISTS AGENDAS AND SHOWS RCI/SVI PROGRESS BARS */}}
             {{if .VotingSummary}}
             {{with .VotingSummary}}
-            <div class="row px-3">
-                <div class="bg-white py-3 px-4 px-lg-5 text-left col-24 col-lg-12 my-4">
+            <div class="row">
+                <div class="py-1 px-4 px-lg-3 text-left col-24 col-lg-12 my-2">
                   {{range .Agendas}}
-                    <div class="fs16 w-100 text-left hash-box rounded mb-3 p-3">
+                    <div class="fs16 w-100 text-left bg-white mb-3 p-3">
                       {{if .IsDefined}}
                         {{if .VotingTriggered}}
                             <span class="fs18 font-weight-bold lh1rem">{{.ID}} vote scheduled</span><br />
@@ -74,7 +74,7 @@
                     </div>
                   {{end}}{{/* END AGENDA ITERATION, START RCI/SVI PROGRESS BARS */}}
                     <div class="row justify-content-between">
-                        <div class="col-24 col-sm-12 text-left mb-3">
+                        <div class="col-24 col-sm-12 text-left">
                             <span class="text-secondary fs14">Rule Change Interval</span>
                             <div class="progress v2-progress col-24 col-sm-18 px-0">
                                 <div
@@ -110,7 +110,7 @@
 
                 {{/* PRE-VOTING */}}
                 {{if or (not .NetworkUpgraded) .VotingTriggered}}
-                    <div class="col-24 col-lg-12 pt-4 px-1 text-center">
+                    <div class="col-24 col-lg-12 pt-2 px-2 text-center">
                       {{if .VotingTriggered}}
                         <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Upgrade complete. A vote has been triggered</div>
                       {{else}}
@@ -150,10 +150,10 @@
                 {{/* FOR CURRENT OR COMPLETED VOTES, SHOW THE TALLIES */}}
                 {{range .Agendas}}
                     {{if .IsVoting}}
-                      <div class="col-24 col-lg-12 d-flex flex-column justify-content-between pt-4 px-1 text-center">
+                      <div class="col-24 col-lg-12 d-flex flex-column justify-content-start pt-2 px-2 text-center">
                           <div>
                             {{if not .QuorumAchieved}}
-                              <span class="bg-white p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> has not achieved quorum yet</span>
+                              <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> has not achieved quorum yet</div>
                             {{else if .IsLocked}}
                               <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border"><span class="font-weight-bold">{{.ID}}</span> has passed</div>
                             {{else if .IsWinning}}
@@ -164,7 +164,7 @@
                               <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Voting on <span class="font-weight-bold">{{.ID}}</span></div>
                             {{end}}
                           </div>
-                          <div class="d-flex justify-content-around align-items-start flex-wrap">
+                          <div class="d-flex justify-content-around align-items-start flex-wrap mt-2">
                             <div class="d-inline-block text-center p-2">
                               <span class="fs16 font-weight-bold">Quorum</span><br>
                               <div

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -82,12 +82,12 @@
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TargetTimespan</td>
-                                <td class="mono">{{TimeDurationFormat .ChainParams.TargetTimespan}}</td>
+                                <td class="mono">{{durationToShortDurationString .ChainParams.TargetTimespan}}</td>
                                 <td>Amount of time that should elapse before the block difficulty requirement is examined to determine how it should be changed in order to maintain the desired block generation rate</td>
                             </tr>
                             <tr>
                                 <td class="mono text-left pr-2 nowrap p03rem0">TargetTimePerBlock</td>
-                                <td class="mono">{{TimeDurationFormat .ChainParams.TargetTimePerBlock}}</td>
+                                <td class="mono">{{durationToShortDurationString .ChainParams.TargetTimePerBlock}}</td>
                                 <td>The desired amount of time to generate each block</td>
                             </tr>
                             <tr>


### PR DESCRIPTION
Adds `VoteTracker`, which refreshes with new blocks to update a cache of voting-related data. VoteTracker produces a `VoteSummary`, which has fields customized for use in templates. There might be some space to integrate `VoteTracker` with `AgendaDB`.

Front end: The information is incorporated at the top of the /agendas page here, with intention to use the same data in some way on the homepage and more. To display a graphic without using the `charts.js` package (which is huge), a new `VoteMeter` class displays a simple graphic with a central value displayed using the Canvas API. It'd be good to drop `charts.js`, which is dcrdata's largest vendor package and we barely use it. `VoteMeter` is about 6 kB unminified, compared to 160 kB for a minified `charts.js`.

![image](https://user-images.githubusercontent.com/6109680/54208151-6a97b600-44a9-11e9-954a-e74c29dbebfc.png)
