### PR TITLE
cache/dcrpg: per-address History/charts data cache

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -164,7 +164,6 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/", app.getAddressTransactions)
 			rd.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
 			rd.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)
-			rd.With(m.ChartGroupingCtx).Get("/unspent/{chartgrouping}", app.getAddressTxUnspentAmountData)
 			rd.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
 			rd.Route("/count/{N}", func(ri chi.Router) {
 				ri.Use(m.NPathCtx)

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -1551,41 +1551,6 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 	writeJSON(w, data, c.getIndentQuery(r))
 }
 
-func (c *appContext) getAddressTxUnspentAmountData(w http.ResponseWriter, r *http.Request) {
-	if c.LiteMode {
-		http.Error(w, "not available in lite mode", 422)
-		return
-	}
-
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
-	if err != nil || len(addresses) > 1 {
-		http.Error(w, http.StatusText(422), 422)
-		return
-	}
-	address := addresses[0]
-
-	chartGrouping := m.GetChartGroupingCtx(r)
-	if chartGrouping == "" {
-		http.Error(w, http.StatusText(422), 422)
-		return
-	}
-
-	data, err := c.AuxDataSource.TxHistoryData(address, dbtypes.TotalUnspent,
-		dbtypes.TimeGroupingFromStr(chartGrouping))
-	if dbtypes.IsTimeoutErr(err) {
-		apiLog.Errorf("TxHistoryData: %v", err)
-		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
-		return
-	}
-	if err != nil {
-		log.Warnf("failed to get address (%s) history by unspent amount flow: %v", address, err)
-		http.Error(w, http.StatusText(422), 422)
-		return
-	}
-
-	writeJSON(w, data, c.getIndentQuery(r))
-}
-
 func (c *appContext) getTicketPriceChartData(w http.ResponseWriter, r *http.Request) {
 	if c.LiteMode {
 		http.Error(w, "not available in lite mode", 422)

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -358,6 +358,24 @@ func AllDebitAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 	return out
 }
 
+// TxHistory contains ChartsData for different chart types (tx type, amount
+// flow, and unspent amount), each with data at known time intervals
+// (TimeBasedGrouping).
+type TxHistory struct {
+	TypeByInterval       [dbtypes.NumIntervals]*dbtypes.ChartsData
+	AmtFlowByInterval    [dbtypes.NumIntervals]*dbtypes.ChartsData
+	UnspentAmtByInterval [dbtypes.NumIntervals]*dbtypes.ChartsData
+}
+
+// Clear sets each *ChartsData to nil, effectively clearing the TxHistory.
+func (th *TxHistory) Clear() {
+	for i := 0; i < dbtypes.NumIntervals; i++ {
+		th.TypeByInterval[i] = nil
+		th.AmtFlowByInterval[i] = nil
+		th.UnspentAmtByInterval[i] = nil
+	}
+}
+
 // AddressCacheItem is the unit of cached data pertaining to a certain address.
 // The height and hash of the best block at the time the data was obtained is
 // stored to determine validity of the cache item. Cached data for an address
@@ -368,7 +386,7 @@ type AddressCacheItem struct {
 	balance *dbtypes.AddressBalance
 	rows    []dbtypes.AddressRowCompact // creditDebitQuery
 	utxos   []apitypes.AddressTxnOutput
-	metrics *dbtypes.AddressMetrics
+	history TxHistory
 	height  int64
 	hash    chainhash.Hash
 }
@@ -426,14 +444,30 @@ func (d *AddressCacheItem) UTXOs() ([]apitypes.AddressTxnOutput, *BlockID) {
 	return d.utxos, d.blockID()
 }
 
-// Metrics is a thread-safe accessor for the *dbtypes.AddressMetrics.
-func (d *AddressCacheItem) Metrics() (*dbtypes.AddressMetrics, *BlockID) {
+// HistoryChart is a thread-safe accessor for the TxHistory.
+func (d *AddressCacheItem) HistoryChart(addrChart dbtypes.HistoryChart, chartGrouping dbtypes.TimeBasedGrouping) (*dbtypes.ChartsData, *BlockID) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
-	if d.metrics == nil {
+
+	if int(chartGrouping) >= dbtypes.NumIntervals {
+		log.Errorf("Invalid chart grouping: %v", chartGrouping)
 		return nil, nil
 	}
-	return d.metrics, d.blockID()
+
+	var cd *dbtypes.ChartsData
+	switch addrChart {
+	case dbtypes.TxsType:
+		cd = d.history.TypeByInterval[chartGrouping]
+	case dbtypes.AmountFlow:
+		cd = d.history.AmtFlowByInterval[chartGrouping]
+	case dbtypes.TotalUnspent:
+		cd = d.history.UnspentAmtByInterval[chartGrouping]
+	}
+
+	if cd == nil {
+		return nil, nil
+	}
+	return cd, d.blockID()
 }
 
 // Rows is a thread-safe accessor for the []*dbtypes.AddressRow.
@@ -518,7 +552,7 @@ func (d *AddressCacheItem) setBlock(block BlockID) {
 	d.hash = block.Hash
 	d.height = block.Height
 	d.utxos = nil
-	d.metrics = nil
+	d.history.Clear()
 	d.balance = nil
 	d.rows = nil
 }
@@ -550,6 +584,7 @@ func (d *AddressCacheItem) SetBalance(block BlockID, balance *dbtypes.AddressBal
 	d.balance = balance
 }
 
+// CacheCounts stores cache hits and misses.
 type CacheCounts struct {
 	Hits, Misses int
 }
@@ -559,11 +594,12 @@ type cacheCounts struct {
 	CacheCounts
 }
 
+// CacheMetrics is a collection of CacheCounts for the various cached data.
 type CacheMetrics struct {
 	rowMetrics     cacheCounts
 	utxoMetrics    cacheCounts
 	balanceMetrics cacheCounts
-	metricMetrics  cacheCounts
+	historyMetrics cacheCounts
 }
 
 func (cm *CacheMetrics) RowStats() (hits, misses int) {
@@ -584,10 +620,10 @@ func (cm *CacheMetrics) UtxoStats() (hits, misses int) {
 	return cm.utxoMetrics.Hits, cm.utxoMetrics.Misses
 }
 
-func (cm *CacheMetrics) MetricStats() (hits, misses int) {
-	cm.metricMetrics.Lock()
-	defer cm.metricMetrics.Unlock()
-	return cm.metricMetrics.Hits, cm.metricMetrics.Misses
+func (cm *CacheMetrics) HistoryStats() (hits, misses int) {
+	cm.historyMetrics.Lock()
+	defer cm.historyMetrics.Unlock()
+	return cm.historyMetrics.Hits, cm.historyMetrics.Misses
 }
 
 func (cm *CacheMetrics) RowHit() {
@@ -626,16 +662,16 @@ func (cm *CacheMetrics) BalanceMiss() {
 	cm.balanceMetrics.Unlock()
 }
 
-func (cm *CacheMetrics) MetricHit() {
-	cm.metricMetrics.Lock()
-	cm.metricMetrics.Hits++
-	cm.metricMetrics.Unlock()
+func (cm *CacheMetrics) HistoryHit() {
+	cm.historyMetrics.Lock()
+	cm.historyMetrics.Hits++
+	cm.historyMetrics.Unlock()
 }
 
-func (cm *CacheMetrics) MetricMiss() {
-	cm.metricMetrics.Lock()
-	cm.metricMetrics.Misses++
-	cm.metricMetrics.Unlock()
+func (cm *CacheMetrics) HistoryMiss() {
+	cm.historyMetrics.Lock()
+	cm.historyMetrics.Misses++
+	cm.historyMetrics.Unlock()
 }
 
 // AddressCache maintains a store of address data. Use NewAddressCache to create
@@ -664,40 +700,56 @@ func NewAddressCache(rowCapacity int) *AddressCache {
 	return ac
 }
 
+// BalanceStats reports the balance hit/miss stats.
 func (ac *AddressCache) BalanceStats() (hits, misses int) {
 	return ac.cacheMetrics.BalanceStats()
 }
 
+// RowStats reports the row hit/miss stats.
 func (ac *AddressCache) RowStats() (hits, misses int) {
 	return ac.cacheMetrics.RowStats()
 }
 
+// UtxoStats reports the utxo hit/miss stats.
 func (ac *AddressCache) UtxoStats() (hits, misses int) {
 	return ac.cacheMetrics.UtxoStats()
 }
 
-func (ac *AddressCache) MetricStats() (hits, misses int) {
-	return ac.cacheMetrics.MetricStats()
+// HistoryStats reports the history data hit/miss stats.
+func (ac *AddressCache) HistoryStats() (hits, misses int) {
+	return ac.cacheMetrics.HistoryStats()
 }
 
+// Reporter prints the number of cached addresses, rows, and utxos, as well as a
+// table of cache hits and misses.
 func (ac *AddressCache) Reporter() {
-	var lastBH, lastBM, lastRH, lastRM, lastUH, lastUM int
+	var lastBH, lastBM, lastRH, lastRM, lastUH, lastUM, lastHH, lastHM int
 	ticker := time.NewTicker(4 * time.Second)
 	for range ticker.C {
 		balHits, balMisses := ac.BalanceStats()
 		rowHits, rowMisses := ac.RowStats()
 		utxoHits, utxoMisses := ac.UtxoStats()
+		histHits, histMisses := ac.HistoryStats()
 		// Only report if a hit/miss count has changed.
 		if balHits != lastBH || balMisses != lastBM ||
 			rowHits != lastRH || rowMisses != lastRM ||
-			utxoHits != lastUH || utxoMisses != lastUM {
+			utxoHits != lastUH || utxoMisses != lastUM ||
+			histHits != lastHH || histMisses != lastHM {
 			lastBH, lastBM = balHits, balMisses
 			lastRH, lastRM = rowHits, rowMisses
 			lastUH, lastUM = utxoHits, utxoMisses
+			lastHH, lastHM = histHits, histMisses
 			numAddrs, numRows, numUTXOs := ac.Length()
-			log.Debugf("CACHE: addresses = %d, rows = %d, utxos = %d", numAddrs, numRows, numUTXOs)
-			log.Debugf("CACHE: row H = %d, M = %d; balance H = %d, M = %d; utxo H = %d, M = %d",
-				rowHits, rowMisses, balHits, balMisses, utxoHits, utxoMisses)
+			log.Debugf("ADDRESS CACHE: addresses = %d, rows = %d, utxos = %d",
+				numAddrs, numRows, numUTXOs)
+			log.Debugf("ADDRESS CACHE:"+
+				"\n\t\t\t\t\t            HITS | MISSES"+
+				"\n\t\t\t\t\trows    %8d | %6d"+
+				"\n\t\t\t\t\tbalance %8d | %6d"+
+				"\n\t\t\t\t\tutxos   %8d | %6d"+
+				"\n\t\t\t\t\thist    %8d | %6d",
+				rowHits, rowMisses, balHits, balMisses,
+				utxoHits, utxoMisses, histHits, histMisses)
 		}
 	}
 }
@@ -762,17 +814,26 @@ func (ac *AddressCache) UTXOs(addr string) ([]apitypes.AddressTxnOutput, *BlockI
 	return aci.UTXOs()
 }
 
-// Metrics attempts to retrieve an AddressMetrics for the given address. The
-// BlockID for the block at which the cached data is valid is also returned. In
-// the event of a cache miss, both returned pointers will be nil.
-func (ac *AddressCache) Metrics(addr string) (*dbtypes.AddressMetrics, *BlockID) {
+// HistoryChart attempts to retrieve ChartsData for the given address, chart
+// type, and grouping inverval. The BlockID for the block at which the cached
+// data is valid is also returned. In the event of a cache miss, both returned
+// pointers will be nil.
+func (ac *AddressCache) HistoryChart(addr string, addrChart dbtypes.HistoryChart,
+	chartGrouping dbtypes.TimeBasedGrouping) (*dbtypes.ChartsData, *BlockID) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
-		ac.cacheMetrics.MetricMiss()
+		ac.cacheMetrics.HistoryMiss()
 		return nil, nil
 	}
-	ac.cacheMetrics.MetricHit()
-	return aci.Metrics()
+
+	cd, blockID := aci.HistoryChart(addrChart, chartGrouping)
+	if cd == nil || blockID == nil {
+		ac.cacheMetrics.HistoryMiss()
+		return nil, nil
+	}
+
+	ac.cacheMetrics.HistoryHit()
+	return cd, blockID
 }
 
 // Rows attempts to retrieve an []*AddressRow for the given address. The BlockID
@@ -819,6 +880,8 @@ func (ac *AddressCache) Transactions(addr string, N, offset int64, txnType dbtyp
 	return rows, blockID, err
 }
 
+// TransactionsMerged is like Transactions, but it must be used with a merged
+// AddrTxnViewType, and it returns a []dbtypes.AddressRowMerged.
 func (ac *AddressCache) TransactionsMerged(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]dbtypes.AddressRowMerged, *BlockID, error) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
@@ -837,6 +900,8 @@ func (ac *AddressCache) TransactionsMerged(addr string, N, offset int64, txnType
 	}
 }
 
+// TransactionsCompact is like Transactions, but it must be used with a
+// non-merged AddrTxnViewType, and it returns a []dbtypes.AddressRowCompact.
 func (ac *AddressCache) TransactionsCompact(addr string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]dbtypes.AddressRowCompact, *BlockID, error) {
 	aci := ac.addressCacheItem(addr)
 	if aci == nil {
@@ -1000,6 +1065,55 @@ func (ac *AddressCache) StoreRows(addr string, rows []*dbtypes.AddressRow, block
 
 	// respect cache capacity
 	return ac.StoreRowsCompact(addr, rowsCompact, block)
+}
+
+// StoreHistoryChart stores the charts data for the given address in cache. The
+// current best block data is required to determine cache freshness.
+func (ac *AddressCache) StoreHistoryChart(addr string, addrChart dbtypes.HistoryChart,
+	chartGrouping dbtypes.TimeBasedGrouping, cd *dbtypes.ChartsData, block *BlockID) bool {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
+		return false
+	}
+
+	if int(chartGrouping) >= dbtypes.NumIntervals {
+		log.Errorf("Invalid chart grouping: %v", chartGrouping)
+		return false
+	}
+
+	if cd == nil {
+		cd = &dbtypes.ChartsData{}
+	}
+
+	ac.mtx.Lock()
+	defer ac.mtx.Unlock()
+	aci := ac.a[addr]
+
+	if aci == nil || aci.BlockHash() != block.Hash {
+		aci = &AddressCacheItem{
+			height: block.Height,
+			hash:   block.Hash,
+		}
+		if !ac.addCacheItem(addr, aci) {
+			return false
+		}
+	}
+
+	// Set the history data in the cache item.
+	aci.mtx.Lock()
+	defer aci.mtx.Unlock()
+
+	switch addrChart {
+	case dbtypes.TxsType:
+		aci.history.TypeByInterval[chartGrouping] = cd
+	case dbtypes.AmountFlow:
+		aci.history.AmtFlowByInterval[chartGrouping] = cd
+	case dbtypes.TotalUnspent:
+		aci.history.UnspentAmtByInterval[chartGrouping] = cd
+	default:
+		return false
+	}
+
+	return true
 }
 
 // StoreRows stores the non-merged AddressRow slice for the given address in

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -358,13 +358,11 @@ func AllDebitAddressRows(rows []*dbtypes.AddressRow) []*dbtypes.AddressRow {
 	return out
 }
 
-// TxHistory contains ChartsData for different chart types (tx type, amount
-// flow, and unspent amount), each with data at known time intervals
-// (TimeBasedGrouping).
+// TxHistory contains ChartsData for different chart types (tx type and amount
+// flow), each with data at known time intervals (TimeBasedGrouping).
 type TxHistory struct {
-	TypeByInterval       [dbtypes.NumIntervals]*dbtypes.ChartsData
-	AmtFlowByInterval    [dbtypes.NumIntervals]*dbtypes.ChartsData
-	UnspentAmtByInterval [dbtypes.NumIntervals]*dbtypes.ChartsData
+	TypeByInterval    [dbtypes.NumIntervals]*dbtypes.ChartsData
+	AmtFlowByInterval [dbtypes.NumIntervals]*dbtypes.ChartsData
 }
 
 // Clear sets each *ChartsData to nil, effectively clearing the TxHistory.
@@ -372,7 +370,6 @@ func (th *TxHistory) Clear() {
 	for i := 0; i < dbtypes.NumIntervals; i++ {
 		th.TypeByInterval[i] = nil
 		th.AmtFlowByInterval[i] = nil
-		th.UnspentAmtByInterval[i] = nil
 	}
 }
 
@@ -460,8 +457,6 @@ func (d *AddressCacheItem) HistoryChart(addrChart dbtypes.HistoryChart, chartGro
 		cd = d.history.TypeByInterval[chartGrouping]
 	case dbtypes.AmountFlow:
 		cd = d.history.AmtFlowByInterval[chartGrouping]
-	case dbtypes.TotalUnspent:
-		cd = d.history.UnspentAmtByInterval[chartGrouping]
 	}
 
 	if cd == nil {
@@ -1107,8 +1102,6 @@ func (ac *AddressCache) StoreHistoryChart(addr string, addrChart dbtypes.History
 		aci.history.TypeByInterval[chartGrouping] = cd
 	case dbtypes.AmountFlow:
 		aci.history.AmtFlowByInterval[chartGrouping] = cd
-	case dbtypes.TotalUnspent:
-		aci.history.UnspentAmtByInterval[chartGrouping] = cd
 	default:
 		return false
 	}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -323,8 +323,12 @@ const (
 	UnknownGrouping
 )
 
-// TimeIntervals is a slice of distinct time intervals used for grouping data.
-var TimeIntervals = []TimeBasedGrouping{
+// NumIntervals is the number of known values for TimeBasedGrouping.
+const NumIntervals = 5
+
+// TimeIntervals is an array of distinct time intervals used for grouping data.
+var TimeIntervals = [NumIntervals]TimeBasedGrouping{
+	AllGrouping,
 	YearGrouping,
 	MonthGrouping,
 	WeekGrouping,

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -421,7 +421,6 @@ type HistoryChart int8
 const (
 	TxsType HistoryChart = iota
 	AmountFlow
-	TotalUnspent
 	ChartUnknown
 )
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -257,12 +257,6 @@ const (
 		GROUP BY timestamp
 		ORDER BY timestamp;`
 
-	selectAddressUnspentAmountByAddress = `SELECT %s as timestamp, SUM(value) as unspent
-		FROM addresses
-		WHERE address=$1 AND is_funding AND matching_tx_hash = ''
-		GROUP BY timestamp
-		ORDER BY timestamp;`
-
 	// UPDATEs/SETs
 
 	// SetAddressMatchingTxHashForOutpoint sets the matching tx hash (a spending
@@ -375,11 +369,6 @@ func MakeSelectAddressTxTypesByAddress(group string) string {
 // MakeSelectAddressAmountFlowByAddress returns the selectAddressAmountFlowByAddress query
 func MakeSelectAddressAmountFlowByAddress(group string) string {
 	return formatGroupingQuery(selectAddressAmountFlowByAddress, group, "block_time")
-}
-
-// MakeSelectAddressUnspentAmountByAddress returns the selectAddressUnspentAmountByAddress query
-func MakeSelectAddressUnspentAmountByAddress(group string) string {
-	return formatGroupingQuery(selectAddressUnspentAmountByAddress, group, "block_time")
 }
 
 func MakeSelectAddressTimeGroupingCount(group string) string {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2382,6 +2382,34 @@ func (pgb *ChainDB) PurgeBestBlocks(N int64) (*dbtypes.DeletionSummary, int64, e
 // type and time grouping.
 func (pgb *ChainDB) TxHistoryData(address string, addrChart dbtypes.HistoryChart,
 	chartGroupings dbtypes.TimeBasedGrouping) (cd *dbtypes.ChartsData, err error) {
+	// First check cache for this address' chart data of the given type and
+	// interval.
+	bestHash, height := pgb.BestBlock()
+	var validHeight *cache.BlockID
+	cd, validHeight = pgb.AddressCache.HistoryChart(address, addrChart, chartGroupings)
+	if cd != nil && *bestHash == validHeight.Hash {
+		return
+	}
+
+	busy, wait, done := pgb.CacheLocks.bal.TryLock(address)
+	if busy {
+		// Let others get the wait channel while we wait.
+		// To return stale cache data if it is available:
+		// utxos, _ := pgb.AddressCache.UTXOs(address)
+		// if utxos != nil {
+		// 	return utxos, nil
+		// }
+		<-wait
+
+		// Try again, starting with the cache.
+		return pgb.TxHistoryData(address, addrChart, chartGroupings)
+	} else {
+		// We will run the DB query, so block others from doing the same. When
+		// query and/or cache update is completed, broadcast to any waiters that
+		// the coast is clear.
+		defer done()
+	}
+
 	timeInterval := chartGroupings.String()
 
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
@@ -2398,9 +2426,16 @@ func (pgb *ChainDB) TxHistoryData(address string, addrChart dbtypes.HistoryChart
 		cd, err = retrieveTxHistoryByUnspentAmount(ctx, pgb.db, address, timeInterval)
 
 	default:
-		err = fmt.Errorf("unknown error occurred")
+		cd, err = nil, fmt.Errorf("unknown error occurred")
 	}
 	err = pgb.replaceCancelError(err)
+	if err != nil {
+		return
+	}
+
+	// Update cache.
+	_ = pgb.AddressCache.StoreHistoryChart(address, addrChart, chartGroupings,
+		cd, cache.NewBlockID(bestHash, height))
 	return
 }
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2422,9 +2422,6 @@ func (pgb *ChainDB) TxHistoryData(address string, addrChart dbtypes.HistoryChart
 	case dbtypes.AmountFlow:
 		cd, err = retrieveTxHistoryByAmountFlow(ctx, pgb.db, address, timeInterval)
 
-	case dbtypes.TotalUnspent:
-		cd, err = retrieveTxHistoryByUnspentAmount(ctx, pgb.db, address, timeInterval)
-
 	default:
 		cd, err = nil, fmt.Errorf("unknown error occurred")
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1811,38 +1811,6 @@ func retrieveTxHistoryByAmountFlow(ctx context.Context, db *sql.DB, addr, timeIn
 	return items, nil
 }
 
-// retrieveTxHistoryByUnspentAmount fetches the unspent amount for all the
-// transactions associated with a given address for the given time interval.
-// The time interval is grouping records by week, month, year, day and all.
-// For all time interval, transactions are grouped by the unique
-// timestamps (blocks) available.
-func retrieveTxHistoryByUnspentAmount(ctx context.Context, db *sql.DB, addr, timeInterval string) (*dbtypes.ChartsData, error) {
-	var totalAmount uint64
-	var items = new(dbtypes.ChartsData)
-
-	rows, err := db.QueryContext(ctx, internal.MakeSelectAddressUnspentAmountByAddress(timeInterval), addr)
-	if err != nil {
-		return nil, err
-	}
-	defer closeRows(rows)
-
-	for rows.Next() {
-		var blockTime dbtypes.TimeDef
-		var amount uint64
-		err = rows.Scan(&blockTime, &amount)
-		if err != nil {
-			return nil, err
-		}
-
-		items.Time = append(items.Time, blockTime)
-
-		// Return cumulative amount data for the unspent chart type.
-		totalAmount += amount
-		items.Amount = append(items.Amount, dcrutil.Amount(totalAmount).ToCoin())
-	}
-	return items, nil
-}
-
 // --- vins and vouts tables ---
 
 // InsertVin either inserts, attempts to insert, or upserts the given vin data

--- a/testutil/apiload/profiles.json
+++ b/testutil/apiload/profiles.json
@@ -163,7 +163,6 @@
           "/api/address/DcaANcUot1dFvyKXvoZUApVej1tY451NRyx/raw",
           "/api/address/DcaAZYsnbCNqq1JPUCikd34zj5qPX6DcXjA/totals",
           "/api/address/DcaDEDuwVUAFAn4TURoyyCFJJvKSExUHHmC/types/week",
-          "/api/address/Dcadx1KZprzZ7bWihExL97xyEHA5fbYU3fX/unspent/month",
           "/api/agenda/lnsupport",
           "/api/block/best",
           "/api/block/best/hash",


### PR DESCRIPTION
This adds to the address cache all of the history that was obtained via
DB query by `(*ChainDB).TxHistoryData`. This corresponds to the data
retrieved from the API via AJAX for the charts on the address page. e.g.:
`/api/address/{addr}/amountflow/month`, `/api/address/{addr}/types/week`, etc.

The `AddressCacheItem` `metrics` placeholder is changed to `history`, of
a new type `TxHistory` that contains all types of address history used by
the charts on the address page.
`(*AddressCache).HistoryChart` gets the specified chart from cache.
`(*AddressCache).StoreHistoryChart` stores the given chart of the
specified type in cache.

`(*ChainDB).TxHistoryData` is modified similar to other cache-wired
functions to first check the cache. For a cache miss, the cache is held
locked while the actual DB queries are run, and the retrieved history
data is stored in cache.

dbtypes: `TimeIntervals` is changed to a fixed-length array, and
`AllGrouping` is added to the array.  `const NumIntervals = 5` is set
to guarantee the expected length, and provide a const value for
`cache.TxHistory` type in defining its `ChartsData` arrays.

Also, the cache reports logged by the address cache now make a table
of hits/misses for type of cached data.