### PR TITLE
db/cache: check input height in NewChartData

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -710,11 +710,15 @@ func (charts *ChartData) Update() {
 
 // NewChartData constructs a new ChartData.
 func NewChartData(height uint32, genesis time.Time, chainParams *chaincfg.Params, ctx context.Context) *ChartData {
+	// Allocate datasets for at least as many blocks as in a sdiff window.
+	if int64(height) < chainParams.StakeDiffWindowSize {
+		height = uint32(chainParams.StakeDiffWindowSize)
+	}
 	// Start datasets at 25% larger than height. This matches golangs default
 	// capacity size increase for slice lengths > 1024
 	// https://github.com/golang/go/blob/87e48c5afdcf5e01bb2b7f51b7643e8901f4b7f9/src/runtime/slice.go#L100-L112
 	size := int(height * 5 / 4)
-	days := int(int64(time.Since(genesis)/time.Hour/24)) * 5 / 4
+	days := int(time.Since(genesis)/time.Hour/24)*5/4 + 1 // at least one day
 	windows := int(int64(height)/chainParams.StakeDiffWindowSize+1) * 5 / 4
 	return &ChartData{
 		ctx:          ctx,

--- a/main.go
+++ b/main.go
@@ -397,10 +397,6 @@ func _main(ctx context.Context) error {
 		return fmt.Errorf("Unable to get height from PostgreSQL DB: %v", err)
 	}
 
-	charts := cache.NewChartData(uint32(lastBlockPG), time.Unix(pgDB.GenesisStamp(), 0), activeChain, ctx)
-	pgDB.RegisterCharts(charts)
-	baseDB.RegisterCharts(charts)
-
 	// Allow WiredDB/stakedb to catch up to the pgDB, but after
 	// fetchToHeight, WiredDB must receive block signals from pgDB, and
 	// stakedb must send connect signals to pgDB.
@@ -411,6 +407,11 @@ func _main(ctx context.Context) error {
 	if heightDB < 0 {
 		heightDB = 0
 	}
+
+	charts := cache.NewChartData(uint32(heightDB), time.Unix(pgDB.GenesisStamp(), 0),
+		activeChain, ctx)
+	pgDB.RegisterCharts(charts)
+	baseDB.RegisterCharts(charts)
 
 	// Aux DB height and stakedb height must be equal. StakeDatabase will
 	// catch up automatically if it is behind, but we must rewind it here if


### PR DESCRIPTION
This add a check on input height in `NewChartData`.  A minimum number of blocks for initial capacities is now `chainParams.StakeDiffWindowSize`.

Also, in main, avoid `uint32(-1)`.