### PR TITLE
insight: clean up middleware

### DIFF
--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -51,14 +51,14 @@ func NewInsightApiRouter(app *insightApiContext, useRealIP, compression bool) Ap
 	}
 
 	// Block endpoints
-	mux.With(app.BlockDateLimitQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
-	mux.With(app.BlockIndexOrHashPathCtx).Get("/block/{idxorhash}", app.getBlockSummary)
-	mux.With(app.BlockIndexOrHashPathCtx).Get("/block-index/{idxorhash}", app.getBlockHash)
-	mux.With(app.BlockIndexOrHashPathCtx).Get("/rawblock/{idxorhash}", app.getRawBlock)
+	mux.With(BlockDateLimitQueryCtx).Get("/blocks", app.getBlockSummaryByTime)
+	mux.With(m.BlockIndexOrHashPathCtx).Get("/block/{idxorhash}", app.getBlockSummary)
+	mux.With(m.BlockIndexOrHashPathCtx).Get("/block-index/{idxorhash}", app.getBlockHash)
+	mux.With(m.BlockIndexOrHashPathCtx).Get("/rawblock/{idxorhash}", app.getRawBlock)
 
 	// Transaction endpoints
 	mux.With(middleware.AllowContentType("application/json"),
-		app.ValidatePostCtx, app.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
+		app.ValidatePostCtx, m.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
 	mux.With(m.TransactionHashCtx).Get("/tx/{txid}", app.getTransaction)
 	mux.With(m.TransactionHashCtx).Get("/rawtx/{txid}", app.getTransactionHex)
 	mux.With(m.TransactionsCtx).Get("/txs", app.getTransactions)
@@ -66,30 +66,30 @@ func NewInsightApiRouter(app *insightApiContext, useRealIP, compression bool) Ap
 	// Status and Utility
 	mux.With(app.StatusInfoCtx).Get("/status", app.getStatusInfo)
 	mux.Get("/sync", app.getSyncInfo)
-	mux.With(app.NbBlocksCtx).Get("/utils/estimatefee", app.getEstimateFee)
+	mux.With(NbBlocksCtx).Get("/utils/estimatefee", app.getEstimateFee)
 	mux.Get("/peer", app.GetPeerStatus)
 
 	// Addresses endpoints
 	mux.Route("/addrs", func(rd chi.Router) {
 		rd.Route("/{address}", func(ra chi.Router) {
-			ra.Use(m.AddressPathCtx, app.FromToPaginationCtx)
+			ra.Use(m.AddressPathCtx, FromToPaginationCtx)
 			ra.Get("/txs", app.getAddressesTxn)
 			ra.Get("/utxo", app.getAddressesTxnOutput)
 		})
 		// POST methods
 		rd.With(middleware.AllowContentType("application/json"),
-			app.ValidatePostCtx, app.PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
+			app.ValidatePostCtx, PostAddrsTxsCtx).Post("/txs", app.getAddressesTxn)
 		rd.With(middleware.AllowContentType("application/json"),
-			app.ValidatePostCtx, app.PostAddrsUtxoCtx).Post("/utxo", app.getAddressesTxnOutput)
+			app.ValidatePostCtx, PostAddrsUtxoCtx).Post("/utxo", app.getAddressesTxnOutput)
 	})
 
 	// Address endpoints
 	mux.Route("/addr/{address}", func(rd chi.Router) {
 		rd.Use(m.AddressPathCtx)
-		rd.With(app.FromToPaginationCtx, app.NoTxListCtx).Get("/", app.getAddressInfo)
+		rd.With(FromToPaginationCtx, NoTxListCtx).Get("/", app.getAddressInfo)
 		rd.Get("/utxo", app.getAddressesTxnOutput)
 		rd.Route("/{command}", func(ra chi.Router) {
-			ra.With(app.AddressCommandCtx).Get("/", app.getAddressInfo)
+			ra.With(AddressCommandCtx).Get("/", app.getAddressInfo)
 		})
 	})
 

--- a/api/insight/apiroutes_test.go
+++ b/api/insight/apiroutes_test.go
@@ -57,3 +57,131 @@ func Test_dateFromStr(t *testing.T) {
 		})
 	}
 }
+
+func Test_fromToForSlice(t *testing.T) {
+	type args struct {
+		from        int64
+		to          int64
+		sliceLength int64
+		txLimit     int64
+	}
+	tests := []struct {
+		testName  string
+		args      args
+		wantStart int64
+		wantEnd   int64
+		wantErr   bool
+	}{
+		{
+			testName: "ok",
+			args: args{
+				from:        0,
+				to:          1,
+				sliceLength: 2,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   2,
+			wantErr:   false,
+		},
+		{
+			testName: "ok, high to",
+			args: args{
+				from:        0,
+				to:          3,
+				sliceLength: 2,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   2,
+			wantErr:   false,
+		},
+		{
+			testName: "ok, high to (edge)",
+			args: args{
+				from:        0,
+				to:          2,
+				sliceLength: 2,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   2,
+			wantErr:   false,
+		},
+		{
+			testName: "ok, one element",
+			args: args{
+				from:        1,
+				to:          1,
+				sliceLength: 2,
+				txLimit:     1000,
+			},
+			wantStart: 1,
+			wantEnd:   2,
+			wantErr:   false,
+		},
+		{
+			testName: "ok, high from",
+			args: args{
+				from:        1,
+				to:          1,
+				sliceLength: 1,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   1,
+			wantErr:   false,
+		},
+		{
+			testName: "ok, low to",
+			args: args{
+				from:        6,
+				to:          1,
+				sliceLength: 20,
+				txLimit:     1000,
+			},
+			wantStart: 6,
+			wantEnd:   7,
+			wantErr:   false,
+		},
+		{
+			testName: "empty slice",
+			args: args{
+				from:        1,
+				to:          1,
+				sliceLength: 0,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   0,
+			wantErr:   true,
+		},
+		{
+			testName: "over limit",
+			args: args{
+				from:        1,
+				to:          20,
+				sliceLength: 200,
+				txLimit:     10,
+			},
+			wantStart: 1,
+			wantEnd:   21,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			start, end, err := fromToForSlice(tt.args.from, tt.args.to, tt.args.sliceLength, tt.args.txLimit)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fromToForSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if start != tt.wantStart {
+				t.Errorf("fromToForSlice() start = %v, want %v", start, tt.wantStart)
+			}
+			if end != tt.wantEnd {
+				t.Errorf("fromToForSlice() end = %v, want %v", end, tt.wantEnd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Remove middleware that duplicates existing functions in the `middleware`
package.
Remove unused method receivers from most Insight middleware.
Move `PostBroadcastTxCtx` to the `middleware` package.
Create `fromToForSlice` for validating and converting `?from=A&to=B` URL
query params to slice indexes.  Add test for `fromToForSlice`.
Numerous simplifications and doc fixes.