### PR TITLE
views: preload link paths must be absolute

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -39,13 +39,13 @@
 
     <meta name="turbolinks-cache-control" content="no-cache">
     <title>{{.}}</title>
-    <link rel="preload" href="fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
-    <link rel="preload" href="fonts/inconsolata-v15-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
-    <link rel="preload" href="fonts/source-sans-pro-v9-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
-    <link rel="preload" href="images/connecting.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="images/themes/light/logo.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="images/connected.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="images/disconnected.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
+    <link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+    <link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+    <link rel="preload" href="/images/connecting.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/images/themes/light/logo.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/images/connected.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/images/disconnected.svg" as="image" type="image/svg+xml" />
     <link href="/dist/css/style.css" rel="stylesheet">
 
     <script src="/js/vendor/turbolinks.min.js"></script>


### PR DESCRIPTION
The `href` for each of the `<link rel="preload"` elements was using relative paths, causing 404s when not on the home page.  This makes the `href`s use an absolute path (e.g. `/images/connecting.svg` vs `images/connecting.svg`, which would end up loading `scheme://host.tld/tx/images/connecting.svg` when on the tx page)