### PR TITLE
cache: validate snip length and test ReorgHandler

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -476,7 +476,7 @@ func (charts *ChartData) ReorgHandler(wg *sync.WaitGroup, c chan *txhelpers.Reor
 			defer charts.mtx.Unlock()
 			newHeight := int(commonAncestorHeight) + 1
 			log.Debug("ChartData.ReorgHandler snipping blocks height to %d", newHeight)
-			charts.Blocks.Snip(int(commonAncestorHeight) + 1)
+			charts.Blocks.Snip(newHeight)
 			// Snip the last two days
 			daysLen := len(charts.Days.Time)
 			daysLen -= 2


### PR DESCRIPTION
I'm still not certain what was the cause of the panic on master, but I think I've corrected a couple of weak spots, and added a test. 

From appearances, it appears the reorg was being attempted on a zero-length day-binned data set. This would have been possible if there was an error in `(ChartData).Lengthen`, in which case the data set would have been emptied to trigger a full refresh. I don't see the associated `Warnf` anywhere though, so it's not clear that's what happened. 

Regardless, the `Snip` length in `ReorgHandler` needed to be checked anyway.  