### PR TITLE
api/types: add (*TimeAPI).UnmarshalJSON and ctors

### DIFF
--- a/api/types/apitypes_test.go
+++ b/api/types/apitypes_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -86,4 +87,107 @@ func TestIsNullDataScript(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTimeAPI_MarshalJSON ensures that (*TimeAPI).MarshalJSON returns a UNIX
+// time stamp as a JSON integer, not a quoted string.
+func TestTimeAPI_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		testName string
+		timeAPI  TimeAPI
+		want     []byte
+		wantErr  bool
+	}{
+		{
+			testName: "ok",
+			timeAPI:  NewTimeAPIFromUNIX(1454954400),
+			want:     []byte(`1454954400`),
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			got, err := tt.timeAPI.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TimeAPI.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TimeAPI.MarshalJSON() = %v, want %v", string(got), string(tt.want))
+			}
+		})
+	}
+
+}
+
+// TestTimeAPI_UnmarshalJSON ensures that (*TimeAPI).UnmarshalJSON works with a
+// JSON integer value, not a quoted string.
+func TestTimeAPI_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		testName string
+		data     []byte
+		wantErr  bool
+	}{
+		{
+			testName: "ok",
+			data:     []byte(`1454954400`), // Correct text has no quotes
+			wantErr:  false,
+		},
+		{
+			testName: "bad",
+			data:     []byte(`"1454954400"`), // Text with quotes is a JSON string, not an integer
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			var td TimeAPI
+			if err := td.UnmarshalJSON(tt.data); (err != nil) != tt.wantErr {
+				t.Errorf("TimeAPI.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			t.Logf("UNIX: %d, formatted: %s", td.UNIX(), td)
+		})
+	}
+}
+
+// TestTimeAPI_MarshalUnmarshalJSON ensures a round trip marshal-unmarshal is
+// successful.
+func TestTimeAPI_MarshalUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		testName string
+		timeAPI  TimeAPI
+		want     []byte
+		wantErr  bool
+	}{
+		{
+			testName: "ok",
+			timeAPI:  NewTimeAPIFromUNIX(1454954400),
+			want:     []byte(`1454954400`),
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			// Marshal TimeAPI.
+			got, err := tt.timeAPI.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TimeAPI.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TimeAPI.MarshalJSON() = %v, want %v", string(got), string(tt.want))
+			}
+
+			// Unmarshal the result.
+			var td TimeAPI
+			if err = td.UnmarshalJSON(got); err != nil {
+				t.Errorf("TimeAPI.UnmarshalJSON() failed: %v", err)
+			}
+			// Ensure the round trip was successful.
+			if !reflect.DeepEqual(td, tt.timeAPI) {
+				t.Errorf("TimeAPI.UnmarshalJSON() = %v, want %v", td, tt.timeAPI)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
This adds `(*TimeAPI).UnmarshalJSON`. The required input must be a JSON
integer (not a string, with quotes), as provided by
`(*TimeAPI).MarshalJSON`.
Tests are added to ensure the proper marshal and unmarshal behavior.

Constructors `NewTimeAPI` and `NewTimeAPIFromUNIX` are added.

A `(TimeAPI).UNIX` method is also added.