### PR TITLE
insight: fix "to" computation when not specified

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -1053,12 +1053,14 @@ func (c *insightApiContext) getAddressInfo(w http.ResponseWriter, r *http.Reques
 	// Final raw tx slice extraction
 	if txcount := int64(len(rawTxs)); txcount > 0 {
 		txLimit := int64(1000)
+		// "from" and "to" are zero-based indexes for inclusive range bounds.
 		from := GetFromCtx(r)
 		to, ok := GetToCtx(r)
 		if !ok || to < from {
-			to = from + txLimit
+			to = from + txLimit - 1 // to is inclusive
 		}
 
+		// [from, to] --(limits)--> [start,end)
 		start, end, err := fromToForSlice(from, to, txcount, txLimit)
 		if err != nil {
 			writeInsightError(w, err.Error())

--- a/api/insight/apiroutes_test.go
+++ b/api/insight/apiroutes_test.go
@@ -109,6 +109,18 @@ func Test_fromToForSlice(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			testName: "ok, at limit",
+			args: args{
+				from:        0,
+				to:          999,
+				sliceLength: 1000,
+				txLimit:     1000,
+			},
+			wantStart: 0,
+			wantEnd:   1000,
+			wantErr:   false,
+		},
+		{
 			testName: "ok, one element",
 			args: args{
 				from:        1,


### PR DESCRIPTION
URL query paramaters "from" and "to" are zero-based indexes for
inclusive range bounds.  This corrects the computation of "to" when it
is not specified.