### PR TITLE
debug exchanges

### DIFF
--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -466,14 +466,21 @@ out:
 	for {
 		select {
 		case update := <-bot.exchangeChan:
+			log.Tracef("exchange update received from %s. price %f, ", update.Token, update.State.Price)
 			err := bot.updateExchange(update)
+			log.Tracef("after exchange update, %s exchange rate is %f", bot.BtcIndex, bot.Price())
 			if err != nil {
 				log.Warnf("Error encountered in exchange update: %v", err)
 				continue
 			}
 			bot.signalExchangeUpdate(update)
 		case update := <-bot.indexChan:
+			btcPrice, found := update.Indices[bot.BtcIndex]
+			if found {
+				log.Tracef("index update received from %s with %d indices, %s price for Bitcoin is %f", update.Token, len(update.Indices), bot.BtcIndex, btcPrice)
+			}
 			err := bot.updateIndices(update)
+			log.Tracef("After index update, %s exchange rate is %f", bot.BtcIndex, bot.Price())
 			if err != nil {
 				log.Warnf("Error encountered in index update: %v", err)
 				continue

--- a/exchanges/bot.go
+++ b/exchanges/bot.go
@@ -466,9 +466,8 @@ out:
 	for {
 		select {
 		case update := <-bot.exchangeChan:
-			log.Tracef("exchange update received from %s. price %f, ", update.Token, update.State.Price)
+			log.Tracef("exchange update received from %s with a BTC price %f, ", update.Token, update.State.Price)
 			err := bot.updateExchange(update)
-			log.Tracef("after exchange update, %s exchange rate is %f", bot.BtcIndex, bot.Price())
 			if err != nil {
 				log.Warnf("Error encountered in exchange update: %v", err)
 				continue
@@ -480,7 +479,6 @@ out:
 				log.Tracef("index update received from %s with %d indices, %s price for Bitcoin is %f", update.Token, len(update.Indices), bot.BtcIndex, btcPrice)
 			}
 			err := bot.updateIndices(update)
-			log.Tracef("After index update, %s exchange rate is %f", bot.BtcIndex, bot.Price())
 			if err != nil {
 				log.Warnf("Error encountered in index update: %v", err)
 				continue

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -620,14 +620,9 @@ func (xc *CommonExchange) wsListening() bool {
 		if sr == nil {
 			return false
 		}
-		return sr.IsOpen()
+		return sr.On()
 	}
-	select {
-	case <-ws.Done():
-		return false
-	default:
-		return true
-	}
+	return ws.On()
 }
 
 // Log the error and time, and increment the error counter.
@@ -654,7 +649,7 @@ func (xc *CommonExchange) wsInitialized() {
 	xc.wsMtx.Lock()
 	defer xc.wsMtx.Unlock()
 	xc.wsSync.init = time.Now()
-	xc.wsSync.update = time.Now()
+	xc.wsSync.update = xc.wsSync.init
 }
 
 // Set the updated flag.

--- a/exchanges/exchanges_live_test.go
+++ b/exchanges/exchanges_live_test.go
@@ -1,0 +1,293 @@
+// +build livexc
+// run these tests with go test -race -tags-livexc -run FuncName
+
+package exchanges
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrdata/dcrrates"
+)
+
+func makeKillSwitch() chan os.Signal {
+	killSwitch := make(chan os.Signal, 1)
+	signal.Notify(killSwitch, os.Interrupt)
+	return killSwitch
+}
+
+func testExchanges(asSlave, quickTest bool, t *testing.T) {
+	enableTestLog()
+
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	killSwitch := makeKillSwitch()
+
+	wg := new(sync.WaitGroup)
+
+	wg.Add(1)
+	go func() {
+		select {
+		case <-killSwitch:
+			shutdown()
+		case <-ctx.Done():
+		}
+		wg.Done()
+	}()
+
+	config := new(ExchangeBotConfig)
+	config.Disabled = make([]string, 0)
+	config.Indent = true
+	if asSlave {
+		config.MasterBot = ":7778"
+		config.MasterCertFile = filepath.Join(dcrrates.DefaultAppDirectory, dcrrates.DefaultCertName)
+	} else {
+		config.DataExpiry = "2m"
+		config.RequestExpiry = "4m"
+	}
+	bot, err := NewExchangeBot(config)
+	if err != nil {
+		shutdown()
+		t.Fatalf("error creating bot. Shutting down: %v", err)
+	}
+
+	updateCounts := make(map[string]int)
+	for token := range bot.Exchanges {
+		updateCounts[token] = 0
+	}
+	logUpdate := func(token string) {
+		if !quickTest {
+			return
+		}
+		updateCounts[token]++
+		lowest := updateCounts[token]
+		for _, v := range updateCounts {
+			if v < lowest {
+				lowest = v
+			}
+		}
+		if lowest > 0 {
+			log.Infof("quick test conditions met. Shutting down early")
+			shutdown()
+		}
+	}
+
+	wg.Add(1)
+	go bot.Start(ctx, wg)
+
+	quitTimer := time.NewTimer(time.Minute * 7)
+	ch := bot.UpdateChannels()
+
+out:
+	for {
+		select {
+		case update := <-ch.Exchange:
+			logUpdate(update.Token)
+			log.Infof("update received from exchange %s", update.Token)
+		case update := <-ch.Index:
+			logUpdate(update.Token)
+			log.Infof("update received from index %s", update.Token)
+		case <-ch.Quit:
+			t.Errorf("ExchangeBot has quit.")
+			break out
+		case <-quitTimer.C:
+			break out
+		case <-ctx.Done():
+			break out
+		}
+	}
+
+	if bot.IsFailed() {
+		log.Infof("ExchangeBot is in failed state")
+	}
+
+	logMissing := func(token string) {
+		for xc := range updateCounts {
+			if xc == token {
+				return
+			}
+		}
+		t.Errorf("no update received for %s", token)
+	}
+
+	for _, token := range Tokens() {
+		logMissing(token)
+	}
+
+	depth, err := bot.QuickDepth(aggregatedOrderbookKey)
+	if err != nil {
+		t.Errorf("failed to create aggregated orderbook")
+	}
+	log.Infof("aggregated orderbook size: %d kiB", len(depth)/1024)
+
+	log.Infof("%d Bitcoin indices available", len(bot.AvailableIndices()))
+	log.Infof("final state is %d kiB", len(bot.StateBytes())/1024)
+
+	shutdown()
+	wg.Wait()
+}
+
+func TestExchanges(t *testing.T) {
+	testExchanges(false, false, t)
+}
+
+func TestSlaveBot(t *testing.T) {
+	// Points to DCRData on local machine port 7778.
+	// Start server with --exchange-refresh=1m --exchange-expiry=2m
+	testExchanges(true, false, t)
+}
+
+func TestQuickExchanges(t *testing.T) {
+	testExchanges(false, true, t)
+}
+
+func checkWsDepths(t *testing.T, depths *DepthData) {
+	askLen := len(depths.Asks)
+	bidLen := len(depths.Bids)
+	log.Infof("%d asks", askLen)
+	log.Infof("%d bids", bidLen)
+	if askLen > 0 && bidLen > 0 {
+		midGap := (depths.Asks[0].Price + depths.Bids[0].Price) / 2
+		highRange := (depths.Asks[askLen-1].Price - midGap) / midGap * 100
+		lowRange := (midGap - depths.Bids[bidLen-1].Price) / midGap * 100
+		log.Infof("depth range +%f%% / -%f%%", highRange, lowRange)
+	} else {
+		t.Fatalf("missing orderbook data")
+	}
+}
+
+func TestPoloniexLiveWebsocket(t *testing.T) {
+	enableTestLog()
+
+	// Skip this test during automated testing.
+	if os.Getenv("GORACE") != "" {
+		t.Skip("Skipping Poloniex websocket test")
+	}
+
+	killSwitch := makeKillSwitch()
+
+	poloniex := newTestPoloniexExchange()
+	processor := func(b []byte) {
+		var s string
+		if len(b) >= 128 {
+			s = string(b[:128]) + "..."
+		} else {
+			s = string(b)
+		}
+		if s == "[1010]" {
+			log.Infof("heartbeat")
+		} else {
+			log.Infof("message received: %s", s)
+		}
+		poloniex.processWsMessage(b)
+	}
+
+	testConnectWs := func() {
+		poloniexDoneChannel = make(chan struct{})
+		poloniex.connectWebsocket(processor, &socketConfig{
+			address: PoloniexURLs.Websocket,
+		})
+		poloniex.wsSend(poloniexOrderbookSubscription)
+	}
+	testConnectWs()
+	select {
+	case <-time.NewTimer(30 * time.Second).C:
+	case <-killSwitch:
+		t.Errorf("ctrl+c detected")
+		return
+	}
+	// Test reconnection by forcing a fail, then checking the wsDepthStatus
+	poloniex.setWsFail(fmt.Errorf("test failure. ignore"))
+	// subsequent calls to close should be inconsequential.
+	poloniex.ws.Close()
+	poloniex.ws.Close()
+	// wsDepthStatus should recognize the closed connection and create a real
+	// websocket connection, signalling to use the HTTP fallback in the meantime.
+	tryHttp, initializing, depth := poloniex.wsDepthStatus(testConnectWs)
+	if !tryHttp {
+		t.Errorf("tryHttp not set as expected")
+		return
+	}
+	if initializing {
+		t.Errorf("websocket unexpectedly in initializing status")
+		return
+	}
+	if depth != nil {
+		t.Errorf("unexpected non-nil depth after forced websocket error")
+		return
+	}
+	select {
+	case <-time.NewTimer(30 * time.Second).C:
+	case <-killSwitch:
+		t.Errorf("ctrl+c detected")
+		return
+	}
+	checkWsDepths(t, poloniex.wsDepths())
+	poloniex.ws.Close()
+}
+
+func TestBittrexLiveWebsocket(t *testing.T) {
+	enableTestLog()
+
+	// Skip this test during automated testing.
+	if os.Getenv("GORACE") != "" {
+		t.Skip("Skipping Bittrex websocket test")
+	}
+
+	killSwitch := makeKillSwitch()
+
+	bittrex := newTestBittrexExchange()
+
+	bittrex.connectWs()
+	sr := bittrex.signalr()
+	if sr == nil {
+		t.Errorf("failed to initialize signalr client")
+	}
+	defer sr.Close()
+
+	testDuration := 180
+	log.Infof("listening for %d seconds total", testDuration*2)
+	select {
+	case <-time.NewTimer(time.Second * time.Duration(testDuration)).C:
+	case <-killSwitch:
+		t.Errorf("ctrl+c detected")
+		return
+	}
+	// Test reconnection by forcing a fail, then checking the wsDepthStatus.
+	bittrex.setWsFail(fmt.Errorf("test failure. ignore"))
+	// Subsequent calls to Close should be inconsequential.
+	bittrex.sr.Close()
+	bittrex.sr.Close()
+	// wsDepthStatus should recognize the closed connection and create a real
+	// websocket connection, signalling to use the HTTP fallback in the meantime.
+	tryHttp, initializing, depth := bittrex.wsDepthStatus(bittrex.connectWs)
+	if !tryHttp {
+		t.Errorf("tryHttp not set as expected")
+		return
+	}
+	if initializing {
+		// initializing is only true the first time the socket is started.
+		t.Errorf("websocket unexpectedly in initializing status")
+		return
+	}
+	if depth != nil {
+		t.Errorf("unexpected non-nil depth after forced websocket error")
+		return
+	}
+	select {
+	case <-time.NewTimer(time.Second * time.Duration(testDuration)).C:
+	case <-killSwitch:
+		t.Errorf("ctrl+c detected")
+		return
+	}
+	if bittrex.wsFailed() {
+		t.Fatalf("bittrex connection in failed state")
+	}
+	checkWsDepths(t, bittrex.wsDepths())
+}

--- a/exchanges/exchanges_test.go
+++ b/exchanges/exchanges_test.go
@@ -4,19 +4,15 @@
 package exchanges
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/signal"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/carterjones/signalr"
 	"github.com/carterjones/signalr/hubs"
-	"github.com/decred/dcrdata/dcrrates"
 	"github.com/decred/slog"
 )
 
@@ -24,157 +20,6 @@ func enableTestLog() {
 	if log == slog.Disabled {
 		UseLogger(slog.NewBackend(os.Stdout).Logger("EXE"))
 		log.SetLevel(slog.LevelTrace)
-	}
-}
-
-func makeKillSwitch() chan os.Signal {
-	killSwitch := make(chan os.Signal, 1)
-	signal.Notify(killSwitch, os.Interrupt)
-	return killSwitch
-}
-
-func testExchanges(asSlave, quickTest bool, t *testing.T) {
-	enableTestLog()
-
-	// Skip this test during automated testing.
-	if os.Getenv("GORACE") != "" {
-		t.Skip("skipping exchange test")
-	}
-
-	ctx, shutdown := context.WithCancel(context.Background())
-
-	killSwitch := makeKillSwitch()
-
-	wg := new(sync.WaitGroup)
-
-	wg.Add(1)
-	go func() {
-		select {
-		case <-killSwitch:
-			shutdown()
-		case <-ctx.Done():
-		}
-		wg.Done()
-	}()
-
-	config := new(ExchangeBotConfig)
-	config.Disabled = make([]string, 0)
-	config.Indent = true
-	if asSlave {
-		config.MasterBot = ":7778"
-		config.MasterCertFile = filepath.Join(dcrrates.DefaultAppDirectory, dcrrates.DefaultCertName)
-	} else {
-		config.DataExpiry = "2m"
-		config.RequestExpiry = "4m"
-	}
-	bot, err := NewExchangeBot(config)
-	if err != nil {
-		shutdown()
-		t.Fatalf("error creating bot. Shutting down: %v", err)
-	}
-
-	updateCounts := make(map[string]int)
-	for token := range bot.Exchanges {
-		updateCounts[token] = 0
-	}
-	logUpdate := func(token string) {
-		if !quickTest {
-			return
-		}
-		updateCounts[token]++
-		lowest := updateCounts[token]
-		for _, v := range updateCounts {
-			if v < lowest {
-				lowest = v
-			}
-		}
-		if lowest > 0 {
-			log.Infof("quick test conditions met. Shutting down early")
-			shutdown()
-		}
-	}
-
-	wg.Add(1)
-	go bot.Start(ctx, wg)
-
-	quitTimer := time.NewTimer(time.Minute * 7)
-	ch := bot.UpdateChannels()
-
-out:
-	for {
-		select {
-		case update := <-ch.Exchange:
-			logUpdate(update.Token)
-			log.Infof("update received from exchange %s", update.Token)
-		case update := <-ch.Index:
-			logUpdate(update.Token)
-			log.Infof("update received from index %s", update.Token)
-		case <-ch.Quit:
-			t.Errorf("ExchangeBot has quit.")
-			break out
-		case <-quitTimer.C:
-			break out
-		case <-ctx.Done():
-			break out
-		}
-	}
-
-	if bot.IsFailed() {
-		log.Infof("ExchangeBot is in failed state")
-	}
-
-	logMissing := func(token string) {
-		for xc := range updateCounts {
-			if xc == token {
-				return
-			}
-		}
-		t.Errorf("no update received for %s", token)
-	}
-
-	for _, token := range Tokens() {
-		logMissing(token)
-	}
-
-	depth, err := bot.QuickDepth(aggregatedOrderbookKey)
-	if err != nil {
-		t.Errorf("failed to create aggregated orderbook")
-	}
-	log.Infof("aggregated orderbook size: %d kiB", len(depth)/1024)
-
-	log.Infof("%d Bitcoin indices available", len(bot.AvailableIndices()))
-	log.Infof("final state is %d kiB", len(bot.StateBytes())/1024)
-
-	shutdown()
-	wg.Wait()
-}
-
-func TestExchanges(t *testing.T) {
-	testExchanges(false, false, t)
-}
-
-func TestSlaveBot(t *testing.T) {
-	// Points to DCRData on local machine port 7778.
-	// Start server with --exchange-refresh=1m --exchange-expiry=2m
-	testExchanges(true, false, t)
-}
-
-func TestQuickExchanges(t *testing.T) {
-	testExchanges(false, true, t)
-}
-
-func checkWsDepths(t *testing.T, depths *DepthData) {
-	askLen := len(depths.Asks)
-	bidLen := len(depths.Bids)
-	log.Infof("%d asks", askLen)
-	log.Infof("%d bids", bidLen)
-	if askLen > 0 && bidLen > 0 {
-		midGap := (depths.Asks[0].Price + depths.Bids[0].Price) / 2
-		highRange := (depths.Asks[askLen-1].Price - midGap) / midGap * 100
-		lowRange := (midGap - depths.Bids[bidLen-1].Price) / midGap * 100
-		log.Infof("depth range +%f%% / -%f%%", highRange, lowRange)
-	} else {
-		t.Fatalf("missing orderbook data")
 	}
 }
 
@@ -379,76 +224,6 @@ func TestPoloniexWebsocket(t *testing.T) {
 	}
 }
 
-func TestPoloniexLiveWebsocket(t *testing.T) {
-	enableTestLog()
-
-	// Skip this test during automated testing.
-	if os.Getenv("GORACE") != "" {
-		t.Skip("Skipping Poloniex websocket test")
-	}
-
-	killSwitch := makeKillSwitch()
-
-	poloniex := newTestPoloniexExchange()
-	processor := func(b []byte) {
-		var s string
-		if len(b) >= 128 {
-			s = string(b[:128]) + "..."
-		} else {
-			s = string(b)
-		}
-		if s == "[1010]" {
-			log.Infof("heartbeat")
-		} else {
-			log.Infof("message received: %s", s)
-		}
-		poloniex.processWsMessage(b)
-	}
-
-	testConnectWs := func() {
-		poloniexDoneChannel = make(chan struct{})
-		poloniex.connectWebsocket(processor, &socketConfig{
-			address: PoloniexURLs.Websocket,
-		})
-		poloniex.wsSend(poloniexOrderbookSubscription)
-	}
-	testConnectWs()
-	select {
-	case <-time.NewTimer(30 * time.Second).C:
-	case <-killSwitch:
-		t.Errorf("ctrl+c detected")
-		return
-	}
-	// Test reconnection by forcing a fail, then checking the wsDepthStatus
-	poloniex.setWsFail(fmt.Errorf("test failure. ignore"))
-	// subsequent calls to close should be inconsequential.
-	poloniex.ws.Close()
-	poloniex.ws.Close()
-	// wsDepthStatus should recognize the closed connection and create a real
-	// websocket connection, signalling to use the HTTP fallback in the meantime.
-	tryHttp, initializing, depth := poloniex.wsDepthStatus(testConnectWs)
-	if !tryHttp {
-		t.Errorf("tryHttp not set as expected")
-		return
-	}
-	if initializing {
-		t.Errorf("websocket unexpectedly in initializing status")
-		return
-	}
-	if depth != nil {
-		t.Errorf("unexpected non-nil depth after forced websocket error")
-		return
-	}
-	select {
-	case <-time.NewTimer(30 * time.Second).C:
-	case <-killSwitch:
-		t.Errorf("ctrl+c detected")
-		return
-	}
-	checkWsDepths(t, poloniex.wsDepths())
-	poloniex.ws.Close()
-}
-
 var (
 	bittrexSignalrTemplate = signalr.Message{}
 	bittrexMsgTemplate     = hubs.ClientMsg{}
@@ -637,64 +412,4 @@ func TestBittrexWebsocket(t *testing.T) {
 	if !bittrex.wsFailed() {
 		t.Fatalf("bittrex not in failed state as expected")
 	}
-}
-
-func TestBittrexLiveWebsocket(t *testing.T) {
-	enableTestLog()
-
-	// Skip this test during automated testing.
-	if os.Getenv("GORACE") != "" {
-		t.Skip("Skipping Bittrex websocket test")
-	}
-
-	killSwitch := makeKillSwitch()
-
-	bittrex := newTestBittrexExchange()
-
-	bittrex.connectWs()
-	sr := bittrex.signalr()
-	if sr == nil {
-		t.Errorf("failed to initialize signalr client")
-	}
-	defer sr.Close()
-
-	testDuration := 180
-	log.Infof("listening for %d seconds total", testDuration*2)
-	select {
-	case <-time.NewTimer(time.Second * time.Duration(testDuration)).C:
-	case <-killSwitch:
-		t.Errorf("ctrl+c detected")
-		return
-	}
-	// Test reconnection by forcing a fail, then checking the wsDepthStatus.
-	bittrex.setWsFail(fmt.Errorf("test failure. ignore"))
-	// Subsequent calls to Close should be inconsequential.
-	bittrex.sr.Close()
-	bittrex.sr.Close()
-	// wsDepthStatus should recognize the closed connection and create a real
-	// websocket connection, signalling to use the HTTP fallback in the meantime.
-	tryHttp, initializing, depth := bittrex.wsDepthStatus(bittrex.connectWs)
-	if !tryHttp {
-		t.Errorf("tryHttp not set as expected")
-		return
-	}
-	if initializing {
-		// initializing is only true the first time the socket is started.
-		t.Errorf("websocket unexpectedly in initializing status")
-		return
-	}
-	if depth != nil {
-		t.Errorf("unexpected non-nil depth after forced websocket error")
-		return
-	}
-	select {
-	case <-time.NewTimer(time.Second * time.Duration(testDuration)).C:
-	case <-killSwitch:
-		t.Errorf("ctrl+c detected")
-		return
-	}
-	if bittrex.wsFailed() {
-		t.Fatalf("bittrex connection in failed state")
-	}
-	checkWsDepths(t, bittrex.wsDepths())
 }

--- a/exchanges/websocket.go
+++ b/exchanges/websocket.go
@@ -33,8 +33,6 @@ type websocketFeed interface {
 	Write(interface{}) error
 	// Close will disconnect, causing any pending Read operations to error out.
 	Close()
-	// On will be true if close has not been called.
-	On() bool
 }
 
 // The socketConfig is the configuration passed to newSocketConnection. It is
@@ -90,13 +88,6 @@ func (client *socketClient) Close() {
 	client.conn.Close()
 }
 
-// On will be true if Close has not been called.
-func (client *socketClient) On() bool {
-	client.mtx.Lock()
-	defer client.mtx.Unlock()
-	return client.on
-}
-
 // Constructor for a socketClient, but returned as a websocketFeed.
 func newSocketConnection(cfg *socketConfig) (websocketFeed, error) {
 	dialer := &websocket.Dialer{
@@ -144,7 +135,6 @@ func dumpSignalrMsg(msg signalr.Message) {
 type signalrClient interface {
 	Send(hubs.ClientMsg) error
 	Close()
-	On() bool
 }
 
 type signalrConfig struct {
@@ -182,13 +172,6 @@ func (conn *signalrConnection) Close() {
 	}
 	conn.on = false
 	conn.c.Close()
-}
-
-// On checks whether Close has been called on this connection.
-func (conn *signalrConnection) On() bool {
-	conn.mtx.Lock()
-	defer conn.mtx.Unlock()
-	return conn.on
 }
 
 // Create a new signalr connection. Returns the signalrClient interface rather


### PR DESCRIPTION
This PR is for testing. The exchanges package seems to have some issues lately that may or may not be related to recent work to implement websockets. This PR effectively just adds some trace output, though the foundations are being laid for some more sophisticated error monitoring. 

If you are testing, run this PR with `--debuglevel=XBOT=trace` on dcrdata, and `--loglevel=trace` on rateserver. Feel free to give me your logs. 