### PR TITLE
txhelpers: store previously-computed ultimate subsidy values

### DIFF
--- a/txhelpers/subsidy.go
+++ b/txhelpers/subsidy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Copyright (c) 2013-2015 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -10,12 +10,21 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 )
 
+// ultimateSubsidies stores ultimate subsidy values computed by UltimateSubsidy.
+var ultimateSubsidies = map[*chaincfg.Params]int64{}
+
 // UltimateSubsidy computes the total subsidy over the entire subsidy
 // distribution period of the network.
 func UltimateSubsidy(params *chaincfg.Params) int64 {
+	// Check previously computed ultimate subsidies.
+	totalSubsidy, ok := ultimateSubsidies[params]
+	if ok {
+		return totalSubsidy
+	}
+
 	subsidyCache := blockchain.NewSubsidyCache(0, params)
 
-	totalSubsidy := params.BlockOneSubsidy()
+	totalSubsidy = params.BlockOneSubsidy()
 	for i := int64(0); ; i++ {
 		// Genesis block or first block.
 		if i <= 1 {
@@ -49,6 +58,10 @@ func UltimateSubsidy(params *chaincfg.Params) int64 {
 			}
 		}
 	}
+
+	// Update the ultimate subsidy store.
+	ultimateSubsidies[params] = totalSubsidy
+
 	return totalSubsidy
 }
 

--- a/txhelpers/subsidy_test.go
+++ b/txhelpers/subsidy_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package txhelpers
 
 import (
@@ -6,10 +10,63 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 )
 
-func TestBlockSubsidy(t *testing.T) {
+func TestUltimateSubsidy(t *testing.T) {
+	// Mainnet
+	wantMainnetSubsidy := int64(2099999999800912)
 	totalSubsidy := UltimateSubsidy(&chaincfg.MainNetParams)
 
-	if totalSubsidy != 2099999999800912 {
-		t.Errorf("Bad total subsidy; want 2099999999800912, got %v", totalSubsidy)
+	if totalSubsidy != wantMainnetSubsidy {
+		t.Errorf("Bad total subsidy; want %d, got %d",
+			wantMainnetSubsidy, totalSubsidy)
+	}
+
+	// verify cache
+	totalSubsidy2 := UltimateSubsidy(&chaincfg.MainNetParams)
+	if totalSubsidy != totalSubsidy2 {
+		t.Errorf("Bad total subsidy; want %d, got %d",
+			totalSubsidy, totalSubsidy2)
+	}
+
+	// Testnet
+	wantTestnetSubsidy := int64(526540305161472)
+	totalTNSubsidy := UltimateSubsidy(&chaincfg.TestNet3Params)
+
+	if totalTNSubsidy != wantTestnetSubsidy {
+		t.Errorf("Bad total subsidy; want %d, got %d",
+			wantTestnetSubsidy, totalTNSubsidy)
+	}
+
+	// verify cache
+	totalTNSubsidy2 := UltimateSubsidy(&chaincfg.TestNet3Params)
+	if totalTNSubsidy != totalTNSubsidy2 {
+		t.Errorf("Bad total subsidy; want %d, got %d",
+			totalTNSubsidy, totalTNSubsidy2)
+	}
+
+	// re-verify mainnet cache
+	totalSubsidy3 := UltimateSubsidy(&chaincfg.MainNetParams)
+	if totalSubsidy != totalSubsidy3 {
+		t.Errorf("Bad total subsidy; want %d, got %d",
+			totalSubsidy, totalSubsidy3)
+	}
+}
+
+func BenchmarkUltimateSubsidy(b *testing.B) {
+	// warm up
+	totalSubsidy := UltimateSubsidy(&chaincfg.MainNetParams)
+	// verify cache
+	totalSubsidy2 := UltimateSubsidy(&chaincfg.MainNetParams)
+	if totalSubsidy != totalSubsidy2 {
+		b.Errorf("Bad total subsidy; want %d, got %d",
+			totalSubsidy, totalSubsidy2)
+	}
+
+	for i := 0; i < b.N; i++ {
+		totalSubsidy = UltimateSubsidy(&chaincfg.MainNetParams)
+	}
+
+	if totalSubsidy != totalSubsidy2 {
+		b.Errorf("Bad total subsidy; want %d, got %d",
+			totalSubsidy, totalSubsidy2)
 	}
 }


### PR DESCRIPTION
The "rotation" API attack shows that right below SQLite queries,
`txhelpers.UltimateSubsidy` dominates CPU use:

```
Profiling CPU now, will take 30 secs...
Profile dump saved to: /tmp/profile382211380
Profiling dump saved to: /tmp/profile382211380
Binary file saved to: /tmp/binary999078659
File: binary999078659
Build ID: dac764d5609000fe955fb95b2afecec454b17e47
Type: cpu
Time: Mar 15, 2019 at 8:33am (CDT)
Duration: 30.14s, Total samples = 1.38mins (275.41%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 75.69s, 91.19% of 83s total
Dropped 543 nodes (cum <= 0.41s)
Showing top 10 nodes out of 126
      flat  flat%   sum%        cum   cum%
    48.31s 58.20% 58.20%     48.32s 58.22%  runtime.cgocall
    23.13s 27.87% 86.07%     23.32s 28.10%  github.com/decred/dcrdata/v4/txhelpers.UltimateSubsidy
     0.89s  1.07% 87.14%      0.91s  1.10%  syscall.Syscall
     0.76s  0.92% 88.06%      1.38s  1.66%  runtime.mapassign
     0.56s  0.67% 88.73%      0.56s  0.67%  runtime.aeshashbody
...
```

These changes add a package-level store for previously computed
ultimate subsidy values.  `txhelpers.UltimateSubsidy` uses it to avoid
recomputing the same value repeatedly.

Before:

```
BenchmarkUltimateSubsidy-32    	    20	  85572558 ns/op	 190943 B/op	   111 allocs/op
```

After:

```
BenchmarkUltimateSubsidy-32    	300000000	  4.52 ns/op	    0 B/op	      0 allocs/op
```