### PR TITLE
rpcutils/main: disable rpcclient autoreconnect

### DIFF
--- a/cmd/rebuilddb/rebuilddb.go
+++ b/cmd/rebuilddb/rebuilddb.go
@@ -56,7 +56,7 @@ func mainCore() int {
 
 	// Connect to node RPC server
 	client, _, err := rpcutils.ConnectNodeRPC(cfg.DcrdServ, cfg.DcrdUser,
-		cfg.DcrdPass, cfg.DcrdCert, cfg.DisableDaemonTLS)
+		cfg.DcrdPass, cfg.DcrdCert, cfg.DisableDaemonTLS, false)
 	if err != nil {
 		log.Fatalf("Unable to connect to RPC server: %v", err)
 		return 1

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -92,7 +92,7 @@ func mainCore() error {
 
 	// Connect to node RPC server
 	client, _, err := rpcutils.ConnectNodeRPC(cfg.DcrdServ, cfg.DcrdUser,
-		cfg.DcrdPass, cfg.DcrdCert, cfg.DisableDaemonTLS)
+		cfg.DcrdPass, cfg.DcrdCert, cfg.DisableDaemonTLS, false)
 	if err != nil {
 		log.Fatalf("Unable to connect to RPC server: %v", err)
 		return err

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -40,7 +40,7 @@ func mainCore() int {
 	}()
 	flag.Parse()
 
-	client, _, err := rpcutils.ConnectNodeRPC(*host, *user, *pass, *cert, *notls)
+	client, _, err := rpcutils.ConnectNodeRPC(*host, *user, *pass, *cert, *notls, false)
 	if err != nil {
 		log.Fatalf("Unable to connect to RPC server: %v", err)
 		return 1

--- a/main.go
+++ b/main.go
@@ -1221,7 +1221,7 @@ func waitForSync(ctx context.Context, base chan dbtypes.SyncResult, aux chan dbt
 
 func connectNodeRPC(cfg *config, ntfnHandlers *rpcclient.NotificationHandlers) (*rpcclient.Client, semver.Semver, error) {
 	return rpcutils.ConnectNodeRPC(cfg.DcrdServ, cfg.DcrdUser, cfg.DcrdPass,
-		cfg.DcrdCert, cfg.DisableDaemonTLS, ntfnHandlers)
+		cfg.DcrdCert, cfg.DisableDaemonTLS, true, ntfnHandlers)
 }
 
 func listenAndServeProto(ctx context.Context, wg *sync.WaitGroup, listen, proto string, mux http.Handler) {

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -41,7 +41,7 @@ var (
 
 // ConnectNodeRPC attempts to create a new websocket connection to a dcrd node,
 // with the given credentials and optional notification handlers.
-func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool,
+func ConnectNodeRPC(host, user, pass, cert string, disableTLS, disableReconnect bool,
 	ntfnHandlers ...*rpcclient.NotificationHandlers) (*rpcclient.Client, semver.Semver, error) {
 	var dcrdCerts []byte
 	var err error
@@ -62,12 +62,13 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool,
 	}
 
 	connCfgDaemon := &rpcclient.ConnConfig{
-		Host:         host,
-		Endpoint:     "ws", // websocket
-		User:         user,
-		Pass:         pass,
-		Certificates: dcrdCerts,
-		DisableTLS:   disableTLS,
+		Host:                 host,
+		Endpoint:             "ws", // websocket
+		User:                 user,
+		Pass:                 pass,
+		Certificates:         dcrdCerts,
+		DisableTLS:           disableTLS,
+		DisableAutoReconnect: disableReconnect,
 	}
 
 	var ntfnHdlrs *rpcclient.NotificationHandlers

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -44,7 +44,7 @@ func testCommonAncestorPositive(t *testing.T, client *rpcclient.Client, hashA, h
 }
 
 func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSameHeights(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestCommonAncestorOnlineSameHeights(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSameHashes(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestCommonAncestorOnlineSameHashes(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineGenesis(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestCommonAncestorOnlineGenesis(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineBadHash(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestCommonAncestorOnlineBadHash(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineTooLong(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestCommonAncestorOnlineTooLong(t *testing.T) {
 }
 
 func TestSideChains(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestSideChains(t *testing.T) {
 }
 
 func TestSideChainFull(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true)
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The RPC client autoreconnect option should be turned OFF.
The assumption is that once dcrdata starts up, there will never be a missed notification.