### PR TITLE
CockroachDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ modern javascript features, as well as SCSS for styling.
     - [From v2.x or earlier](#from-v2x-or-earlier)
   - [Getting Started](#getting-started)
     - [Configuring PostgreSQL (**IMPORTANT!** Seriously, read this.)](#configuring-postgresql-important-seriously-read-this)
+    - [CockroachDB Support (experimental)](#cockroachdb-support-experimental)
     - [Creating the dcrdata Configuration File](#creating-the-dcrdata-configuration-file)
     - [Using Environment Variables for Configuration](#using-environment-variables-for-configuration)
     - [Indexing the Blockchain](#indexing-the-blockchain)
     - [Starting dcrdata](#starting-dcrdata)
-    - [Hiding the PostgreSQL db Configuration settings.](#hiding-the-postgresql-db-configuration-settings)
+    - [Hiding the PostgreSQL Settings Table](#hiding-the-postgresql-settings-table)
     - [Running the Web Interface During Synchronization](#running-the-web-interface-during-synchronization)
   - [System Hardware Requirements](#system-hardware-requirements)
     - [dcrdata only (PostgreSQL on other host)](#dcrdata-only-postgresql-on-other-host)
@@ -142,7 +143,9 @@ Always run the Current release or on the Current stable branch. Do not use `mast
   dcrd version is compatible. dcrdata v3.1.x and later required dcrd v1.4.x or a
   later version with JSON-RPC server version 5.x.y.
 - (For "full" mode) PostgreSQL 10.5+. Version 11.x is supported and recommended
-  for improved performance with a number of tasks.
+  for improved performance with a number of tasks. Support for CockroachDB is an
+  experimental feature. See [CockroachDB Support (experimental)](#cockroachdb-support-experimental)
+  for details.
 
 ## Docker Support
 
@@ -349,6 +352,23 @@ On Linux, you may wish to use a unix domain socket instead of a TCP connection.
 The path to the socket depends on the system, but it is commonly
 `/var/run/postgresql`. Just set this path in `pghost`.
 
+### CockroachDB Support (experimental)
+
+While dcrdata now provides [support for CockroachDB](https://github.com/decred/dcrdata/issues/1291),
+this is an experimental feature with caveats:
+
+- Compared to a well-configure PostgreSQL backend, CoackroachDB performance is
+  suboptimal. See the [CockroachDB issue](https://github.com/decred/dcrdata/issues/1291)
+  for more information.
+- The bulk of the testing and performance optimization is done with PostgreSQL
+  in mind.
+
+If you decide to use CockroachDB with dcrdata, (1) do not do so in production
+and (2) expect some bugs and relatively poor performance.
+
+See [dcrdata's CockroachDB wiki page](https://github.com/decred/dcrdata/wiki/CockroachDB)
+for more information.
+
 ### Creating the dcrdata Configuration File
 
 Begin with the sample configuration file. With the default `appdata` directory
@@ -422,10 +442,10 @@ Unlike dcrdata.conf, which must be placed in the `appdata` folder or explicitly
 set with `-C`, the "public" and "views" folders _must_ be in the same folder as
 the `dcrdata` executable.
 
-### Hiding the PostgreSQL db Configuration settings.
+### Hiding the PostgreSQL Settings Table
 
-By default postgres configuration settings are logged on system start up.
-`--hidepgconfig` flag blocks the logging on dcrdata start up.
+By default, postgres settings are displayed in a table on start up of dcrdata.
+To block display of this table, use the `--hidepgconfig` switch..
 
 ### Running the Web Interface During Synchronization
 
@@ -485,7 +505,6 @@ Recommend:
 - 2+ CPU cores
 - 8+ GB RAM
 - SSD (NVMe preferred) with 60 GB free space
-
 
 ## dcrdata Daemon
 

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2018, The Decred developers
+// Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
 package main
 
 import (
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -194,13 +193,11 @@ func mainCore() error {
 	// Check current height of DB
 	lastBlock, err := db.HeightDB()
 	if err != nil {
-		if err == sql.ErrNoRows {
-			lastBlock = -1
-			log.Info("blocks table is empty, starting fresh.")
-		} else {
-			log.Errorln("RetrieveBestBlockHeight:", err)
-			return err
-		}
+		log.Errorln("RetrieveBestBlockHeight:", err)
+		return err
+	}
+	if lastBlock == -1 {
+		log.Info("tables are empty, starting fresh.")
 	}
 
 	// Start waiting for the interrupt signal

--- a/db/dcrpg/README.md
+++ b/db/dcrpg/README.md
@@ -3,13 +3,24 @@
 The `dcrpg` package provides types and functions for manipulating PostgreSQL
 tables, and storing blocks, transactions, inputs, and outputs.
 
+## Supported Database Software
+
+PostgreSQL versions 10.5 to 11.x are fully supported. The bulk of the testing
+and performance optimization is done with PostgreSQL in mind.
+
+[Experimental support for CockroachDB](https://github.com/decred/dcrdata/issues/1291)
+was added for dcrdata 5.0. However, compared to a well-configure PostgreSQL
+backend, CoackroachDB performance is suboptimal. See the
+[CockroachDB support issue](https://github.com/decred/dcrdata/issues/1291) for
+more information.
+
 ## Performance and Bulk Loading
 
 When performing a bulk data import, it is wise to first drop any existing
 indexes and create them again after insertion is completed.  Functions are
 provided to create and drop the indexes.
 
-PostgreSQL performance will be poor, particuarly during bulk import, unless
+PostgreSQL performance will be poor, particularly during bulk import, unless
 synchronous transaction commits are disabled via the `synchronous_commit = off`
 configuration setting in your postgresql.conf. There are numerous
 [PostreSQL tuning settings](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server),

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -334,6 +334,14 @@ func (pgb *ChainDB) DeleteDuplicateVouts() (int64, error) {
 	return DeleteDuplicateVouts(pgb.db)
 }
 
+func (pgb *ChainDB) DeleteDuplicateVinsCockroach() (int64, error) {
+	return DeleteDuplicateVinsCockroach(pgb.db)
+}
+
+func (pgb *ChainDB) DeleteDuplicateVoutsCockroach() (int64, error) {
+	return DeleteDuplicateVoutsCockroach(pgb.db)
+}
+
 func (pgb *ChainDB) DeleteDuplicateTxns() (int64, error) {
 	return DeleteDuplicateTxns(pgb.db)
 }

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -54,25 +54,25 @@ const (
 	// on (tx_vin_vout_row_id, address, is_funding).
 	IndexAddressTableOnVoutID = `CREATE UNIQUE INDEX ` + IndexOfAddressTableOnVoutID +
 		` ON addresses(tx_vin_vout_row_id, address, is_funding);`
-	DeindexAddressTableOnVoutID = `DROP INDEX ` + IndexOfAddressTableOnVoutID + `;`
+	DeindexAddressTableOnVoutID = `DROP INDEX ` + IndexOfAddressTableOnVoutID + ` CASCADE;`
 
 	// IndexBlockTimeOnTableAddress creates a sorted index on block_time, which
 	// accelerates queries with ORDER BY block_time LIMIT n OFFSET m.
 	IndexBlockTimeOnTableAddress = `CREATE INDEX ` + IndexOfAddressTableOnBlockTime +
 		` ON addresses(block_time DESC NULLS LAST);`
-	DeindexBlockTimeOnTableAddress = `DROP INDEX ` + IndexOfAddressTableOnBlockTime + `;`
+	DeindexBlockTimeOnTableAddress = `DROP INDEX ` + IndexOfAddressTableOnBlockTime + ` CASCADE;`
 
 	IndexMatchingTxHashOnTableAddress = `CREATE INDEX ` + IndexOfAddressTableOnMatchingTx +
 		` ON addresses(matching_tx_hash);`
-	DeindexMatchingTxHashOnTableAddress = `DROP INDEX ` + IndexOfAddressTableOnMatchingTx + `;`
+	DeindexMatchingTxHashOnTableAddress = `DROP INDEX ` + IndexOfAddressTableOnMatchingTx + ` CASCADE;`
 
 	IndexAddressTableOnAddress = `CREATE INDEX ` + IndexOfAddressTableOnAddress +
 		` ON addresses(address);`
-	DeindexAddressTableOnAddress = `DROP INDEX ` + IndexOfAddressTableOnAddress + `;`
+	DeindexAddressTableOnAddress = `DROP INDEX ` + IndexOfAddressTableOnAddress + ` CASCADE;`
 
 	IndexAddressTableOnTxHash = `CREATE INDEX ` + IndexOfAddressTableOnTx +
 		` ON addresses(tx_hash);`
-	DeindexAddressTableOnTxHash = `DROP INDEX ` + IndexOfAddressTableOnTx + `;`
+	DeindexAddressTableOnTxHash = `DROP INDEX ` + IndexOfAddressTableOnTx + ` CASCADE;`
 
 	// SelectSpendingTxsByPrevTx = `SELECT id, tx_hash, tx_index, prev_tx_index FROM vins WHERE prev_tx_hash=$1;`
 	// SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins WHERE prev_tx_hash=$1 AND prev_tx_index=$2;`

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -87,12 +87,12 @@ const (
 
 	// IndexBlockTableOnHash creates the unique index uix_block_hash on (hash).
 	IndexBlockTableOnHash   = `CREATE UNIQUE INDEX ` + IndexOfBlocksTableOnHash + ` ON blocks(hash);`
-	DeindexBlockTableOnHash = `DROP INDEX ` + IndexOfBlocksTableOnHash + `;`
+	DeindexBlockTableOnHash = `DROP INDEX ` + IndexOfBlocksTableOnHash + ` CASCADE;`
 
 	// IndexBlocksTableOnHeight creates the index uix_block_height on (height).
 	// This is not unique because of side chains.
 	IndexBlocksTableOnHeight   = `CREATE INDEX ` + IndexOfBlocksTableOnHeight + ` ON blocks(height);`
-	DeindexBlocksTableOnHeight = `DROP INDEX ` + IndexOfBlocksTableOnHeight + `;`
+	DeindexBlocksTableOnHeight = `DROP INDEX ` + IndexOfBlocksTableOnHeight + ` CASCADE;`
 
 	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
 		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018-2019, The Decred developers
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package internal
 
 import (
@@ -219,8 +223,6 @@ const (
 		WHERE is_mainchain
 		AND height > $1
 		ORDER BY height;`
-
-	// TODO: index block_chain where needed
 )
 
 func MakeBlockInsertStatement(block *dbtypes.Block, checked bool) string {

--- a/db/dcrpg/internal/common.go
+++ b/db/dcrpg/internal/common.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018-2019, The Decred developers
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package internal
 
 import (
@@ -41,29 +45,12 @@ func makeARRAYOfTEXT(text []string) string {
 	return buffer.String()
 }
 
-func makeARRAYOfUnquotedTEXT(text []string) string {
-	if len(text) == 0 {
-		return "ARRAY[]"
-	}
-	buffer := bytes.NewBufferString("ARRAY[")
-	for i, txt := range text {
-		if i == len(text)-1 {
-			buffer.WriteString(txt)
-			break
-		}
-		buffer.WriteString(txt + `, `)
-	}
-	buffer.WriteString("]")
-
-	return buffer.String()
-}
-
 func makeARRAYOfBIGINTs(ints []uint64) string {
 	if len(ints) == 0 {
-		return "ARRAY[]::BIGINT[]"
+		return "'{}'::BIGINT[]" // cockroachdb: "ARRAY[]:::BIGINT[]"
 	}
 
-	buffer := bytes.NewBufferString("ARRAY[")
+	buffer := bytes.NewBufferString("'{")
 	for i, v := range ints {
 		u := strconv.FormatUint(v, 10)
 		if i == len(ints)-1 {
@@ -72,7 +59,7 @@ func makeARRAYOfBIGINTs(ints []uint64) string {
 		}
 		buffer.WriteString(u + `, `)
 	}
-	buffer.WriteString("]")
+	buffer.WriteString("}'::BIGINT[]")
 
 	return buffer.String()
 }

--- a/db/dcrpg/internal/meta.go
+++ b/db/dcrpg/internal/meta.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
 package internal
 
 const (
@@ -31,6 +34,8 @@ const (
 
 	SetMetaDBBestBlock = `UPDATE meta
 		SET best_block_height = $1, best_block_hash = $2;`
+
+	SelectMetaDBIbdComplete = `SELECT ibd_complete FROM meta;`
 
 	SetMetaDBIbdComplete = `UPDATE meta
 		SET ibd_complete = $1;`

--- a/db/dcrpg/internal/rewind.go
+++ b/db/dcrpg/internal/rewind.go
@@ -11,22 +11,53 @@ const (
 		WHERE (
 				(addresses.tx_vin_vout_row_id=ANY(transactions.vin_db_ids) AND addresses.is_funding=false)
 				OR
-				(addresses.tx_vin_vout_row_id=ANY(transactions.vout_DB_IDs) AND addresses.is_funding=true)
+				(addresses.tx_vin_vout_row_id=ANY(transactions.vout_db_ids) AND addresses.is_funding=true)
 			)
 			AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
 			AND blocks.hash=$1;`
 
+	// For CockroachDB, which does not allow the USING clause with DELETE, a
+	// subquery (addressesForBlockHash) is needed.
+
+	// This query with two JOINs is more straight forward, and faster in
+	// PostgreSQL, but much slower in CockroachDB.
+	//
+	// addressesForBlockHash = `SELECT addresses.id
+	// 	FROM transactions
+	// 	JOIN blocks ON
+	// 		blocks.hash=$1
+	// 		AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+	// 	JOIN addresses ON
+	// 		(addresses.tx_vin_vout_row_id=ANY(transactions.vin_db_ids) AND addresses.is_funding=false)
+	// 		OR (addresses.tx_vin_vout_row_id=ANY(transactions.vout_db_ids) AND addresses.is_funding=true)`
+
+	addressesForBlockHash = `SELECT addresses.id
+		FROM addresses 
+		JOIN transactions ON
+			(NOT addresses.is_funding AND addresses.tx_vin_vout_row_id = ANY(transactions.vin_db_ids)) 
+			OR 
+			(addresses.is_funding AND addresses.tx_vin_vout_row_id = ANY(transactions.vout_db_ids))
+		WHERE transactions.id IN 
+			(
+				SELECT transactions.id 
+				FROM transactions 
+				JOIN blocks ON blocks.hash = $1 
+					AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+			)`
+
+	DeleteAddressesSubQry = `DELETE FROM addresses WHERE id IN (` + addressesForBlockHash + `);`
+
 	DeleteStakeAddressesFunding = `DELETE FROM addresses
 		USING transactions, blocks
 		WHERE addresses.tx_vin_vout_row_id=ANY(transactions.vin_db_ids)
-			AND addresses.is_funding=false
+			AND NOT addresses.is_funding
 			AND transactions.id = ANY(blocks.stxdbids)
 			AND blocks.hash=$1;`
 
 	DeleteStakeAddressesSpending = `DELETE FROM addresses
 		USING transactions, blocks
-		WHERE addresses.tx_vin_vout_row_id=ANY(transactions.vout_DB_IDs)
-			AND addresses.is_funding=true
+		WHERE addresses.tx_vin_vout_row_id=ANY(transactions.vout_db_ids)
+			AND addresses.is_funding
 			AND transactions.id = ANY(blocks.stxdbids)
 			AND blocks.hash=$1;`
 
@@ -37,6 +68,33 @@ const (
 		WHERE vins.id=ANY(transactions.vin_db_ids)
 			AND transactions.id = ANY(array_cat(blocks.txdbids,blocks.stxdbids))
 			AND blocks.hash=$1;`
+
+	// For CockroachDB, which does not allow the USING clause with DELETE, a
+	// subquery (vinsForBlockHash) is needed.
+
+	// This query with two JOINs is more straight forward, and faster in
+	// PostgreSQL, but much slower in CockroachDB.
+	//
+	// vinsForBlockHash = `SELECT vins.id
+	// 	FROM transactions
+	// 	JOIN blocks ON
+	// 		blocks.hash=$1
+	// 		AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+	// 	JOIN vins ON
+	// 		vins.id=ANY(transactions.vin_db_ids)`
+
+	vinsForBlockHash = `SELECT vins.id
+		FROM vins 
+		JOIN transactions ON vins.id = ANY(transactions.vin_db_ids)
+		WHERE transactions.id IN 
+			(
+				SELECT transactions.id 
+				FROM transactions 
+				JOIN blocks ON blocks.hash = $1 
+					AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+			)`
+
+	DeleteVinsSubQry = `DELETE FROM vins WHERE id IN (` + vinsForBlockHash + `);`
 
 	// DeleteStakeVins deletes rows of the vins table corresponding to inputs of
 	// the stake transactions (transactions.vin_db_ids) for a block
@@ -87,6 +145,16 @@ const (
 		WHERE vouts.id=ANY(transactions.vout_db_ids)
 			AND transactions.id = ANY(array_cat(blocks.txdbids,blocks.stxdbids))
 			AND blocks.hash=$1;`
+
+	voutsForBlockHash = `SELECT vouts.id
+		FROM transactions
+		JOIN blocks ON
+			blocks.hash=$1
+			AND transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
+		JOIN vouts ON
+			vouts.id=ANY(transactions.vout_db_ids)`
+
+	DeleteVoutsSubQry = `DELETE FROM vouts WHERE id IN (` + voutsForBlockHash + `);`
 
 	// DeleteStakeVouts deletes rows of the vouts table corresponding to inputs
 	// of the stake transactions (transactions.vout_db_ids) for a block
@@ -147,6 +215,8 @@ const (
 		USING blocks
 		WHERE transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
 		AND blocks.hash=$1;`
+	DeleteTransactionsSimple = `DELETE FROM transactions
+		WHERE block_hash=$1;`
 
 	DeleteBlock = `DELETE FROM blocks
 		WHERE hash=$1;`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -79,7 +79,7 @@ const (
 	// uix_ticket_hashes_index on (tx_hash, block_hash).
 	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfTicketsTableOnHashes +
 		` ON tickets(tx_hash, block_hash);`
-	DeindexTicketsTableOnHashes = `DROP INDEX ` + IndexOfTicketsTableOnHashes + `;`
+	DeindexTicketsTableOnHashes = `DROP INDEX ` + IndexOfTicketsTableOnHashes + ` CASCADE;`
 
 	// IndexTicketsTableOnTxDbID creates the unique index that ensures only one
 	// row in the tickets table may refer to a certain row of the transactions
@@ -90,11 +90,11 @@ const (
 	// transactions table.
 	IndexTicketsTableOnTxDbID = `CREATE UNIQUE INDEX ` + IndexOfTicketsTableOnTxRowID +
 		` ON tickets(purchase_tx_db_id);`
-	DeindexTicketsTableOnTxDbID = `DROP INDEX ` + IndexOfTicketsTableOnTxRowID + `;`
+	DeindexTicketsTableOnTxDbID = `DROP INDEX ` + IndexOfTicketsTableOnTxRowID + ` CASCADE;`
 
 	IndexTicketsTableOnPoolStatus = `CREATE INDEX ` + IndexOfTicketsTableOnPoolStatus +
 		` ON tickets(pool_status);`
-	DeindexTicketsTableOnPoolStatus = `DROP INDEX ` + IndexOfTicketsTableOnPoolStatus + `;`
+	DeindexTicketsTableOnPoolStatus = `DROP INDEX ` + IndexOfTicketsTableOnPoolStatus + ` CASCADE;`
 
 	SelectTicketsInBlock        = `SELECT * FROM tickets WHERE block_hash = $1;`
 	SelectTicketsTxDbIDsInBlock = `SELECT purchase_tx_db_id FROM tickets WHERE block_hash = $1;`
@@ -237,27 +237,27 @@ const (
 	// on (tx_hash, block_hash).
 	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfVotesTableOnHashes +
 		` ON votes(tx_hash, block_hash);`
-	DeindexVotesTableOnHashes = `DROP INDEX ` + IndexOfVotesTableOnHashes + `;`
+	DeindexVotesTableOnHashes = `DROP INDEX ` + IndexOfVotesTableOnHashes + ` CASCADE;`
 
 	IndexVotesTableOnBlockHash = `CREATE INDEX ` + IndexOfVotesTableOnBlockHash +
 		` ON votes(block_hash);`
-	DeindexVotesTableOnBlockHash = `DROP INDEX ` + IndexOfVotesTableOnBlockHash + `;`
+	DeindexVotesTableOnBlockHash = `DROP INDEX ` + IndexOfVotesTableOnBlockHash + ` CASCADE;`
 
 	IndexVotesTableOnCandidate = `CREATE INDEX ` + IndexOfVotesTableOnCandBlock +
 		` ON votes(candidate_block_hash);`
-	DeindexVotesTableOnCandidate = `DROP INDEX ` + IndexOfVotesTableOnCandBlock + `;`
+	DeindexVotesTableOnCandidate = `DROP INDEX ` + IndexOfVotesTableOnCandBlock + ` CASCADE;`
 
 	IndexVotesTableOnVoteVersion = `CREATE INDEX ` + IndexOfVotesTableOnVersion +
 		` ON votes(version);`
-	DeindexVotesTableOnVoteVersion = `DROP INDEX ` + IndexOfVotesTableOnVersion + `;`
+	DeindexVotesTableOnVoteVersion = `DROP INDEX ` + IndexOfVotesTableOnVersion + ` CASCADE;`
 
 	IndexVotesTableOnHeight = `CREATE INDEX ` + IndexOfVotesTableOnHeight + ` ON votes(height);`
 
-	DeindexVotesTableOnHeight = `DROP INDEX ` + IndexOfVotesTableOnHeight + `;`
+	DeindexVotesTableOnHeight = `DROP INDEX ` + IndexOfVotesTableOnHeight + ` CASCADE;`
 
 	IndexVotesTableOnBlockTime = `CREATE INDEX ` + IndexOfVotesTableOnBlockTime +
 		` ON votes(block_time);`
-	DeindexVotesTableOnBlockTime = `DROP INDEX ` + IndexOfVotesTableOnBlockTime + `;`
+	DeindexVotesTableOnBlockTime = `DROP INDEX ` + IndexOfVotesTableOnBlockTime + ` CASCADE;`
 
 	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`
 	SelectAllVoteDbIDsHeightsTicketDbIDs  = `SELECT id, height, ticket_tx_db_id FROM votes;`
@@ -330,7 +330,7 @@ const (
 	// on (ticket_hash, block_hash).
 	IndexMissesTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfMissesTableOnHashes +
 		` ON misses(ticket_hash, block_hash);`
-	DeindexMissesTableOnHashes = `DROP INDEX ` + IndexOfMissesTableOnHashes + `;`
+	DeindexMissesTableOnHashes = `DROP INDEX ` + IndexOfMissesTableOnHashes + ` CASCADE;`
 
 	SelectMissesInBlock = `SELECT ticket_hash FROM misses WHERE block_hash = $1;`
 
@@ -364,7 +364,7 @@ const (
 
 	IndexAgendasTableOnAgendaID = `CREATE UNIQUE INDEX ` + IndexOfAgendasTableOnName +
 		` ON agendas(name);`
-	DeindexAgendasTableOnAgendaID = `DROP INDEX ` + IndexOfAgendasTableOnName + `;`
+	DeindexAgendasTableOnAgendaID = `DROP INDEX ` + IndexOfAgendasTableOnName + ` CASCADE;`
 
 	SelectAllAgendas = `SELECT id, name, status, locked_in, activated, hard_forked
 		FROM agendas;`
@@ -407,7 +407,7 @@ const (
 
 	IndexAgendaVotesTableOnAgendaID = `CREATE UNIQUE INDEX ` + IndexOfAgendaVotesTableOnRowIDs +
 		` ON agenda_votes(votes_row_id, agendas_row_id);`
-	DeindexAgendaVotesTableOnAgendaID = `DROP INDEX ` + IndexOfAgendaVotesTableOnRowIDs + `;`
+	DeindexAgendaVotesTableOnAgendaID = `DROP INDEX ` + IndexOfAgendaVotesTableOnRowIDs + ` CASCADE;`
 
 	// DeleteAgendaVotesDuplicateRows removes rows that would violate the unique
 	// index uix_agenda_votes. This should be run prior to creating the index.
@@ -463,7 +463,7 @@ const (
 	IndexProposalsTableOnToken = `CREATE UNIQUE INDEX ` + IndexOfProposalsTableOnToken +
 		` ON proposals(token, time);`
 
-	DeindexProposalsTableOnToken = `DROP INDEX ` + IndexOfProposalsTableOnToken + `;`
+	DeindexProposalsTableOnToken = `DROP INDEX ` + IndexOfProposalsTableOnToken + ` CASCADE;`
 
 	// Select
 
@@ -493,7 +493,7 @@ const (
 	IndexProposalVotesTableOnProposalsID = `CREATE INDEX ` + IndexOfProposalVotesTableOnProposalsID +
 		` ON proposal_votes(proposals_row_id);`
 
-	DeindexProposalVotesTableOnProposalsID = `DROP INDEX ` + IndexOfProposalVotesTableOnProposalsID + `;`
+	DeindexProposalVotesTableOnProposalsID = `DROP INDEX ` + IndexOfProposalVotesTableOnProposalsID + ` CASCADE;`
 
 	// Select
 

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -105,14 +105,14 @@ const (
 	// (tx_hash, block_hash).
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfTransactionsTableOnHashes +
 		` ON transactions(tx_hash, block_hash);`
-	DeindexTransactionTableOnHashes = `DROP INDEX ` + IndexOfTransactionsTableOnHashes + `;`
+	DeindexTransactionTableOnHashes = `DROP INDEX ` + IndexOfTransactionsTableOnHashes + ` CASCADE;`
 
 	// Investigate removing this. block_hash is already indexed. It would be
 	// unique with just (block_hash, block_index). And tree is likely not
 	// important to index.  NEEDS TESTING BEFORE REMOVAL.
 	IndexTransactionTableOnBlockIn = `CREATE UNIQUE INDEX ` + IndexOfTransactionsTableOnBlockInd +
 		` ON transactions(block_hash, block_index, tree);`
-	DeindexTransactionTableOnBlockIn = `DROP INDEX ` + IndexOfTransactionsTableOnBlockInd + `;`
+	DeindexTransactionTableOnBlockIn = `DROP INDEX ` + IndexOfTransactionsTableOnBlockInd + ` CASCADE;`
 
 	SelectTxByHash = `SELECT id, block_hash, block_index, tree
 		FROM transactions

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018-2019, The Decred developers
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package internal
 
 import (
@@ -243,19 +247,6 @@ var (
 		GROUP BY count
 		ORDER BY count;`
 )
-
-// func makeTxInsertStatement(voutDbIDs, vinDbIDs []uint64, vouts []*dbtypes.Vout, checked bool) string {
-// 	voutDbIDsBIGINT := makeARRAYOfBIGINTs(voutDbIDs)
-// 	vinDbIDsBIGINT := makeARRAYOfBIGINTs(vinDbIDs)
-// 	voutCompositeARRAY := makeARRAYOfVouts(vouts)
-// 	var insert string
-// 	if checked {
-// 		insert = insertTxRowChecked
-// 	} else {
-// 		insert = insertTxRow
-// 	}
-// 	return fmt.Sprintf(insert, voutDbIDsBIGINT, voutCompositeARRAY, vinDbIDsBIGINT)
-// }
 
 // MakeTxInsertStatement returns the appropriate transaction insert statement
 // for the desired conflict checking and handling behavior. For checked=false,

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -86,6 +86,21 @@ const (
 			FROM transactions) t
 		WHERE t.rnum > 1);`
 
+	SelectTxDupIDs = `WITH dups AS (
+		SELECT array_agg(id) AS ids
+		FROM transactions
+		GROUP BY tx_hash, block_hash 
+		HAVING count(id)>1
+	)
+	SELECT array_agg(dupids) FROM (
+		SELECT unnest(ids) AS dupids
+		FROM dups
+		ORDER BY dupids DESC
+	) AS _;`
+
+	DeleteTxRows = `DELETE FROM transactions
+		WHERE id = ANY($1);`
+
 	// IndexTransactionTableOnHashes creates the unique index uix_tx_hashes on
 	// (tx_hash, block_hash).
 	IndexTransactionTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfTransactionsTableOnHashes +

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -86,11 +86,11 @@ const (
 
 	IndexVinTableOnVins = `CREATE UNIQUE INDEX ` + IndexOfVinsTableOnVin +
 		` ON vins(tx_hash, tx_index, tx_tree);`
-	DeindexVinTableOnVins = `DROP INDEX ` + IndexOfVinsTableOnVin + `;`
+	DeindexVinTableOnVins = `DROP INDEX ` + IndexOfVinsTableOnVin + ` CASCADE;`
 
 	IndexVinTableOnPrevOuts = `CREATE INDEX ` + IndexOfVinsTableOnPrevOut +
 		` ON vins(prev_tx_hash, prev_tx_index);`
-	DeindexVinTableOnPrevOuts = `DROP INDEX ` + IndexOfVinsTableOnPrevOut + `;`
+	DeindexVinTableOnPrevOuts = `DROP INDEX ` + IndexOfVinsTableOnPrevOut + ` CASCADE;`
 
 	SelectVinIDsALL = `SELECT id FROM vins;`
 	CountVinsRows   = `SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='vins';`
@@ -237,7 +237,7 @@ const (
 	// (tx_hash, tx_index, tx_tree).
 	IndexVoutTableOnTxHashIdx = `CREATE UNIQUE INDEX ` + IndexOfVoutsTableOnTxHashInd +
 		` ON vouts(tx_hash, tx_index, tx_tree);`
-	DeindexVoutTableOnTxHashIdx = `DROP INDEX ` + IndexOfVoutsTableOnTxHashInd + `;`
+	DeindexVoutTableOnTxHashIdx = `DROP INDEX ` + IndexOfVoutsTableOnTxHashInd + ` CASCADE;`
 
 	SelectAddressByTxHash = `SELECT script_addresses, value FROM vouts
 		WHERE tx_hash = $1 AND tx_index = $2 AND tx_tree = $3;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -305,7 +305,7 @@ func NewChainDBRPC(chaindb *ChainDB, cl *rpcclient.Client) (*ChainDBRPC, error) 
 // SyncChainDBAsync calls (*ChainDB).SyncChainDBAsync after a nil pointer check
 // on the ChainDBRPC receiver.
 func (pgb *ChainDBRPC) SyncChainDBAsync(ctx context.Context, res chan dbtypes.SyncResult,
-	client rpcutils.MasterBlockGetter, updateAllAddresses, updateAllVotes, newIndexes bool,
+	client rpcutils.MasterBlockGetter, updateAllAddresses, newIndexes bool,
 	updateExplorer chan *chainhash.Hash, barLoad chan *dbtypes.ProgressBarLoad) {
 	// Allowing db to be nil simplifies logic in caller.
 	if pgb == nil {
@@ -316,7 +316,7 @@ func (pgb *ChainDBRPC) SyncChainDBAsync(ctx context.Context, res chan dbtypes.Sy
 		return
 	}
 	pgb.ChainDB.SyncChainDBAsync(ctx, res, client, updateAllAddresses,
-		updateAllVotes, newIndexes, updateExplorer, barLoad)
+		newIndexes, updateExplorer, barLoad)
 }
 
 // Store satisfies BlockDataSaver. Blocks stored this way are considered valid
@@ -522,8 +522,10 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	}
 	log.Info(pgVersion)
 
+	cockroach := strings.Contains(pgVersion, "CockroachDB")
+
 	// Optionally logs the PostgreSQL configuration.
-	if !hidePGConfig {
+	if !cockroach && !hidePGConfig {
 		perfSettings, err := RetrieveSysSettingsPerformance(db)
 		if err != nil {
 			return nil, err
@@ -538,23 +540,32 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 	}
 
 	// Check the synchronous_commit setting.
-	syncCommit, err := RetrieveSysSettingSyncCommit(db)
-	if err != nil {
-		return nil, err
-	}
-	if syncCommit != "off" {
-		log.Warnf(`PERFORMANCE ISSUE! The synchronous_commit setting is "%s". `+
-			`Changing it to "off".`, syncCommit)
-		// Turn off synchronous_commit.
-		if err = SetSynchronousCommit(db, "off"); err != nil {
-			return nil, fmt.Errorf("failed to set synchronous_commit: %v", err)
-		}
-		// Verify that the setting was changed.
-		if syncCommit, err = RetrieveSysSettingSyncCommit(db); err != nil {
+	if !cockroach {
+		syncCommit, err := RetrieveSysSettingSyncCommit(db)
+		if err != nil {
 			return nil, err
 		}
 		if syncCommit != "off" {
-			log.Errorf(`Failed to set synchronous_commit="off". Check PostgreSQL user permissions.`)
+			log.Warnf(`PERFORMANCE ISSUE! The synchronous_commit setting is "%s". `+
+				`Changing it to "off".`, syncCommit)
+			// Turn off synchronous_commit.
+			if err = SetSynchronousCommit(db, "off"); err != nil {
+				return nil, fmt.Errorf("failed to set synchronous_commit: %v", err)
+			}
+			// Verify that the setting was changed.
+			if syncCommit, err = RetrieveSysSettingSyncCommit(db); err != nil {
+				return nil, err
+			}
+			if syncCommit != "off" {
+				log.Errorf(`Failed to set synchronous_commit="off". Check PostgreSQL user permissions.`)
+			}
+		}
+	} else {
+		// Force CockroachDB to use a real sequence when creating a table with a
+		// SERIAL column.
+		_, err = db.Exec("SET experimental_serial_normalization = sql_sequence;")
+		if err != nil {
+			return nil, fmt.Errorf("failed to set experimental_serial_normalization: %v", err)
 		}
 	}
 
@@ -1001,9 +1012,34 @@ func (pgb *ChainDB) TransactionBlocks(txHash string) ([]*dbtypes.BlockStatus, []
 	return blocks, inds, nil
 }
 
-// HeightDB queries the DB for the best block height. When the tables are empty,
-// the returned height will be -1.
+// HeightDB retrieves the best block height according to the meta table.
 func (pgb *ChainDB) HeightDB() (int64, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	_, height, err := DBBestBlock(ctx, pgb.db)
+	return height, pgb.replaceCancelError(err)
+}
+
+// HashDB retrieves the best block hash according to the meta table.
+func (pgb *ChainDB) HashDB() (string, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	hash, _, err := DBBestBlock(ctx, pgb.db)
+	return hash, pgb.replaceCancelError(err)
+}
+
+// HeightHashDB retrieves the best block height and hash according to the meta
+// table.
+func (pgb *ChainDB) HeightHashDB() (int64, string, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	hash, height, err := DBBestBlock(ctx, pgb.db)
+	return height, hash, pgb.replaceCancelError(err)
+}
+
+// HeightDBLegacy queries the blocks table for the best block height. When the
+// tables are empty, the returned height will be -1.
+func (pgb *ChainDB) HeightDBLegacy() (int64, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	bestHeight, _, _, err := RetrieveBestBlockHeight(ctx, pgb.db)
@@ -1011,20 +1047,20 @@ func (pgb *ChainDB) HeightDB() (int64, error) {
 	if err == sql.ErrNoRows {
 		height = -1
 	}
-	// DO NOT change this to return -1 if err == sql.ErrNoRows.
 	return height, pgb.replaceCancelError(err)
 }
 
-// HashDB queries the DB for the best block's hash.
-func (pgb *ChainDB) HashDB() (string, error) {
+// HashDBLegacy queries the blocks table for the best block's hash.
+func (pgb *ChainDB) HashDBLegacy() (string, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	_, bestHash, _, err := RetrieveBestBlockHeight(ctx, pgb.db)
 	return bestHash, pgb.replaceCancelError(err)
 }
 
-// HeightHashDB queries the DB for the best block's height and hash.
-func (pgb *ChainDB) HeightHashDB() (uint64, string, error) {
+// HeightHashDBLegacy queries the blocks table for the best block's height and
+// hash.
+func (pgb *ChainDB) HeightHashDBLegacy() (uint64, string, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	height, hash, _, err := RetrieveBestBlockHeight(ctx, pgb.db)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -243,6 +243,7 @@ type ChainDB struct {
 	deployments        *ChainDeployments
 	piparser           ProposalsFetcher
 	proposalsSync      lastSync
+	cockroach          bool
 }
 
 // ChainDeployments is mutex-protected blockchain deployment data.
@@ -776,6 +777,7 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		utxoCache:          newUtxoStore(5e4),
 		deployments:        new(ChainDeployments),
 		piparser:           parser,
+		cockroach:          cockroach,
 	}
 
 	// If loading a DB with the legacy versioning system, fully upgrade prior to

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -572,9 +572,11 @@ func NewChainDBWithCancel(ctx context.Context, dbi *DBInfo, params *chaincfg.Par
 		// autoincrement of row primary key by lowering garbage the collection
 		// interval (from 25 hours!).
 		crdbGCInterval := 1200 // 20 minutes between garbage collections
-		_, err = db.Exec(fmt.Sprintf(`ALTER DATABASE %s configure zone using gc.ttlseconds=%d;`,
-			dbi.DBName, crdbGCInterval))
+		_, err = db.Exec(fmt.Sprintf(`ALTER DATABASE %s CONFIGURE ZONE USING gc.ttlseconds=$1;`,
+			dbi.DBName), crdbGCInterval)
 		if err != nil {
+			// In secure mode, the user may need permissions to modify zones. e.g.
+			// GRANT UPDATE ON TABLE dcrdata_mainnet.crdb_internal.zones TO dcrdata_user;
 			return nil, fmt.Errorf(`failed to set gc.ttlseconds=%d for database "%s": %v`,
 				crdbGCInterval, dbi.DBName, err)
 		}

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -97,7 +97,7 @@ func TestChainDB_AddressTransactionsAll(t *testing.T) {
 		t.Fatalf("should have been no rows, got %v", rows)
 	}
 
-	height, hash, _ := db.HeightHashDB()
+	height, hash, _ := db.HeightHashDBLegacy()
 	h, _ := chainhash.NewHashFromStr(hash)
 	blockID := cache.NewBlockID(h, int64(height))
 	wasStored := db.AddressCache.StoreRows(address, rows, blockID)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -175,17 +175,124 @@ func DeleteDuplicateVins(db *sql.DB) (int64, error) {
 	existsIdx, err := ExistsIndex(db, "uix_vin")
 	if err != nil {
 		return 0, err
-	} else if !existsIdx {
+	}
+	if !existsIdx {
 		return sqlExec(db, internal.DeleteVinsDuplicateRows, execErrPrefix)
 	}
 
-	if isuniq, err := IsUniqueIndex(db, "uix_vin"); err != nil && err != sql.ErrNoRows {
+	isuniq, err := IsUniqueIndex(db, "uix_vin")
+	if err != nil && err != sql.ErrNoRows {
 		return 0, err
-	} else if isuniq {
+	}
+	if isuniq {
 		return 0, nil
 	}
 
 	return sqlExec(db, internal.DeleteVinsDuplicateRows, execErrPrefix)
+}
+
+func deleteDupVinsBrute(db *sql.DB) (int64, error) {
+	execErrPrefix := "failed to delete duplicate vins: "
+
+	// CockroachDB doesn't have CREATE TABLE .. (LIKE table), so we have to get
+	// the CREATE TABLE statement from the exinsting vins table.
+	var createStmt string
+	err := db.QueryRow(internal.ShowCreateVinsTable).Scan(&createStmt)
+	if err != nil {
+		err = fmt.Errorf("%s%v", execErrPrefix, err)
+		return 0, err
+	}
+	createStmt = strings.Replace(createStmt, "CREATE TABLE vins",
+		"CREATE TABLE vins_temp", 1)
+
+	var N0 int64
+	err = db.QueryRow(`SELECT COUNT(*) FROM vins;`).Scan(&N0)
+	if err != nil {
+		return 0, err
+	}
+
+	// Create the "vins_temp" table.
+	_, err = sqlExec(db, createStmt, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+
+	// Populate vins_temp with the unique rows.
+	var N int64
+	N, err = sqlExec(db, internal.DistinctVinsToTempTable, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+
+	// Drop the original vins table.
+	err = dropTable(db, "vins")
+	if err != nil {
+		return 0, err
+	}
+
+	// Rename vins_temp to vins.
+	_, err = sqlExec(db, internal.RenameVinsTemp, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+	return N0 - N, nil
+}
+
+func deleteDupVinsAlt(db *sql.DB) (int64, error) {
+	execErrPrefix := "failed to delete duplicate vins: "
+
+	rows, err := db.Query(internal.SelectVinDupIDs)
+	if err != nil {
+		err = fmt.Errorf("%s%v", execErrPrefix, err)
+		return 0, err
+	}
+
+	var deleteIDs []int64
+	for rows.Next() {
+		var dupIDs []int64
+		if err = rows.Scan(&dupIDs); err != nil {
+			err = fmt.Errorf("%s%v", execErrPrefix, err)
+			return 0, err
+		}
+
+		fmt.Println(dupIDs)
+
+		if len(dupIDs) > 1 {
+			deleteIDs = append(deleteIDs, dupIDs[1:]...)
+		}
+	}
+
+	fmt.Println(deleteIDs)
+
+	// Delete the duplicate rows.
+	var N int64
+	N, err = sqlExec(db, internal.DeleteVinRows, execErrPrefix, deleteIDs)
+	if err != nil {
+		return 0, err
+	}
+	return N, nil
+}
+
+// DeleteDuplicateVinsCockroach deletes rows in vin with duplicate tx
+// information, leaving the one row with the lowest id.
+func DeleteDuplicateVinsCockroach(db *sql.DB) (int64, error) {
+	existsIdx, err := ExistsIndex(db, "uix_vin")
+	if err != nil {
+		return 0, err
+	}
+	if !existsIdx {
+		return deleteDupVinsBrute(db)
+	}
+
+	isuniq, err := IsUniqueIndex(db, "uix_vin")
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	if isuniq {
+		return 0, nil
+	}
+
+	return deleteDupVinsBrute(db)
 }
 
 // DeleteDuplicateVouts deletes rows in vouts with duplicate tx information,
@@ -207,6 +314,110 @@ func DeleteDuplicateVouts(db *sql.DB) (int64, error) {
 	}
 
 	return sqlExec(db, internal.DeleteVoutDuplicateRows, execErrPrefix)
+}
+
+func deleteDupVoutsBrute(db *sql.DB) (int64, error) {
+	execErrPrefix := "failed to delete duplicate vouts: "
+
+	// CockroachDB doesn't have CREATE TABLE .. (LIKE table), so we have to get
+	// the CREATE TABLE statement from the exinsting vins table.
+	var createStmt string
+	err := db.QueryRow(internal.ShowCreateVoutsTable).Scan(&createStmt)
+	if err != nil {
+		err = fmt.Errorf("%s%v", execErrPrefix, err)
+		return 0, err
+	}
+	createStmt = strings.Replace(createStmt, "CREATE TABLE vouts",
+		"CREATE TABLE vouts_temp", 1)
+
+	var N0 int64
+	err = db.QueryRow(`SELECT COUNT(*) FROM vouts;`).Scan(&N0)
+	if err != nil {
+		return 0, err
+	}
+
+	// Create the "vouts_temp" table.
+	_, err = sqlExec(db, createStmt, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+
+	// Populate vouts_temp with the unique rows.
+	var N int64
+	N, err = sqlExec(db, internal.DistinctVoutsToTempTable, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+
+	// Drop the original vouts table.
+	err = dropTable(db, "vouts")
+	if err != nil {
+		return 0, err
+	}
+
+	// Rename vouts_temp to vouts.
+	_, err = sqlExec(db, internal.RenameVoutsTemp, execErrPrefix)
+	if err != nil {
+		return 0, err
+	}
+	return N0 - N, nil
+}
+
+func deleteDupVoutsAlt(db *sql.DB) (int64, error) {
+	execErrPrefix := "failed to delete duplicate vouts: "
+
+	rows, err := db.Query(internal.SelectVoutDupIDs)
+	if err != nil {
+		err = fmt.Errorf("%s%v", execErrPrefix, err)
+		return 0, err
+	}
+
+	var deleteIDs []int64
+	for rows.Next() {
+		var dupIDs []int64
+		if err = rows.Scan(&dupIDs); err != nil {
+			err = fmt.Errorf("%s%v", execErrPrefix, err)
+			return 0, err
+		}
+
+		fmt.Println(dupIDs)
+
+		if len(dupIDs) > 1 {
+			deleteIDs = append(deleteIDs, dupIDs[1:]...)
+		}
+	}
+
+	fmt.Println(deleteIDs)
+
+	// Delete the duplicate rows.
+	var N int64
+	N, err = sqlExec(db, internal.DeleteVoutRows, execErrPrefix, deleteIDs)
+	if err != nil {
+		return 0, err
+	}
+	return N, nil
+}
+
+// DeleteDuplicateVoutsCockroach deletes rows in vouts with duplicate tx
+// information, leaving the one row with the highest id.
+func DeleteDuplicateVoutsCockroach(db *sql.DB) (int64, error) {
+	existsIdx, err := ExistsIndex(db, "uix_vout_txhash_ind")
+	if err != nil {
+		return 0, err
+	}
+	if !existsIdx {
+		return deleteDupVoutsBrute(db)
+	}
+
+	isuniq, err := IsUniqueIndex(db, "uix_vout_txhash_ind")
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+	if isuniq {
+		return 0, nil
+	}
+
+	return deleteDupVoutsBrute(db)
 }
 
 // DeleteDuplicateTxns deletes rows in transactions with duplicate tx-block

--- a/db/dcrpg/rewind.go
+++ b/db/dcrpg/rewind.go
@@ -56,23 +56,35 @@ func deleteVotesForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err 
 }
 
 func deleteTicketsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
-	return sqlExec(dbTx, internal.DeleteTickets, "failed to delete tickets", hash)
+	return sqlExec(dbTx, internal.DeleteTicketsSimple, "failed to delete tickets", hash)
 }
 
 func deleteTransactionsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
-	return sqlExec(dbTx, internal.DeleteTransactions, "failed to delete transactions", hash)
+	return sqlExec(dbTx, internal.DeleteTransactionsSimple, "failed to delete transactions", hash)
 }
 
 func deleteVoutsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
 	return sqlExec(dbTx, internal.DeleteVouts, "failed to delete vouts", hash)
 }
 
+func deleteVoutsForBlockSubQry(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(dbTx, internal.DeleteVoutsSubQry, "failed to delete vouts", hash)
+}
+
 func deleteVinsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
 	return sqlExec(dbTx, internal.DeleteVins, "failed to delete vins", hash)
 }
 
+func deleteVinsForBlockSubQry(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(dbTx, internal.DeleteVinsSubQry, "failed to delete vins", hash)
+}
+
 func deleteAddressesForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
 	return sqlExec(dbTx, internal.DeleteAddresses, "failed to delete addresses", hash)
+}
+
+func deleteAddressesForBlockSubQry(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
+	return sqlExec(dbTx, internal.DeleteAddressesSubQry, "failed to delete addresses", hash)
 }
 
 func deleteBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
@@ -150,24 +162,24 @@ func DeleteBlockData(ctx context.Context, db *sql.DB, hash string) (res dbtypes.
 	res.Timings = new(dbtypes.DeletionSummary)
 
 	start := time.Now()
-	if res.Vins, err = deleteVinsForBlock(dbTx, hash); err != nil {
-		err = fmt.Errorf(`deleteVinsForBlock failed with "%v". Rollback: %v`,
+	if res.Vins, err = deleteVinsForBlockSubQry(dbTx, hash); err != nil {
+		err = fmt.Errorf(`deleteVinsForBlockSubQry failed with "%v". Rollback: %v`,
 			err, dbTx.Rollback())
 		return
 	}
 	res.Timings.Vins = time.Since(start).Nanoseconds()
 
 	start = time.Now()
-	if res.Vouts, err = deleteVoutsForBlock(dbTx, hash); err != nil {
-		err = fmt.Errorf(`deleteVoutsForBlock failed with "%v". Rollback: %v`,
+	if res.Vouts, err = deleteVoutsForBlockSubQry(dbTx, hash); err != nil {
+		err = fmt.Errorf(`deleteVoutsForBlockSubQry failed with "%v". Rollback: %v`,
 			err, dbTx.Rollback())
 		return
 	}
 	res.Timings.Vouts = time.Since(start).Nanoseconds()
 
 	start = time.Now()
-	if res.Addresses, err = deleteAddressesForBlock(dbTx, hash); err != nil {
-		err = fmt.Errorf(`deleteAddressesForBlock failed with "%v". Rollback: %v`,
+	if res.Addresses, err = deleteAddressesForBlockSubQry(dbTx, hash); err != nil {
+		err = fmt.Errorf(`deleteAddressesForBlockSubQry failed with "%v". Rollback: %v`,
 			err, dbTx.Rollback())
 		return
 	}

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -6,7 +6,6 @@ package dcrpg
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
@@ -98,10 +97,10 @@ const (
 // which the caller should wait to receive the result. As such, this method
 // should be called as a goroutine or it will hang on send if the channel is
 // unbuffered.
-func (db *ChainDB) SyncChainDBAsync(ctx context.Context, res chan dbtypes.SyncResult,
-	client rpcutils.MasterBlockGetter, updateAllAddresses, updateAllVotes, newIndexes bool,
+func (pgb *ChainDB) SyncChainDBAsync(ctx context.Context, res chan dbtypes.SyncResult,
+	client rpcutils.MasterBlockGetter, updateAllAddresses, newIndexes bool,
 	updateExplorer chan *chainhash.Hash, barLoad chan *dbtypes.ProgressBarLoad) {
-	if db == nil {
+	if pgb == nil {
 		res <- dbtypes.SyncResult{
 			Height: -1,
 			Error:  fmt.Errorf("ChainDB (psql) disabled"),
@@ -109,10 +108,10 @@ func (db *ChainDB) SyncChainDBAsync(ctx context.Context, res chan dbtypes.SyncRe
 		return
 	}
 
-	height, err := db.SyncChainDB(ctx, client, updateAllAddresses,
-		updateAllVotes, newIndexes, updateExplorer, barLoad)
+	height, err := pgb.SyncChainDB(ctx, client, updateAllAddresses, newIndexes,
+		updateExplorer, barLoad)
 	if err != nil {
-		log.Debugf("SyncChainDB quit at height %d, err: %v", height, err)
+		log.Errorf("SyncChainDB quit at height %d, err: %v", height, err)
 	} else {
 		log.Debugf("SyncChainDB completed at height %d.", height)
 	}
@@ -127,43 +126,66 @@ func (db *ChainDB) SyncChainDBAsync(ctx context.Context, res chan dbtypes.SyncRe
 // RPC client. The table indexes may be force-dropped and recreated by setting
 // newIndexes to true. The quit channel is used to break the sync loop. For
 // example, closing the channel on SIGINT.
-func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockGetter,
-	updateAllAddresses, updateAllVotes, newIndexes bool,
-	updateExplorer chan *chainhash.Hash, barLoad chan *dbtypes.ProgressBarLoad) (int64, error) {
-	// Note that we are doing a batch blockchain sync
-	db.InBatchSync = true
-	defer func() { db.InBatchSync = false }()
+func (pgb *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockGetter,
+	updateAllAddresses, newIndexes bool, updateExplorer chan *chainhash.Hash,
+	barLoad chan *dbtypes.ProgressBarLoad) (int64, error) {
+	// Note that we are doing a batch blockchain sync.
+	pgb.InBatchSync = true
+	defer func() { pgb.InBatchSync = false }()
 
-	// Get chain servers's best block
+	// Get the chain servers's best block.
 	nodeHeight, err := client.NodeHeight()
 	if err != nil {
 		return -1, fmt.Errorf("GetBestBlock failed: %v", err)
 	}
 
-	lastBlock, err := db.HeightDB()
+	// Retrieve the best block in the database from the meta table.
+	lastBlock, err := pgb.HeightDB()
 	if err != nil {
-		if err == sql.ErrNoRows {
-			log.Info("blocks table is empty, starting fresh.")
-		} else {
-			return -1, fmt.Errorf("RetrieveBestBlockHeight: %v", err)
-		}
+		return -1, fmt.Errorf("RetrieveBestBlockHeight: %v", err)
+	}
+	if lastBlock == -1 {
+		log.Info("Tables are empty, starting fresh.")
 	}
 
 	// Remove indexes/constraints before an initial sync or when explicitly
 	// requested to reindex and update spending information in the addresses
 	// table.
 	reindexing := newIndexes || lastBlock == -1
+
+	// See if initial sync (initial block download) was previously completed.
+	ibdComplete, err := IBDComplete(pgb.db)
+	if err != nil {
+		return lastBlock, fmt.Errorf("IBDComplete failed: %v", err)
+	}
+
+	// When IBD is not yet completed, force reindexing and update of full
+	// spending info in addresses table after block sync.
+	if !ibdComplete {
+		if lastBlock > -1 {
+			log.Warnf("Detected that initial sync was previously started but not completed!")
+		}
+		if !reindexing {
+			reindexing = true
+			log.Warnf("Forcing table reindexing.")
+		}
+		if !updateAllAddresses {
+			updateAllAddresses = true
+			log.Warnf("Forcing full update of spending information in addresses table.")
+		}
+	}
+
 	if reindexing {
 		// Remove any existing indexes.
 		log.Info("Large bulk load: Removing indexes and disabling duplicate checks.")
-		err = db.DeindexAll()
+		err = pgb.DeindexAll()
 		if err != nil && !strings.Contains(err.Error(), "does not exist") {
 			return lastBlock, err
 		}
 
 		// Disable duplicate checks on insert queries since the unique indexes
 		// that enforce the constraints will not exist.
-		db.EnableDuplicateCheckOnInsert(false)
+		pgb.EnableDuplicateCheckOnInsert(false)
 
 		// Syncing blocks without indexes requires a UTXO cache to avoid
 		// extremely expensive queries. Warm the UTXO cache if resuming an
@@ -171,26 +193,28 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		blocksToSync := nodeHeight - lastBlock
 		if lastBlock > 0 && blocksToSync > 50 {
 			log.Infof("Collecting all UTXO data prior to height %d...", lastBlock+1)
-			utxos, err := RetrieveUTXOs(ctx, db.db)
+			utxos, err := RetrieveUTXOs(ctx, pgb.db)
 			if err != nil {
 				return -1, fmt.Errorf("RetrieveUTXOs: %v", err)
 			}
 			log.Infof("Pre-warming UTXO cache with %d UTXOs...", len(utxos))
-			db.InitUtxoCache(utxos)
+			pgb.InitUtxoCache(utxos)
 			log.Infof("UTXO cache is ready.")
 		}
 	} else {
 		// When the unique indexes exist, inserts should check for conflicts
 		// with the tables' constraints.
-		db.EnableDuplicateCheckOnInsert(true)
+		pgb.EnableDuplicateCheckOnInsert(true)
 	}
 
 	// When reindexing or adding a large amount of data, ANALYZE tables.
 	requireAnalyze := reindexing || nodeHeight-lastBlock > 10000
 
-	if reindexing || updateAllAddresses || updateAllVotes {
+	// If reindexing or batch table data updates are required, set the
+	// ibd_complete flag to false if it is not already false.
+	if ibdComplete && (reindexing || updateAllAddresses) {
 		// Set meta.ibd_complete = FALSE.
-		if err = SetIBDComplete(db.db, false); err != nil {
+		if err = SetIBDComplete(pgb.db, false); err != nil {
 			return nodeHeight, fmt.Errorf("failed to set meta.ibd_complete: %v", err)
 		}
 	}
@@ -313,7 +337,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		}
 
 		// Register for notification from stakedb when it connects this block.
-		waitChan := db.stakeDB.WaitForHeight(ib)
+		waitChan := pgb.stakeDB.WaitForHeight(ib)
 
 		// Get the block, making it available to stakedb, which will signal on
 		// the above channel when it is done connecting it.
@@ -343,7 +367,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 
 		// Winning tickets from StakeDatabase, which just connected the block,
 		// as signaled via the waitChan.
-		tpi, ok := db.stakeDB.PoolInfo(*blockHash)
+		tpi, ok := pgb.stakeDB.PoolInfo(*blockHash)
 		if !ok {
 			return ib - 1, fmt.Errorf("stakeDB.PoolInfo could not locate block %s", blockHash.String())
 		}
@@ -360,8 +384,8 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		// updateExisting is ignored if dupCheck=false, but set it to true since
 		// SyncChainDB is processing main chain blocks.
 		updateExisting := true
-		numVins, numVouts, numAddresses, err := db.StoreBlock(block.MsgBlock(), winners, isValid,
-			isMainchain, updateExisting, !updateAllAddresses, !updateAllVotes, chainWork)
+		numVins, numVouts, numAddresses, err := pgb.StoreBlock(block.MsgBlock(), winners, isValid,
+			isMainchain, updateExisting, !updateAllAddresses, true, chainWork)
 		if err != nil {
 			return ib - 1, fmt.Errorf("StoreBlock failed: %v", err)
 		}
@@ -392,7 +416,7 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 
 	// After the last call to StoreBlock, synchronously update the project fund
 	// and clear the general address balance cache.
-	if err = db.FreshenAddressCaches(false, nil); err != nil {
+	if err = pgb.FreshenAddressCaches(false, nil); err != nil {
 		log.Warnf("FreshenAddressCaches: %v", err)
 		err = nil // not an error with sync
 	}
@@ -415,30 +439,30 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		// invalidated and the transactions are subsequently re-mined in another
 		// block. Remove these before indexing.
 		log.Infof("Finding and removing duplicate table rows before indexing...")
-		if err = db.DeleteDuplicates(barLoad); err != nil {
+		if err = pgb.DeleteDuplicates(barLoad); err != nil {
 			return 0, err
 		}
 
 		// Create all indexes.
-		if err = db.IndexAll(barLoad); err != nil {
+		if err = pgb.IndexAll(barLoad); err != nil {
 			return nodeHeight, fmt.Errorf("IndexAll failed: %v", err)
 		}
 
-		// Only reindex addresses and tickets tables here if not doing it below.
+		// Only reindex addresses table here if not doing it below.
 		if !updateAllAddresses {
-			if err = db.IndexAddressTable(barLoad); err != nil {
+			if err = pgb.IndexAddressTable(barLoad); err != nil {
 				return nodeHeight, fmt.Errorf("IndexAddressTable failed: %v", err)
 			}
 		}
-		if !updateAllVotes {
-			if err = db.IndexTicketsTable(barLoad); err != nil {
-				return nodeHeight, fmt.Errorf("IndexTicketsTable failed: %v", err)
-			}
+
+		// Tickets table index is not included in IndexAll.
+		if err = pgb.IndexTicketsTable(barLoad); err != nil {
+			return nodeHeight, fmt.Errorf("IndexTicketsTable failed: %v", err)
 		}
 
 		// Deep ANALYZE all tables.
 		log.Infof("Performing an ANALYZE(%d) on all tables...", deepStatsTarget)
-		if err = AnalyzeAllTables(db.db, deepStatsTarget); err != nil {
+		if err = AnalyzeAllTables(pgb.db, deepStatsTarget); err != nil {
 			return nodeHeight, fmt.Errorf("failed to ANALYZE tables: %v", err)
 		}
 		analyzed = true
@@ -449,59 +473,28 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 		// Analyze vins and table first.
 		if !analyzed {
 			log.Infof("Performing an ANALYZE(%d) on vins table...", deepStatsTarget)
-			if err = AnalyzeTable(db.db, "vins", deepStatsTarget); err != nil {
+			if err = AnalyzeTable(pgb.db, "vins", deepStatsTarget); err != nil {
 				return nodeHeight, fmt.Errorf("failed to ANALYZE vins table: %v", err)
 			}
 		}
 
 		// Remove existing indexes not on funding txns
-		_ = db.DeindexAddressTable() // ignore errors for non-existent indexes
+		_ = pgb.DeindexAddressTable() // ignore errors for non-existent indexes
 		log.Infof("Populating spending tx info in address table...")
-		numAddresses, err := db.UpdateSpendingInfoInAllAddresses(barLoad)
+		numAddresses, err := pgb.UpdateSpendingInfoInAllAddresses(barLoad)
 		if err != nil {
 			log.Errorf("UpdateSpendingInfoInAllAddresses FAILED: %v", err)
 		}
 		// Index addresses table
 		log.Infof("Updated %d rows of address table", numAddresses)
-		if err = db.IndexAddressTable(barLoad); err != nil {
+		if err = pgb.IndexAddressTable(barLoad); err != nil {
 			log.Errorf("IndexAddressTable FAILED: %v", err)
 		}
 
 		// Deep ANALYZE the newly indexed addresses table.
 		log.Infof("Performing an ANALYZE(%d) on addresses table...", deepStatsTarget)
-		if err = AnalyzeTable(db.db, "addresses", deepStatsTarget); err != nil {
+		if err = AnalyzeTable(pgb.db, "addresses", deepStatsTarget); err != nil {
 			return nodeHeight, fmt.Errorf("failed to ANALYZE addresses table: %v", err)
-		}
-	}
-
-	// Batch update tickets table with spending info.
-	if updateAllVotes {
-		// Analyze vins table first.
-		if !analyzed {
-			log.Infof("Performing an ANALYZE(%d) on vins table...", deepStatsTarget)
-			if err = AnalyzeTable(db.db, "vins", deepStatsTarget); err != nil {
-				return nodeHeight, fmt.Errorf("failed to ANALYZE vins table: %v", err)
-			}
-		}
-
-		// Remove indexes not on funding txns (remove on tickets table indexes)
-		_ = db.DeindexTicketsTable() // ignore errors for non-existent indexes
-		db.EnableDuplicateCheckOnInsert(false)
-		log.Infof("Populating spending tx info in tickets table...")
-		numTicketsUpdated, err := db.UpdateSpendingInfoInAllTickets()
-		if err != nil {
-			log.Errorf("UpdateSpendingInfoInAllTickets FAILED: %v", err)
-		}
-		// Index tickets table
-		log.Infof("Updated %d rows of address table", numTicketsUpdated)
-		if err = db.IndexTicketsTable(barLoad); err != nil {
-			log.Errorf("IndexTicketsTable FAILED: %v", err)
-		}
-
-		// Deep ANALYZE the newly indexed tickets table.
-		log.Infof("Performing an ANALYZE(%d) on tickets table...", deepStatsTarget)
-		if err = AnalyzeTable(db.db, "tickets", deepStatsTarget); err != nil {
-			return nodeHeight, fmt.Errorf("failed to ANALYZE tickets table: %v", err)
 		}
 	}
 
@@ -509,17 +502,17 @@ func (db *ChainDB) SyncChainDB(ctx context.Context, client rpcutils.MasterBlockG
 	if !analyzed && requireAnalyze {
 		// Analyze all tables.
 		log.Infof("Performing an ANALYZE(%d) on all tables...", quickStatsTarget)
-		if err = AnalyzeAllTables(db.db, quickStatsTarget); err != nil {
+		if err = AnalyzeAllTables(pgb.db, quickStatsTarget); err != nil {
 			return nodeHeight, fmt.Errorf("failed to ANALYZE tables: %v", err)
 		}
 	}
 
 	// After sync and indexing, must use upsert statement, which checks for
 	// duplicate entries and updates instead of throwing and error and panicing.
-	db.EnableDuplicateCheckOnInsert(true)
+	pgb.EnableDuplicateCheckOnInsert(true)
 
 	// Set meta.ibd_complete = TRUE.
-	if err = SetIBDComplete(db.db, true); err != nil {
+	if err = SetIBDComplete(pgb.db, true); err != nil {
 		return nodeHeight, fmt.Errorf("failed to set meta.ibd_complete: %v", err)
 	}
 

--- a/db/dcrpg/upgrades_legacy.go
+++ b/db/dcrpg/upgrades_legacy.go
@@ -862,7 +862,7 @@ func (pgb *ChainDB) handleUpgrades(client BlockGetter, tableUpgrade tableUpgrade
 	switch tableUpgrade {
 	case vinsTableCoinSupplyUpgrade, agendasTableUpgrade, agendasTablePruningUpdate:
 		// height is the best block where this table upgrade should stop at.
-		height, err := pgb.HeightDB()
+		height, err := pgb.HeightDBLegacy()
 		if err != nil {
 			return false, err
 		}
@@ -945,7 +945,7 @@ func (pgb *ChainDB) handleUpgrades(client BlockGetter, tableUpgrade tableUpgrade
 	case vinsTxHistogramUpgrade, addressesTxHistogramUpgrade:
 		var height int64
 		// height is the best block where this table upgrade should stop at.
-		height, err = pgb.HeightDB()
+		height, err = pgb.HeightDBLegacy()
 		if err != nil {
 			return false, err
 		}

--- a/db/dcrpg/upgrades_legacy.go
+++ b/db/dcrpg/upgrades_legacy.go
@@ -1237,7 +1237,7 @@ func (pgb *ChainDB) handleTxTypeHistogramUpgrade(bestBlock uint64, upgrade table
 		log.Warnf("histogram upgrade maybe slower since indexing failed: %v", err)
 	} else {
 		defer func() {
-			_, err = pgb.db.Exec("DROP INDEX xxxxx_histogram;")
+			_, err = pgb.db.Exec("DROP INDEX xxxxx_histogram  CASCADE;")
 			if err != nil {
 				log.Warnf("droping the histogram index failed: %v", err)
 			}


### PR DESCRIPTION
<s>Resolves</s> Working toward https://github.com/decred/dcrdata/issues/1291, the following changes are made to support CockroachDB (crdb):

- Detecting use of cockroach.
- Removal of custom PostgreSQL types (i.e. `vin_t` and `vout_t`) and related code since crdb does not support them.
- Not erroring out when checking PostgreSQL-specific information (e.g. `synchronous_commit` and almost all the `pg_settings` dumped in the table at startup).
- Setting the `sql_sequence` SERIAL operating mode since by default `SERIAL` type columns in crdb do not create a sequence.
- Empty arrays made using the `ARRAY[]` constructor in CockroachDB require type _annotation_ (e.g. `ARRAY[]:::BIGINT[]` with ***three*** `:` characters for annotation instead of conversion), a concept that does not exist in PostgreSQL).  May need to use the literal format like `SELECT '{}'::int[];` or whatever works for both PostgreSQL and CockroachDB.
- Replaces `cardinality(arr)` with `array_length(arr,1)` since crdb does not have `cardinality`
- DELETE queries that use the `USING` clause do not work.  This affects the "rewind" queries in rewind.go.  Use a subquery.
- Deleting duplicate rows using most common methods fails to due to CRDB memory use.  A painful temporary table with a simple DISTINCT ON clause is the only way, but it is super duper slow.

Also:
- Remove the `updateAllVotes` option from `ChainDB` sync since it is always done
on the fly. For now, let `StoreBlock` keep the option to update ticket/vote spend info.
Also keep `(*ChainDB).UpdateSpendingInfoInAllTickets` as it could be a
helpful recovery and repair function.
- `HeightDB`, `HashDB`, and `HeightHashDB` now use `DBBestBlock` to get the
data from the `meta` table.  See `HeightDBLegacy`, etc. for the querying the
`blocks` table instead.
- Before sync, check the `ibd_complete` flag in the meta `table` and force indexing
and full update of `addresses` table spending info as required.
- Remove unused code and comments from dcrpg/internal code.