### PR TITLE
explorer: only signal mempool update once

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -470,17 +470,6 @@ func (exp *explorerUI) StoreMPData(_ *mempool.StakeData, _ []types.MempoolTx, in
 	exp.invsMtx.Lock()
 	exp.invs = inv
 	exp.invsMtx.Unlock()
-
-	// Signal to the websocket hub that a new tx was received, but do not block
-	// StoreMPData(), and do not hang forever in a goroutine waiting to send.
-	go func() {
-		select {
-		case exp.wsHub.HubRelay <- sigMempoolUpdate:
-		case <-time.After(time.Second * 10):
-			log.Errorf("sigMempoolUpdate send failed: Timeout waiting for WebsocketHub.")
-		}
-	}()
-
 	log.Debugf("Updated mempool details for the explorerUI.")
 }
 

--- a/public/js/services/messagesocket_service.js
+++ b/public/js/services/messagesocket_service.js
@@ -68,7 +68,7 @@ class MessageSocket {
       this.connection.close()
     }
 
-    // unmarshall message, and forward the message to registered handlers
+    // unmarshal message, and forward the message to registered handlers
     this.connection.onmessage = (evt) => {
       var json = JSON.parse(evt.data)
       forward(json.event, json.message, this.handlers)

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -512,17 +512,6 @@ func (psh *PubSubHub) StoreMPData(_ *mempool.StakeData, _ []exptypes.MempoolTx, 
 	psh.invsMtx.Lock()
 	psh.invs = inv
 	psh.invsMtx.Unlock()
-
-	// Signal to the websocket hub that a new tx was received, but do not block
-	// StoreMPData(), and do not hang forever in a goroutine waiting to send.
-	go func() {
-		select {
-		case psh.wsHub.HubRelay <- sigMempoolUpdate:
-		case <-time.After(time.Second * 10):
-			log.Errorf("sigMempoolUpdate send failed: Timeout waiting for WebsocketHub.")
-		}
-	}()
-
 	log.Debugf("Updated mempool details for the pubsubhub.")
 }
 


### PR DESCRIPTION
The `mempool` package was designed to trigger the mempool update events,
but the `sigMempoolUpdate` sends in `StoreMPData` for both `explorerUI` and
`PubSubHub` were not removed. This eliminates these duplicate sends.