### PR TITLE
[4.1] Proposals cleanup

### DIFF
--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -268,7 +268,11 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 		proposal, err := piclient.RetrieveProposalByToken(db.client, db.APIURLpath,
 			val.Censorship.Token)
 		if err != nil {
-			return 0, fmt.Errorf("RetrieveProposalByToken failed: %v ", err)
+			// Since the proposal tokens bieng updated here are already in the
+			// proposals.db. Do not return errors found since they will still be
+			// updated when the data is available.
+			log.Errorf("RetrieveProposalByToken failed: %v ", err)
+			continue
 		}
 
 		// Do not update if the new proposals status is NotAuthorized or If the

--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -203,6 +203,12 @@
                             chart-options="{tooltipTemplate: '<%=label%>: <%= numeral(value).format('($00[.]00)') %> - <%= numeral(circumference / 6.283).format('(0[.][00]%)') %>'"
                         ></canvas>
                     </div>
+                 {{else}}
+                    <table class="table container">
+                        <tr>
+                            <td class="text-center">No proposal votes data found.</td>
+                        </tr>
+                    </table>
                 {{end}}
             </div>
         </div>

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -100,7 +100,7 @@
                         </nav>
                     </div>
                 {{end}}
-            <div>
+            </div>
 
             <table class="table table-mono-cells my-2">
                 <thead>


### PR DESCRIPTION
- [x] If update of previously added proposal tokens fails for some, the error returned is logged and update proceeds for those that new data is available.
It will help in updating past such an error if new data exists.
```
2019-04-15 19:17:13.120 [ERR] DATD: updating proposals db failed: RetrieveProposalByToken failed: retrieving 5d9cfb07aefb338ba1b74f97de16ee651beabc851c7f2b5f790bd88aea23b3cb proposal vote status failed: request (https://proposals.decred.org/api/v1/proposals/5d9cfb07aefb338ba1b74f97de16ee651beabc851c7f2b5f790bd88aea23b3cb/votestatus) failed with status code: 400 Bad Request 
```

- [x] Added this to proposal details pages that do not show proposal votes charts when there data is missing.
![Screenshot from 2019-04-16 09-57-16](https://user-images.githubusercontent.com/22055953/56191459-1007f180-6035-11e9-900d-0ea17d4c8a3f.png)