### PR TITLE
Charts: Dual x-axis support for all historical charts

### DIFF
--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -1602,11 +1602,11 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 
 func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 	chartType := m.GetChartTypeCtx(r)
-	zoom := r.URL.Query().Get("zoom")
-	chartData, err := c.charts.Chart(chartType, zoom)
+	bin := r.URL.Query().Get("bin")
+	chartData, err := c.charts.Chart(chartType, bin)
 	if err != nil {
 		http.NotFound(w, r)
-		log.Warnf(`Error fetching chart %s at zoom level '%s': %v`, chartType, zoom, err)
+		log.Warnf(`Error fetching chart %s at bin level '%s': %v`, chartType, bin, err)
 		return
 	}
 	writeJSONBytes(w, chartData)

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -1603,6 +1603,10 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 	chartType := m.GetChartTypeCtx(r)
 	bin := r.URL.Query().Get("bin")
+	// Support the deprecated URL parameter "zoom".
+	if bin == "" {
+		bin = r.URL.Query().Get("zoom")
+	}
 	axis := r.URL.Query().Get("axis")
 	chartData, err := c.charts.Chart(chartType, bin, axis)
 	if err != nil {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -1603,7 +1603,8 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 	chartType := m.GetChartTypeCtx(r)
 	bin := r.URL.Query().Get("bin")
-	chartData, err := c.charts.Chart(chartType, bin)
+	axis := r.URL.Query().Get("axis")
+	chartData, err := c.charts.Chart(chartType, bin, axis)
 	if err != nil {
 		http.NotFound(w, r)
 		log.Warnf(`Error fetching chart %s at bin level '%s': %v`, chartType, bin, err)

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -1033,7 +1033,8 @@ func durationBTWChart(charts *ChartData, bin binLevel, axis axisType) ([]byte, e
 			if len(charts.Days.Height) < 2 {
 				return nil, fmt.Errorf("found the length of charts.Days.Height slice to be less than 2")
 			}
-			return charts.encode(avgBlockTimes(charts.Days.Height[:len(charts.Days.Height)-1], charts.Blocks.Time))
+			_, t := avgBlockTimes(charts.Days.Time, charts.Blocks.Time)
+			return charts.encode(charts.Days.Height[:len(charts.Days.Height)-1], t)
 
 		default:
 			return charts.encode(avgBlockTimes(charts.Days.Time, charts.Blocks.Time))

--- a/db/cache/charts_test.go
+++ b/db/cache/charts_test.go
@@ -179,19 +179,19 @@ func TestChartsCache(t *testing.T) {
 	})
 
 	t.Run("get_chart", func(t *testing.T) {
-		chart, err := charts.Chart(BlockSize, string(BlockZoom), string(TimeAxis))
+		chart, err := charts.Chart(BlockSize, string(BlockBin), string(TimeAxis))
 		if err != nil {
 			t.Fatalf("error getting fresh chart: %v", err)
 		}
 		if string(chart) != `{"x":[1,86402,86403,172804,172805,259206],"y":[1,2,3,4,5,6]}` {
 			t.Fatalf("unexpected chart json")
 		}
-		ck := cacheKey(BlockSize, BlockZoom, TimeAxis)
+		ck := cacheKey(BlockSize, BlockBin, TimeAxis)
 		if !reflect.DeepEqual(charts.cache[ck].data, chart) {
 			t.Fatalf("could not match chart to cache")
 		}
 		// Grab chart once more. This should test the cache path.
-		chart2, err := charts.Chart(BlockSize, string(BlockZoom), string(TimeAxis))
+		chart2, err := charts.Chart(BlockSize, string(BlockBin), string(TimeAxis))
 		if err != nil {
 			t.Fatalf("error getting chart from cache: %v", err)
 		}

--- a/db/cache/charts_test.go
+++ b/db/cache/charts_test.go
@@ -179,19 +179,19 @@ func TestChartsCache(t *testing.T) {
 	})
 
 	t.Run("get_chart", func(t *testing.T) {
-		chart, err := charts.Chart(BlockSize, string(BlockZoom))
+		chart, err := charts.Chart(BlockSize, string(BlockZoom), string(TimeAxis))
 		if err != nil {
 			t.Fatalf("error getting fresh chart: %v", err)
 		}
 		if string(chart) != `{"x":[1,86402,86403,172804,172805,259206],"y":[1,2,3,4,5,6]}` {
 			t.Fatalf("unexpected chart json")
 		}
-		ck := cacheKey(BlockSize, BlockZoom)
+		ck := cacheKey(BlockSize, BlockZoom, TimeAxis)
 		if !reflect.DeepEqual(charts.cache[ck].data, chart) {
 			t.Fatalf("could not match chart to cache")
 		}
 		// Grab chart once more. This should test the cache path.
-		chart2, err := charts.Chart(BlockSize, string(BlockZoom))
+		chart2, err := charts.Chart(BlockSize, string(BlockZoom), string(TimeAxis))
 		if err != nil {
 			t.Fatalf("error getting chart from cache: %v", err)
 		}

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -418,9 +418,6 @@ export default class extends Controller {
   _zoomCallback (start, end) {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
-    this.zoomOptionTargets.forEach((button) => {
-      button.classList.remove('active')
-    })
     this.query.replace(this.settings)
     this.setSelectedZoom(Zoom.mapKey(this.settings.zoom, this.limits))
   }

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -446,6 +446,7 @@ export default class extends Controller {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
     this.query.replace(this.settings)
+    this.setActiveOptionBtn(Zoom.mapKey(this.settings.zoom, this.lastZoom), this.zoomOptionTargets)
   }
 
   isTimeAxis () {
@@ -466,11 +467,10 @@ export default class extends Controller {
     var option
     if (!target) {
       let ex = this.chartsView.xAxisExtremes()
-      option = Zoom.mapKey(e, ex, this.isTimeAxis() ? 1 : avgBlockTime)
+      option = Zoom.mapKey(e, ex, this.isTimeAxis() ? 1 : avgBlockTime, true)
     } else {
       option = target.dataset.option
     }
-    if (!option) return
     this.setActiveOptionBtn(option, this.zoomOptionTargets)
     if (!target) return // Exit if running for the first time
     this.validateZoom()

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -433,7 +433,9 @@ export default class extends Controller {
         dateWindow: [this.lastZoom.start, this.lastZoom.end]
       })
     }
-    this._zoomCallback(this.lastZoom.start, this.lastZoom.end)
+    if (selected !== this.settings.zoom) {
+      this._zoomCallback(this.lastZoom.start, this.lastZoom.end)
+    }
     await animationFrame()
     this.chartWrapperTarget.classList.remove('loading')
     this.chartsView.updateOptions({
@@ -446,7 +448,8 @@ export default class extends Controller {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
     this.query.replace(this.settings)
-    this.setActiveOptionBtn(Zoom.mapKey(this.settings.zoom, this.lastZoom), this.zoomOptionTargets)
+    let option = Zoom.mapKey(this.settings.zoom, this.chartsView.xAxisExtremes())
+    this.setActiveOptionBtn(option, this.zoomOptionTargets)
   }
 
   isTimeAxis () {
@@ -467,7 +470,7 @@ export default class extends Controller {
     var option
     if (!target) {
       let ex = this.chartsView.xAxisExtremes()
-      option = Zoom.mapKey(e, ex, this.isTimeAxis() ? 1 : avgBlockTime, true)
+      option = Zoom.mapKey(e, ex, this.isTimeAxis() ? 1 : avgBlockTime)
     } else {
       option = target.dataset.option
     }

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -423,7 +423,8 @@ export default class extends Controller {
     this.limits = this.chartsView.xAxisExtremes()
     var selected = this.selectedZoom()
     if (selected) {
-      this.lastZoom = Zoom.validate(selected, this.limits, avgBlockTime, this.isTimeAxis())
+      this.lastZoom = Zoom.validate(selected, this.limits,
+        this.isTimeAxis() ? avgBlockTime : 1, this.isTimeAxis() ? 1 : avgBlockTime)
     } else {
       this.lastZoom = Zoom.project(this.settings.zoom, oldLimits, this.limits)
     }
@@ -465,7 +466,7 @@ export default class extends Controller {
     var option
     if (!target) {
       let ex = this.chartsView.xAxisExtremes()
-      option = Zoom.mapKey(e, ex, 1, this.isTimeAxis(), avgBlockTime)
+      option = Zoom.mapKey(e, ex, this.isTimeAxis() ? 1 : avgBlockTime)
     } else {
       option = target.dataset.option
     }

--- a/public/js/helpers/zoom_helper.js
+++ b/public/js/helpers/zoom_helper.js
@@ -40,6 +40,15 @@ function tryDecode (zoom) {
   return zoom
 }
 
+function timeToBlockConversion (ratio) {
+  if (!ratio) return zoomMap
+  var newMap = []
+  for (var property in zoomMap) {
+    newMap[property] = Math.floor(zoomMap[property] / ratio)
+  }
+  return newMap
+}
+
 // Zoom is the exported class for dealing with Zoom windows. It is composed
 // entirely of static methods used for working with zoom ranges.
 export default class Zoom {
@@ -47,9 +56,11 @@ export default class Zoom {
     return zoomObject(start, end)
   }
 
-  static mapValue (key, scale) {
+  static mapValue (key, scale, isTimeAxis, ratio) {
     scale = scale || 1
-    return zoomMap[key] / scale
+    isTimeAxis = isTimeAxis || true
+    let datamap = !isTimeAxis ? timeToBlockConversion(ratio) : zoomMap
+    return datamap[key] / scale
   }
 
   // encode uses base 36 encoded unix timestamps to store the range in a
@@ -65,14 +76,16 @@ export default class Zoom {
     return parseInt(start).toString(36) + '-' + parseInt(end).toString(36)
   }
 
-  static decode (encoded, limits, scale) {
+  static decode (encoded, limits, scale, isTimeAxis, ratio) {
     // decodes zoomString, such as from this.encode. zoomObjects pass through.
     // If limits are provided, encoded can be a zoomMap key.
     scale = scale || 1
+    isTimeAxis = isTimeAxis || true
     let decoded = tryDecode(encoded)
     let lims = tryDecode(limits)
-    if (lims && zoomMap.hasOwnProperty(decoded)) {
-      let duration = zoomMap[decoded] / scale
+    let datamap = !isTimeAxis ? timeToBlockConversion(ratio) : zoomMap
+    if (lims && datamap.hasOwnProperty(decoded)) {
+      let duration = datamap[decoded] / scale
       if (duration === 0) return lims
       return zoomObject(lims.end - duration, lims.end)
     }
@@ -81,15 +94,16 @@ export default class Zoom {
 
   // validate will shift and clamp the proposed zoom window to accommodate the
   // range limits and minimum size.
-  static validate (proposal, limits, minSize, scale) {
+  static validate (proposal, limits, minSize, scale, isTimeAxis) {
     // proposed: encoded zoom string || zoomMap key || zoomObject
     // limits: zoomObject || array
     scale = scale || 1
+    let ratio = !isTimeAxis || !minSize ? 1 : minSize
     let lims = tryDecode(limits)
     let proposed = tryDecode(proposal)
     var zoom = lims
     if (typeof proposed === 'string') {
-      zoom = this.decode(proposed, lims, scale)
+      zoom = this.decode(proposed, lims, scale, isTimeAxis, ratio)
       if (!zoom) return false
     } else if (proposed && typeof proposed === 'object') {
       zoom = proposed
@@ -112,19 +126,18 @@ export default class Zoom {
 
   // mapKey returns the corresponding map key, if the zoom meets the correct
   // range and position within the limits, else null.
-  static mapKey (zoom, limits, scale) {
+  static mapKey (zoom, limits, scale, isTimeAxis, ratio) {
+    scale = scale || 1
+    isTimeAxis = isTimeAxis || true
     let lims = tryDecode(limits)
     let decoded = this.decode(zoom, lims)
-    if (decoded.end !== lims.end) return null
-    if (decoded.start === lims.start) return 'all'
-    let keys = Object.keys(zoomMap)
-    for (let idx in keys) {
-      let k = keys[idx]
-      let v = zoomMap[k]
-      if (v === 0) continue
-      if (decoded.start === lims.end - v / scale) return k
+    let range = decoded.end - decoded.start
+    let datamap = !isTimeAxis ? timeToBlockConversion(ratio) : zoomMap
+    for (let k in datamap) {
+      let v = datamap[k]
+      if (v === range) return k
     }
-    return null
+    return 'all'
   }
 
   // project proportionally translates the zoom from oldWindow to newWindow.

--- a/public/js/helpers/zoom_helper.js
+++ b/public/js/helpers/zoom_helper.js
@@ -112,16 +112,31 @@ export default class Zoom {
 
   // mapKey returns the corresponding map key, if the zoom meets the correct
   // range and position within the limits, else null.
-  static mapKey (zoom, limits, scale) {
+  static mapKey (zoom, limits, scale, isLegacyURL) {
     scale = scale || 1
+    isLegacyURL = isLegacyURL || false
     let lims = tryDecode(limits)
     let decoded = this.decode(zoom, lims)
-    let range = decoded.end - decoded.start
-    for (let k in zoomMap) {
-      let v = zoomMap[k]
-      if (v / scale === range) return k
+
+    if (isLegacyURL) { // maps the legacy url zoom lookup
+      let range = decoded.end - decoded.start
+      for (let k in zoomMap) {
+        let v = zoomMap[k]
+        if (v / scale === range) return k
+      }
+      return 'all'
+    } else { // maps the range slider zoom lookup
+      if (decoded.end !== lims.end) return null
+      if (decoded.start === lims.start) return 'all'
+      let keys = Object.keys(zoomMap)
+      for (let idx in keys) {
+        let k = keys[idx]
+        let v = zoomMap[k]
+        if (v === 0) continue
+        if (decoded.start === lims.end - v / scale) return k
+      }
+      return null
     }
-    return 'all'
   }
 
   // project proportionally translates the zoom from oldWindow to newWindow.

--- a/public/js/helpers/zoom_helper.js
+++ b/public/js/helpers/zoom_helper.js
@@ -112,31 +112,18 @@ export default class Zoom {
 
   // mapKey returns the corresponding map key, if the zoom meets the correct
   // range and position within the limits, else null.
-  static mapKey (zoom, limits, scale, isLegacyURL) {
+  static mapKey (zoom, limits, scale) {
     scale = scale || 1
-    isLegacyURL = isLegacyURL || false
     let lims = tryDecode(limits)
     let decoded = this.decode(zoom, lims)
-
-    if (isLegacyURL) { // maps the legacy url zoom lookup
-      let range = decoded.end - decoded.start
-      for (let k in zoomMap) {
-        let v = zoomMap[k]
-        if (v / scale === range) return k
-      }
-      return 'all'
-    } else { // maps the range slider zoom lookup
-      if (decoded.end !== lims.end) return null
-      if (decoded.start === lims.start) return 'all'
-      let keys = Object.keys(zoomMap)
-      for (let idx in keys) {
-        let k = keys[idx]
-        let v = zoomMap[k]
-        if (v === 0) continue
-        if (decoded.start === lims.end - v / scale) return k
-      }
-      return null
+    let range = decoded.end - decoded.start
+    if (decoded.start === lims.start && range === lims.end - lims.start) return 'all'
+    for (let k in zoomMap) {
+      let v = zoomMap[k]
+      if (v === 0) continue
+      if (v / scale === range) return k
     }
+    return null
   }
 
   // project proportionally translates the zoom from oldWindow to newWindow.

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -36,8 +36,8 @@ $progress-bar-color: #333;
 
 // nav
 $nav-pills-border-radius: .2rem;
-$nav-link-padding-y: .45rem;
-$nav-link-padding-x: .55rem;
+$nav-link-padding-y: .3rem;
+$nav-link-padding-x: .45rem;
 
 // transaction type colors
 $regular-light: #2970FF;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -35,8 +35,8 @@ $progress-bar-bg: #74e06b;
 $progress-bar-color: #333;
 
 // nav
-$nav-pills-border-radius: 0;
-$nav-link-padding-y: .55rem;
+$nav-pills-border-radius: .2rem;
+$nav-link-padding-y: .45rem;
 $nav-link-padding-x: .55rem;
 
 // transaction type colors

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -307,6 +307,7 @@
 .chart-control-wrapper {
   border: 1px solid #e6eaed;
   border-left: 1px solid #e6eaed;
+  font-size: 0.9rem;
 }
 
 .chart-control-label {
@@ -320,6 +321,13 @@
 .chart-control {
   padding: 2px;
   background: #fff;
+  width: max-content;
+}
+
+.chart-form-control {
+  width: 250px;
+  font-size: 0.9rem !important;
+  height: calc(1.5em + 0.5rem + 2px) !important;
 }
 
 .chart-control select,

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -55,8 +55,8 @@
                                     class="nav-link active"
                                     href="javascript:void(0);"
                                     data-target="charts.zoomOption"
-                                    data-action="click->charts#onZoom"
-                                    data-zoom="all"
+                                    data-action="click->charts#setZoom"
+                                    data-option="all"
                                 >All</a>
                             </li>
                             <li class="nav-item">
@@ -64,8 +64,8 @@
                                     class="nav-link"
                                     href="javascript:void(0);"
                                     data-target="charts.zoomOption"
-                                    data-action="click->charts#onZoom"
-                                    data-zoom="year"
+                                    data-action="click->charts#setZoom"
+                                    data-option="year"
                                 >Year</a>
                             </li>
                             <li class="nav-item">
@@ -73,8 +73,8 @@
                                     class="nav-link"
                                     href="javascript:void(0);"
                                     data-target="charts.zoomOption"
-                                    data-action="click->charts#onZoom"
-                                    data-zoom="month"
+                                    data-action="click->charts#setZoom"
+                                    data-option="month"
                                 >Month</a>
                             </li>
                             <li class="nav-item">
@@ -82,8 +82,8 @@
                                     class="nav-link"
                                     href="javascript:void(0);"
                                     data-target="charts.zoomOption"
-                                    data-action="click->charts#onZoom"
-                                    data-zoom="week"
+                                    data-action="click->charts#setZoom"
+                                    data-option="week"
                                 >Week</a>
                             </li>
                             <li class="nav-item">
@@ -91,8 +91,8 @@
                                     class="nav-link"
                                     href="javascript:void(0);"
                                     data-target="charts.zoomOption"
-                                    data-action="click->charts#onZoom"
-                                    data-zoom="day"
+                                    data-action="click->charts#setZoom"
+                                    data-option="day"
                                 >Day</a>
                             </li>
                         </ul>
@@ -111,7 +111,7 @@
                                     href="javascript:void(0);"
                                     data-target="charts.binSize"
                                     data-action="click->charts#setBin"
-                                    data-bin="day"
+                                    data-option="day"
                                 >Day</a>
                             </li>
                             <li class="nav-item">
@@ -120,7 +120,7 @@
                                     href="javascript:void(0);"
                                     data-target="charts.binSize"
                                     data-action="click->charts#setBin"
-                                    data-bin="block"
+                                    data-option="block"
                                 >Block</a>
                             </li>
                         </ul>
@@ -137,18 +137,18 @@
                                 <a
                                     class="nav-link active"
                                     href="javascript:void(0);"
-                                    data-target="charts.linearBttn"
-                                    data-action="click->charts#linearScale"
-                                    data-zoom="all"
+                                    data-target="charts.scaleType"
+                                    data-action="click->charts#setScale"
+                                    data-option="linear"
                                 >Linear</a>
                             </li>
                             <li class="nav-item">
                                 <a
                                     class="nav-link"
                                     href="javascript:void(0);"
-                                    data-target="charts.logBttn"
-                                    data-action="click->charts#logScale"
-                                    data-zoom="year"
+                                    data-target="charts.scaleType"
+                                    data-action="click->charts#setScale"
+                                    data-option="log"
                                 >Log</a>
                             </li>
                         </ul>
@@ -165,26 +165,25 @@
                                 <a
                                     class="nav-link active"
                                     href="javascript:void(0);"
-                                    data-target="charts.heightBtn"
-                                    data-action="click->charts#heightAxis"
-                                    data-zoom="all"
-                                >Height</a>
+                                    data-target="charts.axisOption"
+                                    data-action="click->charts#setAxis"
+                                    data-option="time"
+                                >Time</a>
                             </li>
                             <li class="nav-item">
                                 <a
                                     class="nav-link"
                                     href="javascript:void(0);"
-                                    data-target="charts.timeBtn"
-                                    data-action="click->charts#timeAxis"
-                                    data-zoom="year"
-                                >Time</a>
+                                    data-target="charts.axisOption"
+                                    data-action="click->charts#setAxis"
+                                    data-option="height"
+                                >Height</a>
                             </li>
                         </ul>
                     </div>
                 </div>
 
             </div>
-
 
         </div>
 

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -18,7 +18,7 @@
 
             <div class="d-flex flex-wrap justify-content-center align-items-center chart-controls mb-1 mt-1">
 
-                <div class="chart-control-wrapper mr-2 mt-1 mb-1">
+                <div class="chart-control-wrapper mr-2 mb-1">
                     <div class="chart-control-label">CHART</div>
                     <div class="chart-control">
                         <select
@@ -38,9 +38,6 @@
                             <option value="coin-supply">Circulation</option>
                             <option value="fees">Fees</option>
                             <option value="duration-btw-blocks">Duration Between Blocks</option>
-                            <!-- <option value="ticket-spend-type">Ticket Spend Types</option>
-                            <option name="ticket-by-outputs-windows" value="ticket-by-outputs-windows">Ticket Outputs by Price Window</option>
-                            <option name="ticket-by-outputs-blocks" value="ticket-by-outputs-blocks">Ticket Outputs by Block</option> -->
                             <option name="chainwork" value="chainwork">Total Work</option>
                             <option name="hashrate" value="hashrate">Hashrate</option>
                         </select>
@@ -130,7 +127,7 @@
                     </div>
                 </div>
 
-                <div class="chart-control-wrapper mb-1">
+                <div class="chart-control-wrapper mr-2 mb-1">
                     <div class="chart-control-label">SCALE</div>
                     <div class="chart-control">
                         <ul
@@ -153,6 +150,34 @@
                                     data-action="click->charts#logScale"
                                     data-zoom="year"
                                 >Log</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="chart-control-wrapper mr-2 mb-1">
+                    <div class="chart-control-label">X-AXIS</div>
+                    <div class="chart-control">
+                        <ul
+                            class="nav nav-pills"
+                        >
+                            <li class="nav-item active">
+                                <a
+                                    class="nav-link active"
+                                    href="javascript:void(0);"
+                                    data-target="charts.heightBtn"
+                                    data-action="click->charts#heightAxis"
+                                    data-zoom="all"
+                                >Height</a>
+                            </li>
+                            <li class="nav-item">
+                                <a
+                                    class="nav-link"
+                                    href="javascript:void(0);"
+                                    data-target="charts.timeBtn"
+                                    data-action="click->charts#timeAxis"
+                                    data-zoom="year"
+                                >Time</a>
                             </li>
                         </ul>
                     </div>

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -24,10 +24,9 @@
                     <div class="chart-control">
                         <select
                             id="selectBox"
-                            class="form-control"
+                            class="form-control chart-form-control"
                             data-target="charts.chartSelect"
                             data-action="charts#selectChart"
-                            style="width: 250px"
                         >
                             <option value="ticket-price">Ticket Price</option>
                             <option value="ticket-pool-size">Ticket Pool Size</option>
@@ -122,7 +121,7 @@
                                     data-target="charts.binSize"
                                     data-action="click->charts#setBin"
                                     data-option="block"
-                                >Block</a>
+                                >Blocks</a>
                             </li>
                         </ul>
                     </div>
@@ -156,34 +155,6 @@
                     </div>
                 </div>
 
-                <div class="chart-control-wrapper mr-2 mb-1">
-                    <div class="chart-control-label">X-AXIS</div>
-                    <div class="chart-control">
-                        <ul
-                            class="nav nav-pills"
-                        >
-                            <li class="nav-item active">
-                                <a
-                                    class="nav-link active"
-                                    href="javascript:void(0);"
-                                    data-target="charts.axisOption"
-                                    data-action="click->charts#setAxis"
-                                    data-option="time"
-                                >Time</a>
-                            </li>
-                            <li class="nav-item">
-                                <a
-                                    class="nav-link"
-                                    href="javascript:void(0);"
-                                    data-target="charts.axisOption"
-                                    data-action="click->charts#setAxis"
-                                    data-option="height"
-                                >Height</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-
             </div>
 
         </div>
@@ -192,7 +163,31 @@
         <div data-target="charts.chartWrapper" class="chart-wrapper pl-2 pr-2 mb-5">
             <div
                 data-target="charts.chartsView"
-                style="width:100%; height:76vh; margin:0 auto;">
+                style="width:100%; height:73vh; margin:0 auto;">
+            </div>
+            <div class="d-flex flex-wrap justify-content-center align-items-center mb-1 mt-1">
+                <div class="chart-control chart-control-wrapper">
+                    <ul class="nav nav-pills">
+                        <li class="nav-item active">
+                            <a
+                                class="nav-link active"
+                                href="javascript:void(0);"
+                                data-target="charts.axisOption"
+                                data-action="click->charts#setAxis"
+                                data-option="time"
+                            >Time</a>
+                        </li>
+                        <li class="nav-item">
+                            <a
+                                class="nav-link"
+                                href="javascript:void(0);"
+                                data-target="charts.axisOption"
+                                data-action="click->charts#setAxis"
+                                data-option="height"
+                            >Blocks</a>
+                        </li>
+                    </ul>
+                </div>
             </div>
             <div class="spinner-wrapper">
                 <div class="spinner-centerer d-flex align-items-center justify-content-center">

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -12,7 +12,8 @@
          data-charts-bs="{{.ChainParams.BaseSubsidy}}"
          data-charts-sri="{{.ChainParams.SubsidyReductionInterval}}"
          data-charts-mul-subsidy="{{.ChainParams.MulSubsidy}}"
-         data-charts-div-subsidy="{{.ChainParams.DivSubsidy}}">
+         data-charts-div-subsidy="{{.ChainParams.DivSubsidy}}"
+         data-charts-window-size="{{.ChainParams.StakeDiffWindowSize}}">
 
         <div class="container main">
 

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -13,7 +13,8 @@
          data-charts-sri="{{.ChainParams.SubsidyReductionInterval}}"
          data-charts-mul-subsidy="{{.ChainParams.MulSubsidy}}"
          data-charts-div-subsidy="{{.ChainParams.DivSubsidy}}"
-         data-charts-window-size="{{.ChainParams.StakeDiffWindowSize}}">
+         data-charts-window-size="{{.ChainParams.StakeDiffWindowSize}}"
+         data-charts-block-time="{{.ChainParams.TargetTimePerBlock.Seconds}}">
 
         <div class="container main">
 


### PR DESCRIPTION
All historical charts have a button that enables switching between the two x-axis types namely: Block Height and Block Time. A group button at the chart bottom was added to enable easy swapping of either of the two x-axis. Since dygraph doesn't support display of multiple x-axis the two distinct x-axes cannot not be displayed together.

No changes to the data stored in charts cache was made to enable an extra x-axis to be swapped on a chart with the same y-axis data set.
The query below allows the index of each record retrieved to be used like a `Block Height` since the query is ordered by height. Therefore no extra data is required when the bin value is set to blocks.
```sql
SelectBlockStats = `SELECT height, size, time, chainwork, numtx
	FROM blocks
	WHERE is_mainchain
        AND height > $1
	ORDER BY height;`
``` 

When the bin value is set to day a pre-populated height array entry existed.

**Charts UI**
![Screenshot from 2019-05-18 08-52-48](https://user-images.githubusercontent.com/22055953/57965404-7b065a00-794c-11e9-812d-558de50b81cd.png)
