### PR TITLE
charts: Reduce the bars color overlapping

### DIFF
--- a/public/js/helpers/chart_helper.js
+++ b/public/js/helpers/chart_helper.js
@@ -1,11 +1,11 @@
 // shared functions for related to charts
 
 export function barChartPlotter (e) {
-  plotChart(e, fitWidth(e.points))
+  plotChart(e, findWidth(findMinSep(e.points, Infinity)))
 }
 
-function fitWidth (points) {
-  return Math.floor(2.0 / 3 * findMinSep(points, Infinity))
+function findWidth (sep) {
+  return Math.floor(2.0 / 3 * sep * 10000) / 10000 // to 4 decimal places
 }
 
 function findMinSep (points, minSep) {
@@ -16,10 +16,15 @@ function findMinSep (points, minSep) {
   return minSep
 }
 
+function findLineWidth (barWidth) {
+  var width = 0.2 + (0.08 * barWidth)
+  return width > 1 ? 1 : width
+}
+
 export function sizedBarPlotter (binSize) {
   return (e) => {
     let canvasBin = e.dygraph.toDomXCoord(binSize) - e.dygraph.toDomXCoord(0)
-    plotChart(e, Math.floor(2.0 / 3 * canvasBin))
+    plotChart(e, findWidth(canvasBin))
   }
 }
 
@@ -28,6 +33,7 @@ function plotChart (e, barWidth) {
   var yBottom = e.dygraph.toDomYCoord(0)
 
   ctx.fillStyle = e.color
+  ctx.lineWidth = findLineWidth(barWidth)
 
   e.points.map((p) => {
     if (p.yval === 0) return
@@ -48,9 +54,10 @@ export function multiColumnBarPlotter (e) {
 
   var minSep = Infinity
   sets.map((bar) => { minSep = findMinSep(bar, minSep) })
-  var barWidth = Math.floor(2.0 / 3 * minSep)
+  var barWidth = findWidth(minSep)
   var strokeColors = g.getColors()
   var fillColors = g.getOption('fillColors')
+  ctx.lineWidth = findLineWidth(barWidth)
 
   sets.map((bar, i) => {
     ctx.fillStyle = fillColors[i]


### PR DESCRIPTION
When dygraph bar graph has to plot too many bars in a very tiny space, too much color overlapping is distorting the actual data on display.

![fix color overlapping](https://user-images.githubusercontent.com/22055953/58063268-1cc4bb80-7b86-11e9-99ff-b23e4350ddb1.png)
