### PR TITLE
ticketpool: Count only sstxcommitments outputs

### DIFF
--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1094,7 +1094,10 @@ func retrieveTicketsGroupedByType(ctx context.Context, db *sql.DB) (*dbtypes.Poo
 		}
 
 		tickets.Count = append(tickets.Count, count)
-		tickets.Outputs = append(tickets.Outputs, output)
+		// sstxcommitment count is calculated from all the outputs available.
+		// It is a script hash used for payout of voting and is calculated using
+		// the formula (n-1)/2 where n = all possible outputs.
+		tickets.Outputs = append(tickets.Outputs, (output-1)/2)
 	}
 
 	return tickets, nil

--- a/public/js/controllers/ticketpool_controller.js
+++ b/public/js/controllers/ticketpool_controller.js
@@ -78,7 +78,7 @@ function priceGraphData (items, memP) {
 
 function populateOutputs (data) {
   var totalCount = parseInt(data.count.reduce((a, n) => { return a + n }, 0))
-  var tableData = `<thead><td># of Outputs</td><td>Count</td><td>% Occurence</td></thead>`
+  var tableData = `<tr><th style="width: 30%;"># of sstxcommitment outputs</th><th>Count</th><th>% Occurence</th></tr>`
   data.outputs.map((n, i) => {
     var count = parseInt(data.count[i])
     tableData += `<tr><td class="pr-2 lh1rem vam nowrap xs-w117 font-weight-bold">${parseInt(n)}</td>

--- a/views/ticketpool.tmpl
+++ b/views/ticketpool.tmpl
@@ -36,9 +36,10 @@
         <div id="tickets_by_purchase_price" class="tp-charts"></div>
         <br>
         <div class="justify-content-between">
-          <div class="dygraph-label dygraph-title mb-1">Ticket Outputs Distribution</div>
+          <div class="dygraph-label dygraph-title mb-1">Distribution of Tickets by Reward Outputs</div>
           <div class="row col-lg-12 col-sm-8 d-flex text-center m-auto">
-            <table class="tp-outputs-align" data-target="ticketpool.outputs"></table>
+            <table class="tp-outputs-align" data-target="ticketpool.outputs">
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Since counting the `sstxcommitments` outputs is simpler than counting all outputs of a given ticket, the `sstxcommitment` tx count are used to represent the output count for a given ticket in the ticketpool.

**New Tickets Output Distribution Table**
![Screenshot from 2019-05-21 02-06-06](https://user-images.githubusercontent.com/22055953/58057686-7d47fe80-7b6e-11e9-93a8-cacc74ed41af.png)
