### PR TITLE
apis: make compression off by default and add --compress-api

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -35,7 +35,8 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 
 	compMiddleware := m.Next
 	if compressLarge {
-		compMiddleware = middleware.Compress(1)
+		log.Debug("Enabling compressed responses for large JSON payload endpoints.")
+		compMiddleware = middleware.NewCompressor(3).Handler()
 	}
 
 	mux.Route("/block", func(r chi.Router) {

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
@@ -23,7 +24,7 @@ type fileMux struct {
 
 // NewAPIRouter creates a new HTTP request path router/mux for the given API,
 // appContext.
-func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
+func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 	// chi router
 	mux := stackedMux(useRealIP)
 
@@ -31,6 +32,11 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 
 	mux.Get("/status", app.status)
 	mux.Get("/supply", app.coinSupply)
+
+	compMiddleware := m.Next
+	if compressLarge {
+		compMiddleware = middleware.Compress(1)
+	}
 
 	mux.Route("/block", func(r chi.Router) {
 		r.Route("/best", func(rd chi.Router) {
@@ -45,7 +51,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
-			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
+			rd.With(compMiddleware).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
@@ -64,7 +70,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
-			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
+			rd.With(compMiddleware).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtendedByHash)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
@@ -83,7 +89,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/raw", app.getBlockRaw)
 			rd.Get("/size", app.getBlockSize)
 			rd.Get("/subsidy", app.blockSubsidies)
-			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
+			rd.With(compMiddleware).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 			rd.Route("/tx", func(rt chi.Router) {
 				rt.Get("/", app.getBlockTransactions)
@@ -93,7 +99,7 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 
 		r.Route("/range/{idx0}/{idx}", func(rd chi.Router) {
 			rd.Use(m.BlockIndex0PathCtx, m.BlockIndexPathCtx)
-			rd.Use(middleware.Compress(1))
+			rd.Use(compMiddleware)
 			rd.Get("/", app.getBlockRangeSummary)
 			rd.Get("/size", app.getBlockRangeSize)
 			rd.Route("/{step}", func(rs chi.Router) {
@@ -104,8 +110,6 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			// rd.Get("/header", app.getBlockHeader)
 			// rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 		})
-
-		//r.With(middleware.DefaultCompress).Get("/raw", app.someLargeResponse)
 	})
 
 	mux.Route("/stake", func(r chi.Router) {
@@ -164,15 +168,15 @@ func NewAPIRouter(app *appContext, useRealIP bool) apiMux {
 			rd.Get("/", app.getAddressTransactions)
 			rd.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
 			rd.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)
-			rd.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
+			rd.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
 			rd.Route("/count/{N}", func(ri chi.Router) {
 				ri.Use(m.NPathCtx)
 				ri.Get("/", app.getAddressTransactions)
-				ri.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
+				ri.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
 				ri.Route("/skip/{M}", func(rj chi.Router) {
 					rj.Use(m.MPathCtx)
 					rj.Get("/", app.getAddressTransactions)
-					rj.With((middleware.Compress(1))).Get("/raw", app.getAddressTransactionsRaw)
+					rj.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
 				})
 			})
 		})
@@ -278,8 +282,6 @@ func stackedMux(useRealIP bool) *chi.Mux {
 	}
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
-	//mux.Use(middleware.DefaultCompress)
-	//mux.Use(middleware.Compress(2))
 	corsMW := cors.Default()
 	mux.Use(corsMW.Handler)
 	return mux

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -1195,14 +1195,12 @@ func (c *appContext) getBlockRangeSummary(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// TODO: check that we have all in range
-
+	// w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	// N := idx - idx0 + 1
 	// summaries := make([]*apitypes.BlockDataBasic, 0, N)
 	// for i := idx0; i <= idx; i++ {
 	// 	summaries = append(summaries, c.BlockData.GetSummary(i))
 	// }
-
 	// writeJSON(w, summaries, c.getIndentQuery(r))
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -47,7 +47,7 @@ func NewInsightApiRouter(app *insightApiContext, useRealIP, compression bool) Ap
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.StripSlashes)
 	if compression {
-		mux.Use(middleware.DefaultCompress)
+		mux.Use(middleware.NewCompressor(3).Handler())
 	}
 
 	// Block endpoints

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 //
@@ -25,7 +25,7 @@ const APIVersion = 0
 
 // NewInsightApiRouter returns a new HTTP path router, ApiMux, for the Insight
 // API, app.
-func NewInsightApiRouter(app *insightApiContext, useRealIP bool) ApiMux {
+func NewInsightApiRouter(app *insightApiContext, useRealIP, compression bool) ApiMux {
 	// chi router
 	mux := chi.NewRouter()
 
@@ -46,7 +46,9 @@ func NewInsightApiRouter(app *insightApiContext, useRealIP bool) ApiMux {
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.StripSlashes)
-	mux.Use(middleware.DefaultCompress)
+	if compression {
+		mux.Use(middleware.DefaultCompress)
+	}
 
 	// Block endpoints
 	mux.With(app.BlockDateLimitQueryCtx).Get("/blocks", app.getBlockSummaryByTime)

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 The Decred developers
+// Copyright (c) 2016-2019 The Decred developers
 // Copyright (c) 2017 Jonathan Chappelow
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -109,6 +109,7 @@ type config struct {
 	CacheControlMaxAge  int     `long:"cachecontrol-maxage" description:"Set CacheControl in the HTTP response header to a value in seconds for clients to cache the response. This applies only to FileServer routes." env:"DCRDATA_MAX_CACHE_AGE"`
 	InsightReqRateLimit float64 `long:"insight-limit-rps" description:"Requests/second per client IP for the Insight API's rate limiter." env:"DCRDATA_INSIGHT_RATE_LIMIT"`
 	MaxCSVAddrs         int     `long:"max-api-addrs" description:"Maximum allowed comma-separated addresses for endpoints that accept multiple addresses."`
+	CompressAPI         bool    `long:"compress-api" description:"Use compression for a number of endpoints with commonly large responses."`
 
 	// Data I/O
 	MempoolMinInterval int    `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regarless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible
 	github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-chi/chi v4.0.1+incompatible
+	github.com/go-chi/chi v4.0.3-0.20190316151245-d08916613452+incompatible
 	github.com/go-chi/docgen v1.0.5
 	github.com/golang/protobuf v1.2.0
 	github.com/google/go-cmp v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,10 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.0.1+incompatible h1:RSRC5qmFPtO90t7pTL0DBMNpZFsb/sHF3RXVlDgFisA=
 github.com/go-chi/chi v4.0.1+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
+github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.0.3-0.20190316151245-d08916613452+incompatible h1:dxIMPZukTX2GGAhPGrdaw4B+B6agjJjsvL3gsWHcTTI=
+github.com/go-chi/chi v4.0.3-0.20190316151245-d08916613452+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/docgen v1.0.5 h1:TiGvJAuVPZJ9zFSwoF52eORe0SztOYqf9C79LVw/xbY=
 github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJelhWM=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=

--- a/main.go
+++ b/main.go
@@ -681,7 +681,7 @@ func _main(ctx context.Context) error {
 	}
 
 	// Configure the URL path to http handler router for the API.
-	apiMux := api.NewAPIRouter(app, cfg.UseRealIP)
+	apiMux := api.NewAPIRouter(app, cfg.UseRealIP, cfg.CompressAPI)
 	// File downloads piggy-back on the API.
 	fileMux := api.NewFileRouter(app, cfg.UseRealIP)
 	// Configure the explorer web pages router.
@@ -721,7 +721,7 @@ func _main(ctx context.Context) error {
 			insightApp := insight.NewInsightContext(dcrdClient, auxDB,
 				activeChain, baseDB, cfg.IndentJSON, cfg.MaxCSVAddrs)
 			insightApp.SetReqRateLimit(cfg.InsightReqRateLimit)
-			insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP)
+			insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP, cfg.CompressAPI)
 			r.Mount("/insight/api", insightMux.Mux)
 
 			if insightSocketServer != nil {

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -177,6 +177,13 @@ func GetTxnsCtx(r *http.Request) ([]*chainhash.Hash, error) {
 	return hashes, nil
 }
 
+// Next is a dummy middleware that just continues with the next http.Handler.
+func Next(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+}
+
 // PostTxnsCtx extract transaction IDs from the POST body
 func PostTxnsCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
GZ compression with a middleware is not always useful, especially when
a reverse proxy like nginx is in use.  This makes compression a config
setting (`--compress-api`, off by default).

This enables compression for ALL Insight API endpoints, and just verbose
and raw dcrdata API endpoints.

chi is updated to include the compression middleware rewrite.