### PR TITLE
dcrpg: use single transaction for all in/out/tx inserts 

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -40,8 +40,8 @@ func (iapi *InsightApi) BlockHashPathAndIndexCtx(next http.Handler) http.Handler
 	})
 }
 
-// StatusCtx is a middleware that embeds into the request context the data for
-// the "?q=x" URL query, where x is "getInfo" or "getDifficulty" or
+// StatusInfoCtx is a middleware that embeds into the request context the data
+// for the "?q=x" URL query, where x is "getInfo" or "getDifficulty" or
 // "getBestBlockHash" or "getLastBlockHash".
 func (iapi *InsightApi) StatusInfoCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -165,7 +165,8 @@ func (iapi *InsightApi) ValidatePostCtx(next http.Handler) http.Handler {
 	})
 }
 
-// Process params given in post body for an addrs endpoint
+// PostAddrsTxsCtx middleware processes parameters given in the POST request
+// body for an addrs endpoint.
 func PostAddrsTxsCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req apitypes.InsightMultiAddrsTx
@@ -182,7 +183,7 @@ func PostAddrsTxsCtx(next http.Handler) http.Handler {
 			writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
 			return
 		}
-		// Successful extraction of Body JSON
+		// Successful extraction of body JSON.
 		ctx := context.WithValue(r.Context(), m.CtxAddress, req.Addresses)
 
 		if req.From != "" {
@@ -221,7 +222,8 @@ func PostAddrsTxsCtx(next http.Handler) http.Handler {
 	})
 }
 
-// Process params given in post body for an addrs Utxo endpoint
+// PostAddrsUtxoCtx middleware processes parameters given in the POST request
+// body for an addrs utxo endpoint.
 func PostAddrsUtxoCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := apitypes.InsightAddr{}

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -803,7 +803,7 @@ func (ar *AddressRow) IsMerged() bool {
 // stored as chainhash.Hash ([32]byte) for efficiency and data locality. The
 // fields of AddressRow that only pertain to merged views (AtomsCredit,
 // AtomsDebit, and MergedTxCount) are omitted. VinVoutDbID is also omitted since
-// it is only used when inserting data (see InsertVouts and storeTxns).
+// it is only used when inserting data (see InsertVouts and storeBlockTxnTree).
 type AddressRowCompact struct {
 	Address        string
 	TxBlockTime    int64

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -35,6 +35,7 @@ require (
 )
 
 replace (
+	github.com/decred/dcrdata/db/dbtypes => ../dbtypes
 	github.com/decred/dcrdata/rpcutils => ../../rpcutils
 	github.com/decred/dcrdata/txhelpers => ../../txhelpers
 )

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -201,8 +201,9 @@ const (
 	UpdateLastBlockValid = `UPDATE blocks SET is_valid = $2 WHERE id = $1;`
 	UpdateBlockMainchain = `UPDATE blocks SET is_mainchain = $2 WHERE hash = $1 RETURNING previous_hash;`
 
-	// block_chain table. The primary key is not a SERIAL, but rather the row ID
-	// of the block in the blocks table.
+	// CreateBlockPrevNextTable creates a new table named block_chain. The
+	// primary key is not a SERIAL, but rather the row ID of the block in the
+	// blocks table.
 	CreateBlockPrevNextTable = `CREATE TABLE IF NOT EXISTS block_chain (
 		block_db_id INT8 PRIMARY KEY,
 		prev_hash TEXT NOT NULL,

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -163,8 +163,9 @@ const (
 
 	// votes table
 
-	// block_time field is needed to plot "Cumulative Vote Choices" agendas chart
-	// that plots cumulative votes count against time over the voting period.
+	// CreateVotesTable creates a new table named votes. block_time field is
+	// needed to plot "Cumulative Vote Choices" agendas chart that plots
+	// cumulative votes count against time over the voting period.
 	CreateVotesTable = `CREATE TABLE IF NOT EXISTS votes (
 		id SERIAL PRIMARY KEY,
 		height INT4,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -3328,10 +3328,8 @@ func (pgb *ChainDB) storeTxns(txns []*dbtypes.Tx, vouts [][]*dbtypes.Vout, vins 
 		}
 		numIns += len(Tx.VinDbIds)
 
-		// return the transactions vout slice if processing stake tree
-		//if txTree == wire.TxTreeStake {
+		// Return the transactions vout slice.
 		Tx.Vouts = vouts[it]
-		//}
 	}
 
 	// Get the tx PK IDs for storage in the blocks, tickets, and votes table.
@@ -3352,8 +3350,8 @@ func (pgb *ChainDB) storeBlockTxnTree(msgBlock *MsgBlockPG, txTree int8,
 	chainParams *chaincfg.Params, isValid, isMainchain bool,
 	updateExistingRecords, updateAddressesSpendingInfo,
 	updateTicketsSpendingInfo bool) storeTxnsResult {
-	// For the given block, transaction tree, and network, extract the
-	// transactions, vins, and vouts.
+	// For the given block and transaction tree, extract the transactions, vins,
+	// and vouts.
 	dbTransactions, dbTxVouts, dbTxVins := dbtypes.ExtractBlockTransactions(
 		msgBlock.MsgBlock, txTree, chainParams, isValid, isMainchain)
 
@@ -3558,7 +3556,7 @@ func (pgb *ChainDB) storeBlockTxnTree(msgBlock *MsgBlockPG, txTree int8,
 
 	wg.Wait()
 
-	// Check the new vins, inserting spending address rows, and (if
+	// Begin a database transaction to insert spending address rows, and (if
 	// updateAddressesSpendingInfo) update matching_tx_hash in corresponding
 	// funding rows.
 	dbTx, err := pgb.db.Begin()
@@ -3589,7 +3587,7 @@ func (pgb *ChainDB) storeBlockTxnTree(msgBlock *MsgBlockPG, txTree int8,
 			// Transaction that spends an outpoint paying to >=0 addresses
 			vin := &txVins[iv]
 
-			// Skip coinbase inputs (they are generated and thus have no
+			// Skip coinbase inputs (they are new coins and thus have no
 			// previous outpoint funding them).
 			if bytes.Equal(zeroHashStringBytes, []byte(vin.PrevTxHash)) {
 				continue
@@ -3727,7 +3725,7 @@ func (pgb *ChainDB) CollectTicketSpendDBInfo(dbTxns []*dbtypes.Tx, txDbIDs []uin
 			continue
 		}
 
-		// Ensure the transaction slices correspond.
+		// Ensure the transactions in dbTxns and msgBlock.STransactions correspond.
 		msgTx := msgTxns[i]
 		if tx.TxID != msgTx.TxHash().String() {
 			err = fmt.Errorf("txid of dbtypes.Tx does not match that of msgTx")

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -24,8 +24,8 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/db/dbtypes"
-	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/db/dcrpg/internal"
+	"github.com/decred/dcrdata/txhelpers"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/lib/pq"
 )

--- a/db/dcrpg/system.go
+++ b/db/dcrpg/system.go
@@ -224,7 +224,7 @@ func CheckCurrentTimeZone(db *sql.DB) (currentTZ string, err error) {
 	return
 }
 
-// CheckCurrentTimeZone queries for the default postgres time zone. This is the
+// CheckDefaultTimeZone queries for the default postgres time zone. This is the
 // value that would be observed if postgres were restarted using its current
 // configuration. The currently set time zone is also returned.
 func CheckDefaultTimeZone(db *sql.DB) (defaultTZ, currentTZ string, err error) {

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -16,9 +16,9 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/db/dbtypes"
+	"github.com/decred/dcrdata/db/dcrpg/internal"
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/db/dcrpg/internal"
 )
 
 // tableUpgradeType defines the types of upgrades that currently exists and

--- a/explorer/explorermiddleware.go
+++ b/explorer/explorermiddleware.go
@@ -18,8 +18,7 @@ import (
 type contextKey int
 
 const (
-	ctxSearch contextKey = iota
-	ctxBlockIndex
+	ctxBlockIndex contextKey = iota
 	ctxBlockHash
 	ctxTxHash
 	ctxTxInOut

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -20,49 +20,49 @@ func (source dataSourceStub) GetStakeVersionInfo(version int32) (*dcrjson.GetSta
 		CurrentHeight: h,
 		Hash:          strconv.Itoa(int(version)),
 		Intervals: []dcrjson.VersionInterval{
-			dcrjson.VersionInterval{
+			{
 				StartHeight: h - 500,
 				EndHeight:   h + 500,
 				PoSVersions: []dcrjson.VersionCount{
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   5,
 					},
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   100000,
 					},
 				},
 				VoteVersions: []dcrjson.VersionCount{
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   5,
 					},
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   100000,
 					},
 				},
 			},
-			dcrjson.VersionInterval{
+			{
 				StartHeight: h - 1500,
 				EndHeight:   h - 501,
 				PoSVersions: []dcrjson.VersionCount{
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   5,
 					},
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   100000,
 					},
 				},
 				VoteVersions: []dcrjson.VersionCount{
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   5,
 					},
-					dcrjson.VersionCount{
+					{
 						Version: uint32(version),
 						Count:   100000,
 					},
@@ -86,7 +86,7 @@ func (source dataSourceStub) GetVoteInfo(version uint32) (*dcrjson.GetVoteInfoRe
 		Quorum:        4032,
 		TotalVotes:    10000,
 		Agendas: []dcrjson.Agenda{
-			dcrjson.Agenda{
+			{
 				ID:             "test agenda",
 				Description:    "agenda for testing",
 				Mask:           6,
@@ -95,7 +95,7 @@ func (source dataSourceStub) GetVoteInfo(version uint32) (*dcrjson.GetVoteInfoRe
 				Status:         "failed",
 				QuorumProgress: 0,
 				Choices: []dcrjson.Choice{
-					dcrjson.Choice{
+					{
 						ID:          "abstain",
 						Description: "abstain voting for change",
 						Bits:        0,
@@ -104,7 +104,7 @@ func (source dataSourceStub) GetVoteInfo(version uint32) (*dcrjson.GetVoteInfoRe
 						Count:       0,
 						Progress:    0,
 					},
-					dcrjson.Choice{
+					{
 						ID:          "no",
 						Description: "keep the existing consensus rules",
 						Bits:        2,
@@ -113,7 +113,7 @@ func (source dataSourceStub) GetVoteInfo(version uint32) (*dcrjson.GetVoteInfoRe
 						Count:       0,
 						Progress:    0,
 					},
-					dcrjson.Choice{
+					{
 						ID:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        4,

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -134,6 +134,8 @@ const (
 	//   * PropStatusPublic
 	//   * PropStatusAbandoned
 	VettedState
+
+	// UnknownState indicates a proposal state that is unrecognized.
 	UnknownState
 )
 

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -38,7 +38,6 @@ const (
 	ctxTxHash
 	ctxTxns
 	ctxTxInOutIndex
-	ctxSearch
 	ctxN
 	ctxCount
 	ctxOffset
@@ -616,17 +615,6 @@ func apiDocs(mux *chi.Mux) func(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
-}
-
-// SearchPathCtx returns a http.HandlerFunc that embeds the value at the url part
-// {search} into the request context (Still need this for the error page)
-// TODO: make new error system
-func SearchPathCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		str := chi.URLParam(r, "search")
-		ctx := context.WithValue(r.Context(), ctxSearch, str)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
 }
 
 // APIDirectory is the actual handler used with apiDocs

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -234,14 +234,14 @@ func TestSideChainFull(t *testing.T) {
 	}
 
 	// Try to get side chain for a main chain block
-	sideChain, err := SideChainFull(client, "00000000aab245a5b4c5cd4c3318310c45edcc1aa016305820602e76551daf87")
+	_, err = SideChainFull(client, "00000000aab245a5b4c5cd4c3318310c45edcc1aa016305820602e76551daf87")
 	if err == nil {
 		t.Errorf("SideChainFull should have failed for a mainchain block")
 	}
 	t.Logf("Main chain block is not on sidechain, as expected: %v", err)
 
 	// Try to get side chain for a block that was recorded on one node as a side chain tip.
-	sideChain, err = SideChainFull(client, "00000000cef7d921ccbb78282509c6a693d67c74d1bc046f0154ef89f082c231")
+	sideChain, err := SideChainFull(client, "00000000cef7d921ccbb78282509c6a693d67c74d1bc046f0154ef89f082c231")
 	if err != nil {
 		t.Errorf("SideChainFull failed: %v", err)
 	}

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -21,8 +21,8 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/rpcutils"
+	"github.com/decred/dcrdata/txhelpers"
 )
 
 // PoolInfoCache contains a map of block hashes to ticket pool info data at that

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -4,7 +4,6 @@
 
 // Package txhelpers contains helper functions for working with transactions and
 // blocks (e.g. checking for a transaction in a block).
-
 package txhelpers
 
 import (
@@ -48,7 +47,7 @@ var CoinbaseScript = append([]byte{0x00, 0x00}, []byte(CoinbaseFlags)...)
 //   			\  -> B' -> C' -> D'
 // CommonAncestor - Hash of A
 // OldChainHead - Hash of C
-// OldChainHeight - Hieght of C
+// OldChainHeight - Height of C
 // OldChain - Chain from B to C
 // NewChainHead - Hash of D'
 // NewChainHeight - Height of D'


### PR DESCRIPTION
A single database transaction is used to insert all of a blocks
intputs, outputs, and transactions: https://github.com/decred/dcrdata/pull/1233/commits/7ebd251e8fbf9cabefff056a6c69eb40f89ba76a

Spending address rows are also inserted in a single transaction: https://github.com/decred/dcrdata/pull/1233/commits/8930afc95a5a4d96f85a5a26471d9926d08a486e

Prepare address rows and UTXO cache concurrently with stake inserts: https://github.com/decred/dcrdata/pull/1233/commits/ef3f3804558ae69dde970a6ad53dea40d17fc849

99% of the speed gains come from 7ebd251e8fbf9cabefff056a6c69eb40f89ba76a

**`[INF] PSQL: Avg. speed: 1329 tx/s, 4894 vout/s`**

```
[INF] PSQL: Processing blocks 1 to 500...
[INF] PSQL: Processing blocks 501 to 1000...
[INF] PSQL: Processing blocks 1001 to 1500...
[INF] PSQL: Processing blocks 1501 to 2000...
[INF] PSQL: Processing blocks 2001 to 2500...
[INF] PSQL: (103 blk/s, 1504 tx/s, 1681 vin/sec, 4943 vout/s)
[INF] PSQL: Processing blocks 2501 to 3000...
[INF] PSQL: Processing blocks 3001 to 3500...
[INF] PSQL: Processing blocks 3501 to 4000...
[INF] PSQL: Processing blocks 4001 to 4500...
[INF] PSQL: Processing blocks 4501 to 5000...
[INF] PSQL: (125 blk/s, 1406 tx/s, 1907 vin/sec, 4266 vout/s)

<snip>

[INF] PSQL: ( 81 blk/s, 1339 tx/s, 2840 vin/sec, 4670 vout/s)
[INF] PSQL: Processing blocks 330501 to 331000...
[INF] PSQL: Processing blocks 331001 to 331500...
[INF] PSQL: Processing blocks 331501 to 332000...
[INF] PSQL: ( 76 blk/s, 1280 tx/s, 2674 vin/sec, 4420 vout/s)
[INF] PSQL: Processing blocks 332001 to 332254...
[INF] SQLT: Scanning blocks 332001 to 332254 (41107 live)...
[INF] SQLT: Rescan finished successfully at height 332254.
[DBG] SQLT: New best block (chain server):     332254
[DBG] SQLT: New best block (sqlite block DB):  332254
[DBG] SQLT: New best block (stakedb):          332254
[INF] SQLT: resyncDBWithPoolValue completed in 1h13m26.531699902s
[INF] PSQL: Avg. speed: 1329 tx/s, 4894 vout/s
```