### PR TITLE
gov:proposals: new proposal votes charts

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -224,6 +224,10 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 		r.Get("/charts", app.getTicketPoolCharts)
 	})
 
+	mux.Route("/proposal", func(r chi.Router) {
+		r.With(m.ProposalTokenCtx).Get("/{token}", app.getProposalChartData)
+	})
+
 	mux.Route("/exchanges", func(r chi.Router) {
 		r.Get("/", app.getExchanges)
 		r.Get("/codes", app.getCurrencyCodes)

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/stakedb"
 	"github.com/decred/slog"
+	"github.com/dmigwi/go-piparser/proposals"
 )
 
 var (
@@ -122,9 +123,19 @@ func mainCore() error {
 		Pass:   cfg.DBPass,
 		DBName: cfg.DBName,
 	}
+
+	log.Infof("Setting up the Politeia's proposals clone repository. Please wait...")
+
+	// repoName and repoOwner are set to empty string so that the defaults can be used.
+	parser, err := proposals.NewParser("", "", cfg.LogDir)
+	if err != nil {
+		return err
+	}
+
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
 	mpChecker := rpcutils.NewMempoolAddressChecker(client, activeChain)
-	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0, mpChecker)
+	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0,
+		mpChecker, parser)
 	if db != nil {
 		defer db.Close()
 	}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1266,6 +1266,13 @@ type ChartsData struct {
 	NetHash     []uint64  `json:"nethash,omitempty"`
 }
 
+// ProposalChartsData defines the data used to plot proposal votes charts.
+type ProposalChartsData struct {
+	Yes  []uint64  `json:"yes,omitempty"`
+	No   []uint64  `json:"no,omitempty"`
+	Time []TimeDef `json:"time,omitempty"`
+}
+
 // ScriptPubKeyData is part of the result of decodescript(ScriptPubKeyHex)
 type ScriptPubKeyData struct {
 	ReqSigs   uint32   `json:"reqSigs"`

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/decred/dcrdata/stakedb v1.0.1
 	github.com/decred/dcrdata/txhelpers v1.0.1
 	github.com/decred/slog v1.0.0
+	github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golang/snappy v0.0.1 // indirect

--- a/db/dcrpg/go.sum
+++ b/db/dcrpg/go.sum
@@ -105,6 +105,8 @@ github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f h1:zpnMq37RjYYJ
 github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec h1:sElGDs3V8VdCxH5tWi0ycWJzteOPLJ3HtItSSKI95PY=
 github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46 h1:7KNcotki/7608UlREIiMt2Hvt1buNquIjc0y502r/Oc=
+github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46/go.mod h1:W32k3EjyoIwHKldGzl4Do26mlHQDtvM8R7nKiKJ81K4=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -300,6 +300,30 @@ func DeindexAgendaVotesTableOnAgendaID(db *sql.DB) (err error) {
 	return
 }
 
+// proposals table indexes
+
+func IndexProposalsTableOnToken(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexProposalsTableOnToken)
+	return
+}
+
+func DeindexProposalsTableOnToken(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexProposalsTableOnToken)
+	return
+}
+
+// proposal votes table indexes
+
+func IndexProposalVotesTableOnProposalsID(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexProposalVotesTableOnProposalsID)
+	return
+}
+
+func DeindexProposalVotesTableOnProposalsID(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexProposalVotesTableOnProposalsID)
+	return
+}
+
 // Delete duplicates
 
 func (pgb *ChainDB) DeleteDuplicateVins() (int64, error) {
@@ -417,8 +441,14 @@ func (pgb *ChainDB) DeindexAll() error {
 		// agendas table
 		{DeindexAgendasTableOnAgendaID},
 
-		// agenda votes
+		// agenda votes table
 		{DeindexAgendaVotesTableOnAgendaID},
+
+		// proposals table
+		{DeindexProposalsTableOnToken},
+
+		// proposal votes table
+		{DeindexProposalVotesTableOnProposalsID},
 	}
 
 	var err error
@@ -480,7 +510,11 @@ func (pgb *ChainDB) IndexAll(barLoad chan *dbtypes.ProgressBarLoad) error {
 		{Msg: "addresses table on matching tx hash", IndexFunc: IndexMatchingTxHashOnTableAddress},
 		{Msg: "addresses table on block time", IndexFunc: IndexBlockTimeOnTableAddress},
 
-		// See IndexTicketsTable to create the tickets table indexes.
+		// proposals table
+		{Msg: "proposals table on Token+Time", IndexFunc: IndexProposalsTableOnToken},
+
+		// Proposals votes table
+		{Msg: "Proposals votes table on Proposals ID", IndexFunc: IndexProposalVotesTableOnProposalsID},
 	}
 
 	for _, val := range allIndexes {

--- a/db/dcrpg/internal/indexes.go
+++ b/db/dcrpg/internal/indexes.go
@@ -2,21 +2,26 @@ package internal
 
 const (
 	// blocks table
+
 	IndexOfBlocksTableOnHash   = "uix_block_hash"
 	IndexOfBlocksTableOnHeight = "uix_block_height"
 
 	// transactions table
+
 	IndexOfTransactionsTableOnHashes   = "uix_tx_hashes"
 	IndexOfTransactionsTableOnBlockInd = "uix_tx_block_in"
 
 	// vins table
+
 	IndexOfVinsTableOnVin     = "uix_vin"
 	IndexOfVinsTableOnPrevOut = "uix_vin_prevout"
 
 	// vouts table
+
 	IndexOfVoutsTableOnTxHashInd = "uix_vout_txhash_ind"
 
 	// addresses table
+
 	IndexOfAddressTableOnAddress    = "uix_addresses_address"
 	IndexOfAddressTableOnVoutID     = "uix_addresses_vout_id"
 	IndexOfAddressTableOnBlockTime  = "block_time_index"
@@ -24,11 +29,13 @@ const (
 	IndexOfAddressTableOnMatchingTx = "matching_tx_hash_index"
 
 	// tickets table
+
 	IndexOfTicketsTableOnHashes     = "uix_ticket_hashes_index"
 	IndexOfTicketsTableOnTxRowID    = "uix_ticket_ticket_db_id"
 	IndexOfTicketsTableOnPoolStatus = "uix_tickets_pool_status"
 
 	// votes table
+
 	IndexOfVotesTableOnHashes    = "uix_votes_hashes_index"
 	IndexOfVotesTableOnBlockHash = "uix_votes_block_hash"
 	IndexOfVotesTableOnCandBlock = "uix_votes_candidate_block"
@@ -37,13 +44,24 @@ const (
 	IndexOfVotesTableOnBlockTime = "uix_votes_block_time"
 
 	// misses table
+
 	IndexOfMissesTableOnHashes = "uix_misses_hashes_index"
 
 	// agendas table
+
 	IndexOfAgendasTableOnName = "uix_agendas_name"
 
 	// agenda_votes table
+
 	IndexOfAgendaVotesTableOnRowIDs = "uix_agenda_votes"
+
+	// proposals table
+
+	IndexOfProposalsTableOnToken = "uix_proposals"
+
+	// proposal votes table
+
+	IndexOfProposalVotesTableOnProposalsID = "uix_proposal_votes"
 )
 
 // AddressesIndexNames are the names of the indexes on the addresses table.
@@ -53,28 +71,30 @@ var AddressesIndexNames = []string{IndexOfAddressTableOnAddress,
 
 // IndexDescriptions relate table index names to descriptions of the indexes.
 var IndexDescriptions = map[string]string{
-	IndexOfBlocksTableOnHash:           "blocks on hash",
-	IndexOfBlocksTableOnHeight:         "blocks on height",
-	IndexOfTransactionsTableOnHashes:   "transactions on block hash and transaction hash",
-	IndexOfTransactionsTableOnBlockInd: "transactions on block hash and block index",
-	IndexOfVinsTableOnVin:              "vins on transaction hash and index",
-	IndexOfVinsTableOnPrevOut:          "vins on previous outpoint",
-	IndexOfVoutsTableOnTxHashInd:       "vouts on transaction hash and index",
-	IndexOfAddressTableOnAddress:       "addresses table on address",
-	IndexOfAddressTableOnVoutID:        "addresses table on vout row id, address, and is_funding",
-	IndexOfAddressTableOnBlockTime:     "addresses table on block time",
-	IndexOfAddressTableOnTx:            "addresses table on transaction hash",
-	IndexOfAddressTableOnMatchingTx:    "addresses table on matching tx hash",
-	IndexOfTicketsTableOnHashes:        "tickets table on block hash and transaction hash",
-	IndexOfTicketsTableOnTxRowID:       "tickets table on transactions table row ID",
-	IndexOfTicketsTableOnPoolStatus:    "tickets table on pool status",
-	IndexOfVotesTableOnHashes:          "votes table on block hash and transaction hash",
-	IndexOfVotesTableOnBlockHash:       "votes table on block hash",
-	IndexOfVotesTableOnCandBlock:       "votes table on candidate block",
-	IndexOfVotesTableOnVersion:         "votes table on vote version",
-	IndexOfVotesTableOnHeight:          "votes table on height",
-	IndexOfVotesTableOnBlockTime:       "votes table on block time",
-	IndexOfMissesTableOnHashes:         "misses on ticket hash and block hash",
-	IndexOfAgendasTableOnName:          "agendas on agenda name",
-	IndexOfAgendaVotesTableOnRowIDs:    "agenda_votes on votes table row ID and agendas table row ID",
+	IndexOfBlocksTableOnHash:               "blocks on hash",
+	IndexOfBlocksTableOnHeight:             "blocks on height",
+	IndexOfTransactionsTableOnHashes:       "transactions on block hash and transaction hash",
+	IndexOfTransactionsTableOnBlockInd:     "transactions on block hash and block index",
+	IndexOfVinsTableOnVin:                  "vins on transaction hash and index",
+	IndexOfVinsTableOnPrevOut:              "vins on previous outpoint",
+	IndexOfVoutsTableOnTxHashInd:           "vouts on transaction hash and index",
+	IndexOfAddressTableOnAddress:           "addresses table on address",
+	IndexOfAddressTableOnVoutID:            "addresses table on vout row id, address, and is_funding",
+	IndexOfAddressTableOnBlockTime:         "addresses table on block time",
+	IndexOfAddressTableOnTx:                "addresses table on transaction hash",
+	IndexOfAddressTableOnMatchingTx:        "addresses table on matching tx hash",
+	IndexOfTicketsTableOnHashes:            "tickets table on block hash and transaction hash",
+	IndexOfTicketsTableOnTxRowID:           "tickets table on transactions table row ID",
+	IndexOfTicketsTableOnPoolStatus:        "tickets table on pool status",
+	IndexOfVotesTableOnHashes:              "votes table on block hash and transaction hash",
+	IndexOfVotesTableOnBlockHash:           "votes table on block hash",
+	IndexOfVotesTableOnCandBlock:           "votes table on candidate block",
+	IndexOfVotesTableOnVersion:             "votes table on vote version",
+	IndexOfVotesTableOnHeight:              "votes table on height",
+	IndexOfVotesTableOnBlockTime:           "votes table on block time",
+	IndexOfMissesTableOnHashes:             "misses on ticket hash and block hash",
+	IndexOfAgendasTableOnName:              "agendas on agenda name",
+	IndexOfAgendaVotesTableOnRowIDs:        "agenda_votes on votes table row ID and agendas table row ID",
+	IndexOfProposalsTableOnToken:           "proposals on token and time",
+	IndexOfProposalVotesTableOnProposalsID: "proposal_votes on proposals row ID",
 }

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -439,6 +439,74 @@ const (
 		INNER JOIN votes ON agenda_votes.votes_row_id = votes.id
 		WHERE agenda_votes.agendas_row_id = (SELECT id from agendas WHERE name = $4)
 		AND votes.height >= $5 AND votes.height <= $6 `
+
+	// Proposals Table
+
+	CreateProposalsTable = `CREATE TABLE IF NOT EXISTS proposals (
+		id SERIAL PRIMARY KEY,
+		token TEXT NOT NULL,
+		author TEXT,
+		commit_sha TEXT NOT NULL,
+		time TIMESTAMPTZ
+	);`
+
+	// Insert
+
+	insertProposalsRow = `INSERT INTO proposals (token, author, commit_sha, time)
+		VALUES ($1, $2, $3, $4) `
+
+	InsertProposalsRow = insertProposalsRow + `RETURNING id;`
+
+	UpsertProposalsRow = insertProposalsRow + `ON CONFLICT (token, time)
+		DO UPDATE SET commit_sha = $3, time = $4  RETURNING id;`
+
+	// Index
+
+	IndexProposalsTableOnToken = `CREATE UNIQUE INDEX ` + IndexOfProposalsTableOnToken +
+		` ON proposals(token, time);`
+
+	DeindexProposalsTableOnToken = `DROP INDEX ` + IndexOfProposalsTableOnToken + `;`
+
+	// Select
+
+	SelectProposalsLastCommitTime = `Select time
+		FROM proposals
+		ORDER BY time DESC
+		LIMIT 1;`
+
+	// Proposal Votes table
+
+	CreateProposalVotesTable = `CREATE TABLE IF NOT EXISTS proposal_votes (
+		id SERIAL PRIMARY KEY,
+		proposals_row_id INT8,
+		ticket TEXT NOT NULL,
+		choice TEXT NOT NULL
+	);`
+
+	// Insert
+
+	insertProposalVotesRow = `INSERT INTO proposal_votes (proposals_row_id, ticket, choice)
+		VALUES ($1, $2, $3) `
+
+	InsertProposalVotesRow = insertProposalVotesRow + `RETURNING id;`
+
+	// Index
+
+	IndexProposalVotesTableOnProposalsID = `CREATE INDEX ` + IndexOfProposalVotesTableOnProposalsID +
+		` ON proposal_votes(proposals_row_id);`
+
+	DeindexProposalVotesTableOnProposalsID = `DROP INDEX ` + IndexOfProposalVotesTableOnProposalsID + `;`
+
+	// Select
+
+	SelectProposalVotesChartData = `SELECT proposals.time,
+		COUNT(CASE WHEN proposal_votes.choice = 'No' THEN 1 ElSE NULL END) as no,
+		COUNT(CASE WHEN proposal_votes.choice = 'Yes' THEN 1 ElSE NULL END) as yes
+		FROM proposal_votes
+		INNER JOIN proposals on proposals.id = proposal_votes.proposals_row_id
+		WHERE proposals.token = $1
+		GROUP BY proposals.time
+		ORDER BY proposals.time;`
 )
 
 // MakeTicketInsertStatement returns the appropriate tickets insert statement
@@ -504,6 +572,16 @@ func MakeAgendaVotesInsertStatement(checked bool) string {
 		return UpsertAgendaVotesRow
 	}
 	return InsertAgendaVotesRow
+}
+
+// MakeProposalsInsertStatement returns the appropriate proposals insert statement for
+// the desired conflict checking and handling behavior. See the description of
+// MakeTicketInsertStatement for details.
+func MakeProposalsInsertStatement(checked bool) string {
+	if checked {
+		return UpsertProposalsRow
+	}
+	return InsertProposalsRow
 }
 
 // MakeSelectTicketsByPurchaseDate returns the selectTicketsByPurchaseDate query

--- a/db/dcrpg/pgblockchain_charts_test.go
+++ b/db/dcrpg/pgblockchain_charts_test.go
@@ -9,16 +9,32 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrdata/db/dbtypes"
 	tc "github.com/decred/dcrdata/v4/testutil/dbload/testsconfig"
+	pitypes "github.com/dmigwi/go-piparser/proposals/types"
 )
 
 var (
 	db           *ChainDB
 	addrCacheCap int = 1e4
 )
+
+type parserInstance struct{}
+
+func (p *parserInstance) UpdateSignal() <-chan struct{} {
+	return make(chan struct{})
+}
+
+func (p *parserInstance) ProposalsHistory() ([]*pitypes.History, error) {
+	return []*pitypes.History{}, nil
+}
+
+func (p *parserInstance) ProposalsHistorySince(since time.Time) ([]*pitypes.History, error) {
+	return []*pitypes.History{}, nil
+}
 
 func openDB() (func() error, error) {
 	dbi := DBInfo{
@@ -29,7 +45,8 @@ func openDB() (func() error, error) {
 		DBName: tc.PGChartsTestsDBName,
 	}
 	var err error
-	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true, true, addrCacheCap)
+	db, err = NewChainDB(&dbi, &chaincfg.MainNetParams, nil, true, true, addrCacheCap,
+		nil, new(parserInstance))
 	cleanUp := func() error { return nil }
 	if db != nil {
 		cleanUp = db.Close

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -14,18 +14,20 @@ import (
 )
 
 var createTableStatements = map[string]string{
-	"blocks":       internal.CreateBlockTable,
-	"transactions": internal.CreateTransactionTable,
-	"vins":         internal.CreateVinTable,
-	"vouts":        internal.CreateVoutTable,
-	"block_chain":  internal.CreateBlockPrevNextTable,
-	"addresses":    internal.CreateAddressTable,
-	"tickets":      internal.CreateTicketsTable,
-	"votes":        internal.CreateVotesTable,
-	"misses":       internal.CreateMissesTable,
-	"agendas":      internal.CreateAgendasTable,
-	"agenda_votes": internal.CreateAgendaVotesTable,
-	"testing":      internal.CreateTestingTable,
+	"blocks":         internal.CreateBlockTable,
+	"transactions":   internal.CreateTransactionTable,
+	"vins":           internal.CreateVinTable,
+	"vouts":          internal.CreateVoutTable,
+	"block_chain":    internal.CreateBlockPrevNextTable,
+	"addresses":      internal.CreateAddressTable,
+	"tickets":        internal.CreateTicketsTable,
+	"votes":          internal.CreateVotesTable,
+	"misses":         internal.CreateMissesTable,
+	"agendas":        internal.CreateAgendasTable,
+	"agenda_votes":   internal.CreateAgendaVotesTable,
+	"testing":        internal.CreateTestingTable,
+	"proposals":      internal.CreateProposalsTable,
+	"proposal_votes": internal.CreateProposalVotesTable,
 }
 
 var createTypeStatements = map[string]string{
@@ -49,24 +51,26 @@ type dropDuplicatesInfo struct {
 // re-indexing and a duplicate scan/purge.
 const (
 	tableMajor = 3
-	tableMinor = 10
+	tableMinor = 11
 	tablePatch = 0
 )
 
 // TODO eliminiate this map since we're actually versioning each table the same.
 var requiredVersions = map[string]TableVersion{
-	"blocks":       NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"transactions": NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"vins":         NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"vouts":        NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"block_chain":  NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"addresses":    NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"tickets":      NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"votes":        NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"misses":       NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"agendas":      NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"agenda_votes": NewTableVersion(tableMajor, tableMinor, tablePatch),
-	"testing":      NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"blocks":         NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"transactions":   NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"vins":           NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"vouts":          NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"block_chain":    NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"addresses":      NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"tickets":        NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"votes":          NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"misses":         NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"agendas":        NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"agenda_votes":   NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"testing":        NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"proposals":      NewTableVersion(tableMajor, tableMinor, tablePatch),
+	"proposal_votes": NewTableVersion(tableMajor, tableMinor, tablePatch),
 }
 
 // TableVersion models a table version by major.minor.patch

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/decred/slog v1.0.0
 	github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible
 	github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d
+	github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-chi/chi v4.0.3-0.20190316151245-d08916613452+incompatible
 	github.com/google/gops v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible h1:
 github.com/didip/tollbooth v4.0.1-0.20180415195142-b10a036da5f0+incompatible/go.mod h1:A9b0665CE6l1KmzpDws2++elm/CsuWBMa5Jv4WY0PEY=
 github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d h1:vs5Nf6IE0N/PwGJ8//zRed4gpCdcr99K2HzX7RuLOQ8=
 github.com/didip/tollbooth_chi v0.0.0-20170928041846-6ab5f3083f3d/go.mod h1:YWyIfq3y4ArRfWZ9XksmuusP+7Mad+T0iFZ0kv0XG/M=
+github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46 h1:7KNcotki/7608UlREIiMt2Hvt1buNquIjc0y502r/Oc=
+github.com/dmigwi/go-piparser/proposals v0.0.0-20190411222856-0732954b2d46/go.mod h1:W32k3EjyoIwHKldGzl4Do26mlHQDtvM8R7nKiKJ81K4=
 github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -224,7 +224,7 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 	// Add the sum of the newly added proposals.
 	numRecords += n
 
-	log.Infof("%d proposal records (politeia proposals) were updated", numRecords)
+	log.Infof("%d proposal records (politeia proposals-storm) were updated", numRecords)
 
 	return nil
 }
@@ -255,7 +255,6 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 			q.Eq("VoteStatus", statuses[2]),
 		),
 	).Find(&inProgress)
-
 	// Return an error only if the said error is not 'not found' error.
 	if err != nil && err != storm.ErrNotFound {
 		return 0, err

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -51,6 +51,7 @@ const (
 	ctxChartGrouping
 	ctxTp
 	ctxAgendaId
+	ctxProposalToken
 	ctxXcToken
 	ctxStickWidth
 )
@@ -143,6 +144,17 @@ func GetTpCtx(r *http.Request) string {
 	tp, ok := r.Context().Value(ctxTp).(string)
 	if !ok {
 		apiLog.Trace("ticket pool interval not set")
+		return ""
+	}
+	return tp
+}
+
+// GetProposalTokenCtx retrieves the ctxProposalToken data from the request context.
+// If the value is not set, an empty string is returned.
+func GetProposalTokenCtx(r *http.Request) string {
+	tp, ok := r.Context().Value(ctxProposalToken).(string)
+	if !ok {
+		apiLog.Trace("proposal token hash not set")
 		return ""
 	}
 	return tp
@@ -535,6 +547,16 @@ func TicketPoolCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tp := chi.URLParam(r, "tp")
 		ctx := context.WithValue(r.Context(), ctxTp, tp)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ProposalTokenCtx returns a http.HandlerFunc that embeds the value at the url
+// part {token} into the request context
+func ProposalTokenCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := chi.URLParam(r, "token")
+		ctx := context.WithValue(r.Context(), ctxProposalToken, token)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/public/js/controllers/proposal_controller.js
+++ b/public/js/controllers/proposal_controller.js
@@ -1,78 +1,180 @@
 import { Controller } from 'stimulus'
 import { getDefault } from '../helpers/module_helper'
+import { multiColumnBarPlotter, synchronize } from '../helpers/chart_helper'
+import dompurify from 'dompurify'
+import axios from 'axios'
 
+let common = {
+  labelsKMB: true,
+  legend: 'always',
+  fillGraph: true,
+  strokeWidth: 2,
+  labelsUTC: true,
+  gridLineColor: '#C4CBD2',
+  legendFormatter: legendFormatter
+}
+
+let percentConfig = {
+  ...common,
+  labels: ['Date', 'Percent Yes'],
+  ylabel: 'Approval (%)',
+  colors: ['#2971FF'],
+  labelsSeparateLines: true,
+  labelsDiv: 'percent-of-votes-legend',
+  underlayCallback: function (context, area, g) {
+    let xVals = g.xAxisExtremes()
+    let xl = g.toDomCoords(xVals[0], 60)
+    let xr = g.toDomCoords(xVals[1], 60)
+
+    context.beginPath()
+    context.strokeStyle = '#ED6D47'
+    context.moveTo(xl[0], xl[1])
+    context.lineTo(xr[0], xr[1])
+    context.fillStyle = '#ED6D47'
+    context.fillText('60% Approval', xl[0] + 20, xl[1] + 10)
+    context.closePath()
+    context.stroke()
+  }
+}
+
+let cumulativeConfig = {
+  ...common,
+  labels: ['Date', 'Total Votes'],
+  ylabel: 'Vote Count',
+  colors: ['#2971FF'],
+  labelsDiv: 'cumulative-legend',
+  underlayCallback: function (context, area, g) {
+    let xVals = g.xAxisExtremes()
+    let xl = g.toDomCoords(xVals[0], 8269)
+    let xr = g.toDomCoords(xVals[1], 8269)
+
+    context.beginPath()
+    context.strokeStyle = '#ED6D47'
+    context.moveTo(xl[0], xl[1])
+    context.lineTo(xr[0], xr[1])
+    context.fillStyle = '#ED6D47'
+    context.fillText('20% Quorum', xl[0] + 20, xl[1] + 10)
+    context.closePath()
+    context.stroke()
+  }
+}
+
+function legendFormatter (data) {
+  let html
+  if (data.x == null) {
+    html = data.series.map(function (series) {
+      return series.dashHTML + ' <span style="color:' +
+        series.color + ';">' + series.labelHTML + ' </span>'
+    }).join('<br>')
+  } else {
+    html = this.getLabels()[0] + ': ' + data.xHTML + ' UTC <br>'
+    data.series.forEach(function (series, index) {
+      if (!series.isVisible) return
+
+      var symbol = ''
+      if (series.labelHTML.includes('Percent')) {
+        series.labelHTML = 'Yes'
+        symbol = '%'
+      } else if (index === 0) {
+        html = ''
+      } else {
+        html += ' <br> '
+      }
+
+      var labeledData = '<span style="color:' + series.color + ';">' +
+        series.labelHTML + ' </span> : ' + Math.abs(series.y)
+      html += series.dashHTML + ' ' + labeledData + '' + symbol
+    })
+  }
+  dompurify.sanitize(html)
+  return html
+}
+
+var hourlyVotesConfig = {
+  ...common,
+  plotter: multiColumnBarPlotter,
+  showRangeSelector: true,
+  labels: ['Date', 'Yes', 'No'],
+  ylabel: 'Votes Per Hour',
+  xlabel: 'Date',
+  colors: ['#2DD8A3', '#ED6D47'],
+  labelsDiv: 'votes-by-time-legend',
+  fillColors: ['rgb(150,235,209)', 'rgb(246,182,163)']
+}
+
+let gs = []
+let Dygraph
+let chartData = {}
+
+let percentData
+let cumulativeData
+let hourlyVotesData
 export default class extends Controller {
   static get targets () {
-    return ['chartdata']
+    return ['token']
   }
 
   async connect () {
-    this.setChartData()
+    let response = await axios.get('/api/proposal/' + this.tokenTarget.dataset.hash)
+    chartData = response.data
 
-    let Chart = await getDefault(
-      import('../vendor/charts.min.js')
+    Dygraph = await getDefault(
+      import(/* webpackChunkName: "dygraphs" */ '../vendor/dygraphs.min.js')
     )
 
-    this.chart = new Chart(
-      document.getElementById('donutgraph').getContext('2d'), {
-        options: {
-          width: 300,
-          height: 300,
-          responsive: true,
-          animation: { animateScale: true },
-          legend: { position: 'bottom' },
-          title: {
-            display: true,
-            text: 'Proposal Vote Results'
-          },
-          tooltips: {
-            callbacks: {
-              label: (tooltipItem, data) => {
-                var sum = 0
-                var currentValue = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
-                this.graphData.map((u) => { sum += u })
-                return currentValue + ' Votes ( ' + ((currentValue / sum) * 100).toFixed(2) + '% )'
-              }
-            }
-          }
-        },
-        type: 'doughnut',
-        data: {
-          labels: this.graphLabels,
-          datasets: [{
-            data: this.graphData,
-            label: 'Yes',
-            backgroundColor: this.graphColors,
-            borderColor: ['grey', 'grey'],
-            borderWidth: 0.5
-          }]
-        }
-      }
-    )
+    this.setChartsData()
+    this.plotGraph()
   }
 
-  setChartData () {
-    this.graphLabels = []
-    this.graphData = []
-    this.graphColors = []
-
-    this.graphLabels.push(this.chartdataTarget.dataset.firstvotesid)
-    this.graphLabels.push(this.chartdataTarget.dataset.secondvotesid)
-
-    this.graphData.push(parseInt(this.chartdataTarget.dataset.firstvotescount))
-    this.graphData.push(parseInt(this.chartdataTarget.dataset.secondvotescount))
-
-    this.graphColors.push(this.chartColor(this.chartdataTarget.dataset.firstvotesid))
-    this.graphColors.push(this.chartColor(this.chartdataTarget.dataset.secondvotesid))
+  disconnect () {
+    gs.map((chart) => { chart.destroy() })
   }
 
-  chartColor (id) {
-    if (id === 'Yes') {
-      return '#2DD8A3' // green
-    } else if (id === 'No') {
-      return '#ED6D47' // red
-    } else {
-      return '#2970FF' // blue
+  setChartsData () {
+    var total = 0
+    var yes = 0
+
+    percentData = []
+    cumulativeData = []
+    hourlyVotesData = []
+
+    chartData.time.map((n, i) => {
+      let formatedDate = new Date(n)
+      yes += chartData.yes[i]
+      total += (chartData.no[i] + chartData.yes[i])
+
+      let percent = ((yes * 100) / total).toFixed(2)
+
+      percentData.push([formatedDate, parseFloat(percent)])
+      cumulativeData.push([formatedDate, total])
+      hourlyVotesData.push([formatedDate, chartData.yes[i], chartData.no[i] * -1])
+    })
+  }
+
+  plotGraph () {
+    gs = [
+      new Dygraph(
+        document.getElementById('percent-of-votes'),
+        percentData,
+        percentConfig
+      ),
+      new Dygraph(
+        document.getElementById('cumulative'),
+        cumulativeData,
+        cumulativeConfig
+      ),
+      new Dygraph(
+        document.getElementById('votes-by-time'),
+        hourlyVotesData,
+        hourlyVotesConfig
+      )
+    ]
+
+    var options = {
+      zoom: true,
+      selection: true
     }
+
+    synchronize(gs, options)
   }
 }

--- a/public/js/helpers/chart_helper.js
+++ b/public/js/helpers/chart_helper.js
@@ -5,12 +5,15 @@ export function barChartPlotter (e) {
 }
 
 function fitWidth (points) {
-  var minSep = Infinity
+  return Math.floor(2.0 / 3 * findMinSep(points, Infinity))
+}
+
+function findMinSep (points, minSep) {
   for (var i = 1; i < points.length; i++) {
     var sep = points[i].canvasx - points[i - 1].canvasx
     if (sep < minSep) minSep = sep
   }
-  return Math.floor(2.0 / 3 * minSep)
+  return minSep
 }
 
 export function sizedBarPlotter (binSize) {
@@ -34,6 +37,35 @@ function plotChart (e, barWidth) {
   })
 }
 
+export function multiColumnBarPlotter (e) {
+  if (e.seriesIndex !== 0) return
+
+  var g = e.dygraph
+  var ctx = e.drawingContext
+  var sets = e.allSeriesPoints
+  var yBottom = e.dygraph.toDomYCoord(0)
+
+  var minSep = Infinity
+  sets.map((bar) => { minSep = findMinSep(bar, minSep) })
+  var barWidth = Math.floor(2.0 / 3 * minSep)
+  var strokeColors = g.getColors()
+  var fillColors = g.getOption('fillColors')
+
+  sets.map((bar, i) => {
+    ctx.fillStyle = fillColors[i]
+    ctx.strokeStyle = strokeColors[i]
+
+    bar.map((p) => {
+      var xLeft = p.canvasx - (barWidth / 2) * (1 - i / (sets.length - 1))
+      var height = yBottom - p.canvasy
+      var width = barWidth / sets.length
+
+      ctx.fillRect(xLeft, p.canvasy, width, height)
+      ctx.strokeRect(xLeft, p.canvasy, width, height)
+    })
+  })
+}
+
 export function padPoints (pts, binSize, sustain) {
   var pad = binSize / 2.0
   var lastPt = pts[pts.length - 1]
@@ -52,4 +84,140 @@ export function padPoints (pts, binSize, sustain) {
   }
   pts.unshift(front)
   pts.push(back)
+}
+
+function isEqual (a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false
+  var i = a.length
+  if (i !== b.length) return false
+  while (i--) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function minViewValueRange (chartIndex) {
+  if (chartIndex === 0) {
+    return 70
+  } else if (chartIndex === 1) {
+    return 8400
+  }
+  return 0
+}
+
+function attachZoomHandlers (gs, prevCallbacks) {
+  var block = false
+  gs.map((g) => {
+    g.updateOptions({
+      drawCallback: function (me, initial) {
+        if (block || initial) return
+        block = true
+        var opts = { dateWindow: me.xAxisRange() }
+
+        gs.map((gCopy, j) => {
+          if (gCopy === me) {
+            if (prevCallbacks[j] && prevCallbacks[j].drawCallback) {
+              prevCallbacks[j].drawCallback.apply(this, arguments)
+            }
+            return
+          }
+
+          if (isEqual(opts.dateWindow, gCopy.getOption('dateWindow'))) {
+            return
+          }
+
+          var yMinRange = minViewValueRange(j)
+          if (yMinRange > 0) {
+            var yRange = gCopy.yAxisRange()
+            if (yRange && yMinRange > yRange[1]) {
+              opts.valueRange = [yRange[0], yMinRange]
+            } else if (yRange && yMinRange < yRange[1]) {
+              opts.valueRange = yRange
+            }
+          }
+
+          gCopy.updateOptions(opts)
+
+          delete opts.valueRange
+        })
+        block = false
+      }
+    }, true)
+  })
+}
+
+function attachSelectionHandlers (gs, prevCallbacks) {
+  var block = false
+  gs.map((g) => {
+    g.updateOptions({
+      highlightCallback: function (event, x, points, row, seriesName) {
+        if (block) return
+        block = true
+        var me = this
+        gs.map((gCopy, i) => {
+          if (me === gCopy) {
+            if (prevCallbacks[i] && prevCallbacks[i].highlightCallback) {
+              prevCallbacks[i].highlightCallback.apply(this, arguments)
+            }
+            return
+          }
+          var idx = gCopy.getRowForX(x)
+          if (idx !== null) {
+            gCopy.setSelection(idx, seriesName)
+          }
+        })
+        block = false
+      },
+      unhighlightCallback: function (event) {
+        if (block) return
+        block = true
+        var me = this
+        gs.map((gCopy, i) => {
+          if (me === gCopy) {
+            if (prevCallbacks[i] && prevCallbacks[i].unhighlightCallback) {
+              prevCallbacks[i].unhighlightCallback.apply(this, arguments)
+            }
+            return
+          }
+          gCopy.clearSelection()
+        })
+        block = false
+      }
+    }, true)
+  })
+}
+
+export function synchronize (dygraphs, syncOptions) {
+  let prevCallbacks = []
+
+  dygraphs.map((g, index) => {
+    g.ready(() => {
+      var callBackTypes = ['drawCallback', 'highlightCallback', 'unhighlightCallback']
+      for (var j = 0; j < dygraphs.length; j++) {
+        if (!prevCallbacks[j]) {
+          prevCallbacks[j] = {}
+        }
+        for (var k = callBackTypes.length - 1; k >= 0; k--) {
+          prevCallbacks[j][callBackTypes[k]] = dygraphs[j].getFunctionOption(callBackTypes[k])
+        }
+      }
+
+      if (syncOptions.zoom) {
+        attachZoomHandlers(dygraphs, prevCallbacks)
+      }
+
+      if (syncOptions.selection) {
+        attachSelectionHandlers(dygraphs, prevCallbacks)
+      }
+
+      var yMinRange = minViewValueRange(index)
+      if (yMinRange === 0) {
+        return
+      }
+      var yRange = g.yAxisRange()
+      if (yRange && yMinRange > yRange[1]) {
+        g.updateOptions({ valueRange: [yRange[0], yMinRange] })
+      }
+    })
+  })
 }

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -1,6 +1,6 @@
 .dygraph-legend {
   position: absolute;
-  font-size: 14px;
+  font-size: 13px;
   z-index: 10;
   background: white;
   line-height: normal;
@@ -11,6 +11,7 @@
   border-radius: 5px;
   font-weight: bold;
   width: fit-content !important;
+  height: fit-content !important;
 }
 
 .dygraph-rangesel-bgcanvas {
@@ -573,4 +574,19 @@ body.darkBG {
   .market-chart-title {
     background-color: #333a;
   }
+}
+
+.proposal-chart-legend {
+  left: 85%;
+}
+
+.proposal-chart-align {
+  height: 20vh !important;
+  margin: 0 auto 0 auto;
+  width: 70%;
+}
+
+.proposal-charts-align {
+  margin: auto;
+  height: inherit;
 }

--- a/run_tests_with_chartests.sh
+++ b/run_tests_with_chartests.sh
@@ -59,7 +59,7 @@ testrepo () {
 
   # run tests on all modules
   for MODPATH in $MODPATHS; do
-    env GORACE='halt_on_error=1' go test -v -race $(cd $MODPATH && go list -m)
+    env GORACE='halt_on_error=1' go test -v -race -tags chartests $(cd $MODPATH && go list -m)
   done
 
   # Drop the tests db.

--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -4,54 +4,92 @@
     {{template "html-head" printf "Decred Vote Proposal Pages"}}
         {{template "navbar" .}}
         {{with .Data}}
-        <div class="container main">
+        <div class="container">
             <div class="row justify-content-between">
-                <div class="col-lg-14 col-sm-12 d-flex">
-                    <a class="medium row" href="/proposals">All Proposals</a>
+                <div class="col-lg-20 col-sm-12 d-flex">
+                    <a class="medium row" href="/proposals">All Proposals ></a>
                 </div>
-                <div class="col-lg-14 col-sm-12 d-flex">
+                <div class="col-lg-20 col-sm-12 d-flex">
                     <h4 class="mb-2 row">{{.Name}}</h4>
                 </div>
             </div>
             <div class="row justify-content-between">
-                <div class="col-lg-20 col-sm-12 d-flex">
-                    <table class="">
+                <div class="col-lg-12 col-sm-12 d-flex">
+                    <table>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Token</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Token:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">
+                                <span class="break-word py-1 lh1rem">
                                     <a href="{{$.PoliteiaURL}}/proposals/{{.Censorship.Token}}">{{.Censorship.Token}}</a>
                                 </span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">State</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Author:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">{{with .State}}{{toTitleCase .String}}{{end}}</span>
+                                <span class="break-word py-1 lh1rem">{{.Username}}</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Status</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Published:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">{{with .Status}}{{toTitleCase .String}}{{end}}</span>
+                                <span class="break-word py-1 lh1rem">{{TimeConversion .PublishedDate}}</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Author</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Updated:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">{{.Username}}</span>
+                                <span class="break-word py-1 lh1rem">{{TimeConversion .Timestamp}}</span>
+                            </td>
+                        </tr>
+                         {{if ne .CensoredDate 0}}
+                            <tr>
+                                <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Censored:</td>
+                                <td>
+                                    <span class="break-word py-1 lh1rem">{{TimeConversion .CensoredDate}}</span>
+                                </td>
+                            </tr>
+                        {{end}}
+                        {{if ne .AbandonedDate 0}}
+                            <tr>
+                                <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Abandoned:</td>
+                                <td>
+                                    <span class="break-word py-1 lh1rem">{{TimeConversion .AbandonedDate}}</span>
+                                </td>
+                            </tr>
+                        {{end}}
+                        <tr>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Comments Count:</td>
+                            <td>
+                                <span class="break-word py-1 lh1rem">{{.NumComments}}</span>
+                           </td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="col-lg-4 col-sm-12 d-flex">
+                    <table>
+                        <tr>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">State:</td>
+                            <td>
+                                <span class="break-word py-1 lh1rem">{{with .State}}{{toTitleCase .String}}{{end}}</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Version</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Status:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">v{{.Version}}</span>
+                                <span class="break-word py-1 lh1rem">{{with .Status}}{{toTitleCase .String}}{{end}}</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">End Height</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Version:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">
+                                <span class="break-word lh1rem">v{{.Version}}</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">End Height:</td>
+                            <td>
+                                <span class="break-word py-1 lh1rem">
                                     {{if .Endheight}}
                                         <a href="/block/{{.Endheight}}">{{.Endheight}}</a>
                                     {{else}}
@@ -60,14 +98,50 @@
                                 </span>
                             </td>
                         </tr>
+                        {{if ne $.TimeRemaining ""}}
+                            <tr>
+                                <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Remaining:</td>
+                                <td>
+                                    <span class="break-word py-1 lh1rem">{{$.TimeRemaining}}</span>
+                                </td>
+                            </tr>
+                        {{end}}
+                    </table>
+                </div>
+                <div class="col-lg-7 col-sm-12 d-flex">
+                    <table>
+                        {{if .VoteStatus}}
+                            {{range $i, $v := .VoteResults}}
+                                {{if eq $v.Option.OptionID "yes"}}
+                                    <tr>
+                                        <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Yes Votes:</td>
+                                        <td>
+                                            <span class="break-word py-1 lh1rem">{{$v.VotesReceived}}</span>
+                                        </td>
+                                    </tr>
+                                {{end}}
+                            {{end}}
+                        {{end}}
+                        {{if .VoteStatus}}
+                            {{range $i, $v := .VoteResults}}
+                                {{if eq $v.Option.OptionID "no"}}
+                                    <tr>
+                                        <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">No Votes:</td>
+                                        <td>
+                                            <span class="break-word py-1 lh1rem">{{$v.VotesReceived}}</span>
+                                        </td>
+                                    </tr>
+                                {{end}}
+                            {{end}}
+                        {{end}}
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Vote Status</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Vote Status:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">
+                                <span class="break-word py-1 lh1rem">
                                     {{if .VoteStatus}}
                                         {{with .VoteStatus}}
                                             {{.ShortDesc}}
-                                            <span class="hash break-word lh1rem position-relative d-inline-block" data-tooltip="{{.LongDesc}}">
+                                            <span class="position-relative d-inline-block" data-tooltip="{{.LongDesc}}">
                                         {{end}}
                                     {{else}}
                                         N/A
@@ -76,77 +150,12 @@
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Published</td>
+                            <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Quorum:</td>
                             <td>
-                                <span class="hash break-word  lh1rem">{{TimeConversion .PublishedDate}}</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Updated</td>
-                            <td>
-                                <span class="hash break-word  lh1rem">{{TimeConversion .Timestamp}}</span>
-                            </td>
-                        </tr>
-                         {{if ne .CensoredDate 0}}
-                            <tr>
-                                <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Censored</td>
-                                <td>
-                                    <span class="hash break-word  lh1rem">{{TimeConversion .CensoredDate}}</span>
-                                </td>
-                            </tr>
-                        {{end}}
-                        {{if ne .AbandonedDate 0}}
-                            <tr>
-                                <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Abandoned</td>
-                                <td>
-                                    <span class="hash break-word  lh1rem">{{TimeConversion .AbandonedDate}}</span>
-                                </td>
-                            </tr>
-                        {{end}}
-                    </table>
-                </div>
-                <div class="col-lg-4 col-sm-12 d-flex">
-                    <table class="">
-                        {{if .VoteStatus}}
-                            {{range $i, $v := .VoteResults}}
-                                <tr>
-                                    <td class="text-right pr-2 lh1rem vam nowrap xs-w117">{{toTitleCase $v.Option.OptionID}} Votes</td>
-                                    <td>
-                                        <span class="hash break-word  lh1rem">{{$v.VotesReceived}}</span>
-                                    </td>
-                                </tr>
-                            {{end}}
-                        {{end}}
-                        <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Total Votes</td>
-                            <td>
-                                <span class="hash break-word  lh1rem">
-                                    {{if .TotalVotes}}
-                                        {{.TotalVotes}}
-                                    {{else}}
-                                        N/A
-                                    {{end}}
-                                </span>
-                            </td>
-                        </tr>
-                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Eligible Votes Count</td>
-                            <td>
-                                <span class="hash break-word  lh1rem">
-                                    {{if .NumOfEligibleVotes}}
-                                        {{.NumOfEligibleVotes}}
-                                    {{else}}
-                                        N/A
-                                    {{end}}
-                                </span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Quorum</td>
-                            <td>
-                                <span class="hash break-word  lh1rem">
-                                    {{if .QuorumPercentage}}
-                                        {{.QuorumPercentage}}%
+                                <span class="break-word py-1 lh1rem">
+                                    {{if and .QuorumPercentage (and .NumOfEligibleVotes .TotalVotes)}}
+                                        {{$voted := (percentage .TotalVotes .NumOfEligibleVotes)}}
+                                        {{.TotalVotes}} of {{.NumOfEligibleVotes}},  {{printf "%.0f" $voted}}% voted,  {{.QuorumPercentage}}% needed
                                     {{else}}
                                         N/A
                                     {{end}}
@@ -157,57 +166,43 @@
                             {{range $i, $v := .VoteResults}}
                                 {{if eq $v.Option.OptionID "yes"}}
                                     <tr>
-                                        <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Actual</td>
+                                        <td class="text-right pr-2 py-2 vam nowrap xs-w117 font-weight-bold">Total:</td>
                                         <td>
-                                            <span class="hash break-word lh1rem">
-                                                {{printf "%.2f" (percentage $v.VotesReceived $.Data.TotalVotes)}}%
+                                            <span class="break-word py-1 lh1rem">
+                                                {{printf "%.0f" (percentage $v.VotesReceived $.Data.TotalVotes)}}% yes, {{if $.Data.PassPercentage}}{{$.Data.PassPercentage}}%{{end}} needed
                                             </span>
                                         </td>
                                     </tr>
                                 {{end}}
                             {{end}}
                         {{end}}
-                         <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Pass</td>
-                            <td>
-                                <span class="hash break-word  lh1rem">
-                                    {{if .PassPercentage}}
-                                        {{.PassPercentage}}%
-                                    {{else}}
-                                        N/A
-                                    {{end}}
-                                </span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2 lh1rem vam nowrap xs-w117">Comments Count</td>
-                            <td>
-                                <span class="hash break-word lh1rem">{{.NumComments}}</span>
-                            </td>
-                        </tr>
                     </table>
                 </div>
-                {{if gt (len .VoteResults) 1}}
-                    <div style="margin: auto;" data-controller="proposal">
-                        {{$firstentry := index .VoteResults 0}}
-                        {{$secondentry := index .VoteResults 1}}
-                        <canvas
-                            width="400"
-                            height="400"
-                            id="donutgraph"
-                            data-target="proposal.chartdata"
-                            data-firstvotesid="{{toTitleCase $firstentry.Option.OptionID}}"
-                            data-secondvotesid="{{toTitleCase $secondentry.Option.OptionID}}"
-                            data-firstvotescount="{{$firstentry.VotesReceived}}"
-                            data-secondvotescount="{{$secondentry.VotesReceived}}"
-                            chart-options="{tooltipTemplate: '<%=label%>: <%= numeral(value).format('($00[.]00)') %> - <%= numeral(circumference / 6.283).format('(0[.][00]%)') %>'"
-                        ></canvas>
-                    </div>
-                {{end}}
             </div>
         </div>
+        {{if gt (len .VoteResults) 1}}
+            <div
+                class="proposal-charts-align"
+                data-controller="proposal"
+                data-target="proposal.token"
+                data-hash="{{$.Data.Censorship.Token}}"
+                >
+                <div class="d-flex proposal-chart-responsive">
+                    <div id="percent-of-votes" class="proposal-chart-align"></div>
+                    <div id="percent-of-votes-legend" class="dygraph-legend proposal-chart-legend"></div>
+                </div>
+                <div class="d-flex proposal-chart-responsive">
+                    <div id="cumulative" class="proposal-chart-align mt-1"></div>
+                    <div id="cumulative-legend" class="dygraph-legend proposal-chart-legend"></div>
+                </div>
+                <div class="d-flex proposal-chart-responsive">
+                    <div id="votes-by-time" class="proposal-chart-align mt-1"></div>
+                    <div id="votes-by-time-legend" class="dygraph-legend proposal-chart-legend"></div>
+                </div>
+            </div>
         {{end}}
-        {{template "footer" . }}
+    {{end}}
+    {{template "footer" . }}
     </body>
 </html>
 {{end}}

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -52,15 +52,14 @@
                                 data-action="change->pagenavigation#setPageSize"
                                 data-offset="{{$.Offset}}"
                                 data-offsetkey="offset"
-                                class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 10}}disabled{{end}}"
-                                {{if lt $pending 10}}disabled="disabled"{{end}}
+                                class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $pending 20}}disabled{{end}}"
+                                {{if lt $pending 20}}disabled="disabled"{{end}}
                             >
-                            {{if ge $pending 10}}<option {{if eq $count 10}}selected{{end}} value="10">10</option>{{end}}
                             {{if ge $pending 20}}<option {{if eq $count 20}}selected{{end}} value="20">20</option>{{end}}
                             {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30</option>{{end}}
                             {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50</option>{{end}}
-                            {{if eq $.TotalCount $count 10 20 30 50}}{{else}}<option value="{{$.TotalCount}}">{{$.TotalCount}}</option>{{end}}
-                            {{if eq $count 10 20 30 50}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
+                            {{if eq $.TotalCount $count 20 30 50}}{{else}}<option value="{{$.TotalCount}}">{{$.TotalCount}}</option>{{end}}
+                            {{if eq $count 20 30 50}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
                             </select>
                         </span>
                         <span class="fs12 nowrap text-right">
@@ -109,13 +108,11 @@
                         <th class="text-left">Author</th>
                         <th class="text-left">Proposal Status</th>
                         <th class="text-left">Vote Status</th>
-                        <th class="text-right">Published</th>
+                        <th class="text-right">Age</th>
                         <th class="text-right">Updated</th>
-                        <th class="text-right">Version</th>
-                        <th class="text-right">Comments</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody data-controller="time">
                 {{range $i, $v := .Proposals}}
                 {{with $v}}
                     <tr>
@@ -127,17 +124,15 @@
                         <td class="text-left">
                             {{if .VoteStatus}}{{with .VoteStatus}}{{.ShortDesc}}{{end}}{{else}}N/A{{end}}
                         </td>
-                        <td class="text-right">{{timeWithoutDateAndTimeZone .PublishedDate}}</td>
+                        <td class="text-right" data-target="time.age" data-age="{{.Timestamp}}"></td>
                         <td class="text-right">{{timeWithoutDateAndTimeZone .Timestamp}}</td>
-                        <td class="text-right">v{{.Version}}</td>
-                        <td class="text-right">{{.NumComments}}</td>
                     </tr>
                 {{end}}
                 {{end}}
                 </tbody>
             </table>
 
-            {{if gt .Limit 10}}
+            {{if gt .Limit 20}}
                 {{template "proposalsPagination" .}}
             {{end}}
             {{end}}


### PR DESCRIPTION
fixes #995 
Using a [parser tool](https://github.com/dmigwi/go-piparser) to clone, query and parse politeia's votes data pushed to github with the help of git cmd tool and relevant  proposal tokens votes data is extracted.
The votes data is stored in `proposals` and `proposal_votes` tables after the db upgrade to `v3.11.0`.

Here are the UI changes made:

**Proposals Page**

![proposals-page](https://user-images.githubusercontent.com/22055953/55045978-ff291900-5050-11e9-916a-c308991001a9.png)


**Proposal Details Page** - The donut pie has been replaced with the following synchronized charts.

![proposal-page](https://user-images.githubusercontent.com/22055953/55046000-08b28100-5051-11e9-853d-8ffa2c8e859f.png)
