### PR TITLE
use replace statements

### DIFF
--- a/api/types/go.mod
+++ b/api/types/go.mod
@@ -2,5 +2,6 @@ module github.com/decred/dcrdata/api/types
 
 go 1.11
 
-require github.com/decred/dcrdata v4.0.0-rc3
+require github.com/decred/dcrdata/v4 v4.0.0-rc4
 
+replace github.com/decred/dcrdata/v4 => ../..

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
 	github.com/decred/dcrd/txscript v1.0.2
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/decred/dcrdata/api/types v1.0.1
+	github.com/decred/dcrdata/api/types v1.0.2
 	github.com/decred/dcrwallet/wallet v1.2.0
 	github.com/decred/politeia v0.0.0-20190325135210-6d7b23a66d77
 	github.com/decred/slog v1.0.0
@@ -55,3 +55,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190219182410-082222b4a5c5 // indirect
 	google.golang.org/grpc v1.18.0
 )
+
+replace github.com/decred/dcrdata/api/types => ./api/types


### PR DESCRIPTION
This adds replace statements to the main go.mod and api/types/go.mod to the local code can be used.

This also changes api/types to require v4.0.0-rc4, and dcrdata to require api/types/v1.0.2