### PR TITLE
[4.1] Fix the incorrect single proposal marshaling

### DIFF
--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -5,7 +5,6 @@
 package piclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,24 +13,6 @@ import (
 
 	pitypes "github.com/decred/dcrdata/gov/politeia/types"
 	piapi "github.com/decred/politeia/politeiawww/api/v1"
-)
-
-var (
-	// nullProposalData defines a case scenario where the proposal could have had
-	// a null pointer attached to it.
-	nullProposalData = []byte(`{"proposal": null}`)
-
-	// nullVotesData defines a case scenario where the votes could have had a null
-	// pointer attached to it.
-	nullVotesData = []byte(`{"votes": null}`)
-
-	// nullProposalsData defines a case scenario where the proposals array could
-	// have had a null pointer attached to it.
-	nullProposalsData = []byte(`{"proposals": null}`)
-
-	// nullVotesStatusData defines a case scenario where the votesstatus array
-	// could have had a null pointer attached to it.
-	nullVotesStatusData = []byte(`{"votesstatus": null}`)
 )
 
 // HandleGetRequests accepts a http client and API URL path as arguments. If the
@@ -79,12 +60,6 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 		return nil, err
 	}
 
-	// Check if proposals data with null entry were returned as part of the
-	// proposals details.
-	if bytes.Equal(data, nullProposalsData) {
-		return nil, fmt.Errorf("invalid proposals array with null data found")
-	}
-
 	var publicProposals pitypes.Proposals
 	err = json.Unmarshal(data, &publicProposals)
 	if err != nil || len(publicProposals.Data) == 0 {
@@ -96,12 +71,6 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 	data, err = HandleGetRequests(client, URLpath)
 	if err != nil {
 		return nil, err
-	}
-
-	// Check if votesstatuses data with null entry were returned as part of the
-	// votesstatus details.
-	if bytes.Equal(data, nullVotesStatusData) {
-		return nil, fmt.Errorf("invalid votesstatus array with null data found")
 	}
 
 	var votesInfo pitypes.Votes
@@ -134,15 +103,15 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
-	// Check if null proposal data was returned as part of the proposal details.
-	if bytes.Equal(data, nullProposalData) {
-		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
-	}
-
 	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if null proposal data was returned as part of the proposal details.
+	if proposal.Data == nil {
+		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
 	}
 
 	// Constructs the full votes status URL and fetch its data.
@@ -150,11 +119,6 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 	data, err = HandleGetRequests(client, votesStatusRoute)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
-	}
-
-	// Check if null votes data was returned as part of the proposal votes details.
-	if bytes.Equal(data, nullVotesData) {
-		return nil, fmt.Errorf("invalid votes with null data found for %s", token)
 	}
 
 	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)

--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -95,7 +95,7 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 
 // RetrieveProposalByToken returns a single proposal identified by the token
 // hash provided if it exists. Data returned is queried from Politeia API.
-func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*pitypes.ProposalInfo, error) {
+func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*pitypes.Proposal, error) {
 	// Constructs the full proposal's URl and fetch is data.
 	proposalRoute := APIRootPath + DropURLRegex(piapi.RouteProposalDetails, token)
 	data, err := HandleGetRequests(client, proposalRoute)
@@ -103,7 +103,7 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
-	var proposal pitypes.ProposalInfo
+	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
 	}
 
-	err = json.Unmarshal(data, &proposal.ProposalVotes)
+	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)
 	if err != nil {
 		return nil, err
 	}

--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -5,6 +5,7 @@
 package piclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +14,24 @@ import (
 
 	pitypes "github.com/decred/dcrdata/gov/politeia/types"
 	piapi "github.com/decred/politeia/politeiawww/api/v1"
+)
+
+var (
+	// nullProposalData defines a case scenario where the proposal could have had
+	// a null pointer attached to it.
+	nullProposalData = []byte(`{"proposal": null}`)
+
+	// nullVotesData defines a case scenario where the votes could have had a null
+	// pointer attached to it.
+	nullVotesData = []byte(`{"votes": null}`)
+
+	// nullProposalsData defines a case scenario where the proposals array could
+	// have had a null pointer attached to it.
+	nullProposalsData = []byte(`{"proposals": null}`)
+
+	// nullVotesStatusData defines a case scenario where the votesstatus array
+	// could have had a null pointer attached to it.
+	nullVotesStatusData = []byte(`{"votesstatus": null}`)
 )
 
 // HandleGetRequests accepts a http client and API URL path as arguments. If the
@@ -60,6 +79,12 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 		return nil, err
 	}
 
+	// Check if proposals data with null entry were returned as part of the
+	// proposals details.
+	if bytes.Equal(data, nullProposalsData) {
+		return nil, fmt.Errorf("invalid proposals array with null data found")
+	}
+
 	var publicProposals pitypes.Proposals
 	err = json.Unmarshal(data, &publicProposals)
 	if err != nil || len(publicProposals.Data) == 0 {
@@ -71,6 +96,12 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 	data, err = HandleGetRequests(client, URLpath)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if votesstatuses data with null entry were returned as part of the
+	// votesstatus details.
+	if bytes.Equal(data, nullVotesStatusData) {
+		return nil, fmt.Errorf("invalid votesstatus array with null data found")
 	}
 
 	var votesInfo pitypes.Votes
@@ -103,6 +134,11 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
+	// Check if null proposal data was returned as part of the proposal details.
+	if bytes.Equal(data, nullProposalData) {
+		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
+	}
+
 	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
@@ -114,6 +150,11 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 	data, err = HandleGetRequests(client, votesStatusRoute)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
+	}
+
+	// Check if null votes data was returned as part of the proposal votes details.
+	if bytes.Equal(data, nullVotesData) {
+		return nil, fmt.Errorf("invalid votes with null data found for %s", token)
 	}
 
 	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -101,6 +101,8 @@ func (db *ProposalDB) saveProposals(URLParams string) (int, error) {
 
 		// Break if no valid data was found.
 		if data == nil || data.Data == nil {
+			// Should help detect when API changes are effected on Politeia's end.
+			log.Warnf("invalid or empty data entries were returned")
 			break
 		}
 
@@ -267,6 +269,8 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 	for _, val := range inProgress {
 		proposal, err := piclient.RetrieveProposalByToken(db.client, db.APIURLpath,
 			val.Censorship.Token)
+		// Do not update if:
+		// 1. piclient.RetrieveProposalByToken returned an error
 		if err != nil {
 			// Since the proposal tokens bieng updated here are already in the
 			// proposals.db. Do not return errors found since they will still be
@@ -275,15 +279,22 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 			continue
 		}
 
-		// Do not update if the new proposals status is NotAuthorized or If the
-		// last update has not changed.
-		if proposal.VoteStatus == statuses[0] || proposal.Timestamp == val.Timestamp {
+		// 2. The new proposals status is NotAuthorized(has not changed).
+		// 3. The last update timestamp has not changed.
+		if proposal.Data.VoteStatus == statuses[0] || proposal.Data.Timestamp == val.Timestamp {
 			continue
 		}
 
-		proposal.ID = val.ID
+		// 4. Some or all data returned was empty or invalid.
+		if proposal.Data.VoteStatus < statuses[0] || proposal.Data.Timestamp < val.Timestamp {
+			// Should help detect when API changes are effected on Politeia's end.
+			log.Warnf("invalid or empty data entries were returned for %v", val.Token)
+			continue
+		}
 
-		err = db.dbP.Update(proposal)
+		proposal.Data.ID = val.ID
+
+		err = db.dbP.Update(proposal.Data)
 		if err != nil {
 			return 0, fmt.Errorf("Update for %s failed with error: %v ",
 				val.Censorship.Token, err)

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -35,6 +35,11 @@ type Proposals struct {
 	Data []*ProposalInfo `json:"proposals"`
 }
 
+// Proposal defines a object proposals as returned by RouteProposalDetails route.
+type Proposal struct {
+	Data *ProposalInfo `json:"proposal"`
+}
+
 // CensorshipRecord is an entry that was created when the proposal was submitted.
 // https://github.com/decred/politeia/blob/master/politeiawww/api/v1/api.md#censorship-record
 type CensorshipRecord struct {

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -30,12 +30,12 @@ type ProposalInfo struct {
 	// Files           []AttachmentFile   `json:"files"`
 }
 
-// Proposals defines an array of proposals as returned by RouteAllVetted.
+// Proposals defines an array of proposals payload as returned by RouteAllVetted route.
 type Proposals struct {
 	Data []*ProposalInfo `json:"proposals"`
 }
 
-// Proposal defines a object proposals as returned by RouteProposalDetails route.
+// Proposal defines a proposal payload as returned by RouteProposalDetails route.
 type Proposal struct {
 	Data *ProposalInfo `json:"proposal"`
 }


### PR DESCRIPTION
This is a bug fix that corrects the wrong marshaling of the single proposal payload fetched.
It also adds logs to warn when empty or invalid payloads are detected.