### PR TITLE
explorer: check dark mode cookie server-side

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -30,7 +30,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-// Information from the request cookies.
+// Cookies contains information from the request cookies.
 type Cookies struct {
 	DarkMode bool
 }
@@ -2052,10 +2052,11 @@ func (exp *explorerUI) commonData(r *http.Request) *CommonPageData {
 	tip, err := exp.blockData.GetTip()
 	if err != nil {
 		log.Errorf("Failed to get the chain tip from the database.: %v", err)
+		return nil
 	}
-	darkMode, ckErr := r.Cookie("dcrdataDarkBG")
+	darkMode, err := r.Cookie("dcrdataDarkBG")
 	if err != nil && err != http.ErrNoCookie {
-		log.Errorf("Cookie dcrdataDarkBG retrieval error: %v", ckErr)
+		log.Errorf("Cookie dcrdataDarkBG retrieval error: %v", err)
 	}
 	return &CommonPageData{
 		Tip:           tip,

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -30,6 +30,11 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
+// Information from the request cookies.
+type Cookies struct {
+	DarkMode bool
+}
+
 // CommonPageData is the basis for data structs used for HTML templates.
 // explorerUI.commonData returns an initialized instance or CommonPageData,
 // which itself should be used to initialize page data template structs.
@@ -41,6 +46,7 @@ type CommonPageData struct {
 	DevAddress    string
 	Links         *links
 	NetName       string
+	Cookies       Cookies
 }
 
 // Status page strings
@@ -174,7 +180,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		Blocks      []*types.BlockBasic
 		Conversions *homeConversions
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Info:           homeInfo,
 		Mempool:        inv,
 		BestBlock:      bestBlock,
@@ -214,7 +220,7 @@ func (exp *explorerUI) SideChains(w http.ResponseWriter, r *http.Request) {
 		*CommonPageData
 		Data []*dbtypes.BlockStatus
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           sideBlocks,
 	})
 
@@ -245,7 +251,7 @@ func (exp *explorerUI) DisapprovedBlocks(w http.ResponseWriter, r *http.Request)
 		*CommonPageData
 		Data []*dbtypes.BlockStatus
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           disapprovedBlocks,
 	})
 
@@ -304,7 +310,7 @@ func (exp *explorerUI) NextHome(w http.ResponseWriter, r *http.Request) {
 		Mempool *types.TrimmedMempoolInfo
 		Blocks  []*types.TrimmedBlockInfo
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Info:           exp.pageData.HomeInfo,
 		Mempool:        mempoolInfo,
 		Blocks:         trimmedBlocks,
@@ -369,7 +375,7 @@ func (exp *explorerUI) StakeDiffWindows(w http.ResponseWriter, r *http.Request) 
 		OffsetWindow int64
 		Limit        int64
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           windows,
 		WindowSize:     exp.ChainParams.StakeDiffWindowSize,
 		BestWindow:     int64(bestWindow),
@@ -479,7 +485,7 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		Limit        int64
 		BestGrouping int64
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           data,
 		TimeGrouping:   val,
 		Offset:         int64(offset),
@@ -557,7 +563,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		Rows       int64
 		WindowSize int64
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           summaries,
 		BestBlock:      bestBlockHeight,
 		Rows:           int64(rows),
@@ -627,7 +633,7 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 		Data           *types.BlockInfo
 		FiatConversion *exchanges.Conversion
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           data,
 	}
 
@@ -659,7 +665,7 @@ func (exp *explorerUI) Mempool(w http.ResponseWriter, r *http.Request) {
 		*CommonPageData
 		Mempool *types.MempoolInfo
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Mempool:        inv,
 	})
 	inv.RUnlock()
@@ -682,7 +688,7 @@ func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	str, err := exp.templates.execTemplateToString("ticketpool", exp.commonData())
+	str, err := exp.templates.execTemplateToString("ticketpool", exp.commonData(r))
 
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1165,7 +1171,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			Fees  *exchanges.Conversion
 		}
 	}{
-		CommonPageData:       exp.commonData(),
+		CommonPageData:       exp.commonData(r),
 		Data:                 tx,
 		Blocks:               blocks,
 		BlockInds:            blockInds,
@@ -1289,7 +1295,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 
 	// Execute the HTML template.
 	pageData := AddressPageData{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           addrData,
 		IsLiteMode:     exp.liteMode,
 		CRLFDownload:   UseCRLF,
@@ -1448,7 +1454,7 @@ func (exp *explorerUI) DecodeTxPage(w http.ResponseWriter, r *http.Request) {
 	str, err := exp.templates.execTemplateToString("rawtx", struct {
 		*CommonPageData
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1471,7 +1477,7 @@ func (exp *explorerUI) Charts(w http.ResponseWriter, r *http.Request) {
 	str, err := exp.templates.execTemplateToString("charts", struct {
 		*CommonPageData
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)
@@ -1594,6 +1600,8 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 	exp.StatusPage(w, "search failed", message, "", ExpStatusNotFound)
 }
 
+var dummyRequest = new(http.Request)
+
 // StatusPage provides a page for displaying status messages and exception
 // handling without redirecting. Be sure to return after calling StatusPage if
 // this completes the processing of the calling http handler.
@@ -1605,7 +1613,7 @@ func (exp *explorerUI) StatusPage(w http.ResponseWriter, code, message, addition
 		Message        string
 		AdditionalInfo string
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(dummyRequest),
 		StatusType:     sType,
 		Code:           code,
 		Message:        message,
@@ -1671,7 +1679,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 		*CommonPageData
 		ExtendedParams
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		ExtendedParams: ExtendedParams{
 			MaximumBlockSize:     maxBlockSize,
 			AddressPrefix:        addrPrefix,
@@ -1760,7 +1768,7 @@ func (exp *explorerUI) AgendaPage(w http.ResponseWriter, r *http.Request) {
 		TimeRemaining string
 		TotalVotes    uint32
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Ai:             agendaInfo,
 		QuorumVotes:    qVotes,
 		RuleChangeI:    ruleChangeI,
@@ -1795,7 +1803,7 @@ func (exp *explorerUI) AgendasPage(w http.ResponseWriter, r *http.Request) {
 		Agendas       []*agendas.AgendaTagged
 		VotingSummary *agendas.VoteSummary
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Agendas:        agenda,
 		VotingSummary:  exp.voteTracker.Summary(),
 	})
@@ -1834,7 +1842,7 @@ func (exp *explorerUI) ProposalPage(w http.ResponseWriter, r *http.Request) {
 		Data        *pitypes.ProposalInfo
 		PoliteiaURL string
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Data:           proposalInfo,
 		PoliteiaURL:    exp.politeiaAPIURL,
 	})
@@ -1891,7 +1899,7 @@ func (exp *explorerUI) ProposalsPage(w http.ResponseWriter, r *http.Request) {
 		TotalCount    int64
 		PoliteiaURL   string
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Proposals:      proposals,
 		VotesStatus:    pitypes.VotesStatuses(),
 		Offset:         int64(offset),
@@ -2023,7 +2031,7 @@ func (exp *explorerUI) StatsPage(w http.ResponseWriter, r *http.Request) {
 		*CommonPageData
 		Stats types.StatsInfo
 	}{
-		CommonPageData: exp.commonData(),
+		CommonPageData: exp.commonData(r),
 		Stats:          stats,
 	})
 
@@ -2040,10 +2048,14 @@ func (exp *explorerUI) StatsPage(w http.ResponseWriter, r *http.Request) {
 // commonData grabs the common page data that is available to every page.
 // This is particularly useful for extras.tmpl, parts of which
 // are used on every page
-func (exp *explorerUI) commonData() *CommonPageData {
+func (exp *explorerUI) commonData(r *http.Request) *CommonPageData {
 	tip, err := exp.blockData.GetTip()
 	if err != nil {
 		log.Errorf("Failed to get the chain tip from the database.: %v", err)
+	}
+	darkMode, ckErr := r.Cookie("dcrdataDarkBG")
+	if err != nil && err != http.ErrNoCookie {
+		log.Errorf("Cookie dcrdataDarkBG retrieval error: %v", ckErr)
 	}
 	return &CommonPageData{
 		Tip:           tip,
@@ -2053,5 +2065,8 @@ func (exp *explorerUI) commonData() *CommonPageData {
 		DevAddress:    exp.pageData.HomeInfo.DevAddress,
 		NetName:       exp.NetName,
 		Links:         explorerLinks,
+		Cookies: Cookies{
+			DarkMode: darkMode != nil && darkMode.Value == "1",
+		},
 	}
 }

--- a/public/scss/nexthome.scss
+++ b/public/scss/nexthome.scss
@@ -1,10 +1,7 @@
-#nexthome .container {
+#mainContainer {
   max-width: 100% !important;
   width: 100%;
   padding: 0 10%;
-}
-
-#mainContainer {
   display: flex;
   flex-wrap: wrap;
   margin: 30px 0;
@@ -327,7 +324,7 @@ body.darkBG {
 }
 
 @media only screen and (max-width: 768px) {
-  #nexthome .container {
+  #mainContainer {
     padding: 0 5%;
   }
 }

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -3,7 +3,6 @@
 <html lang="en">
 
 {{template "html-head" printf "Decred Address %s" .Data.Address}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
     {{with .Data}}
     {{$TxnCount := add .TxnCount .NumUnconfirmed}}

--- a/views/agenda.tmpl
+++ b/views/agenda.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decred Vote Agenda Pages"}}
-    <body class="{{ theme }}">
         {{template "navbar" .}}
         {{with .Ai}}
         <div class="container main">

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decred Vote Agendas Page"}}
-    <body class="{{ theme }}">
         {{template "navbar" .}}
         <div class="container main pb-5" data-controller="agendas">
 

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" printf "Decred Block %d" .Data.Height}}
-<body class="{{ theme }}">
     {{ template "navbar" . }}
     <div class="container main" data-controller="time">
     {{with .Data}}

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" "Decred Charts"}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
 
     <div data-controller="charts" data-charts-tps="{{.ChainParams.TicketExpiry}}">

--- a/views/disapproved.tmpl
+++ b/views/disapproved.tmpl
@@ -3,7 +3,6 @@
 <html lang="en">
 
 {{template "html-head" "Stakeholder Disapproved Blocks"}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time">
         <h4><span title="blocks disapproved by stakeholder voting"><img class="h30 p2tb" src="/images/pos-hammer.svg" alt="pos hammer"> Stakeholder Disapproved Blocks</span></h4>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -3,7 +3,6 @@
 <html lang="en">
 
 {{template "html-head" "Decred Blocks List"}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time pagenavigation blocklist">
         <span class="h4">Blocks</span>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -19,7 +19,7 @@
         <link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-touch-icon-144x144.png?v=yHh3NA">
         <link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon-152x152.png?v=yHh3NA">
         <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon-180x180.png?v=yHh3NA">
-        
+
         <!-- Browser -->
         <link rel="icon" href="/images/favicon/favicon.ico?v=yHh3NA">
         <link rel="icon" href="/images/favicon/favicon-32x32.png?v=yHh3NA" type="image/png" sizes="32x32">
@@ -27,7 +27,7 @@
 
         <!-- Android PWA -->
         <link rel="manifest" href="/images/favicon/manifest.json?v=yHh3NA">
-        
+
         <!-- Safari -->
         <link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=yHh3NA" color="#091440">
 
@@ -45,6 +45,7 @@
 {{end}}
 
 {{define "navbar"}}
+<body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
 <header class="top-nav"
         id="navBar"
         data-blocktime="{{.BlockTimeUnix}}">

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -4,8 +4,6 @@
 <html lang="en">
 
 {{ template "html-head" "Decred Block Explorer by dcrdata.org"}}
-
-<body class="{{ theme }}">
     {{ template "navbar" . }}
     <div class="container main" data-controller="time blocklist homepage">
         <div class="row">

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -1,11 +1,11 @@
 {{define "mempool"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Mempool"}}
-    <body data-controller="mempool time" class="{{ theme }}">
-        {{template "navbar" . }}
+{{template "html-head" printf "Decred Mempool"}}
+    {{template "navbar" . }}
         {{with .Mempool}}
         <div class="container main"
+        data-controller="mempool time"
         data-target="mempool.mempool"
         {{template "mempoolDump" .}}
         >

--- a/views/nexthome.tmpl
+++ b/views/nexthome.tmpl
@@ -2,8 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ template "html-head" "Decred Block Explorer by dcrdata.org"}}
-
-<body id="nexthome">
     {{ template "navbar" . }}
 
     <div

--- a/views/parameters.tmpl
+++ b/views/parameters.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{ template "html-head" printf "Decred Chain Parameters"}}
-    <body class="{{ theme }}">
         {{template "navbar" . }}
         <div class="container main">
             <div class="row justify-content-between">

--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decred Vote Proposal Pages"}}
-    <body class="{{ theme }}">
         {{template "navbar" .}}
         {{with .Data}}
         <div class="container main">

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decred Vote Proposals Page"}}
-    <body class="{{ theme }}">
         {{template "navbar" .}}
         <div class="container main" data-controller="pagenavigation">
             <div class="row justify-content-between">

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{template "html-head" printf "Decode Raw Decred Transaction"}}
-    <body class="{{ theme }}">
         {{template "navbar" . }}
         <div class="container main" data-controller="rawtx">
             <h4 class="mb-2">Decred transaction to decode or broadcast</h4>

--- a/views/sidechains.tmpl
+++ b/views/sidechains.tmpl
@@ -3,7 +3,6 @@
 <html lang="en">
 
 {{template "html-head" "Decred Side Chains"}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time">
         <h4><span title="side chain blocks known to this dcrdata instance"><img class="h30 p2tb" src="/images/dcr-side-chains.svg" alt="side chain"> Side Chain Blocks</span></h4>

--- a/views/statistics.tmpl
+++ b/views/statistics.tmpl
@@ -2,8 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
     {{ template "html-head" printf "Decred Statistics"}}
-
-    <body>
         {{ template "navbar" . }}
         {{with .Stats}}
         <div class="container py-1">

--- a/views/status.tmpl
+++ b/views/status.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" printf "Status %s" .StatusType}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
 
     <div class="container py-1" data-controller="status">

--- a/views/ticketpool.tmpl
+++ b/views/ticketpool.tmpl
@@ -2,8 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" printf "Decred Ticket Pool"}}
-<body>
-
     {{template "navbar" . }}
 
     <div class="container main" data-controller="ticketpool">

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -3,7 +3,6 @@
 <html lang="en">
 
 {{template "html-head" printf "Decred %s List" .TimeGrouping}}
-<body class="{{ theme }}">
     {{template "navbar" . }}
     <div class="container main" data-controller="time pagenavigation">
         <h4>{{.TimeGrouping}}</h4>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" printf "Decred Transaction %.20s..." .Data.TxID}}
-<body class="{{ theme }}">
 {{template "navbar" . }}
 {{$conv := .Conversions}}
 {{with .Data}}

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -3,9 +3,8 @@
 <html lang="en">
 
 {{template "html-head" "Decred Windows List"}}
-<body class="{{ theme }}" data-controller="pagenavigation">
     {{template "navbar" . }}
-    <div class="container main">
+    <div data-controller="pagenavigation" class="container main">
         <h4>Ticket Price Windows</h4><h6>The ticket price and mining difficulty are adjusted every {{$.WindowSize}} blocks on {{toLowerCase .NetName}} (~12 hours).</h6>
 
         {{block "windowsPagination" .}}


### PR DESCRIPTION
Sets the `darkBG` CSS class on the body ahead of time to prevent flashing of light mode before script loads.

I'm also sneaking this in so that user's fiat index preference can be stored and `ExchangeBot` can serve personalized results. 