### PR TITLE
api: create endpoint for ticket-specific info

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -149,6 +149,7 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 					ri.With(m.TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionInput)
 				})
 				rd.Get("/vinfo", app.getTxVoteInfo)
+				rd.Get("/tinfo", app.getTxTicketInfo)
 			})
 		})
 		r.With(m.TransactionHashCtx).Get("/hex/{txid}", app.getTransactionHex)

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -112,7 +112,7 @@ type DataSourceAux interface {
 	AddressTxIoCsv(address string) ([][]string, error)
 	Height() int64
 	AllAgendas() (map[string]dbtypes.MileStone, error)
-	GetTicketInfo(txid string) (*dbtypes.TicketInfo, error)
+	GetTicketInfo(txid string) (*apitypes.TicketInfo, error)
 }
 
 // dcrdata application context used by all route handlers

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -112,6 +112,7 @@ type DataSourceAux interface {
 	AddressTxIoCsv(address string) ([][]string, error)
 	Height() int64
 	AllAgendas() (map[string]dbtypes.MileStone, error)
+	GetTicketInfo(txid string) (*dbtypes.TicketInfo, error)
 }
 
 // dcrdata application context used by all route handlers
@@ -750,6 +751,24 @@ func (c *appContext) getTxVoteInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, vinfo, c.getIndentQuery(r))
+}
+
+// For /tx/{txid}/tinfo
+func (c *appContext) getTxTicketInfo(w http.ResponseWriter, r *http.Request) {
+	txid, err := m.GetTxIDCtx(r)
+	if err != nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+	tinfo, err := c.AuxDataSource.GetTicketInfo(txid.String())
+	if err != nil {
+		err = fmt.Errorf("unable to get ticket info for tx %v: %v",
+			txid, err)
+		apiLog.Error(err)
+		http.Error(w, err.Error(), 422)
+		return
+	}
+	writeJSON(w, tinfo, c.getIndentQuery(r))
 }
 
 // getTransactionInputs serves []TxIn

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -560,6 +560,24 @@ type MempoolTicketDetails struct {
 // MempoolTicketDetails
 type TicketsDetails []*TicketDetails
 
+// TicketInfo combines spend and pool statuses and relevant block and spending
+// transaction IDs.
+type TicketInfo struct {
+	Status           string     `json:"status"`
+	PurchaseBlock    *TinyBlock `json:"purchase_block"`
+	MaturityHeight   uint32     `json:"maturity_height"`
+	ExpirationHeight uint32     `json:"expiration_height"`
+	LotteryBlock     *TinyBlock `json:"lottery_block"`
+	Vote             *string    `json:"vote"`
+	Revocation       *string    `json:"revocation"`
+}
+
+// TinyBlock is the hash and height of a block.
+type TinyBlock struct {
+	Hash   string `json:"hash"`
+	Height uint32 `json:"height"`
+}
+
 // TicketPoolChartsData is for data used to display ticket pool statistics at
 // /ticketpool.
 type TicketPoolChartsData struct {

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -484,24 +484,6 @@ func (v VoteChoice) String() string {
 	}
 }
 
-// TicketInfo combines spend and pool statuses and relevant block and spending
-// transaction IDs.
-type TicketInfo struct {
-	Status           string     `json:"status"`
-	PurchaseBlock    *TinyBlock `json:"purchase_block"`
-	MaturityHeight   uint32     `json:"maturity_height"`
-	ExpirationHeight uint32     `json:"expiration_height"`
-	LotteryBlock     *TinyBlock `json:"lottery_block"`
-	Vote             *string    `json:"vote"`
-	Revocation       *string    `json:"revocation"`
-}
-
-// TinyBlock is the hash and height of a block.
-type TinyBlock struct {
-	Hash   string `json:"hash"`
-	Height uint32 `json:"height"`
-}
-
 // ChoiceIndexFromStr converts the vote choice string to a vote choice index.
 func ChoiceIndexFromStr(choice string) (VoteChoice, error) {
 	switch choice {

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -484,6 +484,24 @@ func (v VoteChoice) String() string {
 	}
 }
 
+// TicketInfo combines spend and pool statuses and relevant block and spending
+// transaction IDs.
+type TicketInfo struct {
+	Status           string     `json:"status"`
+	PurchaseBlock    *TinyBlock `json:"purchase_block"`
+	MaturityHeight   uint32     `json:"maturity_height"`
+	ExpirationHeight uint32     `json:"expiration_height"`
+	LotteryBlock     *TinyBlock `json:"lottery_block"`
+	Vote             *string    `json:"vote"`
+	Revocation       *string    `json:"revocation"`
+}
+
+// TinyBlock is the hash and height of a block.
+type TinyBlock struct {
+	Hash   string `json:"hash"`
+	Height uint32 `json:"height"`
+}
+
 // ChoiceIndexFromStr converts the vote choice string to a vote choice index.
 func ChoiceIndexFromStr(choice string) (VoteChoice, error) {
 	switch choice {

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -5,7 +5,7 @@ package internal
 const (
 	// tickets table
 
-	CreateTicketsTable = `CREATE TABLE IF NOT EXISTS tickets (  
+	CreateTicketsTable = `CREATE TABLE IF NOT EXISTS tickets (
 		id SERIAL PRIMARY KEY,
 		tx_hash TEXT NOT NULL,
 		block_hash TEXT NOT NULL,
@@ -33,7 +33,7 @@ const (
 	VALUES (
 		$1, $2, $3,	$4,
 		$5, $6, $7,
-		$8, $9, $10, $11, $12, 
+		$8, $9, $10, $11, $12,
 		$13) `
 
 	// InsertTicketRow inserts a new ticket row without checking for unique
@@ -44,7 +44,7 @@ const (
 	// UpsertTicketRow is an upsert (insert or update on conflict), returning
 	// the inserted/updated ticket row id. is_mainchain is updated as this might
 	// be a reorganization.
-	UpsertTicketRow = insertTicketRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+	UpsertTicketRow = insertTicketRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE
 		SET is_mainchain = $13 RETURNING id;`
 
 	// InsertTicketRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
@@ -104,6 +104,7 @@ const (
 	SelectTicketIDHeightByHash = `SELECT id, block_height FROM tickets` + forTxHashMainchainFirst
 	SelectTicketIDByHash       = `SELECT id FROM tickets` + forTxHashMainchainFirst
 	SelectTicketStatusByHash   = `SELECT id, spend_type, pool_status FROM tickets` + forTxHashMainchainFirst
+	SelectTicketInfoByHash     = `SELECT block_hash, block_height, spend_type, pool_status, spend_tx_db_id FROM tickets` + forTxHashMainchainFirst
 
 	SelectUnspentTickets = `SELECT id, tx_hash FROM tickets
 		WHERE spend_type = 0 AND is_mainchain = true;`
@@ -126,7 +127,7 @@ const (
 		WHERE pool_status = 0 AND tickets.is_mainchain = TRUE
 		GROUP BY timestamp ORDER BY timestamp;`
 
-	SelectTicketSpendTypeByBlock = `SELECT block_height, 
+	SelectTicketSpendTypeByBlock = `SELECT block_height,
 		SUM(CASE WHEN spend_type = 0 THEN 1 ELSE 0 END) as unspent,
 		SUM(CASE WHEN spend_type = 1 THEN 1 ELSE 0 END) as revoked
 		FROM tickets GROUP BY block_height ORDER BY block_height;`
@@ -154,7 +155,7 @@ const (
 		WHERE block_hash = b.hash;`
 
 	UpdateTicketsMainchainByBlock = `UPDATE tickets
-		SET is_mainchain=$1 
+		SET is_mainchain=$1
 		WHERE block_hash=$2;`
 
 	// votes table
@@ -200,7 +201,7 @@ const (
 	// UpsertVoteRow is an upsert (insert or update on conflict), returning the
 	// inserted/updated vote row id. is_mainchain is updated as this might be a
 	// reorganization.
-	UpsertVoteRow = insertVoteRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+	UpsertVoteRow = insertVoteRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE
 		SET is_mainchain = $12 RETURNING id;`
 
 	// InsertVoteRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
@@ -268,7 +269,7 @@ const (
 		WHERE block_hash = b.hash;`
 
 	UpdateVotesMainchainByBlock = `UPDATE votes
-		SET is_mainchain=$1 
+		SET is_mainchain=$1
 		WHERE block_hash=$2;`
 
 	// misses table
@@ -294,7 +295,7 @@ const (
 
 	// UpsertMissRow is an upsert (insert or update on conflict), returning
 	// the inserted/updated miss row id.
-	UpsertMissRow = insertMissRow + `ON CONFLICT (ticket_hash, block_hash) DO UPDATE 
+	UpsertMissRow = insertMissRow + `ON CONFLICT (ticket_hash, block_hash) DO UPDATE
 		SET ticket_hash = $4, block_hash = $2 RETURNING id;`
 
 	// InsertMissRowOnConflictDoNothing allows an INSERT with a DO NOTHING on

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -36,12 +36,12 @@ const (
 	// insertTxRow is the basis for several tx insert/upsert statements.
 	insertTxRow = `INSERT INTO transactions (
 		block_hash, block_height, block_time, time,
-		tx_type, version, tree, tx_hash, block_index, 
-		lock_time, expiry, size, spent, sent, fees, 
+		tx_type, version, tree, tx_hash, block_index,
+		lock_time, expiry, size, spent, sent, fees,
 		num_vin, vin_db_ids, num_vout, vout_db_ids,
 		is_valid, is_mainchain)
 	VALUES (
-		$1, $2, $3, $4, 
+		$1, $2, $3, $4,
 		$5, $6, $7, $8, $9,
 		$10, $11, $12, $13, $14, $15,
 		$16, $17, $18, $19,
@@ -54,7 +54,7 @@ const (
 
 	// UpsertTxRow is an upsert (insert or update on conflict), returning the
 	// inserted/updated transaction row id.
-	UpsertTxRow = insertTxRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+	UpsertTxRow = insertTxRow + `ON CONFLICT (tx_hash, block_hash) DO UPDATE
 		SET is_valid = $20, is_mainchain = $21 RETURNING id;`
 
 	// InsertTxRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
@@ -108,16 +108,16 @@ const (
 		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC
 		LIMIT 1;`
 
-	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time, 
-		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry, 
+	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time,
+		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry,
 		size, spent, sent, fees, num_vin, vin_db_ids, num_vout, vout_db_ids,
 		is_valid, is_mainchain
 		FROM transactions WHERE tx_hash = $1
 		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC
 		LIMIT 1;`
 
-	SelectFullTxsByHash = `SELECT id, block_hash, block_height, block_time, 
-		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry, 
+	SelectFullTxsByHash = `SELECT id, block_hash, block_height, block_time,
+		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry,
 		size, spent, sent, fees, num_vin, vin_db_ids, num_vout, vout_db_ids,
 		is_valid, is_mainchain
 		FROM transactions WHERE tx_hash = $1
@@ -142,15 +142,15 @@ const (
 		ORDER BY is_valid DESC, is_mainchain DESC, block_height DESC;`
 
 	UpdateRegularTxnsValidMainchainByBlock = `UPDATE transactions
-		SET is_valid=$1, is_mainchain=$2 
+		SET is_valid=$1, is_mainchain=$2
 		WHERE block_hash=$3 and tree=0;`
 
 	UpdateRegularTxnsValidByBlock = `UPDATE transactions
-		SET is_valid=$1 
+		SET is_valid=$1
 		WHERE block_hash=$2 and tree=0;`
 
 	UpdateTxnsMainchainByBlock = `UPDATE transactions
-		SET is_mainchain=$1 
+		SET is_mainchain=$1
 		WHERE block_hash=$2
 		RETURNING id;`
 
@@ -184,6 +184,8 @@ const (
 		FROM transactions JOIN tickets
 		ON transactions.id=purchase_tx_db_id WHERE pool_status=0
 		AND tickets.is_mainchain = TRUE GROUP BY ticket_bucket;`
+
+	SelectTxnByDbID = `SELECT block_hash, block_height, tx_hash FROM transactions WHERE id = $1;`
 
 	//SelectTxByPrevOut = `SELECT * FROM transactions WHERE vins @> json_build_array(json_build_object('prevtxhash',$1)::jsonb)::jsonb;`
 	//SelectTxByPrevOut = `SELECT * FROM transactions WHERE vins #>> '{"prevtxhash"}' = '$1';`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1293,8 +1293,8 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 }
 
 // GetTicketInfo retrieves information about the pool and spend statuses, the
-// purchase block, the lottery block, and the spending transaction. 
-func (pgb *ChainDB) GetTicketInfo(txid string) (*dbtypes.TicketInfo, error) {
+// purchase block, the lottery block, and the spending transaction.
+func (pgb *ChainDB) GetTicketInfo(txid string) (*apitypes.TicketInfo, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	spendStatus, poolStatus, purchaseBlock, lotteryBlock, spendTxid, err := RetrieveTicketInfoByHash(ctx, pgb.db, txid)
@@ -1322,13 +1322,13 @@ func (pgb *ChainDB) GetTicketInfo(txid string) (*dbtypes.TicketInfo, error) {
 		if err != nil {
 			return nil, pgb.replaceCancelError(err)
 		}
-		lotteryBlock = &dbtypes.TinyBlock{
+		lotteryBlock = &apitypes.TinyBlock{
 			Hash:   hash,
 			Height: uint32(height),
 		}
 	}
 
-	return &dbtypes.TicketInfo{
+	return &apitypes.TicketInfo{
 		Status:           status,
 		PurchaseBlock:    purchaseBlock,
 		MaturityHeight:   maturity,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1292,6 +1292,53 @@ func (pgb *ChainDB) ticketPoolVisualization(interval dbtypes.TimeBasedGrouping) 
 	return
 }
 
+// GetTicketInfo retrieves information about the pool and spend statuses, the
+// purchase block, the lottery block, and the spending transaction. 
+func (pgb *ChainDB) GetTicketInfo(txid string) (*dbtypes.TicketInfo, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	spendStatus, poolStatus, purchaseBlock, lotteryBlock, spendTxid, err := RetrieveTicketInfoByHash(ctx, pgb.db, txid)
+
+	if err != nil {
+		return nil, pgb.replaceCancelError(err)
+	}
+
+	var vote, revocation *string
+	status := strings.ToLower(poolStatus.String())
+	maturity := purchaseBlock.Height + uint32(pgb.chainParams.TicketMaturity)
+	expiration := maturity + pgb.chainParams.TicketExpiry
+	if pgb.Height() < int64(maturity) {
+		status = "immature"
+	}
+	if spendStatus == dbtypes.TicketRevoked {
+		status = spendStatus.String()
+		revocation = &spendTxid
+	} else if spendStatus == dbtypes.TicketVoted {
+		vote = &spendTxid
+	}
+
+	if poolStatus == dbtypes.PoolStatusMissed {
+		hash, height, err := RetrieveMissForTicket(ctx, pgb.db, txid)
+		if err != nil {
+			return nil, pgb.replaceCancelError(err)
+		}
+		lotteryBlock = &dbtypes.TinyBlock{
+			Hash:   hash,
+			Height: uint32(height),
+		}
+	}
+
+	return &dbtypes.TicketInfo{
+		Status:           status,
+		PurchaseBlock:    purchaseBlock,
+		MaturityHeight:   maturity,
+		ExpirationHeight: expiration,
+		LotteryBlock:     lotteryBlock,
+		Vote:             vote,
+		Revocation:       revocation,
+	}, nil
+}
+
 func (pgb *ChainDB) updateProjectFundCache() error {
 	_, _, err := pgb.AddressHistoryAll(pgb.devAddress, 1, 0)
 	return err

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -889,7 +889,7 @@ func RetrieveTicketStatusByHash(ctx context.Context, db *sql.DB, ticketHash stri
 // RetrieveTicketInfoByHash retrieves the ticket spend and pool statuses as well
 // as the purchase and spending block info and spending txid.
 func RetrieveTicketInfoByHash(ctx context.Context, db *sql.DB, ticketHash string) (spendStatus dbtypes.TicketSpendType,
-	poolStatus dbtypes.TicketPoolStatus, purchaseBlock, lotteryBlock *dbtypes.TinyBlock, spendTxid string, err error) {
+	poolStatus dbtypes.TicketPoolStatus, purchaseBlock, lotteryBlock *apitypes.TinyBlock, spendTxid string, err error) {
 	var dbid sql.NullInt64
 	var purchaseHash, spendHash string
 	var purchaseHeight, spendHeight uint32
@@ -899,7 +899,7 @@ func RetrieveTicketInfoByHash(ctx context.Context, db *sql.DB, ticketHash string
 		return
 	}
 
-	purchaseBlock = &dbtypes.TinyBlock{
+	purchaseBlock = &apitypes.TinyBlock{
 		Hash:   purchaseHash,
 		Height: purchaseHeight,
 	}
@@ -921,7 +921,7 @@ func RetrieveTicketInfoByHash(ctx context.Context, db *sql.DB, ticketHash string
 	}
 
 	if spendStatus == dbtypes.TicketVoted {
-		lotteryBlock = &dbtypes.TinyBlock{
+		lotteryBlock = &apitypes.TinyBlock{
 			Hash:   spendHash,
 			Height: spendHeight,
 		}


### PR DESCRIPTION
Adds the /tx/{txid}/tinfo endpoint, which responds with ticket status, purchase and lottery blocks, and spending txid.

Some endpoints for testing

- immature: /api/tx/10659139fc3a4ef2e00d8539180a761b1c2d1b823645ecff5c8ffba0dc909403/tinfo?indent=1
- live: /api/tx/07f0daf8be13be8e995931afb98b725d8ef23529c26749100ef26821e8eb3025/tinfo?indent=1
- missed, not revoked: /api/tx/08b98e68e18ebb82440d07f3dc70cc8c017df1dcb639493e9b7cd356d66174ae/tinfo?indent=1
- missed, revoked: /api/tx/7405d619e673ca4bb4681951828dcf1893e4004973133ff012e30e7c182bf168/tinfo?indent=1
- voted: /api/tx/5ba836dec32969110487f857be9a59ca98898860c84f66d5497e211f525e66e4/tinfo?indent=1
- expired, not revoked: /api/tx/0974112f3f7a41b2bafbbd4c0c7bd61b9db6f9838721d82e9bc59c42e40f6da6/tinfo?indent=1

Resolves #1024