### PR TITLE
update packages and checking package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -330,9 +330,9 @@
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
-      "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1740,9 +1740,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
-      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/decred/dcrdata#readme",
   "devDependencies": {
     "@babel/core": "~7.4.0",
-    "@babel/plugin-syntax-dynamic-import": "~7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "~7.2.0",
     "@babel/preset-env": "~7.4.2",
     "axios": "~0.18.0",
     "babel-eslint": "~10.0.1",
@@ -59,9 +59,9 @@
     "webpack-merge": "~4.2.1"
   },
   "dependencies": {
-    "bootstrap": "~4.1.3",
-    "dompurify": "~1.0.8",
+    "bootstrap": "~4.3.1",
+    "dompurify": "~1.0.10",
     "lodash-es": "~4.17.11",
-    "qrcode": "~1.3.2"
+    "qrcode": "~1.3.3"
   }
 }


### PR DESCRIPTION
Need reproducible webpack builds.

```
$  npm list --depth=0 --prod
dcrdata@1.0.0 /home/jon/github/decred/dcrdata
├── bootstrap@4.3.1
├── dompurify@1.0.10
├── lodash-es@4.17.11
└── qrcode@1.3.3
```

```
$  npm list --depth=0
dcrdata@1.0.0 /home/jon/github/decred/dcrdata
├── @babel/core@7.4.0
├── @babel/plugin-syntax-dynamic-import@7.2.0
├── @babel/preset-env@7.4.2
├── axios@0.18.0
├── babel-eslint@10.0.1
├── babel-loader@8.0.5
├── babel-polyfill@6.26.0
├── bootstrap@4.3.1
├── clean-webpack-plugin@1.0.1
├── css-loader@1.0.1
├── dompurify@1.0.10
├── eslint@5.16.0
├── eslint-config-standard@12.0.0
├── eslint-loader@2.1.2
├── eslint-plugin-import@2.16.0
├── eslint-plugin-node@8.0.1
├── eslint-plugin-promise@4.1.1
├── eslint-plugin-standard@4.0.0
├── UNMET PEER DEPENDENCY jquery@1.9.1 - 3
├── lodash-es@4.17.11
├── mini-css-extract-plugin@0.4.5
├── mousetrap@1.6.3
├── node-sass@4.11.0
├── notifyjs@3.0.0
├── optimize-css-assets-webpack-plugin@5.0.1
├── UNMET PEER DEPENDENCY popper.js@^1.14.7
├── qrcode@1.3.3
├── sass-loader@7.1.0
├── stimulus@1.1.1
├── style-loader@0.23.1
├── UNMET PEER DEPENDENCY stylelint@9.10.1
├── stylelint-config-standard@18.2.0
├── stylelint-webpack-plugin@0.10.5
├── uglifyjs-webpack-plugin@2.1.2
├── webpack@4.29.6
├── webpack-bundle-analyzer@3.1.0
├── webpack-cli@3.3.0
├── webpack-dev-server@3.2.1
└── webpack-merge@4.2.1
```