### PR TITLE
db/dbtypes v1.0.0

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -28,7 +28,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer"
 	"github.com/decred/dcrdata/v4/gov/agendas"

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg"
 	m "github.com/decred/dcrdata/v4/middleware"
 	"github.com/decred/dcrdata/v4/semver"

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/dcrjson/v2"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/txhelpers"
 )
 

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -7,7 +7,7 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 // SyncResponse contains sync status information.

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -17,7 +17,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/stakedb"
 )
 

--- a/cmd/scanblocks/scanblocks.go
+++ b/cmd/scanblocks/scanblocks.go
@@ -14,7 +14,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/rpcutils"
 	"github.com/decred/slog"
 )

--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/netparams"
 	"github.com/decred/dcrdata/v4/version"
 	"github.com/decred/slog"

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 const (

--- a/db/dbtypes/go.mod
+++ b/db/dbtypes/go.mod
@@ -1,0 +1,12 @@
+module github.com/decred/dcrdata/db/dbtypes
+
+go 1.11
+
+require (
+	github.com/decred/dcrdata/txhelpers v1.0.0
+	github.com/decred/dcrdata/v4 v4.0.0-rc4
+)
+
+replace github.com/decred/dcrdata/txhelpers => ../../txhelpers
+
+replace github.com/decred/dcrdata/v4 => ../..

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrdata/db/dbtypes/internal"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes/internal"
 )
 
 var (

--- a/db/dbtypes/types_blackbox_test.go
+++ b/db/dbtypes/types_blackbox_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg"
 )
 

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -7,7 +7,7 @@ import (
 	"database/sql"
 	"strings"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 )
 

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -14,7 +14,7 @@ import (
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/v4/db/cache"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/rpcutils"
 )
 

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 const (

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/lib/pq"
 )
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -29,7 +29,7 @@ import (
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/v4/blockdata"
 	"github.com/decred/dcrdata/v4/db/cache"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 	"github.com/decred/dcrdata/v4/rpcutils"
 	"github.com/decred/dcrdata/v4/stakedb"

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/v4/db/cache"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 )
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -23,7 +23,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/lib/pq"

--- a/db/dcrpg/rewind.go
+++ b/db/dcrpg/rewind.go
@@ -43,7 +43,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 )
 

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/rpcutils"
 )
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -8,7 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 	"github.com/decred/dcrdata/v4/semver"
 )

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -16,7 +16,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg/internal"
 	"github.com/decred/dcrdata/v4/rpcutils"
 )

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/mempool"
 	"github.com/decred/dcrdata/v4/rpcutils"

--- a/db/dcrsqlite/blocksretrieval_test.go
+++ b/db/dcrsqlite/blocksretrieval_test.go
@@ -3,7 +3,7 @@ package dcrsqlite
 import (
 	"testing"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/testutil"
 	"github.com/google/go-cmp/cmp"
 )

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/v4/blockdata"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/slog"
 	sqlite3 "github.com/mattn/go-sqlite3" // register sqlite driver with database/sql
 )

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -16,7 +16,7 @@ import (
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/v4/blockdata"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/rpcutils"
 )
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/v4/blockdata"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/gov/agendas"

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/exchanges"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/gov/agendas"

--- a/explorer/syncstatus.go
+++ b/explorer/syncstatus.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 // SyncStatusInfo defines information for a single progress bar.

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	humanize "github.com/dustin/go-humanize"
 )

--- a/explorer/websockethandlers.go
+++ b/explorer/websockethandlers.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	pstypes "github.com/decred/dcrdata/v4/pubsub/types"
 	"golang.org/x/net/websocket"

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/decred/dcrd/txscript v1.0.2
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types v1.0.2
+	github.com/decred/dcrdata/db/dbtypes v1.0.0
 	github.com/decred/dcrdata/txhelpers v1.0.0
 	github.com/decred/dcrwallet/wallet v1.2.0
 	github.com/decred/politeia v0.0.0-20190325135210-6d7b23a66d77
@@ -44,5 +45,7 @@ require (
 )
 
 replace github.com/decred/dcrdata/api/types => ./api/types
+
+replace github.com/decred/dcrdata/db/dbtypes => ./db/dbtypes
 
 replace github.com/decred/dcrdata/txhelpers => ./txhelpers

--- a/gov/agendas/deployments.go
+++ b/gov/agendas/deployments.go
@@ -12,7 +12,7 @@ import (
 	"github.com/asdine/storm"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson/v2"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 // AgendaDB represents the data for the stored DB.

--- a/gov/agendas/deployments_test.go
+++ b/gov/agendas/deployments_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/asdine/storm"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson/v2"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 )
 
 var db *storm.DB

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/decred/dcrdata/v4/api"
 	"github.com/decred/dcrdata/v4/api/insight"
 	"github.com/decred/dcrdata/v4/blockdata"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/db/dcrpg"
 	"github.com/decred/dcrdata/v4/db/dcrsqlite"
 	"github.com/decred/dcrdata/v4/exchanges"

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/decred/dcrd/dcrjson/v2"
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 )
 

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -19,7 +19,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/v4/blockdata"
-	"github.com/decred/dcrdata/v4/db/dbtypes"
+	"github.com/decred/dcrdata/db/dbtypes"
 	"github.com/decred/dcrdata/v4/explorer/types"
 	exptypes "github.com/decred/dcrdata/v4/explorer/types"
 	"github.com/decred/dcrdata/v4/mempool"


### PR DESCRIPTION
New db/dbtypes/go.mod:

```
module github.com/decred/dcrdata/db/dbtypes

go 1.11

require (
	github.com/decred/dcrdata/txhelpers v1.0.0
	github.com/decred/dcrdata/v4 v4.0.0-rc4
)

replace github.com/decred/dcrdata/txhelpers => ../../txhelpers

replace github.com/decred/dcrdata/v4 => ../..
```

Change all v4/db/dbtypes imports in dcrdata.