### PR TITLE
Hashrate chart: labeling and legend units update

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -75,7 +75,7 @@ func (e ChartError) Error() string {
 
 // UnknownChartErr is returned when a chart key is provided that does not match
 // any known chart type constant.
-const UnknownChartErr = ChartError("unkown chart")
+const UnknownChartErr = ChartError("unknown chart")
 
 // InvalidZoomErr is returned when a ChartMaker receives an unknown ZoomLevel.
 // In practice, this should be impossible, since ParseZoom returns a default
@@ -205,7 +205,7 @@ type zoomSet struct {
 	BlockSize ChartUints
 	TxCount   ChartUints
 	NewAtoms  ChartUints
-	Chainwork ChartUints
+	Chainwork ChartFloats
 	Fees      ChartUints
 }
 
@@ -235,7 +235,7 @@ func newBlockSet(size int) *zoomSet {
 		BlockSize: newChartUints(size),
 		TxCount:   newChartUints(size),
 		NewAtoms:  newChartUints(size),
-		Chainwork: newChartUints(size),
+		Chainwork: newChartFloats(size),
 		Fees:      newChartUints(size),
 	}
 }
@@ -286,7 +286,7 @@ type ChartGobject struct {
 	BlockSize   ChartUints
 	TxCount     ChartUints
 	NewAtoms    ChartUints
-	Chainwork   ChartUints
+	Chainwork   ChartFloats
 	Fees        ChartUints
 	WindowTime  ChartUints
 	PowDiff     ChartFloats
@@ -979,14 +979,14 @@ func durationBTWChart(charts *ChartData, zoom ZoomLevel) ([]byte, error) {
 // is HashrateAvgLength shorter than the provided chainwork. A time slice is
 // required as well, and a truncated time slice with the same length as the
 // hashrate slice is returned.
-func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
+func hashrate(time ChartUints, chainwork ChartFloats) (ChartUints, ChartFloats) {
 	hrLen := len(chainwork) - HashrateAvgLength
 	if hrLen <= 0 {
-		return newChartUints(0), newChartUints(0)
+		return newChartUints(0), newChartFloats(0)
 	}
 	t := make(ChartUints, 0, hrLen)
-	y := make(ChartUints, 0, hrLen)
-	var rotator [HashrateAvgLength]uint64
+	y := make(ChartFloats, 0, hrLen)
+	var rotator [HashrateAvgLength]float64
 	for i, work := range chainwork {
 		idx := i % HashrateAvgLength
 		rotator[idx] = work
@@ -996,7 +996,7 @@ func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 			thisTime := time[i]
 			// 1e6: exahash -> terahash/s
 			t = append(t, thisTime)
-			y = append(y, (work-lastWork)*1e6/(thisTime-lastTime))
+			y = append(y, (work-lastWork)*1e6/float64(thisTime-lastTime))
 		}
 	}
 	return t, y

--- a/db/cache/go.mod
+++ b/db/cache/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/decred/dcrdata/api/types v1.0.7-0.20190416202529-23d1eb95ca1b
 	github.com/decred/dcrdata/blockdata v1.0.1
 	github.com/decred/dcrdata/db/dbtypes v1.0.2-0.20190416202529-23d1eb95ca1b
+	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790
 	github.com/decred/slog v1.0.0
 )

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2995,8 +2995,8 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 	defer closeRows(rows)
 
 	// In order to store chainwork values as uint64, they are represented
-	// as terahash/s (10^12) for both chainwork and hashrate.
-	bigTera := big.NewInt(int64(1e12))
+	// as exahash (10^18) for work, and terahash/s (10^12) for hashrate.
+	bigExa := big.NewInt(int64(1e18))
 	badRows := 0
 	// badRow is used to log chainwork errors without returning an error from
 	// retrieveChartBlocks.
@@ -3022,8 +3022,7 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 			badRow()
 			continue
 		}
-
-		bigwork.Div(bigwork, bigTera)
+		bigwork.Div(bigwork, bigExa)
 		if !bigwork.IsUint64() {
 			badRow()
 			// Something is wrong, but pretend that no work was done to keep the

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -42,7 +42,7 @@
                             <option name="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
                             <option name="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option> -->
                             <option name="chainwork" value="chainwork">Total Work</option>
-                            <option name="hashrate" value="hashrate">Network Hashrate</option>
+                            <option name="hashrate" value="hashrate">Hashrate</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
The following changes were made and UI changes are shown on the screenshot below:
1. The chart was renamed from `Network Hashrate` to `Hashrate`.
2. The previous y-Axis and legend used `K` instead of hash rate specific labeling like `TeraHash/s`, `PentaHash/s` for the legend and `Th`, `Ph` for the axis.
3. The charts cache versioning implementation was added back - It should help in managing the cache especially when its data has new structural changes whose only solution is to trigger a fresh update.

**UI Changes**

![Screenshot from 2019-05-15 07-38-02-updated](https://user-images.githubusercontent.com/22055953/57749365-66c12380-76e6-11e9-9e24-e41016250b4c.png)