### PR TITLE
CICD: Run tests for all dcrdata modules

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,6 +22,25 @@ set -ex
 # Default GOVERSION
 [[ ! "$GOVERSION" ]] && GOVERSION=1.11
 REPO=dcrdata
+ROOTMODULE="github.com/decred/dcrdata"
+ALLMODULES="$ROOTMODULE/api/types
+  $ROOTMODULE/blockdata
+  $ROOTMODULE/db/cache
+  $ROOTMODULE/db/dbtypes
+  $ROOTMODULE/db/dcrpg
+  $ROOTMODULE/db/dcrsqlite
+  $ROOTMODULE/exchanges
+  $ROOTMODULE/explorer/types
+  $ROOTMODULE/gov/agendas
+  $ROOTMODULE/gov/politeia
+  $ROOTMODULE/mempool
+  $ROOTMODULE/middleware
+  $ROOTMODULE/pubsub
+  $ROOTMODULE/pubsub/types
+  $ROOTMODULE/rpcutils
+  $ROOTMODULE/semver
+  $ROOTMODULE/stakedb
+  $ROOTMODULE/txhelpers"
 
 testrepo () {
   TMPDIR=$(mktemp -d)
@@ -40,7 +59,7 @@ testrepo () {
   git clone https://github.com/dcrlabs/bug-free-happiness $TMPDIR/test-data-repo
   tar xvf $TMPDIR/test-data-repo/stakedb/test_ticket_pool.bdgr.tar.xz -C ./stakedb
 
-  env GORACE='halt_on_error=1' go test -v -race ./...
+  env GORACE='halt_on_error=1' go test -v -race ./... $ALLMODULES
 
   # check linters
   golangci-lint run --deadline=10m --disable-all --enable govet --enable staticcheck \


### PR DESCRIPTION
`go test ./...` seems to be working only for the package where `run_tests.sh` scripts is located.
`go test all` runs way too many unnecessary tests. https://go-review.googlesource.com/c/go/+/134095/1/src/cmd/go/internal/test/test.go

Therefore dcrdata submodules have to be passed as arguments as `go tests ./... {dcrdata_submodules}` for all the necessary tests to be run.