### PR TITLE
Insight root page and api redirect

### DIFF
--- a/api/Insight_API_documentation.md
+++ b/api/Insight_API_documentation.md
@@ -1,4 +1,4 @@
-# Insight API (EXPERIMENTAL)
+# Insight API
 
 The [Insight API](https://github.com/bitpay/insight-api) is accessible via HTTP via REST or WebSocket. 
 

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -1,13 +1,13 @@
 // Copyright (c) 2018-2019, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
-//
-// This is tested against Insight API Implementation v5.3.04beta
 
-// Package insight handles the insight api
+// Package insight implements the Insight API.
 package insight
 
 import (
+	"net/http"
+
 	m "github.com/decred/dcrdata/middleware"
 	"github.com/didip/tollbooth"
 	"github.com/didip/tollbooth_chi"
@@ -49,6 +49,10 @@ func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
 	if compression {
 		mux.Use(middleware.NewCompressor(3).Handler())
 	}
+
+	mux.With(m.OriginalRequestURI).Get("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path+"/status", http.StatusSeeOther)
+	})
 
 	// Block endpoints
 	mux.With(BlockDateLimitQueryCtx).Get("/blocks", app.getBlockSummaryByTime)

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -576,7 +576,7 @@ func (charts *ChartData) Load(cacheDumpPath string) {
 	// Bring the charts up to date.
 	charts.Update()
 
-	log.Debugf("Completed the initial chart load in %d s", time.Since(t).Seconds())
+	log.Debugf("Completed the initial chart load in %f s", time.Since(t).Seconds())
 }
 
 // Dump dumps a ChartGobject to a gob file at the given path.

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -131,6 +131,7 @@ type links struct {
 	CoinbaseComment string
 	POSExplanation  string
 	APIDocs         string
+	InsightAPIDocs  string
 	Github          string
 	License         string
 	NetParams       string
@@ -147,6 +148,7 @@ var explorerLinks = &links{
 	CoinbaseComment: "https://github.com/decred/dcrd/blob/2a18beb4d56fe59d614a7309308d84891a0cba96/chaincfg/genesis.go#L17-L53",
 	POSExplanation:  "https://docs.decred.org/faq/proof-of-stake/general/#9-what-is-proof-of-stake-voting",
 	APIDocs:         "https://github.com/decred/dcrdata#apis",
+	InsightAPIDocs:  "https://github.com/decred/dcrdata/blob/master/api/Insight_API_documentation.md",
 	Github:          "https://github.com/decred/dcrdata",
 	License:         "https://github.com/decred/dcrdata/blob/master/LICENSE",
 	NetParams:       "https://github.com/decred/dcrd/blob/master/chaincfg/params.go",
@@ -351,7 +353,8 @@ func New(cfg *ExplorerConfig) *explorerUI {
 	tmpls := []string{"home", "explorer", "mempool", "block", "tx", "address",
 		"rawtx", "status", "parameters", "agenda", "agendas", "charts",
 		"sidechains", "disapproved", "ticketpool", "nexthome", "statistics",
-		"windows", "timelisting", "addresstable", "proposals", "proposal", "market"}
+		"windows", "timelisting", "addresstable", "proposals", "proposal",
+		"market", "insight_root"}
 
 	for _, name := range tmpls {
 		if err := exp.templates.addTemplate(name); err != nil {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -242,6 +242,24 @@ func (exp *explorerUI) SideChains(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, str)
 }
 
+// InsightRootPage is the page for the "/insight" path.
+func (exp *explorerUI) InsightRootPage(w http.ResponseWriter, r *http.Request) {
+	str, err := exp.templates.execTemplateToString("insight_root", struct {
+		*CommonPageData
+	}{
+		CommonPageData: exp.commonData(r),
+	})
+
+	if err != nil {
+		log.Errorf("Template execute failure: %v", err)
+		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, str)
+}
+
 // DisapprovedBlocks is the page handler for the "/disapproved" path.
 func (exp *explorerUI) DisapprovedBlocks(w http.ResponseWriter, r *http.Request) {
 	disapprovedBlocks, err := exp.explorerSource.DisapprovedBlocks()

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -446,6 +446,18 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		},
 		"toLowerCase": strings.ToLower,
 		"toTitleCase": strings.Title,
+		"prefixPath": func(prefix, path string) string {
+			if path == "" {
+				if strings.HasSuffix(prefix, "/") {
+					return strings.TrimRight(prefix, "/") + "/"
+				}
+				return prefix
+			}
+			if prefix == "" {
+				return path
+			}
+			return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(path, "/")
+		},
 		"fetchRowLinkURL": func(groupingStr string, start, end time.Time) string {
 			// fetchRowLinkURL creates links url to be used in the blocks list views
 			// in heirachical order i.e. /years -> /months -> weeks -> /days -> /blocks

--- a/explorer/templates_test.go
+++ b/explorer/templates_test.go
@@ -4,6 +4,53 @@ import (
 	"testing"
 )
 
+func TestPrefixPath(t *testing.T) {
+	funcs := makeTemplateFuncMap(nil)
+
+	prefixPath, ok := funcs["prefixPath"]
+	if !ok {
+		t.Fatalf(`Template function map does not contain "prefixPath".`)
+	}
+
+	prefixPathFn, ok := prefixPath.(func(prefix, path string) string)
+	if !ok {
+		t.Fatalf(`Template function "prefixPath" is not of type "func(prefix, path string) string".`)
+	}
+
+	testData := []struct {
+		prefix string
+		path   string
+		out    string
+	}{
+		{"", "", ""},
+		{"", "/", "/"},
+		{"/", "", "/"},
+		{"/", "/path", "/path"},
+		{"/", "path", "/path"},
+		{"//", "//", "/"},
+		{"//", "/", "/"},
+		{"/", "//", "/"},
+		{"/", "/", "/"},
+		{"", "/path", "/path"},
+		{"stuff", "/", "stuff/"},
+		{"stuff", "", "stuff"},
+		{"/things", "", "/things"},
+		{"/insight", "/api/status", "/insight/api/status"},
+		{"/insight", "api/status", "/insight/api/status"},
+		{"/insight/", "api/status", "/insight/api/status"},
+		{"/insight/", "/api/status", "/insight/api/status"},
+		{"insight", "api/status", "insight/api/status"},
+	}
+
+	for i := range testData {
+		actual := prefixPathFn(testData[i].prefix, testData[i].path)
+		if actual != testData[i].out {
+			t.Errorf(`prefixPathFn("%s", "%s") returned "%s", expected "%s"`,
+				testData[i].prefix, testData[i].path, actual, testData[i].out)
+		}
+	}
+}
+
 func TestHashStart(t *testing.T) {
 	funcs := makeTemplateFuncMap(nil)
 

--- a/main.go
+++ b/main.go
@@ -752,8 +752,10 @@ func _main(ctx context.Context) error {
 
 	// Configure the URL path to http handler router for the API.
 	apiMux := api.NewAPIRouter(app, cfg.UseRealIP, cfg.CompressAPI)
+
 	// File downloads piggy-back on the API.
 	fileMux := api.NewFileRouter(app, cfg.UseRealIP)
+
 	// Configure the explorer web pages router.
 	webMux := chi.NewRouter()
 	webMux.With(explore.SyncStatusPageIntercept).Group(func(r chi.Router) {
@@ -762,15 +764,27 @@ func _main(ctx context.Context) error {
 	})
 	webMux.Get("/ws", explore.RootWebsocket)
 	webMux.Get("/ps", psHub.WebSocketHandler)
-	webMux.Get("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "./public/images/favicon.ico")
-	})
-	cacheControlMaxAge := int64(cfg.CacheControlMaxAge)
-	FileServer(webMux, "/js", "./public/js", cacheControlMaxAge)
-	FileServer(webMux, "/css", "./public/css", cacheControlMaxAge)
-	FileServer(webMux, "/fonts", "./public/fonts", cacheControlMaxAge)
-	FileServer(webMux, "/images", "./public/images", cacheControlMaxAge)
-	FileServer(webMux, "/dist", "./public/dist", cacheControlMaxAge)
+
+	// Make the static assets available under a path with the given prefix.
+	mountAssetPaths := func(pathPrefix string) {
+		if !strings.HasSuffix(pathPrefix, "/") {
+			pathPrefix += "/"
+		}
+
+		webMux.Get(pathPrefix+"favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+			log.Infof("Serving %s", r.URL.String())
+			http.ServeFile(w, r, "./public/images/favicon/favicon.ico")
+		})
+
+		cacheControlMaxAge := int64(cfg.CacheControlMaxAge)
+		FileServer(webMux, pathPrefix+"js", "./public/js", cacheControlMaxAge)
+		FileServer(webMux, pathPrefix+"css", "./public/css", cacheControlMaxAge)
+		FileServer(webMux, pathPrefix+"fonts", "./public/fonts", cacheControlMaxAge)
+		FileServer(webMux, pathPrefix+"images", "./public/images", cacheControlMaxAge)
+		FileServer(webMux, pathPrefix+"dist", "./public/dist", cacheControlMaxAge)
+	}
+	// Mount under root (e.g. /js, /css, etc.).
+	mountAssetPaths("/")
 
 	// HTTP profiler
 	if cfg.HTTPProfile {
@@ -842,6 +856,15 @@ func _main(ctx context.Context) error {
 		// fallback.
 		r.With(explorer.MenuFormParser).Post("/set", explore.Home)
 	})
+
+	// Configure a page for the bare "/insight" path. This mounts the static
+	// assets under /insight (e.g. /insight/js) to support the page's complete
+	// loading when the root mounter is not accessible, such as the case in
+	// certain reverse proxy configurations that map /insight as the root path.
+	webMux.With(m.OriginalRequestURI).Get("/insight", explore.InsightRootPage)
+	// Serve static assets under /insight for when the a reverse proxy prefixes
+	// all requests with "/insight". (e.g. /insight/js, /insight/css, etc.).
+	mountAssetPaths("/insight")
 
 	// Start the web server.
 	listenAndServeProto(ctx, &wg, cfg.APIListen, cfg.APIProto, webMux)

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -106,9 +106,28 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
+
             proxy_set_header X-Real-IP $realip_remote_addr;
             proxy_pass http://127.0.0.1:7777;
             proxy_http_version 1.1;
+
+            # NOTE: To proxy to a non-root path like
+            #     proxy_pass http://127.0.0.1:7777/insight";
+            # such as when defining
+            #     server_name insight.domain.tld;
+            # it is necessary to pass the original request URI to the backend.
+            # Certain endpoints look for the X-Original-Request-URI request
+            # header. Without this, the request URI in the backend will contain
+            # the "/insight/" prefix and certain generated links and redirects
+            # may be incorrect. This is only needed for endpoints using the
+            # OriginalRequestURI middleware.
+            proxy_set_header X-Original-Request-URI $request_uri;
+
+            # When using X-Original-Request-URI along with proxy_cache, the
+            # cache key should use $request_uri instead of the dynamic $uri.
+            proxy_cache_key $scheme$proxy_host$request_uri;
+            # Alternatively, use $host:
+            # proxy_cache_key $scheme$host$uri$is_args$args;
 
             # setup proxy cache to use "dcrcache" cache
             proxy_cache dcrcache;

--- a/views/insight_root.tmpl
+++ b/views/insight_root.tmpl
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
-{{template "html-head" "Insight Fallback Page"}}
+{{template "html-head" "Insight API"}}
     {{template "navbar" . }}
     <div class="container main">
         <div>

--- a/views/insight_root.tmpl
+++ b/views/insight_root.tmpl
@@ -1,0 +1,23 @@
+{{define "insight_root"}}
+<!DOCTYPE html>
+<html lang="en">
+
+{{template "html-head" "Insight Fallback Page"}}
+    {{template "navbar" . }}
+    <div class="container main">
+        <div>
+            <h2 style="text-align: center; margin-top: 0px">Looking for the Insight API?</h2>
+            <p style="text-align: center; margin-bottom: 5px">
+                The Insight API is available under the API sub-path. (e.g. <a href="{{prefixPath .RequestURI `api/status`}}">{{prefixPath .RequestURI `api/status`}}</a>).
+            </p>
+            <p style="text-align: center; margin-bottom: 5px">
+                For more information, see <a href="{{.Links.InsightAPIDocs}}">dcrdata's documentation of the Insight API.
+            </p>
+        </div>
+    </div>
+
+{{ template "footer" . }}
+
+</body>
+</html>
+{{ end }}

--- a/views/ticketpool.tmpl
+++ b/views/ticketpool.tmpl
@@ -8,8 +8,8 @@
       <div>
         <h2 style="text-align: center; margin-top: 0px">Ticket Pool Visualization</h2>
         <p style="text-align: center; margin-bottom: 5px">
-        These charts represent the current ticket pool. For historic views go
-        <a href="/charts">here</a>
+          These charts represent the current ticket pool. For historic views go <a href="/charts">here</a>.
+        </p>
       </div>
       <br>
 


### PR DESCRIPTION
This makes a basic HTML page for the `/insight` to provide information about the Insight API on dcrdata.

![image](https://user-images.githubusercontent.com/9373513/56991200-ab808280-6b5c-11e9-8763-45c6d4c6063d.png)

The above shows "https://alpha.dcrdata.org/insight".  To support reverse proxy configurations that map requests on the root path to /insight on the backend, a middleware (`OriginalRequestURI`) is added to embed the original request URI.  This middleware allows the new Insight page handler to generate links relative to *the original client request URI*, not the host root or the request URI as known by the backend.  Again, this will happen with a reverse proxy that modifies the request URI.  For example, here is http://insight.alpha.dcrdata.org:

![image](https://user-images.githubusercontent.com/9373513/56991523-7d4f7280-6b5d-11e9-897e-cb9b2f61e044.png)

Note that the "API sub-path" now links to /api/status instead of /insight/api/status since the proxy prefixes all requests with /insight behind the scenes.

Also, the `/insight/api` endpoint now redirects to `/insight/api/status`. This endpoint's handler also uses the `OriginalRequestURI` since it appends to the request URI and it must be the original request URI, not the URI passed to the backend by the reverse proxy.