### PR TITLE
dcrpg: check and set synchronous_commit

### DIFF
--- a/db/dcrpg/internal/system.go
+++ b/db/dcrpg/internal/system.go
@@ -48,5 +48,7 @@ const (
 			OR name='jit'
 			OR name='jit_provider';`
 
+	RetrieveSyncCommitSetting = `SELECT setting FROM pg_settings WHERE name='synchronous_commit';`
+
 	RetrievePGVersion = `SELECT version();`
 )

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -496,10 +496,17 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	}
 	if syncCommit != "off" {
 		log.Warnf(`PERFORMANCE ISSUE! The synchronous_commit setting is = "%s". `+
-			`" We will atttempt to set it to "off".`, syncCommit)
+			`Changing it to "off".`, syncCommit)
 		// Turn off synchronous_commit.
 		if err = SetSynchronousCommit(db, "off"); err != nil {
 			return nil, fmt.Errorf("failed to set synchronous_commit: %v", err)
+		}
+		// Verify that the setting was changed.
+		if syncCommit, err = RetrieveSysSettingSyncCommit(db); err != nil {
+			return nil, err
+		}
+		if syncCommit != "off" {
+			log.Errorf(`Failed to set synchronous_commit="off". Check PostgreSQL user permissions.`)
 		}
 	}
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -495,7 +495,7 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		return nil, err
 	}
 	if syncCommit != "off" {
-		log.Warnf(`PERFORMANCE ISSUE! The synchronous_commit setting is = "%s". `+
+		log.Warnf(`PERFORMANCE ISSUE! The synchronous_commit setting is "%s". `+
 			`Changing it to "off".`, syncCommit)
 		// Turn off synchronous_commit.
 		if err = SetSynchronousCommit(db, "off"); err != nil {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -24,8 +24,8 @@ import (
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
 	"github.com/decred/dcrdata/db/dbtypes"
-	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/db/dcrpg/internal"
+	"github.com/decred/dcrdata/txhelpers"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/lib/pq"
 )

--- a/db/dcrpg/system.go
+++ b/db/dcrpg/system.go
@@ -216,6 +216,18 @@ func RetrieveSysSettingsServer(db *sql.DB) (PGSettings, error) {
 	return retrieveSysSettings(internal.RetrieveSysSettingsServer, db)
 }
 
+// RetrieveSysSettingSyncCommit retrieves the synchronous_commit setting.
+func RetrieveSysSettingSyncCommit(db *sql.DB) (syncCommit string, err error) {
+	err = db.QueryRow(internal.RetrieveSyncCommitSetting).Scan(&syncCommit)
+	return
+}
+
+// SetSynchronousCommit sets the synchronous_commit setting.
+func SetSynchronousCommit(db *sql.DB, syncCommit string) error {
+	_, err := db.Exec(fmt.Sprintf(`SET synchronous_commit TO %s;`, syncCommit))
+	return err
+}
+
 // CheckCurrentTimeZone queries for the currently set postgres time zone.
 func CheckCurrentTimeZone(db *sql.DB) (currentTZ string, err error) {
 	if err = db.QueryRow(`SHOW TIME ZONE`).Scan(&currentTZ); err != nil {

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -16,9 +16,9 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/db/dbtypes"
+	"github.com/decred/dcrdata/db/dcrpg/internal"
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/txhelpers"
-	"github.com/decred/dcrdata/db/dcrpg/internal"
 )
 
 // tableUpgradeType defines the types of upgrades that currently exists and

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -21,8 +21,8 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types"
-	"github.com/decred/dcrdata/txhelpers"
 	"github.com/decred/dcrdata/rpcutils"
+	"github.com/decred/dcrdata/txhelpers"
 )
 
 // PoolInfoCache contains a map of block hashes to ticket pool info data at that


### PR DESCRIPTION
Running PostgreSQL with `synchronous_commit = on` is an absolute performance killer,
and a quite common configuration mistake.  However, it is safe to set it to `"off"`.

These changes check the current setting, and set it to `"off"` if it is not already set that way.