### PR TITLE
politeia/piclient: Check for valid http status code

### DIFF
--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -28,8 +28,14 @@ func HandleGetRequests(client *http.Client, URLPath string) ([]byte, error) {
 	}
 
 	response, err := client.Get(URLPath)
-	if err != nil {
-		return nil, err
+	if err != nil || response == nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+
+	// Check if valid status code (200 Ok) was returned.
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request (%s) failed with status code: %s",
+			URLPath, response.Status)
 	}
 
 	defer response.Body.Close()


### PR DESCRIPTION
fixes #1132

Since Politeia [guarantees](https://github.com/decred/politeia/blob/master/politeiawww/api/v1/api.md#http-status-codes-and-errors) that most requests should return http status code `200 OK`. 
Any of the Politeia API endpoints request returned with another other status code is considered to be a failed request.