### PR TITLE
insight: set new limits on Insight API addrs endpoints

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,7 +56,7 @@ var (
 	defaultIndentJSON          = "   "
 	defaultCacheControlMaxAge  = 86400
 	defaultInsightReqRateLimit = 20.0
-	defaultMaxCSVAddrs         = 3
+	defaultMaxCSVAddrs         = 25
 
 	defaultMempoolMinInterval = 2
 	defaultMempoolMaxInterval = 120


### PR DESCRIPTION
config: increase default max insight addrs to 25 

insight: set limits on Insight addrs UTXOs and txns

maxInsightAddrsUTXOs limits the number of UTXOs returned by the
addrs[/{addresses}]/utxo endpoints when the {addresses} list has more
than one address. The project fund address has 263383 UTXOs at block
height 342553, and this is a ~75MB JSON payload. Set
maxInsightAddrsUTXOs to 500000.

maxInsightAddrsTxns limits the number of transactions that may be
returned by the addrs[/{addresses}]/txs endpoints when the {addresses}
list has more than one address. This limit is applied to the "to" and
"from" URL query parameters. Note that each transaction requires a
getrawtransaction RPC call to dcrd. Set maxInsightAddrsTxns to 250.