### PR TITLE
rpcutils: fix test code, make note about regnet

### DIFF
--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -1,5 +1,8 @@
 // +build testnetRPC
 
+// TODO: All these test should run with regnet. They were originally made for
+// testnet2, which no longer exists.
+
 package rpcutils
 
 import (
@@ -44,7 +47,7 @@ func testCommonAncestorPositive(t *testing.T, client *rpcclient.Client, hashA, h
 }
 
 func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +69,7 @@ func TestCommonAncestorOnlineDifferentHeights(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSameHeights(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +87,7 @@ func TestCommonAncestorOnlineSameHeights(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSameHashes(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +104,7 @@ func TestCommonAncestorOnlineSameHashes(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +128,7 @@ func TestCommonAncestorOnlineSharedBlock(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineGenesis(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +167,7 @@ func TestCommonAncestorOnlineGenesis(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineBadHash(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +190,7 @@ func TestCommonAncestorOnlineBadHash(t *testing.T) {
 }
 
 func TestCommonAncestorOnlineTooLong(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +213,7 @@ func TestCommonAncestorOnlineTooLong(t *testing.T) {
 }
 
 func TestSideChains(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +225,7 @@ func TestSideChains(t *testing.T) {
 }
 
 func TestSideChainFull(t *testing.T) {
-	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, """", true, false))
+	client, _, err := ConnectNodeRPC("127.0.0.1:19109", nodeUser, nodePass, "", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes syntax problems, but does not fix the "testnetRPC" tests since testnet2 is gone.

As noted in the added comment, all these test should run with regnet (TODO).