### PR TITLE
[4.1] Compare all proposal data to check for updates

### DIFF
--- a/gov/politeia/piclient/piclient.go
+++ b/gov/politeia/piclient/piclient.go
@@ -63,7 +63,7 @@ func RetrieveAllProposals(client *http.Client, APIRootPath, URLParams string) (
 	var publicProposals pitypes.Proposals
 	err = json.Unmarshal(data, &publicProposals)
 	if err != nil || len(publicProposals.Data) == 0 {
-		return nil, err
+		return &publicProposals, err
 	}
 
 	// Constructs the full vote status API URL

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
 	"sync"
 	"time"
 
@@ -103,6 +104,11 @@ func (db *ProposalDB) saveProposals(URLParams string) (int, error) {
 		if data == nil || data.Data == nil {
 			// Should help detect when API changes are effected on Politeia's end.
 			log.Warnf("invalid or empty data entries were returned")
+			break
+		}
+
+		if len(data.Data) == 0 {
+			// No updates found.
 			break
 		}
 
@@ -279,20 +285,20 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 			continue
 		}
 
-		// 2. The new proposals status is NotAuthorized(has not changed).
-		// 3. The last update timestamp has not changed.
-		if proposal.Data.VoteStatus == statuses[0] || proposal.Data.Timestamp == val.Timestamp {
+		// Add the generated field.
+		proposal.Data.ID = val.ID
+
+		// 2. The new proposal data has not changed.
+		if reflect.DeepEqual(*proposal.Data, *val) {
 			continue
 		}
 
-		// 4. Some or all data returned was empty or invalid.
-		if proposal.Data.VoteStatus < statuses[0] || proposal.Data.Timestamp < val.Timestamp {
+		// 3. Some or all data returned was empty or invalid.
+		if proposal.Data.Censorship.Token == "" || proposal.Data.TotalVotes < val.TotalVotes {
 			// Should help detect when API changes are effected on Politeia's end.
 			log.Warnf("invalid or empty data entries were returned for %v", val.Token)
 			continue
 		}
-
-		proposal.Data.ID = val.ID
 
 		err = db.dbP.Update(proposal.Data)
 		if err != nil {

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"sync"
 	"time"
 
@@ -289,7 +288,7 @@ func (db *ProposalDB) updateInProgressProposals() (int, error) {
 		proposal.Data.ID = val.ID
 
 		// 2. The new proposal data has not changed.
-		if reflect.DeepEqual(*proposal.Data, *val) {
+		if val.IsEqual(proposal.Data) {
 			continue
 		}
 

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -184,3 +184,18 @@ func VotesStatuses() map[VoteStatusType]string {
 	}
 	return m
 }
+
+// IsEqual compares CensorshipRecord, Name, State, NumComments, StatusChangeMsg,
+// Timestamp, CensoredDate, AbandonedDate, PublishedDate, Token, VoteStatus,
+// TotalVotes and count of VoteResults between the two ProposalsInfo structs passed.
+func (a *ProposalInfo) IsEqual(b *ProposalInfo) bool {
+	if a.Censorship != b.Censorship || a.Name != b.Name || a.State != b.State ||
+		a.NumComments != b.NumComments || a.StatusChangeMsg != b.StatusChangeMsg ||
+		a.Status != b.Status || a.Timestamp != b.Timestamp || a.Token != b.Token ||
+		a.CensoredDate != b.CensoredDate || a.AbandonedDate != b.AbandonedDate ||
+		a.VoteStatus != b.VoteStatus || a.TotalVotes != b.TotalVotes ||
+		a.PublishedDate != b.PublishedDate || len(a.VoteResults) != len(b.VoteResults) {
+		return false
+	}
+	return true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6107,9 +6107,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6107,9 +6107,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Instead of comparing `votestatus` and `timestamp` only to check for updates, compare more `proposalInfo` fields to capture lots more changes when they happen.

```Golang
if proposal.Data.VoteStatus == statuses[0] || proposal.Data.Timestamp == val.Timestamp {
```
In the conditions above, the `Timestamp` was expected to change every time a minor change was effected on the proposal but was only found to change when the proposal author changed the proposal version.

Also Lots of other properties like `Censorship`, `Name`, `State`, `NumComments`, `StatusChangeMsg`, `CensoredDate`, `AbandonedDate`, `PublishedDate`, `Token`, `VoteStatus`, `TotalVotes` and `VoteResults` have a high likelihood of changing as the proposals moves through the various life cycle stages but were not initially considered.