### PR TITLE
proposals: add votes count and approval percentage columns

### DIFF
--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -570,5 +570,15 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			return addrPKH.EncodeAddress()
 		},
 		"toAbsValue": math.Abs,
+		"toFloat64": func(x uint32) float64 {
+			return float64(x)
+		},
+		"toInt": func(str string) int {
+			intStr, err := strconv.Atoi(str)
+			if err != nil {
+				return 0
+			}
+			return intStr
+		},
 	}
 }

--- a/public/scss/themes.scss
+++ b/public/scss/themes.scss
@@ -183,4 +183,8 @@ body.darkBG {
   .text-green {
     color: #2eefa1;
   }
+
+  .text-abandoned {
+    color: #c4cbd2;
+  }
 }

--- a/public/scss/typography.scss
+++ b/public/scss/typography.scss
@@ -159,6 +159,22 @@ a.grayed {
   color: #00a100;
 }
 
+.text-progress {
+  color: #2970ff;
+}
+
+.text-no-quorum {
+  color: #feb8a5;
+}
+
+.text-failed {
+  color: #ed6d47;
+}
+
+.text-abandoned {
+  color: #3d5873;
+}
+
 // numbers
 .decimal-parts {
   .int {

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -106,8 +106,8 @@
                     <tr>
                         <th class="text-left">Title</th>
                         <th class="text-left">Author</th>
-                        <th class="text-left">Proposal Status</th>
-                        <th class="text-left">Vote Status</th>
+                        <th class="text-left">Proposal Vote Status</th>
+                        <th class="text-left">Vote Count</th>
                         <th class="text-right">Age</th>
                         <th class="text-right">Updated</th>
                     </tr>
@@ -118,12 +118,43 @@
                     <tr>
                         <td class="text-left"><a href="/proposal/{{.RefID}}">{{.Name}}</a></td>
                         <td class="text-left">{{.Username}}</td>
-                        {{with .Status}}
-                            <td class="text-left">{{toTitleCase .String}}</td>
-                        {{end}}
                         <td class="text-left">
-                            {{if .VoteStatus}}{{with .VoteStatus}}{{.ShortDesc}}{{end}}{{else}}N/A{{end}}
+                            {{if .VoteStatus}}
+                                {{if eq .VoteStatus.ShortDesc "Not Authorized"}}
+                                    <span class="text-abandoned">
+                                        In Discussion
+                                    </span>
+                                {{else}}
+                                    {{range $i, $vr := .VoteResults}}
+                                        {{if eq $vr.Option.OptionID "yes"}}
+                                            {{$votesPercent :=  percentage $vr.VotesReceived $v.TotalVotes}}
+                                            {{if lt $.Tip.Height (toInt $v.Endheight)}}
+                                                <span class="text-progress">
+                                                    In Progress ({{printf "%.0f" ($votesPercent)}}%)
+                                                </span>
+                                            {{else if lt (percentage $v.TotalVotes $v.NumOfEligibleVotes) (toFloat64 $v.QuorumPercentage)}}
+                                                <span class="text-no-quorum">No quorum</span>
+                                            {{else}}
+                                                {{if lt $votesPercent (toFloat64 $v.PassPercentage)}}
+                                                    <span class="text-failed">
+                                                        Failed ({{printf "%.0f" ($votesPercent)}}%)
+                                                    </span>
+                                                {{else}}
+                                                    <span class="text-green">
+                                                        Passed ({{printf "%.0f" ($votesPercent)}}%)
+                                                    </span>
+                                                {{end}}
+                                            {{end}}
+                                        {{end}}
+                                    {{end}}
+                                {{end}}
+                            {{else}}
+                                <span class="text-abandoned">
+                                    Abandoned
+                                </span>
+                            {{end}}
                         </td>
+                        <td class="text-left">{{.TotalVotes}}</td>
                         <td class="text-right" data-target="time.age" data-age="{{.Timestamp}}"></td>
                         <td class="text-right">{{timeWithoutDateAndTimeZone .Timestamp}}</td>
                     </tr>


### PR DESCRIPTION
Partiallyresolves(editing this so that the main issue is not closed) #1287 

add votes count and approval percentage columns in the proposals view


<img width="1247" alt="Screen Shot 2019-05-22 at 9 43 35 PM" src="https://user-images.githubusercontent.com/2056512/58201440-bc489200-7cdd-11e9-9577-8d766f82cd28.png">
