### PR TITLE
[4.1] explorer: give StatusPage the  http.Request

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +30,11 @@ import (
 	"github.com/decred/dcrdata/txhelpers"
 	humanize "github.com/dustin/go-humanize"
 )
+
+func init() {
+	// URL should be set because commonData call a method on it.
+	dummyRequest.URL, _ = url.Parse("/")
+}
 
 // Cookies contains information from the request cookies.
 type Cookies struct {


### PR DESCRIPTION
Backport of the URL fix that was included in https://github.com/decred/dcrdata/pull/1274 to `4.1-stable.`

StatusPage panics because `dummyRequest` has a nil `*URL`.  This give `StatusPage` and `timeoutErrorPage` the `*http.Request`.