### PR TITLE
txhelpers and mempool: UnconfirmedTxnsForAddress

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -33,7 +33,7 @@ const (
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
 // part {blockhash}, and the corresponding block index, into a request context.
-func (c *insightApiContext) BlockHashPathAndIndexCtx(next http.Handler) http.Handler {
+func (c *InsightApiContext) BlockHashPathAndIndexCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := m.BlockHashPathAndIndexCtx(r, c.BlockData.ChainDB)
 		next.ServeHTTP(w, r.WithContext(ctx))
@@ -43,7 +43,7 @@ func (c *insightApiContext) BlockHashPathAndIndexCtx(next http.Handler) http.Han
 // StatusCtx is a middleware that embeds into the request context the data for
 // the "?q=x" URL query, where x is "getInfo" or "getDifficulty" or
 // "getBestBlockHash" or "getLastBlockHash".
-func (c *insightApiContext) StatusInfoCtx(next http.Handler) http.Handler {
+func (c *InsightApiContext) StatusInfoCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := m.StatusInfoCtx(r, c.BlockData.ChainDB)
 		next.ServeHTTP(w, r.WithContext(ctx))
@@ -51,7 +51,7 @@ func (c *insightApiContext) StatusInfoCtx(next http.Handler) http.Handler {
 
 }
 
-func (c *insightApiContext) getBlockHashCtx(r *http.Request) (string, error) {
+func (c *InsightApiContext) getBlockHashCtx(r *http.Request) (string, error) {
 	hash, err := m.GetBlockHashCtx(r)
 	if err != nil {
 		idx := int64(m.GetBlockIndexCtx(r))
@@ -64,7 +64,7 @@ func (c *insightApiContext) getBlockHashCtx(r *http.Request) (string, error) {
 	return hash, nil
 }
 
-func (c *insightApiContext) getBlockChainHashCtx(r *http.Request) (*chainhash.Hash, error) {
+func (c *InsightApiContext) getBlockChainHashCtx(r *http.Request) (*chainhash.Hash, error) {
 	hashStr, err := c.getBlockHashCtx(r)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func FromToPaginationCtx(next http.Handler) http.Handler {
 }
 
 // ValidatePostCtx will confirm Post content length is valid.
-func (c *insightApiContext) ValidatePostCtx(next http.Handler) http.Handler {
+func (c *InsightApiContext) ValidatePostCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		contentLengthString := r.Header.Get("Content-Length")
 		contentLength, err := strconv.Atoi(contentLengthString)

--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -33,9 +33,9 @@ const (
 
 // BlockHashPathAndIndexCtx is a middleware that embeds the value at the url
 // part {blockhash}, and the corresponding block index, into a request context.
-func (c *InsightApiContext) BlockHashPathAndIndexCtx(next http.Handler) http.Handler {
+func (iapi *InsightApi) BlockHashPathAndIndexCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := m.BlockHashPathAndIndexCtx(r, c.BlockData.ChainDB)
+		ctx := m.BlockHashPathAndIndexCtx(r, iapi.BlockData.ChainDB)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -43,19 +43,19 @@ func (c *InsightApiContext) BlockHashPathAndIndexCtx(next http.Handler) http.Han
 // StatusCtx is a middleware that embeds into the request context the data for
 // the "?q=x" URL query, where x is "getInfo" or "getDifficulty" or
 // "getBestBlockHash" or "getLastBlockHash".
-func (c *InsightApiContext) StatusInfoCtx(next http.Handler) http.Handler {
+func (iapi *InsightApi) StatusInfoCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := m.StatusInfoCtx(r, c.BlockData.ChainDB)
+		ctx := m.StatusInfoCtx(r, iapi.BlockData.ChainDB)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 
 }
 
-func (c *InsightApiContext) getBlockHashCtx(r *http.Request) (string, error) {
+func (iapi *InsightApi) getBlockHashCtx(r *http.Request) (string, error) {
 	hash, err := m.GetBlockHashCtx(r)
 	if err != nil {
 		idx := int64(m.GetBlockIndexCtx(r))
-		hash, err = c.BlockData.ChainDB.GetBlockHash(idx)
+		hash, err = iapi.BlockData.ChainDB.GetBlockHash(idx)
 		if err != nil {
 			apiLog.Errorf("Unable to GetBlockHash: %v", err)
 			return "", err
@@ -64,8 +64,8 @@ func (c *InsightApiContext) getBlockHashCtx(r *http.Request) (string, error) {
 	return hash, nil
 }
 
-func (c *InsightApiContext) getBlockChainHashCtx(r *http.Request) (*chainhash.Hash, error) {
-	hashStr, err := c.getBlockHashCtx(r)
+func (iapi *InsightApi) getBlockChainHashCtx(r *http.Request) (*chainhash.Hash, error) {
+	hashStr, err := iapi.getBlockHashCtx(r)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func FromToPaginationCtx(next http.Handler) http.Handler {
 }
 
 // ValidatePostCtx will confirm Post content length is valid.
-func (c *InsightApiContext) ValidatePostCtx(next http.Handler) http.Handler {
+func (iapi *InsightApi) ValidatePostCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		contentLengthString := r.Header.Get("Content-Length")
 		contentLength, err := strconv.Atoi(contentLengthString)
@@ -154,9 +154,9 @@ func (c *InsightApiContext) ValidatePostCtx(next http.Handler) http.Handler {
 			return
 		}
 		// Broadcast Tx has the largest possible body.  Cap max content length
-		// to c.params.MaxTxSize * 2 plus some arbitrary extra for JSON
+		// to iapi.params.MaxTxSize * 2 plus some arbitrary extra for JSON
 		// encapsulation.
-		maxPayload := (c.params.MaxTxSize * 2) + 50
+		maxPayload := (iapi.params.MaxTxSize * 2) + 50
 		if contentLength > maxPayload {
 			writeInsightError(w, fmt.Sprintf("Maximum Content-Length is %d", maxPayload))
 			return

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -25,7 +25,7 @@ const APIVersion = 0
 
 // NewInsightApiRouter returns a new HTTP path router, ApiMux, for the Insight
 // API, app.
-func NewInsightApiRouter(app *insightApiContext, useRealIP, compression bool) ApiMux {
+func NewInsightApiRouter(app *InsightApiContext, useRealIP, compression bool) ApiMux {
 	// chi router
 	mux := chi.NewRouter()
 

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -25,7 +25,7 @@ const APIVersion = 0
 
 // NewInsightApiRouter returns a new HTTP path router, ApiMux, for the Insight
 // API, app.
-func NewInsightApiRouter(app *InsightApiContext, useRealIP, compression bool) ApiMux {
+func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
 	// chi router
 	mux := chi.NewRouter()
 

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -42,8 +42,8 @@ type InsightApi struct {
 	maxCSVAddrs    int
 }
 
-// NewInsightContext is the constructor for InsightApi.
-func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, params *chaincfg.Params,
+// NewInsightApi is the constructor for InsightApi.
+func NewInsightApi(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, params *chaincfg.Params,
 	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, maxAddrs int, status *apitypes.Status) *InsightApi {
 
 	newContext := InsightApi{
@@ -56,12 +56,6 @@ func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, pa
 		maxCSVAddrs:    maxAddrs,
 	}
 	return &newContext
-}
-
-// UseMempoolChecker assigns a MempoolAddressChecker for searching mempool for
-// transactions involving a certain address.
-func (iapi *InsightApi) UseMempoolChecker(mp rpcutils.MempoolAddressChecker) {
-	iapi.mp = mp
 }
 
 // SetReqRateLimit is used to set the requests/second/IP for the Insight API's

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -29,7 +29,9 @@ import (
 
 const defaultReqPerSecLimit = 20.0
 
-type InsightApiContext struct {
+// InsightApi contains the resources for the Insight HTTP API. InsightApi's
+// methods include the http.Handlers for the URL path routes.
+type InsightApi struct {
 	nodeClient     *rpcclient.Client
 	BlockData      *dcrpg.ChainDBRPC
 	params         *chaincfg.Params
@@ -40,12 +42,12 @@ type InsightApiContext struct {
 	maxCSVAddrs    int
 }
 
-// NewInsightContext is the constructor for InsightApiContext.
+// NewInsightContext is the constructor for InsightApi.
 func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, params *chaincfg.Params,
-	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, maxAddrs int, status *apitypes.Status) *InsightApiContext {
+	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, maxAddrs int, status *apitypes.Status) *InsightApi {
 
-	newContext := InsightApiContext{
-		nodeClient: client,
+	newContext := InsightApi{
+		nodeClient:     client,
 		BlockData:      blockData,
 		params:         params,
 		mp:             memPoolData,
@@ -58,20 +60,20 @@ func NewInsightContext(client *rpcclient.Client, blockData *dcrpg.ChainDBRPC, pa
 
 // UseMempoolChecker assigns a MempoolAddressChecker for searching mempool for
 // transactions involving a certain address.
-func (c *InsightApiContext) UseMempoolChecker(mp rpcutils.MempoolAddressChecker) {
-	c.mp = mp
+func (iapi *InsightApi) UseMempoolChecker(mp rpcutils.MempoolAddressChecker) {
+	iapi.mp = mp
 }
 
 // SetReqRateLimit is used to set the requests/second/IP for the Insight API's
 // rate limiter.
-func (c *InsightApiContext) SetReqRateLimit(reqPerSecLimit float64) {
-	c.ReqPerSecLimit = reqPerSecLimit
+func (iapi *InsightApi) SetReqRateLimit(reqPerSecLimit float64) {
+	iapi.ReqPerSecLimit = reqPerSecLimit
 }
 
-func (c *InsightApiContext) getIndentQuery(r *http.Request) (indent string) {
+func (iapi *InsightApi) getIndentQuery(r *http.Request) (indent string) {
 	useIndentation := r.URL.Query().Get("indent")
 	if useIndentation == "1" || useIndentation == "true" {
-		indent = c.JSONIndent
+		indent = iapi.JSONIndent
 	}
 	return
 }
@@ -104,7 +106,7 @@ func writeInsightNotFound(w http.ResponseWriter, str string) {
 	io.WriteString(w, str)
 }
 
-func (c *InsightApiContext) getTransaction(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getTransaction(w http.ResponseWriter, r *http.Request) {
 	txid, err := m.GetTxIDCtx(r)
 	if err != nil {
 		writeInsightError(w, err.Error())
@@ -112,7 +114,7 @@ func (c *InsightApiContext) getTransaction(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Return raw transaction
-	txOld, err := c.BlockData.GetRawTransaction(txid)
+	txOld, err := iapi.BlockData.GetRawTransaction(txid)
 	if err != nil {
 		apiLog.Errorf("Unable to get transaction %s", txid)
 		writeInsightNotFound(w, fmt.Sprintf("Unable to get transaction (%s)", txid))
@@ -122,7 +124,7 @@ func (c *InsightApiContext) getTransaction(w http.ResponseWriter, r *http.Reques
 	txsOld := []*dcrjson.TxRawResult{txOld}
 
 	// convert to insight struct
-	txsNew, err := c.TxConverter(txsOld)
+	txsNew, err := iapi.TxConverter(txsOld)
 
 	if err != nil {
 		apiLog.Errorf("Error Processing Transactions")
@@ -130,17 +132,17 @@ func (c *InsightApiContext) getTransaction(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeJSON(w, txsNew[0], c.getIndentQuery(r))
+	writeJSON(w, txsNew[0], iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getTransactionHex(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getTransactionHex(w http.ResponseWriter, r *http.Request) {
 	txid, err := m.GetTxIDCtx(r)
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
 	}
 
-	txHex := c.BlockData.GetTransactionHex(txid)
+	txHex := iapi.BlockData.GetTransactionHex(txid)
 	if txHex == "" {
 		writeInsightNotFound(w, fmt.Sprintf("Unable to get transaction (%s)", txHex))
 		return
@@ -150,10 +152,10 @@ func (c *InsightApiContext) getTransactionHex(w http.ResponseWriter, r *http.Req
 		Rawtx: txHex,
 	}
 
-	writeJSON(w, hexOutput, c.getIndentQuery(r))
+	writeJSON(w, hexOutput, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getBlockSummary(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getBlockSummary(w http.ResponseWriter, r *http.Request) {
 	// Attempt to get hash or height of block from URL path.
 	hash, err := m.GetBlockHashCtx(r)
 	if err != nil {
@@ -163,7 +165,7 @@ func (c *InsightApiContext) getBlockSummary(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		hash, err = c.BlockData.ChainDB.GetBlockHash(int64(idx))
+		hash, err = iapi.BlockData.ChainDB.GetBlockHash(int64(idx))
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("GetBlockHash: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -175,36 +177,36 @@ func (c *InsightApiContext) getBlockSummary(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	block := c.BlockData.GetBlockVerboseByHash(hash, false)
+	block := iapi.BlockData.GetBlockVerboseByHash(hash, false)
 	if block == nil {
 		writeInsightNotFound(w, "Unable to get block")
 		return
 	}
 
 	blockSummary := []*dcrjson.GetBlockVerboseResult{block}
-	blockInsight, err := c.DcrToInsightBlock(blockSummary)
+	blockInsight, err := iapi.DcrToInsightBlock(blockSummary)
 	if err != nil {
 		apiLog.Errorf("Unable to process block (%s)", hash)
 		writeInsightError(w, "Unable to process block")
 		return
 	}
 
-	writeJSON(w, blockInsight, c.getIndentQuery(r))
+	writeJSON(w, blockInsight, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getBlockHash(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getBlockHash(w http.ResponseWriter, r *http.Request) {
 	idx := m.GetBlockIndexCtx(r)
 	if idx < 0 {
 		writeInsightError(w, "No index found in query")
 		return
 	}
 
-	height := c.BlockData.ChainDB.Height()
+	height := iapi.BlockData.ChainDB.Height()
 	if idx < 0 || idx > int(height) {
 		writeInsightError(w, "Block height out of range")
 		return
 	}
-	hash, err := c.BlockData.ChainDB.GetBlockHash(int64(idx))
+	hash, err := iapi.BlockData.ChainDB.GetBlockHash(int64(idx))
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("GetBlockHash: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -220,10 +222,10 @@ func (c *InsightApiContext) getBlockHash(w http.ResponseWriter, r *http.Request)
 	}{
 		hash,
 	}
-	writeJSON(w, blockOutput, c.getIndentQuery(r))
+	writeJSON(w, blockOutput, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getRawBlock(w http.ResponseWriter, r *http.Request) {
 
 	hash, err := m.GetBlockHashCtx(r)
 	if err != nil {
@@ -233,7 +235,7 @@ func (c *InsightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		hash, err = c.BlockData.ChainDB.GetBlockHash(int64(idx))
+		hash, err = iapi.BlockData.ChainDB.GetBlockHash(int64(idx))
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("GetBlockHash: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -251,7 +253,7 @@ func (c *InsightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	blockMsg, err := c.nodeClient.GetBlock(chainHash)
+	blockMsg, err := iapi.nodeClient.GetBlock(chainHash)
 	if err != nil {
 		writeInsightNotFound(w, fmt.Sprintf("Failed to retrieve block %s: %v",
 			chainHash.String(), err))
@@ -270,10 +272,10 @@ func (c *InsightApiContext) getRawBlock(w http.ResponseWriter, r *http.Request) 
 	}{
 		hex.EncodeToString(blockHex.Bytes()),
 	}
-	writeJSON(w, blockJSON, c.getIndentQuery(r))
+	writeJSON(w, blockJSON, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) broadcastTransactionRaw(w http.ResponseWriter, r *http.Request) {
 	// Check for rawtx.
 	rawHexTx, err := m.GetRawHexTx(r)
 	if err != nil {
@@ -283,14 +285,14 @@ func (c *InsightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *ht
 	}
 
 	// Check maximum transaction size.
-	if len(rawHexTx)/2 > c.params.MaxTxSize {
+	if len(rawHexTx)/2 > iapi.params.MaxTxSize {
 		writeInsightError(w, fmt.Sprintf("Rawtx length exceeds maximum allowable characters"+
 			"(%d bytes received)", len(rawHexTx)/2))
 		return
 	}
 
 	// Broadcast the transaction.
-	txid, err := c.BlockData.SendRawTransaction(rawHexTx)
+	txid, err := iapi.BlockData.SendRawTransaction(rawHexTx)
 	if err != nil {
 		apiLog.Errorf("Unable to send transaction %s", rawHexTx)
 		writeInsightError(w, fmt.Sprintf("SendRawTransaction failed: %v", err))
@@ -303,11 +305,11 @@ func (c *InsightApiContext) broadcastTransactionRaw(w http.ResponseWriter, r *ht
 	}{
 		txid,
 	}
-	writeJSON(w, txidJSON, c.getIndentQuery(r))
+	writeJSON(w, txidJSON, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, c.params, c.maxCSVAddrs) // Required
+func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Request) {
+	addresses, err := m.GetAddressCtx(r, iapi.params, iapi.maxCSVAddrs) // Required
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
@@ -317,7 +319,7 @@ func (c *InsightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http
 	txnOutputs := make([]apitypes.AddressTxnOutput, 0)
 
 	for _, address := range addresses {
-		confirmedTxnOutputs, _, err := c.BlockData.ChainDB.AddressUTXO(address)
+		confirmedTxnOutputs, _, err := iapi.BlockData.ChainDB.AddressUTXO(address)
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("AddressUTXO: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -328,7 +330,7 @@ func (c *InsightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http
 			continue
 		}
 
-		addressOuts, _, err := c.mp.UnconfirmedTxnsForAddress(address)
+		addressOuts, _, err := iapi.mp.UnconfirmedTxnsForAddress(address)
 		if err != nil {
 			apiLog.Errorf("Error getting unconfirmed transactions: %v", err)
 			continue
@@ -402,12 +404,12 @@ func (c *InsightApiContext) getAddressesTxnOutput(w http.ResponseWriter, r *http
 		return txnOutputs[i].Confirmations < txnOutputs[j].Confirmations
 	})
 
-	writeJSON(w, txnOutputs, c.getIndentQuery(r))
+	writeJSON(w, txnOutputs, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) {
 	hash, blockerr := m.GetBlockHashCtx(r)
-	addresses, addrerr := m.GetAddressCtx(r, c.params, 1)
+	addresses, addrerr := m.GetAddressCtx(r, iapi.params, 1)
 
 	if blockerr != nil && addrerr != nil {
 		writeInsightError(w, "Required query parameters (address or block) not present.")
@@ -419,7 +421,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 	}
 
 	if blockerr == nil {
-		blkTrans := c.BlockData.GetBlockVerboseByHash(hash, true)
+		blkTrans := iapi.BlockData.GetBlockVerboseByHash(hash, true)
 		if blkTrans == nil {
 			apiLog.Errorf("Unable to get block %s transactions", hash)
 			writeInsightError(w, fmt.Sprintf("Unable to get block %s transactions", hash))
@@ -448,7 +450,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 		}
 
 		// Convert to Insight struct
-		txsNew, err := c.TxConverter(txsOld)
+		txsNew, err := iapi.TxConverter(txsOld)
 		if err != nil {
 			apiLog.Error("Error Processing Transactions")
 			writeInsightError(w, "Error Processing Transactions")
@@ -459,7 +461,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 			PagesTotal: int64(txcount),
 			Txs:        txsNew,
 		}
-		writeJSON(w, blockTransactions, c.getIndentQuery(r))
+		writeJSON(w, blockTransactions, iapi.getIndentQuery(r))
 		return
 	}
 
@@ -473,7 +475,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 		}
 		addresses := []string{address}
 		rawTxs, recentTxs, err :=
-			c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.status.Height()-2))
+			iapi.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(iapi.status.Height()-2))
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("InsightAddressTransactions: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -486,7 +488,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		addressOuts, _, err := c.mp.UnconfirmedTxnsForAddress(address)
+		addressOuts, _, err := iapi.mp.UnconfirmedTxnsForAddress(address)
 		var UnconfirmedTxs []chainhash.Hash
 
 		if err != nil {
@@ -527,7 +529,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 
 		txsOld := []*dcrjson.TxRawResult{}
 		for _, rawTx := range rawTxs {
-			txOld, err1 := c.BlockData.GetRawTransaction(&rawTx)
+			txOld, err1 := iapi.BlockData.GetRawTransaction(&rawTx)
 			if err1 != nil {
 				apiLog.Errorf("Unable to get transaction %s", rawTx)
 				writeInsightError(w, fmt.Sprintf("Error gathering transaction details (%s)", err1))
@@ -537,7 +539,7 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 		}
 
 		// Convert to Insight struct
-		txsNew, err := c.TxConverter(txsOld)
+		txsNew, err := iapi.TxConverter(txsOld)
 		if err != nil {
 			apiLog.Error("Error Processing Transactions")
 			writeInsightError(w, "Error Processing Transactions")
@@ -548,12 +550,12 @@ func (c *InsightApiContext) getTransactions(w http.ResponseWriter, r *http.Reque
 			PagesTotal: int64(txcount),
 			Txs:        txsNew,
 		}
-		writeJSON(w, addrTransactions, c.getIndentQuery(r))
+		writeJSON(w, addrTransactions, iapi.getIndentQuery(r))
 	}
 }
 
-func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, c.params, c.maxCSVAddrs) // Required
+func (iapi *InsightApi) getAddressesTxn(w http.ResponseWriter, r *http.Request) {
+	addresses, err := m.GetAddressCtx(r, iapi.params, iapi.maxCSVAddrs) // Required
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
@@ -573,7 +575,7 @@ func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 	var UnconfirmedTxs []chainhash.Hash
 
 	rawTxs, recentTxs, err :=
-		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.status.Height()-2))
+		iapi.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(iapi.status.Height()-2))
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("InsightAddressTransactions: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -593,7 +595,7 @@ func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 			writeInsightError(w, fmt.Sprintf("Address is invalid (%s)", addr))
 			return
 		}
-		addressOuts, _, err := c.mp.UnconfirmedTxnsForAddress(address.String())
+		addressOuts, _, err := iapi.mp.UnconfirmedTxnsForAddress(address.String())
 		if err != nil {
 			writeInsightError(w, fmt.Sprintf("Error gathering mempool transactions (%s)", err))
 			return
@@ -656,7 +658,7 @@ func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 
 	txsOld := []*dcrjson.TxRawResult{}
 	for _, rawTx := range rawTxs {
-		txOld, err := c.BlockData.GetRawTransaction(&rawTx)
+		txOld, err := iapi.BlockData.GetRawTransaction(&rawTx)
 		if err != nil {
 			apiLog.Errorf("Unable to get transaction %s", rawTx)
 			writeInsightError(w, fmt.Sprintf("Error gathering transaction details (%s)", err))
@@ -666,7 +668,7 @@ func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Convert to Insight API struct
-	txsNew, err := c.DcrToInsightTxns(txsOld, noAsm, noScriptSig, noSpent)
+	txsNew, err := iapi.DcrToInsightTxns(txsOld, noAsm, noScriptSig, noSpent)
 	if err != nil {
 		apiLog.Error("Unable to process transactions")
 		writeInsightError(w, fmt.Sprintf("Unable to convert transactions (%s)", err))
@@ -677,17 +679,17 @@ func (c *InsightApiContext) getAddressesTxn(w http.ResponseWriter, r *http.Reque
 		// Make sure we pass an empty array not null to json response if no Tx
 		addressOutput.Items = make([]apitypes.InsightTx, 0)
 	}
-	writeJSON(w, addressOutput, c.getIndentQuery(r))
+	writeJSON(w, addressOutput, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getAddressBalance(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, c.params, 1)
+func (iapi *InsightApi) getAddressBalance(w http.ResponseWriter, r *http.Request) {
+	addresses, err := m.GetAddressCtx(r, iapi.params, 1)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return
 	}
 
-	addressInfo, _, err := c.BlockData.ChainDB.AddressBalance(addresses[0])
+	addressInfo, _, err := iapi.BlockData.ChainDB.AddressBalance(addresses[0])
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressBalance: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -698,10 +700,10 @@ func (c *InsightApiContext) getAddressBalance(w http.ResponseWriter, r *http.Req
 		http.Error(w, http.StatusText(422), 422)
 		return
 	}
-	writeJSON(w, addressInfo.TotalUnspent, c.getIndentQuery(r))
+	writeJSON(w, addressInfo.TotalUnspent, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getSyncInfo(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getSyncInfo(w http.ResponseWriter, r *http.Request) {
 	errorResponse := func(err error) {
 		// To insure JSON encodes an error properly as a string, and no error as
 		// null, use a pointer to a string.
@@ -714,16 +716,16 @@ func (c *InsightApiContext) getSyncInfo(w http.ResponseWriter, r *http.Request) 
 			Status: "error",
 			Error:  errorString,
 		}
-		writeJSON(w, syncInfo, c.getIndentQuery(r))
+		writeJSON(w, syncInfo, iapi.getIndentQuery(r))
 	}
 
-	blockChainHeight, err := c.nodeClient.GetBlockCount()
+	blockChainHeight, err := iapi.nodeClient.GetBlockCount()
 	if err != nil {
 		errorResponse(err)
 		return
 	}
 
-	height := c.BlockData.Height()
+	height := iapi.BlockData.Height()
 	syncPercentage := int64((float64(height) / float64(blockChainHeight)) * 100)
 
 	st := "syncing"
@@ -738,17 +740,17 @@ func (c *InsightApiContext) getSyncInfo(w http.ResponseWriter, r *http.Request) 
 		Height:           height,
 		Type:             "from RPC calls",
 	}
-	writeJSON(w, syncInfo, c.getIndentQuery(r))
+	writeJSON(w, syncInfo, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getStatusInfo(w http.ResponseWriter, r *http.Request) {
 	statusInfo := m.GetStatusInfoCtx(r)
 
 	// best block idx is also embedded through the middleware.  We could use
 	// this value or the other best blocks as done below.  Which one is best?
 	// idx := m.GetBlockIndexCtx(r)
 
-	infoResult, err := c.nodeClient.GetInfo()
+	infoResult, err := iapi.nodeClient.GetInfo()
 	if err != nil {
 		apiLog.Error("Error getting status")
 		writeInsightError(w, fmt.Sprintf("Error getting status (%s)", err))
@@ -762,9 +764,9 @@ func (c *InsightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request
 		}{
 			infoResult.Difficulty,
 		}
-		writeJSON(w, info, c.getIndentQuery(r))
+		writeJSON(w, info, iapi.getIndentQuery(r))
 	case "getBestBlockHash":
-		blockhash, err := c.nodeClient.GetBlockHash(int64(infoResult.Blocks))
+		blockhash, err := iapi.nodeClient.GetBlockHash(int64(infoResult.Blocks))
 		if err != nil {
 			apiLog.Errorf("Error getting block hash %d (%s)", infoResult.Blocks, err)
 			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", infoResult.Blocks, err))
@@ -776,18 +778,18 @@ func (c *InsightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request
 		}{
 			blockhash.String(),
 		}
-		writeJSON(w, info, c.getIndentQuery(r))
+		writeJSON(w, info, iapi.getIndentQuery(r))
 	case "getLastBlockHash":
-		blockhashtip, err := c.nodeClient.GetBlockHash(int64(infoResult.Blocks))
+		blockhashtip, err := iapi.nodeClient.GetBlockHash(int64(infoResult.Blocks))
 		if err != nil {
 			apiLog.Errorf("Error getting block hash %d (%s)", infoResult.Blocks, err)
 			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", infoResult.Blocks, err))
 			return
 		}
-		lastblockhash, err := c.nodeClient.GetBlockHash(int64(c.status.Height()))
+		lastblockhash, err := iapi.nodeClient.GetBlockHash(int64(iapi.status.Height()))
 		if err != nil {
-			apiLog.Errorf("Error getting block hash %d (%s)", c.status.Height(), err)
-			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", c.status.Height(), err))
+			apiLog.Errorf("Error getting block hash %d (%s)", iapi.status.Height(), err)
+			writeInsightError(w, fmt.Sprintf("Error getting block hash %d (%s)", iapi.status.Height(), err))
 			return
 		}
 
@@ -798,7 +800,7 @@ func (c *InsightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request
 			blockhashtip.String(),
 			lastblockhash.String(),
 		}
-		writeJSON(w, info, c.getIndentQuery(r))
+		writeJSON(w, info, iapi.getIndentQuery(r))
 	default:
 		info := struct {
 			Version         int32   `json:"version"`
@@ -824,7 +826,7 @@ func (c *InsightApiContext) getStatusInfo(w http.ResponseWriter, r *http.Request
 			infoResult.Errors,
 		}
 
-		writeJSON(w, info, c.getIndentQuery(r))
+		writeJSON(w, info, iapi.getIndentQuery(r))
 	}
 
 }
@@ -850,7 +852,7 @@ func dateFromStr(format, dateStr string) (date time.Time, isToday bool, err erro
 	return
 }
 
-func (c *InsightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getBlockSummaryByTime(w http.ResponseWriter, r *http.Request) {
 	// Format of the blockDate URL param, and of the pagination parameters
 	blockDateStr := m.GetBlockDateCtx(r)
 	ymdFormat := "2006-01-02"
@@ -873,7 +875,7 @@ func (c *InsightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http
 
 	// TODO: limit the query rather than returning all and limiting in go.
 	minTime, maxTime := minDate.Unix(), maxDate.Unix()
-	blockSummary, err := c.BlockData.ChainDB.BlockSummaryTimeRange(minTime, maxTime, 0)
+	blockSummary, err := iapi.BlockData.ChainDB.BlockSummaryTimeRange(minTime, maxTime, 0)
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("BlockSummaryTimeRange: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -909,11 +911,11 @@ func (c *InsightApiContext) getBlockSummaryByTime(w http.ResponseWriter, r *http
 	summaryOutput.Pagination.CurrentTs = maxTime
 	summaryOutput.Length = len(summaryOutput.Blocks)
 
-	writeJSON(w, summaryOutput, c.getIndentQuery(r))
+	writeJSON(w, summaryOutput, iapi.getIndentQuery(r))
 }
 
-func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, c.params, 1)
+func (iapi *InsightApi) getAddressInfo(w http.ResponseWriter, r *http.Request) {
+	addresses, err := m.GetAddressCtx(r, iapi.params, 1)
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
@@ -930,7 +932,7 @@ func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Get confirmed balance.
-	balance, _, err := c.BlockData.ChainDB.AddressBalance(address)
+	balance, _, err := iapi.BlockData.ChainDB.AddressBalance(address)
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("AddressSpentUnspent: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -946,20 +948,20 @@ func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	if isCmd {
 		switch command {
 		case "balance":
-			writeJSON(w, balance.TotalUnspent, c.getIndentQuery(r))
+			writeJSON(w, balance.TotalUnspent, iapi.getIndentQuery(r))
 			return
 		case "totalReceived":
-			writeJSON(w, balance.TotalSpent+balance.TotalUnspent, c.getIndentQuery(r))
+			writeJSON(w, balance.TotalSpent+balance.TotalUnspent, iapi.getIndentQuery(r))
 			return
 		case "totalSent":
-			writeJSON(w, balance.TotalSpent, c.getIndentQuery(r))
+			writeJSON(w, balance.TotalSpent, iapi.getIndentQuery(r))
 			return
 		}
 	}
 
 	// Get confirmed transactions.
 	rawTxs, recentTxs, err :=
-		c.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(c.status.Height()-2))
+		iapi.BlockData.ChainDB.InsightAddressTransactions(addresses, int64(iapi.status.Height()-2))
 	if dbtypes.IsTimeoutErr(err) {
 		apiLog.Errorf("InsightAddressTransactions: %v", err)
 		http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -977,7 +979,7 @@ func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	// Get unconfirmed transactions.
 	var unconfirmedBalanceSat int64
 	var unconfirmedTxs []chainhash.Hash
-	addressOuts, _, err := c.mp.UnconfirmedTxnsForAddress(address)
+	addressOuts, _, err := iapi.mp.UnconfirmedTxnsForAddress(address)
 	if err != nil {
 		apiLog.Errorf("Error in getting unconfirmed transactions")
 	}
@@ -1033,7 +1035,7 @@ func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	}
 
 	if isCmd && command == "unconfirmedBalance" {
-		writeJSON(w, unconfirmedBalanceSat, c.getIndentQuery(r))
+		writeJSON(w, unconfirmedBalanceSat, iapi.getIndentQuery(r))
 		return
 	}
 
@@ -1083,7 +1085,7 @@ func (c *InsightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	writeJSON(w, addressInfo, c.getIndentQuery(r))
+	writeJSON(w, addressInfo, iapi.getIndentQuery(r))
 }
 
 // fromToForSlice takes ?from=A&to=B from the URL queries where A is the "from"
@@ -1120,7 +1122,7 @@ func fromToForSlice(from, to, sliceLength, txLimit int64) (int64, int64, error) 
 	return start, end, nil
 }
 
-func (c *InsightApiContext) getEstimateFee(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) getEstimateFee(w http.ResponseWriter, r *http.Request) {
 	nbBlocks := GetNbBlocksCtx(r)
 	if nbBlocks == 0 {
 		nbBlocks = 2
@@ -1128,7 +1130,7 @@ func (c *InsightApiContext) getEstimateFee(w http.ResponseWriter, r *http.Reques
 
 	// A better solution would be a call to the DCRD RPC "estimatefee" endpoint
 	// but that does not appear to be exposed currently.
-	infoResult, err := c.nodeClient.GetInfo()
+	infoResult, err := iapi.nodeClient.GetInfo()
 	if err != nil {
 		apiLog.Error("Error getting status")
 		writeInsightError(w, fmt.Sprintf("Error getting status (%s)", err))
@@ -1139,13 +1141,13 @@ func (c *InsightApiContext) getEstimateFee(w http.ResponseWriter, r *http.Reques
 		strconv.Itoa(nbBlocks): infoResult.RelayFee,
 	}
 
-	writeJSON(w, estimateFee, c.getIndentQuery(r))
+	writeJSON(w, estimateFee, iapi.getIndentQuery(r))
 }
 
 // GetPeerStatus handles requests for node peer info (i.e. getpeerinfo RPC).
-func (c *InsightApiContext) GetPeerStatus(w http.ResponseWriter, r *http.Request) {
+func (iapi *InsightApi) GetPeerStatus(w http.ResponseWriter, r *http.Request) {
 	// Use a RPC call to tell if we are connected or not
-	_, err := c.nodeClient.GetPeerInfo()
+	_, err := iapi.nodeClient.GetPeerInfo()
 	connected := err == nil
 
 	var port *string
@@ -1157,5 +1159,5 @@ func (c *InsightApiContext) GetPeerStatus(w http.ResponseWriter, r *http.Request
 		connected, "127.0.0.1", port,
 	}
 
-	writeJSON(w, peerInfo, c.getIndentQuery(r))
+	writeJSON(w, peerInfo, iapi.getIndentQuery(r))
 }

--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -12,14 +12,14 @@ import (
 )
 
 // TxConverter converts dcrd-tx to insight tx
-func (c *InsightApiContext) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.InsightTx, error) {
-	return c.DcrToInsightTxns(txs, false, false, false)
+func (iapi *InsightApi) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.InsightTx, error) {
+	return iapi.DcrToInsightTxns(txs, false, false, false)
 }
 
 // DcrToInsightTxns converts a dcrjson TxRawResult to a InsightTx. The asm,
 // scriptSig, and spending status may be skipped by setting the appropriate
 // input arguments.
-func (c *InsightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
+func (iapi *InsightApi) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
 	newTxs := make([]apitypes.InsightTx, 0, len(txs))
 	for _, tx := range txs {
 		// Build new InsightTx
@@ -60,7 +60,7 @@ func (c *InsightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, 
 
 			// Note: this only gathers information from the database, which does
 			// not include mempool transactions.
-			_, addresses, value, err := c.BlockData.ChainDB.AddressIDsByOutpoint(vin.Txid, vin.Vout)
+			_, addresses, value, err := iapi.BlockData.ChainDB.AddressIDsByOutpoint(vin.Txid, vin.Vout)
 			if err == nil {
 				if len(addresses) > 0 {
 					// Update Vin due to DCRD AMOUNTIN - START
@@ -124,7 +124,7 @@ func (c *InsightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, 
 			// Populate the spending status of all vouts. Note: this only
 			// gathers information from the database, which does not include
 			// mempool transactions.
-			addrFull, err := c.BlockData.ChainDB.SpendDetailsForFundingTx(txNew.Txid)
+			addrFull, err := iapi.BlockData.ChainDB.SpendDetailsForFundingTx(txNew.Txid)
 			if err != nil {
 				return nil, err
 			}
@@ -140,12 +140,12 @@ func (c *InsightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, 
 }
 
 // DcrToInsightBlock converts a dcrjson.GetBlockVerboseResult to Insight block.
-func (c *InsightApiContext) DcrToInsightBlock(inBlocks []*dcrjson.GetBlockVerboseResult) ([]*apitypes.InsightBlockResult, error) {
+func (iapi *InsightApi) DcrToInsightBlock(inBlocks []*dcrjson.GetBlockVerboseResult) ([]*apitypes.InsightBlockResult, error) {
 	RewardAtBlock := func(blocknum int64, voters uint16) float64 {
-		subsidyCache := blockchain.NewSubsidyCache(0, c.params)
-		work := blockchain.CalcBlockWorkSubsidy(subsidyCache, blocknum, voters, c.params)
-		stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, blocknum, c.params) * int64(voters)
-		tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, blocknum, voters, c.params)
+		subsidyCache := blockchain.NewSubsidyCache(0, iapi.params)
+		work := blockchain.CalcBlockWorkSubsidy(subsidyCache, blocknum, voters, iapi.params)
+		stake := blockchain.CalcStakeVoteSubsidy(subsidyCache, blocknum, iapi.params) * int64(voters)
+		tax := blockchain.CalcBlockTaxSubsidy(subsidyCache, blocknum, voters, iapi.params)
 		return dcrutil.Amount(work + stake + tax).ToCoin()
 	}
 

--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -12,14 +12,14 @@ import (
 )
 
 // TxConverter converts dcrd-tx to insight tx
-func (c *insightApiContext) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.InsightTx, error) {
+func (c *InsightApiContext) TxConverter(txs []*dcrjson.TxRawResult) ([]apitypes.InsightTx, error) {
 	return c.DcrToInsightTxns(txs, false, false, false)
 }
 
 // DcrToInsightTxns converts a dcrjson TxRawResult to a InsightTx. The asm,
 // scriptSig, and spending status may be skipped by setting the appropriate
 // input arguments.
-func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
+func (c *InsightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noScriptSig, noSpent bool) ([]apitypes.InsightTx, error) {
 	newTxs := make([]apitypes.InsightTx, 0, len(txs))
 	for _, tx := range txs {
 		// Build new InsightTx
@@ -140,7 +140,7 @@ func (c *insightApiContext) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, 
 }
 
 // DcrToInsightBlock converts a dcrjson.GetBlockVerboseResult to Insight block.
-func (c *insightApiContext) DcrToInsightBlock(inBlocks []*dcrjson.GetBlockVerboseResult) ([]*apitypes.InsightBlockResult, error) {
+func (c *InsightApiContext) DcrToInsightBlock(inBlocks []*dcrjson.GetBlockVerboseResult) ([]*apitypes.InsightBlockResult, error) {
 	RewardAtBlock := func(blocknum int64, voters uint16) float64 {
 		subsidyCache := blockchain.NewSubsidyCache(0, c.params)
 		work := blockchain.CalcBlockWorkSubsidy(subsidyCache, blocknum, voters, c.params)

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -123,7 +123,8 @@ func mainCore() error {
 		DBName: cfg.DBName,
 	}
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
-	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0)
+	mpChecker := rpcutils.NewMempoolAddressChecker(client, activeChain)
+	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0, mpChecker)
 	if db != nil {
 		defer db.Close()
 	}

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -3,8 +3,6 @@ module github.com/decred/dcrdata/db/dcrpg
 go 1.12
 
 require (
-	github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 // indirect
-	github.com/DataDog/zstd v1.3.5 // indirect
 	github.com/chappjc/trylock v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/blockchain/stake v1.1.0
@@ -24,9 +22,11 @@ require (
 	github.com/decred/dcrdata/stakedb v1.0.1
 	github.com/decred/dcrdata/txhelpers v1.0.1
 	github.com/decred/slog v1.0.0
-	github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/lib/pq v1.0.0
-	github.com/pkg/errors v0.8.1 // indirect
-	google.golang.org/appengine v1.5.0 // indirect
+)
+
+replace (
+	github.com/decred/dcrdata/rpcutils => ../../rpcutils
+	github.com/decred/dcrdata/txhelpers => ../../txhelpers
 )

--- a/db/dcrpg/go.sum
+++ b/db/dcrpg/go.sum
@@ -80,6 +80,7 @@ github.com/decred/dcrdata/db/cache v1.0.1 h1:sqE2RXy6jNhhWdRHASJZyHsaipYRpDlGxEH
 github.com/decred/dcrdata/db/cache v1.0.1/go.mod h1:WPkmV72Cal2OOjt4bG35XrjzSqspxMqvWAGpwUUw1B4=
 github.com/decred/dcrdata/db/dbtypes v1.0.1 h1:bcKtATFczVDZj/CE7uDJ1Y3pV+ZldO+IoHv9mwqRYMM=
 github.com/decred/dcrdata/db/dbtypes v1.0.1/go.mod h1:d9qVcMl+l5rOEY7zJB5nqQ0WDEHof9vWlW/9hpK0xpc=
+github.com/decred/dcrdata/db/dcrpg v1.0.0/go.mod h1:b1YmLNZH2p7evVJU6hapsW5Mup5Xtvx3OK48jQa6PYE=
 github.com/decred/dcrdata/rpcutils v1.0.1 h1:6QRdrsD71sfhQbDp6wMt3tgsck+0MW0N7bB4ZnWL7mA=
 github.com/decred/dcrdata/rpcutils v1.0.1/go.mod h1:ZQ3lZzgIiyE75+4CL3d8rDGJZLxd+ftbgWX1jAPSco8=
 github.com/decred/dcrdata/semver v1.0.0 h1:DBqYU/x+4LqHq/3r4xKdF6xG5ewktG2KDC+g/p3f8mc=

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1912,7 +1912,7 @@ SPENDING_TX_DUPLICATE_CHECK:
 		}
 		spendingTx, ok := addressUTXOs.TxnsStore[f.TxSpending]
 		if !ok {
-			log.Errorf("An outpoint's transaction is not available in TxnStore.")
+			log.Errorf("A previous outpoint's spending transaction is not available in TxnStore.")
 			continue
 		}
 		if spendingTx.Confirmed() {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -29,10 +29,10 @@ import (
 	"github.com/decred/dcrdata/blockdata"
 	"github.com/decred/dcrdata/db/cache"
 	"github.com/decred/dcrdata/db/dbtypes"
+	"github.com/decred/dcrdata/db/dcrpg/internal"
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/stakedb"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/db/dcrpg/internal"
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -191,6 +191,7 @@ type ChainDB struct {
 	ctx                context.Context
 	queryTimeout       time.Duration
 	db                 *sql.DB
+	mp                 rpcutils.MempoolAddressChecker
 	chainParams        *chaincfg.Params
 	devAddress         string
 	dupChecks          bool
@@ -429,10 +430,10 @@ type DBInfo struct {
 // parameters. By default, duplicate row checks on insertion are enabled. See
 // NewChainDBWithCancel to enable context cancellation of running queries.
 func NewChainDB(dbi *DBInfo, params *chaincfg.Params, stakeDB *stakedb.StakeDatabase,
-	devPrefetch, hidePGConfig bool, addrCacheCap int) (*ChainDB, error) {
+	devPrefetch, hidePGConfig bool, addrCacheCap int, mp rpcutils.MempoolAddressChecker) (*ChainDB, error) {
 	ctx := context.Background()
 	chainDB, err := NewChainDBWithCancel(ctx, dbi, params, stakeDB,
-		devPrefetch, hidePGConfig, addrCacheCap)
+		devPrefetch, hidePGConfig, addrCacheCap, mp)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params, stakeDB *stakedb.StakeData
 // (context.Background()) except by the pg timeouts. If it is necessary to
 // cancel queries with CTRL+C, for example, use NewChainDBWithCancel.
 func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool, addrCacheCap int) (*ChainDB, error) {
+	stakeDB *stakedb.StakeDatabase, devPrefetch, hidePGConfig bool, addrCacheCap int, mp rpcutils.MempoolAddressChecker) (*ChainDB, error) {
 	// Connect to the PostgreSQL daemon and return the *sql.DB.
 	db, err := Connect(dbi.Host, dbi.Port, dbi.User, dbi.Pass, dbi.DBName)
 	if err != nil {
@@ -548,6 +549,7 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		ctx:                ctx,
 		queryTimeout:       queryTimeout,
 		db:                 db,
+		mp:                 mp,
 		chainParams:        params,
 		devAddress:         devSubsidyAddress,
 		dupChecks:          true,
@@ -579,6 +581,12 @@ func (pgb *ChainDB) InitUtxoCache(utxos []dbtypes.UTXO) {
 // creating or loading a StakeDatabase, such as when dropping tables.
 func (pgb *ChainDB) UseStakeDB(stakeDB *stakedb.StakeDatabase) {
 	pgb.stakeDB = stakeDB
+}
+
+// UseMempoolChecker assigns a MempoolAddressChecker for searching mempool for
+// transactions involving a certain address.
+func (pgb *ChainDB) UseMempoolChecker(mp rpcutils.MempoolAddressChecker) {
+	pgb.mp = mp
 }
 
 // EnableDuplicateCheckOnInsert specifies whether SQL insertions should check
@@ -1829,7 +1837,7 @@ func (db *ChainDBRPC) AddressData(address string, limitN, offsetAddrOuts int64,
 	}
 
 	// Check for unconfirmed transactions.
-	addressUTXOs, numUnconfirmed, err := rpcutils.UnconfirmedTxnsForAddress(db.Client, address, db.chainParams)
+	addressUTXOs, numUnconfirmed, err := db.mp.UnconfirmedTxnsForAddress(address)
 	if err != nil || addressUTXOs == nil {
 		return nil, fmt.Errorf("UnconfirmedTxnsForAddress failed for address %s: %v", address, err)
 	}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1760,19 +1760,6 @@ func (db *WiredDB) GetExplorerAddress(address string, count, offset int64) (*dbt
 	return addrData, addrType, nil
 }
 
-// CountUnconfirmedTransactions returns the number of unconfirmed transactions
-// involving the specified address, given a maximum possible unconfirmed.
-func (db *WiredDB) CountUnconfirmedTransactions(address string) (int64, error) {
-	_, numUnconfirmed, err := db.UnconfirmedTxnsForAddress(address)
-	return numUnconfirmed, err
-}
-
-// UnconfirmedTxnsForAddress routes through rpcutils with appropriate
-// arguments. Returns mempool inputs/outputs associated with the given address.
-func (db *WiredDB) UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error) {
-	return rpcutils.UnconfirmedTxnsForAddress(db.client, address, db.params)
-}
-
 // GetMempool gets all transactions from the mempool for explorer and adds the
 // total out for all the txs and vote info for the votes. The returned slice
 // will be nil if the GetRawMempoolVerbose RPC fails. A zero-length non-nil

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -70,7 +70,6 @@ type explorerDataSourceLite interface {
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() (int64, error)
 	GetChainParams() *chaincfg.Params
-	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 	GetMempool() []types.MempoolTx
 	TxHeight(txid *chainhash.Hash) (height int64)
 	BlockSubsidy(height int64, voters uint16) *dcrjson.GetBlockSubsidyResult

--- a/main.go
+++ b/main.go
@@ -752,7 +752,7 @@ func _main(ctx context.Context) error {
 
 	// SyncStatusAPIIntercept returns a json response if the sync status page is
 	// enabled (no the full explorer while syncing).
-	var insightApp *insight.InsightApiContext
+	var insightApp *insight.InsightApi
 	webMux.With(explore.SyncStatusAPIIntercept).Group(func(r chi.Router) {
 		// Mount the dcrdata's REST API.
 		r.Mount("/api", apiMux.Mux)

--- a/main.go
+++ b/main.go
@@ -1192,14 +1192,13 @@ func _main(ctx context.Context) error {
 	signalToExplorer, mpDataToExplorer := explore.MempoolSignals()
 	mempoolSigOuts := []chan<- pstypes.HubSignal{signalToPSHub, signalToExplorer}
 	newTxOuts := []chan<- *exptypes.MempoolTx{mpDataToPSHub, mpDataToExplorer}
-	mpm := mempool.NewMempoolMonitor(ctx, mpoolCollector, mempoolSavers,
-		activeChain, &wg, notify.NtfnChans.NewTxChan, mempoolSigOuts, newTxOuts)
-
-	// Collect and store initial mempool data before starting the monitor.
-	if err = mpm.CollectAndStore(); err != nil {
+	mpm, err := mempool.NewMempoolMonitor(ctx, mpoolCollector, mempoolSavers,
+		activeChain, &wg, notify.NtfnChans.NewTxChan, mempoolSigOuts, newTxOuts, true)
+	// Ensure the initial collect/store succeeded.
+	if err != nil {
 		// Shutdown goroutines.
 		requestShutdown()
-		return fmt.Errorf("mpm.CollectAndStore: %v", err)
+		return fmt.Errorf("NewMempoolMonitor: %v", err)
 	}
 
 	auxDB.UseMempoolChecker(mpm)

--- a/main.go
+++ b/main.go
@@ -480,7 +480,7 @@ func _main(ctx context.Context) error {
 	}
 
 	blockDataSavers = append(blockDataSavers, baseDB)
-	mempoolSavers = append(mempoolSavers, baseDB.MPC)
+	mempoolSavers = append(mempoolSavers, baseDB.MPC) // mempool.MempoolDataCache
 
 	// Allow Ctrl-C to halt startup here.
 	if shutdownRequested(ctx) {

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -42,7 +42,8 @@ func NewMempoolDataCollector(dcrdChainSvr *rpcclient.Client, params *chaincfg.Pa
 }
 
 // mempoolTxns retrieves all transactions and returns them as a
-// []exptypes.MempoolTx. See also ParseTxns, which may process this slice.
+// []exptypes.MempoolTx. See also ParseTxns, which may process this slice. A
+// fresh MempoolAddressStore and TxnsStore are also generated.
 func (t *MempoolDataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAddressStore, txhelpers.TxnsStore, error) {
 	mempooltxs, err := t.dcrdChainSvr.GetRawMempoolVerbose(dcrjson.GRMAll)
 	if err != nil {

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/decred/dcrd/dcrjson/v2 v2.0.0
 	github.com/decred/dcrd/dcrutil v1.2.1-0.20190118223730-3a5281156b73
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
+	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types v1.0.6
 	github.com/decred/dcrdata/db/dbtypes v1.0.1
 	github.com/decred/dcrdata/db/dcrpg v1.0.0 // indirect
@@ -25,3 +26,5 @@ require (
 	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 )
+
+replace github.com/decred/dcrdata/txhelpers => ../txhelpers

--- a/mempool/go.sum
+++ b/mempool/go.sum
@@ -159,6 +159,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90Pveol
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -181,6 +182,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.1 h1:TrBcJ1yqAl1G++wO39nD/qtgpsW9/1+QGrluyMGEYgM=

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -71,8 +71,8 @@ type MempoolMonitor struct {
 // via the newTxOutChan following an appropriate signal on hubRelay.
 func NewMempoolMonitor(ctx context.Context, collector *MempoolDataCollector,
 	savers []MempoolDataSaver, params *chaincfg.Params, wg *sync.WaitGroup,
-	newTxInChan <-chan *dcrjson.TxRawResult,
-	signalOuts []chan<- pstypes.HubSignal, newTxOutChans []chan<- *exptypes.MempoolTx) *MempoolMonitor {
+	newTxInChan <-chan *dcrjson.TxRawResult, signalOuts []chan<- pstypes.HubSignal,
+	newTxOutChans []chan<- *exptypes.MempoolTx, initialStore bool) (*MempoolMonitor, error) {
 
 	// Make the skeleton MempoolMonitor.
 	p := &MempoolMonitor{
@@ -86,13 +86,11 @@ func NewMempoolMonitor(ctx context.Context, collector *MempoolDataCollector,
 		wg:         wg,
 	}
 
-	// Gather data and fill in MempoolMonitor's internal data fields.
-	// _, _, _, err := p.Refresh()
-	// if err != nil {
-	// 	return nil
-	// }
-
-	return p
+	if initialStore {
+		return p, p.CollectAndStore()
+	}
+	_, _, _, err := p.Refresh()
+	return p, err
 }
 
 // LastBlockHash returns the hash of the most recently stored block.

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -27,6 +27,10 @@ type MempoolDataSaver interface {
 	StoreMPData(*StakeData, []exptypes.MempoolTx, *exptypes.MempoolInfo)
 }
 
+type MempoolAddressChecker interface {
+	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
+}
+
 // MempoolMonitor processes new transactions as they are added to mempool, and
 // forwards the processed data on channels assigned during construction. An
 // inventory of transactions in the current mempool is maintained to prevent
@@ -386,3 +390,7 @@ func (p *MempoolMonitor) CollectAndStore() error {
 
 	return nil
 }
+
+// func (p *MempoolMonitor) UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error) {
+
+// }

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
-	"time"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -506,48 +505,6 @@ func GetChainWork(client *rpcclient.Client, hash *chainhash.Hash) (string, error
 	return header.ChainWork, nil
 }
 
-// func txnAddressOutpoints(txns map[string]dcrjson.GetRawMempoolVerboseResult, params *chaincfg.Params) (map[string]*txhelpers.AddressOutpoints, int64, error) {
-// 	addrsOuts := make(map[string]*txhelpers.AddressOutpoints)
-// 	// Check each transaction for involvement with provided address.
-// 	//addressOutpoints := txhelpers.NewAddressOutpoints(address)
-// 	for hash, tx := range txns {
-// 		// Transaction details from dcrd
-// 		txhash, err := chainhash.NewHashFromStr(hash)
-// 		if err != nil {
-// 			log.Errorf("Invalid transaction hash %s", hash)
-// 			return addrsOuts, 0, err
-// 		}
-
-// 		Tx, err := client.GetRawTransaction(txhash)
-// 		if err != nil {
-// 			log.Warnf("Unable to GetRawTransaction(%s): %v", hash, err)
-// 			return
-// 		}
-// 		// Scan transaction for inputs/outputs involving the address of interest
-// 		outpoints, prevouts, prevTxns := txhelpers.TxInvolvesAddress(Tx.MsgTx(),
-// 			address, client, params)
-// 		if len(outpoints) == 0 && len(prevouts) == 0 {
-// 			continue
-// 		}
-// 		// Update previous outpoint txn slice with mempool time
-// 		for f := range prevTxns {
-// 			prevTxns[f].MemPoolTime = tx.Time
-// 		}
-
-// 		// Add present transaction to previous outpoint txn slice
-// 		numUnconfirmed++
-// 		thisTxUnconfirmed := &txhelpers.TxWithBlockData{
-// 			Tx:          Tx.MsgTx(),
-// 			MemPoolTime: tx.Time,
-// 		}
-// 		prevTxns = append(prevTxns, thisTxUnconfirmed)
-// 		// Merge the I/Os and the transactions into results
-// 		addressOutpoints.Update(prevTxns, outpoints, prevouts)
-// 	}
-
-// 	return addressOutpoints, numUnconfirmed, err
-// }
-
 type MempoolAddressChecker interface {
 	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 }
@@ -569,11 +526,6 @@ func NewMempoolAddressChecker(client *rpcclient.Client, params *chaincfg.Params)
 // mempool that (1) pay to the given address, or (2) spend a previous outpoint
 // that paid to the address.
 func UnconfirmedTxnsForAddress(client *rpcclient.Client, address string, params *chaincfg.Params) (*txhelpers.AddressOutpoints, int64, error) {
-	// Time this process.
-	defer func(start time.Time) {
-		fmt.Printf("rpcutils.UnconfirmedTxnsForAddress completed in %v\n", time.Since(start))
-	}(time.Now())
-
 	// Mempool transactions
 	var numUnconfirmed int64
 	mempoolTxns, err := client.GetRawMempoolVerbose(dcrjson.GRMAll)

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -19,8 +19,8 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/semver"
+	"github.com/decred/dcrdata/txhelpers"
 )
 
 // Any of the following dcrd RPC API versions are deemed compatible with
@@ -504,6 +504,48 @@ func GetChainWork(client *rpcclient.Client, hash *chainhash.Hash) (string, error
 	}
 	return header.ChainWork, nil
 }
+
+// func txnAddressOutpoints(txns map[string]dcrjson.GetRawMempoolVerboseResult, params *chaincfg.Params) (map[string]*txhelpers.AddressOutpoints, int64, error) {
+// 	addrsOuts := make(map[string]*txhelpers.AddressOutpoints)
+// 	// Check each transaction for involvement with provided address.
+// 	//addressOutpoints := txhelpers.NewAddressOutpoints(address)
+// 	for hash, tx := range txns {
+// 		// Transaction details from dcrd
+// 		txhash, err := chainhash.NewHashFromStr(hash)
+// 		if err != nil {
+// 			log.Errorf("Invalid transaction hash %s", hash)
+// 			return addrsOuts, 0, err
+// 		}
+
+// 		Tx, err := client.GetRawTransaction(txhash)
+// 		if err != nil {
+// 			log.Warnf("Unable to GetRawTransaction(%s): %v", hash, err)
+// 			return
+// 		}
+// 		// Scan transaction for inputs/outputs involving the address of interest
+// 		outpoints, prevouts, prevTxns := txhelpers.TxInvolvesAddress(Tx.MsgTx(),
+// 			address, client, params)
+// 		if len(outpoints) == 0 && len(prevouts) == 0 {
+// 			continue
+// 		}
+// 		// Update previous outpoint txn slice with mempool time
+// 		for f := range prevTxns {
+// 			prevTxns[f].MemPoolTime = tx.Time
+// 		}
+
+// 		// Add present transaction to previous outpoint txn slice
+// 		numUnconfirmed++
+// 		thisTxUnconfirmed := &txhelpers.TxWithBlockData{
+// 			Tx:          Tx.MsgTx(),
+// 			MemPoolTime: tx.Time,
+// 		}
+// 		prevTxns = append(prevTxns, thisTxUnconfirmed)
+// 		// Merge the I/Os and the transactions into results
+// 		addressOutpoints.Update(prevTxns, outpoints, prevouts)
+// 	}
+
+// 	return addressOutpoints, numUnconfirmed, err
+// }
 
 // UnconfirmedTxnsForAddress returns the chainhash.Hash of all transactions in
 // mempool that (1) pay to the given address, or (2) spend a previous outpoint

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -381,6 +381,9 @@ func TxPrevOutsByAddr(txAddrOuts MempoolAddressStore, txnsStore TxnsStore, msgTx
 		}
 
 		if len(txAddrs) == 0 {
+			fmt.Printf("pkScript of a previous transaction output "+
+				"(%v:%d) unexpectedly encoded no addresses.",
+				prevOut.Hash, prevOut.Index)
 			continue
 		}
 

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -258,11 +258,10 @@ type TxnsStore map[chainhash.Hash]*TxWithBlockData
 // TxOutpointsByAddr sets the Outpoints field for the AddressOutpoints stored in
 // the input MempoolAddressStore. For addresses not yet present in the
 // MempoolAddressStore, a new AddressOutpoints is added to the store. The
-// provided MempoolAddressStore must be initialized. The number of outpoints
-// paying to addresses in the provided transaction are counted and returned. The
-// addresses paid to by the transaction are listed in the output addrs map,
-// where the value of the stored bool indicates the address is new to the
-// MempoolAddressStore.
+// provided MempoolAddressStore must be initialized. The number of msgTx outputs
+// that pay to any address are counted and returned. The addresses paid to by
+// the transaction are listed in the output addrs map, where the value of the
+// stored bool indicates the address is new to the MempoolAddressStore.
 func TxOutpointsByAddr(txAddrOuts MempoolAddressStore, msgTx *wire.MsgTx, params *chaincfg.Params) (newOuts int, addrs map[string]bool) {
 	if txAddrOuts == nil {
 		panic("TxAddressOutpoints: input map must be initialized: map[string]*AddressOutpoints")


### PR DESCRIPTION
The `rpcutils` package implementation of `UnconfirmedTxnsForAddress` is convenient, but it involves many RPCs, including a full `getrawmempool`.  These changes implement `UnconfirmedTxnsForAddress` in `mempool.MempoolMonitor`, the hub for mempool data and events for the other packages.

```
rpcutils.UnconfirmedTxnsForAddress completed in 8.912882ms

(*MempoolMonitor).UnconfirmedTxnsForAddress completed in 1.462µs
```

`mempool.MempoolMonitor` now keeps an address-keyed mempool txn inventory to facilitate
fast retrieval of transactions that are relevant to specific addresses.

`txhelpers` defines new types and functions for maintaining this address-txn inventory. `(*mempool.MempoolMonitor).Refresh`, `(*mempool.MempoolMonitor).TxHandler`, and `(*mempool.MempoolDataCollector).mempoolTxns` are updated to maintain the address inventory using these new `txhelpers` features.



rpcutils: define `MempoolAddressChecker` interface.

The new `MempoolAddressChecker` interface is satisfied by a
type with the `UnconfirmedTxnsForAddress` method.  Both
`rpcutils.mempoolAddressChecker` (from `NewMempoolAddressChecker`)
and `mempool.MempoolMonitor` satisfy `MempoolAddressChecker`.


dcprg: Add a `rpcutils.MempoolAddressChecker` field.

The new `rpcutils.MempoolAddressChecker` field is set via the constructor
or `UseMempoolChecker`, a new method.

In main, construct the `ChainDB` with `rpcutils`' `MempoolAddressChecker`,
and switch to `mempoolMempoolMonitor` after its construction.


insight: use `MempoolAddressChecker`

Export and rename: `insightApiContext` -->  `InsightApi`.

Replace the `DataSourceLite` interface `MemPool` field in `InsightApiContext`
with a `rpcutils.MempoolAddressChecker`.

Specify the `rpcutils.MempoolAddressChecker` in the constructor, or via
`UseMempoolChecker`.

Resolves https://github.com/decred/dcrdata/issues/1154