### PR TITLE
views: preload webfonts and svg

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -39,7 +39,15 @@
 
     <meta name="turbolinks-cache-control" content="no-cache">
     <title>{{.}}</title>
+    <link rel="preload" href="fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
+    <link rel="preload" href="fonts/inconsolata-v15-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+    <link rel="preload" href="fonts/source-sans-pro-v9-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+    <link rel="preload" href="images/connecting.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="images/themes/light/logo.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="images/connected.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="images/disconnected.svg" as="image" type="image/svg+xml" />
     <link href="/dist/css/style.css" rel="stylesheet">
+    
     <script src="/js/vendor/turbolinks.min.js"></script>
 </head>
 {{end}}


### PR DESCRIPTION
This enables browsers that support `rel="preload"` to preload the fonts and svg symbols instead of waiting to process style.css.

Working: Chrome, Epiphany (probably Safari too), Firefox ([network.preload setting](https://user-images.githubusercontent.com/9373513/56443923-3db29c00-62bc-11e9-9980-e0c63a12eab1.png))
https://caniuse.com/#search=preload

**Without preload (first 200ms of page load):**

![image](https://user-images.githubusercontent.com/9373513/56442038-cc231f80-62b4-11e9-8ff5-33996232a59e.png)

The webfonts, logo.svg, and connecting.svg are delayed for about 160 ms while the stylesheet is processed.  Also, Chrome reports the initiator is Turbolinks.

Also note that connected.svg is not loaded in this time period because it is loaded only after the websocket connects.

**With preload (first 200ms of page load):**

![image](https://user-images.githubusercontent.com/9373513/56442067-eb21b180-62b4-11e9-8351-95f45196d4a1.png)

The webfonts, the logo.svg, and connecting.svg are loaded immediately.  Also, Chrome reports the initiator is the index (html head).

Both connected.svg and disconnected.svg are loaded in this time period rather than after the websocket connects or disconnects. Note that if the server is down or not reachable, the browser will not be able to retrieve disconnected.svg, so it makes sense to do it while the connection is up.

Resolving https://github.com/decred/dcrdata/issues/1221.