### PR TITLE
pubsub: add version, and version request/response

### DIFF
--- a/pubsub/democlient/go.mod
+++ b/pubsub/democlient/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/decred/dcrdata/explorer/types v1.0.1-0.20190501025527-02d6f8e648f7
 	github.com/decred/dcrdata/pubsub v1.0.1-0.20190501025527-02d6f8e648f7
 	github.com/decred/dcrdata/pubsub/types v1.0.1-0.20190501025527-02d6f8e648f7
+	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190501025527-02d6f8e648f7 // indirect
 	github.com/decred/slog v1.0.0
 	github.com/google/go-cmp v0.3.0 // indirect

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/decred/dcrdata/explorer/types v1.0.1-0.20190416204615-70a58657e02f
 	github.com/decred/dcrdata/mempool v1.0.0
 	github.com/decred/dcrdata/pubsub/types v1.0.1-0.20190416204615-70a58657e02f
+	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416161040-1dc819eb191d
 	github.com/decred/slog v1.0.0
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2

--- a/pubsub/types/pubsub_types.go
+++ b/pubsub/types/pubsub_types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -9,6 +10,23 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	exptypes "github.com/decred/dcrdata/explorer/types"
 )
+
+// Ver is a json tagged version type.
+type Ver struct {
+	Major uint32 `json:"major"`
+	Minor uint32 `json:"minor"`
+	Patch uint32 `json:"patch"`
+}
+
+// NewVer creates a Ver from the major/minor/patch version components.
+func NewVer(major, minor, patch uint32) Ver {
+	return Ver{major, minor, patch}
+}
+
+// String implements Stringer for Ver.
+func (v Ver) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
 
 var (
 	// ErrWsClosed is the error message when a websocket.(*Conn).Close tries to
@@ -71,6 +89,10 @@ type HubSignal int
 const (
 	SigSubscribe HubSignal = iota
 	SigUnsubscribe
+	SigDecodeTx
+	SigGetMempoolTxs
+	SigSendTx
+	SigVersion
 	SigNewBlock
 	SigMempoolUpdate
 	SigPingAndUserCount
@@ -94,6 +116,10 @@ var Subscriptions = map[string]HubSignal{
 var eventIDs = map[HubSignal]string{
 	SigSubscribe:        "subscribe",
 	SigUnsubscribe:      "unsubscribe",
+	SigDecodeTx:         "decodetx",
+	SigGetMempoolTxs:    "getmempooltxs",
+	SigSendTx:           "sendtx",
+	SigVersion:          "getversion",
 	SigNewBlock:         "newblock",
 	SigMempoolUpdate:    "mempool",
 	SigPingAndUserCount: "ping",


### PR DESCRIPTION
pubsub/types: Create a JSON-tagged `Ver` struct for sending the pubsub server version in JSON messages.

pubsub (server): Create an unexported `var version = semver.NewSemver(3, 0, 0)`, accessible via the new  `pubsub.Version() semver.Semver` function.  Recognize incoming messages with the event ID `"version"`, and respond to the client with a marshaled `pubsub/types.Ver`.

pubsub/psclient (client): Add `psclient.Version() semver.Semver`, which returns `pubsub.Version()` result. Note that the shared version indicates a module version.  On startup of a new client, a server version check is performed:

```
[INF] PSCL: Server pubsub version: 3.0.0
[DBG] PSCL: Response to  request ID=1 received. Success = true. Data: {"major":3,"minor":0,"patch":0}
```

If the server version is not compatible, and error is thrown:

```
Failed to connect to ws://127.0.0.1:7777/ps: server pubsub version is 3.0.0, but client is version 3.1.0
```

This also adds `psclient.(*Client).ServerVersion` to query the server version at any time.