### PR TITLE
ticketpool: Presents the ticket pool PercentTarget as a diff from 100% target

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -180,13 +180,14 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 
 	str, err := exp.templates.execTemplateToString("home", struct {
 		*CommonPageData
-		Info        *types.HomeInfo
-		Mempool     *types.MempoolInfo
-		BestBlock   *types.BlockBasic
-		BlockTally  []int
-		Consensus   int
-		Blocks      []*types.BlockBasic
-		Conversions *homeConversions
+		Info          *types.HomeInfo
+		Mempool       *types.MempoolInfo
+		BestBlock     *types.BlockBasic
+		BlockTally    []int
+		Consensus     int
+		Blocks        []*types.BlockBasic
+		Conversions   *homeConversions
+		PercentChange float64
 	}{
 		CommonPageData: exp.commonData(r),
 		Info:           homeInfo,
@@ -196,6 +197,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		Consensus:      consensus,
 		Blocks:         blocks,
 		Conversions:    conversions,
+		PercentChange:  homeInfo.PoolInfo.PercentTarget - 100,
 	})
 
 	inv.RUnlock()

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -569,5 +569,6 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			}
 			return addrPKH.EncodeAddress()
 		},
+		"toAbsValue": math.Abs,
 	}
 }

--- a/public/js/controllers/homepage_controller.js
+++ b/public/js/controllers/homepage_controller.js
@@ -173,7 +173,7 @@ export default class extends Controller {
     this.windowIndexTarget.textContent = ex.window_idx
     this.posBarTarget.style.width = `${(ex.window_idx / ex.params.window_size) * 100}%`
     this.poolSizeTarget.innerHTML = humanize.decimalParts(ex.pool_info.size, true, 0)
-    this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target).toFixed(2)
+    this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target - 100).toFixed(2)
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`
     this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -245,7 +245,9 @@
                                 </span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-target="homepage.targetPct">{{printf "%.2f" .PoolInfo.PercentTarget}}</span> % of target&nbsp;<span>{{intComma .PoolInfo.Target}}</span>
+                                <span data-target="homepage.targetPct">{{printf "%.2f" (toAbsValue $.PercentChange)}}</span>%
+                                {{if lt $.PercentChange 0.0}} under {{else}} over {{end}}
+                                target
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">


### PR DESCRIPTION
Resolves #1225 

Instead of

`Ticket Pool Size: 41,285 (100.79% of target 40,960)`

shows

`Ticket Pool Size: 41,285 (+0.79% of target 40,960)`

It takes less space, faster to read, and in case of negative number -1% is more useful than 99%

<img width="162" alt="Screen Shot 2019-05-20 at 12 18 28 PM" src="https://user-images.githubusercontent.com/2056512/58012567-70d78d80-7afd-11e9-8758-ab64d985a113.png">
