### PR TITLE
[4.0] Fix proposal update

### DIFF
--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -5,7 +5,6 @@
 package piclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,24 +13,6 @@ import (
 
 	pitypes "github.com/decred/dcrdata/gov/politeia/types"
 	piapi "github.com/decred/politeia/politeiawww/api/v1"
-)
-
-var (
-	// nullProposalData defines a case scenario where the proposal could have had
-	// a null pointer attached to it.
-	nullProposalData = []byte(`{"proposal": null}`)
-
-	// nullVotesData defines a case scenario where the votes could have had a null
-	// pointer attached to it.
-	nullVotesData = []byte(`{"votes": null}`)
-
-	// nullProposalsData defines a case scenario where the proposals array could
-	// have had a null pointer attached to it.
-	nullProposalsData = []byte(`{"proposals": null}`)
-
-	// nullVotesStatusData defines a case scenario where the votesstatus array
-	// could have had a null pointer attached to it.
-	nullVotesStatusData = []byte(`{"votesstatus": null}`)
 )
 
 // HandleGetRequests accepts a http client and API URL path as arguments. If the
@@ -79,12 +60,6 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 		return nil, err
 	}
 
-	// Check if proposals data with null entry were returned as part of the
-	// proposals details.
-	if bytes.Equal(data, nullProposalsData) {
-		return nil, fmt.Errorf("invalid proposals array with null data found")
-	}
-
 	var publicProposals pitypes.Proposals
 	err = json.Unmarshal(data, &publicProposals)
 	if err != nil || len(publicProposals.Data) == 0 {
@@ -96,12 +71,6 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 	data, err = HandleGetRequests(client, URLpath)
 	if err != nil {
 		return nil, err
-	}
-
-	// Check if votesstatuses data with null entry were returned as part of the
-	// votesstatus details.
-	if bytes.Equal(data, nullVotesStatusData) {
-		return nil, fmt.Errorf("invalid votesstatus array with null data found")
 	}
 
 	var votesInfo pitypes.Votes
@@ -134,15 +103,15 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
-	// Check if null proposal data was returned as part of the proposal details.
-	if bytes.Equal(data, nullProposalData) {
-		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
-	}
-
 	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if null proposal data was returned as part of the proposal details.
+	if proposal.Data == nil {
+		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
 	}
 
 	// Constructs the full votes status URL and fetch its data.
@@ -150,11 +119,6 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 	data, err = HandleGetRequests(client, votesStatusRoute)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
-	}
-
-	// Check if null votes data was returned as part of the proposal votes details.
-	if bytes.Equal(data, nullVotesData) {
-		return nil, fmt.Errorf("invalid votes with null data found for %s", token)
 	}
 
 	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)

--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -95,7 +95,7 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 
 // RetrieveProposalByToken returns a single proposal identified by the token
 // hash provided if it exists. Data returned is queried from Politeia API.
-func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*pitypes.ProposalInfo, error) {
+func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*pitypes.Proposal, error) {
 	// Constructs the full proposal's URl and fetch is data.
 	proposalRoute := APIRootPath + DropURLRegex(piapi.RouteProposalDetails, token)
 	data, err := HandleGetRequests(client, proposalRoute)
@@ -103,7 +103,7 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
-	var proposal pitypes.ProposalInfo
+	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
 	}
 
-	err = json.Unmarshal(data, &proposal.ProposalVotes)
+	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)
 	if err != nil {
 		return nil, err
 	}

--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -5,6 +5,7 @@
 package piclient
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +14,24 @@ import (
 
 	pitypes "github.com/decred/dcrdata/gov/politeia/types"
 	piapi "github.com/decred/politeia/politeiawww/api/v1"
+)
+
+var (
+	// nullProposalData defines a case scenario where the proposal could have had
+	// a null pointer attached to it.
+	nullProposalData = []byte(`{"proposal": null}`)
+
+	// nullVotesData defines a case scenario where the votes could have had a null
+	// pointer attached to it.
+	nullVotesData = []byte(`{"votes": null}`)
+
+	// nullProposalsData defines a case scenario where the proposals array could
+	// have had a null pointer attached to it.
+	nullProposalsData = []byte(`{"proposals": null}`)
+
+	// nullVotesStatusData defines a case scenario where the votesstatus array
+	// could have had a null pointer attached to it.
+	nullVotesStatusData = []byte(`{"votesstatus": null}`)
 )
 
 // HandleGetRequests accepts a http client and API URL path as arguments. If the
@@ -60,6 +79,12 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 		return nil, err
 	}
 
+	// Check if proposals data with null entry were returned as part of the
+	// proposals details.
+	if bytes.Equal(data, nullProposalsData) {
+		return nil, fmt.Errorf("invalid proposals array with null data found")
+	}
+
 	var publicProposals pitypes.Proposals
 	err = json.Unmarshal(data, &publicProposals)
 	if err != nil || len(publicProposals.Data) == 0 {
@@ -71,6 +96,12 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 	data, err = HandleGetRequests(client, URLpath)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if votesstatuses data with null entry were returned as part of the
+	// votesstatus details.
+	if bytes.Equal(data, nullVotesStatusData) {
+		return nil, fmt.Errorf("invalid votesstatus array with null data found")
 	}
 
 	var votesInfo pitypes.Votes
@@ -103,6 +134,11 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 		return nil, fmt.Errorf("retrieving %s proposal details failed: %v", token, err)
 	}
 
+	// Check if null proposal data was returned as part of the proposal details.
+	if bytes.Equal(data, nullProposalData) {
+		return nil, fmt.Errorf("invalid proposal with null data found for %s", token)
+	}
+
 	var proposal pitypes.Proposal
 	err = json.Unmarshal(data, &proposal)
 	if err != nil {
@@ -114,6 +150,11 @@ func RetrieveProposalByToken(client *http.Client, APIRootPath, token string) (*p
 	data, err = HandleGetRequests(client, votesStatusRoute)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s proposal vote status failed: %v", token, err)
+	}
+
+	// Check if null votes data was returned as part of the proposal votes details.
+	if bytes.Equal(data, nullVotesData) {
+		return nil, fmt.Errorf("invalid votes with null data found for %s", token)
 	}
 
 	err = json.Unmarshal(data, &proposal.Data.ProposalVotes)

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -272,7 +272,6 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 		// Do not update if:
 		// 1. piclient.RetrieveProposalByToken returned an error
 		if err != nil {
-			return 0, fmt.Errorf("RetrieveProposalByToken failed: %v ", err)
 			// Since the proposal tokens bieng updated here are already in the
 			// proposals.db. Do not return errors found since they will still be
 			// updated when the data is available.

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -35,6 +35,11 @@ type Proposals struct {
 	Data []*ProposalInfo `json:"proposals"`
 }
 
+// Proposal defines a object proposals as returned by RouteProposalDetails route.
+type Proposal struct {
+	Data *ProposalInfo `json:"proposal"`
+}
+
 // CensorshipRecord is an entry that was created when the proposal was submitted.
 // https://github.com/decred/politeia/blob/master/politeiawww/api/v1/api.md#censorship-record
 type CensorshipRecord struct {

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -30,12 +30,12 @@ type ProposalInfo struct {
 	// Files           []AttachmentFile   `json:"files"`
 }
 
-// Proposals defines an array of proposals as returned by RouteAllVetted.
+// Proposals defines an array of proposals payload as returned by RouteAllVetted route.
 type Proposals struct {
 	Data []*ProposalInfo `json:"proposals"`
 }
 
-// Proposal defines a object proposals as returned by RouteProposalDetails route.
+// Proposal defines a proposal payload as returned by RouteProposalDetails route.
 type Proposal struct {
 	Data *ProposalInfo `json:"proposal"`
 }

--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -204,6 +204,12 @@
                             chart-options="{tooltipTemplate: '<%=label%>: <%= numeral(value).format('($00[.]00)') %> - <%= numeral(circumference / 6.283).format('(0[.][00]%)') %>'"
                         ></canvas>
                     </div>
+                {{else}}
+                    <table class="table container">
+                        <tr>
+                            <td class="text-center">No proposal votes data found.</td>
+                        </tr>
+                    </table>
                 {{end}}
             </div>
         </div>

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -101,7 +101,7 @@
                         </nav>
                     </div>
                 {{end}}
-            <div>
+            </div>
 
             <table class="table table-mono-cells my-2">
                 <thead>


### PR DESCRIPTION
- [x]  Bug fix that corrects the wrong marshaling of the single proposal payload fetched.
It also adds logs to warn when empty or invalid payloads are detected.

- [x] If update of previously added proposal tokens fails for some, the error returned is logged and update proceeds for those that new data is available.
It will help in updating past such an error if new data exists.
```
2019-04-15 19:17:13.120 [ERR] DATD: updating proposals db failed: RetrieveProposalByToken failed: retrieving 5d9cfb07aefb338ba1b74f97de16ee651beabc851c7f2b5f790bd88aea23b3cb proposal vote status failed: request (https://proposals.decred.org/api/v1/proposals/5d9cfb07aefb338ba1b74f97de16ee651beabc851c7f2b5f790bd88aea23b3cb/votestatus) failed with status code: 400 Bad Request 
```
- [x] Added this to proposal details pages that do not show proposal votes charts when there data is missing.
![Screenshot from 2019-04-16 09-57-16](https://user-images.githubusercontent.com/22055953/56191459-1007f180-6035-11e9-900d-0ea17d4c8a3f.png)