### PR TITLE
API: /api/status/happy and periodic node peer connection check

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -31,6 +31,7 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 	mux.Get("/", app.root)
 
 	mux.Get("/status", app.status)
+	mux.Get("/status/happy", app.statusHappy)
 	mux.Get("/supply", app.coinSupply)
 
 	compMiddleware := m.Next
@@ -42,7 +43,7 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 	mux.Route("/block", func(r chi.Router) {
 		r.Route("/best", func(rd chi.Router) {
 			rd.Use(app.BlockIndexLatestCtx)
-			rd.Get("/", app.getBlockSummary) // app.getLatestBlock
+			rd.Get("/", app.getBlockSummary)
 			rd.Get("/height", app.currentHeight)
 			rd.Get("/hash", app.getBlockHash)
 			rd.Route("/header", func(rt chi.Router) {
@@ -108,8 +109,6 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 				rs.Get("/", app.getBlockRangeSteppedSummary)
 				rs.Get("/size", app.getBlockRangeSteppedSize)
 			})
-			// rd.Get("/header", app.getBlockHeader)
-			// rd.Get("/pos", app.getBlockStakeInfoExtendedByHeight)
 		})
 	})
 

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -175,8 +175,8 @@ func (c *appContext) updateNodeConnections() error {
 	nodeConnections, err := c.nodeClient.GetConnectionCount()
 	if err != nil {
 		// Assume there arr no connections if RPC had an error.
-		nodeConnections = 0
-		err = fmt.Errorf("failed to get connection count: %v", err)
+		c.Status.SetConnections(0)
+		return fmt.Errorf("failed to get connection count: %v", err)
 	}
 
 	// Before updating connections, get the previous connection count.
@@ -184,7 +184,7 @@ func (c *appContext) updateNodeConnections() error {
 
 	c.Status.SetConnections(nodeConnections)
 	if nodeConnections == 0 {
-		return err
+		return nil
 	}
 
 	// Detect if the node's peer connections were just restored.

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -171,29 +171,66 @@ func NewContext(cfg *AppContextConfig) *appContext {
 	}
 }
 
+func (c *appContext) updateNodeConnections() error {
+	nodeConnections, err := c.nodeClient.GetConnectionCount()
+	if err != nil {
+		// Assume there arr no connections if RPC had an error.
+		nodeConnections = 0
+		err = fmt.Errorf("failed to get connection count: %v", err)
+	}
+
+	// Before updating connections, get the previous connection count.
+	prevConnections := c.Status.NodeConnections()
+
+	c.Status.SetConnections(nodeConnections)
+	if nodeConnections == 0 {
+		return err
+	}
+
+	// Detect if the node's peer connections were just restored.
+	if prevConnections != 0 {
+		// Status.ready may be false, but since connections were not lost and
+		// then recovered, it is not our job to check other readiness factors.
+		return nil
+	}
+
+	// Check the reconnected node's best block, and update Status.height.
+	_, nodeHeight, err := c.nodeClient.GetBestBlock()
+	if err != nil {
+		c.Status.SetReady(false)
+		return fmt.Errorf("node: getbestblock failed: %v", err)
+	}
+
+	// Update Status.height with current node height. This also sets
+	// Status.ready according to the previously-set Status.dbHeight.
+	c.Status.SetHeight(uint32(nodeHeight))
+
+	return nil
+}
+
 // StatusNtfnHandler keeps the appContext's Status up-to-date with changes in
 // node and DB status.
 func (c *appContext) StatusNtfnHandler(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
+	// Check the node connection count periodically.
+	rpcCheckTicker := time.NewTicker(5 * time.Second)
 out:
 	for {
 	keepon:
 		select {
+		case <-rpcCheckTicker.C:
+			if err := c.updateNodeConnections(); err != nil {
+				log.Warn("updateNodeConnections: ", err)
+				break keepon
+			}
+
 		case height, ok := <-notify.NtfnChans.UpdateStatusNodeHeight:
 			if !ok {
 				log.Warnf("Block connected channel closed.")
 				break out
 			}
 
-			nodeConnections, err := c.nodeClient.GetConnectionCount()
-			if err == nil {
-				c.Status.SetHeightAndConnections(height, nodeConnections)
-			} else {
-				c.Status.SetHeight(height)
-				c.Status.SetReady(false)
-				log.Warn("Failed to get connection count: ", err)
-				break keepon
-			}
+			c.Status.SetHeight(height)
 
 		case height, ok := <-notify.NtfnChans.UpdateStatusDBHeight:
 			if !ok {
@@ -211,7 +248,7 @@ out:
 				break keepon
 			}
 
-			c.Status.DBUpdate(height, summary.Time.S.UNIX())
+			c.Status.DBUpdate(height, summary.Time.UNIX())
 
 			bdHeight, err := c.BlockData.GetHeight()
 			// Catch certain pathological conditions.
@@ -232,6 +269,7 @@ out:
 
 		case <-ctx.Done():
 			log.Debugf("Got quit signal. Exiting block connected handler for STATUS monitor.")
+			rpcCheckTicker.Stop()
 			break out
 		}
 	}
@@ -250,7 +288,12 @@ func (c *appContext) writeJSONHandlerFunc(thing interface{}) http.HandlerFunc {
 }
 
 func writeJSON(w http.ResponseWriter, thing interface{}, indent string) {
+	writeJSONWithStatus(w, thing, http.StatusOK, indent)
+}
+
+func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int, indent string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", indent)
 	if err := encoder.Encode(thing); err != nil {
@@ -337,6 +380,16 @@ func (c *appContext) status(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, c.Status.API(), c.getIndentQuery(r))
 }
 
+func (c *appContext) statusHappy(w http.ResponseWriter, r *http.Request) {
+	happy := c.Status.Happy()
+	statusCode := http.StatusOK
+	if !happy.Happy {
+		// For very simple health checks, set the status code.
+		statusCode = http.StatusServiceUnavailable
+	}
+	writeJSONWithStatus(w, happy, statusCode, c.getIndentQuery(r))
+}
+
 func (c *appContext) coinSupply(w http.ResponseWriter, r *http.Request) {
 	supply := c.BlockData.CoinSupply()
 	if supply == nil {
@@ -353,17 +406,6 @@ func (c *appContext) currentHeight(w http.ResponseWriter, _ *http.Request) {
 	if _, err := io.WriteString(w, strconv.Itoa(int(c.Status.Height()))); err != nil {
 		apiLog.Infof("failed to write height response: %v", err)
 	}
-}
-
-func (c *appContext) getLatestBlock(w http.ResponseWriter, r *http.Request) {
-	latestBlockSummary := c.BlockData.GetBestBlockSummary()
-	if latestBlockSummary == nil {
-		apiLog.Error("Unable to get latest block summary")
-		http.Error(w, http.StatusText(422), 422)
-		return
-	}
-
-	writeJSON(w, latestBlockSummary, c.getIndentQuery(r))
 }
 
 func (c *appContext) getBlockHeight(w http.ResponseWriter, r *http.Request) {

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -460,6 +460,29 @@ func (s *Status) API() APIStatus {
 	}
 }
 
+// Happy describes just how happy dcrdata is.
+type Happy struct {
+	Happy           bool  `json:"happy"`
+	APIReady        bool  `json:"api_ready"`
+	TipAge          int64 `json:"tip_age"`
+	NodeConnections int64 `json:"node_connections"`
+}
+
+// Happy indicates how dcrdata is or isn't happy.
+func (s *Status) Happy() Happy {
+	s.RLock()
+	blockAge := time.Since(time.Unix(s.dbLastBlockTime, 0))
+	h := Happy{
+		APIReady:        s.ready,
+		TipAge:          int64(blockAge.Seconds()),
+		NodeConnections: s.nodeConnections,
+	}
+	s.RUnlock()
+
+	h.Happy = h.APIReady && blockAge < 90*time.Minute && h.NodeConnections > 0
+	return h
+}
+
 // Height is the last known node height.
 func (s *Status) Height() uint32 {
 	s.RLock()
@@ -471,37 +494,56 @@ func (s *Status) Height() uint32 {
 // if Status.height is the same as Status.dbHeight.
 func (s *Status) SetHeight(height uint32) {
 	s.Lock()
-	defer s.Unlock()
-	s.ready = height == s.dbHeight
+	s.ready = height == s.dbHeight && s.nodeConnections > 0
 	s.height = height
+	s.Unlock()
 }
 
-// SetHeightAndConnections simultaneously sets the node height and node
-// connection count. Status.ready is set to true if the height and dbHeight are
-// the same.
-func (s *Status) SetHeightAndConnections(height uint32, conns int64) {
+// DBHeight is the block most recently stored in the DB.
+func (s *Status) DBHeight() uint32 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.dbHeight
+}
+
+// NodeConnections gets the number of node peer connections.
+func (s *Status) NodeConnections() int64 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.nodeConnections
+}
+
+// SetConnections sets the node connection count.
+func (s *Status) SetConnections(conns int64) {
 	s.Lock()
-	defer s.Unlock()
 	s.nodeConnections = conns
-	s.ready = height == s.dbHeight
-	s.height = height
+	s.ready = s.ready && s.nodeConnections > 0
+	s.Unlock()
 }
 
 // SetReady sets the ready state.
 func (s *Status) SetReady(ready bool) {
 	s.Lock()
-	defer s.Unlock()
 	s.ready = ready
+	s.Unlock()
+}
+
+// Ready checks the ready state.
+func (s *Status) Ready() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.ready
 }
 
 // DBUpdate updates both the height and time of the best DB block. Status.ready
-// is set to true if Status.height is the same as Status.dbHeight.
+// is set to true if Status.height is the same as Status.dbHeight and the node
+// has connections.
 func (s *Status) DBUpdate(height uint32, blockTime int64) {
 	s.Lock()
-	defer s.Unlock()
 	s.dbHeight = height
 	s.dbLastBlockTime = blockTime
-	s.ready = s.dbHeight == height
+	s.ready = s.dbHeight == s.height
+	s.Unlock()
 }
 
 // CoinSupply models the coin supply at a certain best block.


### PR DESCRIPTION
This adds a new API endpoint, `/api/status/happy`, for bottom line health checks.

The happy endpoint responds with a 503 (service unavailable) if dcrdata is not "happy".
A JSON response marshaled from the new `api/types.Happy` struct is returned
regardless of 200 (OK) or 503 (service unavailable).

An example response with HTTP response code 200:

```json
{
  "happy": true,
  "api_ready": true,
  "tip_age": 1530,
  "node_connections": 1
}
```

This may seem redundant with the `/api/status` data, but the configuration of health checks
is often very limited.  The 503 response code is returned when `"happy"` is `false`.
The condition for `"happy"` is `api_ready && node_connections > 0 && tip_age > 90min`.

To keep `node_connections` current, a 5 second ticker triggers an RPC and update of `node_connections`.

`(*Status).SetHeight` and `(*Status).SetConnections` account for `Status.nodeConnections`.

Add `writeJSONWithStatus` to write a JSON response to the http.ResponseWriter
with a custom http status code.