### PR TITLE
gov/agendas: Correct the usage of the stake version

### DIFF
--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -129,17 +129,17 @@ type VoteTracker struct {
 // NewVoteTracker is a constructor for a VoteTracker.
 func NewVoteTracker(params *chaincfg.Params, node VoteDataSource, counter voteCounter,
 	activeVersions map[uint32][]chaincfg.ConsensusDeployment) (*VoteTracker, error) {
-	var lastStakeVersion uint32
+	var latestStakeVersion uint32
 	var starttime uint64
 
 	// Consensus deployments that share a stake version as the key should also
 	// have matching starttime.
 	for stakeVersion, val := range activeVersions {
-		if lastStakeVersion == 0 {
-			lastStakeVersion = stakeVersion
+		if latestStakeVersion == 0 {
+			latestStakeVersion = stakeVersion
 			starttime = val[0].StartTime
 		} else if val[0].StartTime >= starttime {
-			lastStakeVersion = stakeVersion
+			latestStakeVersion = stakeVersion
 			starttime = val[0].StartTime
 		}
 	}
@@ -150,7 +150,7 @@ func NewVoteTracker(params *chaincfg.Params, node VoteDataSource, counter voteCo
 		voteCounter:    counter,
 		countCache:     make(map[string]*voteCount),
 		params:         params,
-		version:        lastStakeVersion,
+		version:        latestStakeVersion,
 		ringIndex:      -1,
 		blockRing:      make([]int32, params.BlockUpgradeNumToCheck),
 		minerThreshold: float32(params.BlockRejectNumRequired) / float32(params.BlockUpgradeNumToCheck),
@@ -288,17 +288,17 @@ func (tracker *VoteTracker) refreshSVIs(voteInfo *dcrjson.GetVoteInfoResult) (*d
 }
 
 // The cached voteCount for the given agenda, or nil if not found.
-func (tracker *VoteTracker) cachedCounts(agendaId string) *voteCount {
+func (tracker *VoteTracker) cachedCounts(agendaID string) *voteCount {
 	tracker.mtx.RLock()
 	defer tracker.mtx.RUnlock()
-	return tracker.countCache[agendaId]
+	return tracker.countCache[agendaID]
 }
 
 // Cache the voteCount for the given agenda.
-func (tracker *VoteTracker) cacheVoteCounts(agendaId string, counts *voteCount) {
+func (tracker *VoteTracker) cacheVoteCounts(agendaID string, counts *voteCount) {
 	tracker.mtx.Lock()
 	defer tracker.mtx.Unlock()
-	tracker.countCache[agendaId] = counts
+	tracker.countCache[agendaID] = counts
 }
 
 // Once all resources have been retrieved from dcrd, update VoteTracker fields.

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -152,7 +152,8 @@ func counter(hash string) (uint32, uint32, uint32, error) {
 }
 
 func TestVoteTracker(t *testing.T) {
-	tracker, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter)
+	data := map[uint32][]chaincfg.ConsensusDeployment{4: []chaincfg.ConsensusDeployment{{StartTime: 1493164800}}}
+	tracker, err := NewVoteTracker(&chaincfg.MainNetParams, dataSourceStub{}, counter, data)
 	if err != nil {
 		t.Errorf("NewVoteTracker error: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -572,7 +572,8 @@ func _main(ctx context.Context) error {
 	}()
 
 	// A vote tracker tracks current block and stake versions and votes.
-	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient, pgDB.AgendaVoteCounts)
+	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient,
+		pgDB.AgendaVoteCounts, activeChain.Deployments)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize vote tracker: %v", err)
 	}


### PR DESCRIPTION
Fetches the stake version from the active deployments map instead of using the wire protocol version.

Fixes this bug on testnet3.
```
2019-04-15 20:31:55.429 [INF] DATD: Closing connection to dcrd.
2019-04-15 20:31:55.429 [INF] DATD: Bye!
2019-04-15 20:31:55.680 [ERR] DATD: Unable to initialize vote tracker: Vote information not found: -32603: stake version 6 does not exist
```