### PR TITLE
tighten npm dep version specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "bootstrap": "^4.1.3",
+    "bootstrap": "~4.1.3",
     "dompurify": "^1.0.8",
     "lodash-es": "^4.17.11",
-    "qrcode": "^1.3.2"
+    "qrcode": "~1.3.2"
   }
 }


### PR DESCRIPTION
Resolving https://github.com/decred/dcrdata/issues/1128.

This unbreaks formatting issues with Bootstrap 4.3 and possibly 4.2.
Run npm install after applying these changes.

The bug in issue #1128 is manifested when bootstrap is allowed to upgrade too liberally:

```sh
$ npm list |grep bootstrap     
├── bootstrap@4.3.1 invalid                        
```

With this change:

```sh
$ npm list |grep bootstrap     
├── bootstrap@4.1.3
```

Also pins down qrcode more tightly.

TODO: We should consider checking in a package-lock.json with our stamp of approval.  Otherwise we aren't sufficiently controlling what goes into the asset bundle.