### PR TITLE
db/{cache,dcrpg}: improved memory management

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg"
@@ -42,19 +44,27 @@ const (
 	// "from" URL query parameters. Note that each transaction requires a
 	// getrawtransaction RPC call to dcrd.
 	maxInsightAddrsTxns = 250
+
+	// inflightUTXOLimit is a soft limit on the number of in-flight UTXOs that
+	// may be handled by the /addr/{address}/utxo endpoint. It is set slightly
+	// higher than maxInsightAddrsUTXOs to allow smaller requests to be
+	// processed concurrently with a very large request.
+	inflightUTXOLimit = maxInsightAddrsUTXOs * 5 / 4
 )
 
 // InsightApi contains the resources for the Insight HTTP API. InsightApi's
 // methods include the http.Handlers for the URL path routes.
 type InsightApi struct {
-	nodeClient     *rpcclient.Client
-	BlockData      *dcrpg.ChainDBRPC
-	params         *chaincfg.Params
-	mp             rpcutils.MempoolAddressChecker
-	status         *apitypes.Status
-	JSONIndent     string
-	ReqPerSecLimit float64
-	maxCSVAddrs    int
+	nodeClient      *rpcclient.Client
+	BlockData       *dcrpg.ChainDBRPC
+	params          *chaincfg.Params
+	mp              rpcutils.MempoolAddressChecker
+	status          *apitypes.Status
+	JSONIndent      string
+	ReqPerSecLimit  float64
+	maxCSVAddrs     int
+	inflightUTXOs   int64
+	inflightLimiter sync.Mutex
 }
 
 // NewInsightApi is the constructor for InsightApi.
@@ -93,7 +103,7 @@ func writeJSON(w http.ResponseWriter, thing interface{}, indent string) {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", indent)
 	if err := encoder.Encode(thing); err != nil {
-		apiLog.Infof("JSON encode error: %v", err)
+		apiLog.Warnf("JSON encode error: %v", err)
 	}
 }
 
@@ -324,11 +334,70 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Initialize output slice.
-	txnOutputs := make([]apitypes.AddressTxnOutput, 0)
+	t0 := time.Now()
 
-	for _, address := range addresses {
+	// When complete, subtract inflightUTXOs from this goroutine. If this call
+	// got completion priority (hit the UTXO limit), and thus held the lock,
+	// unlock prior to decrementing the in-flight UTXO count.
+	var inflightUTXOs int64
+	var priority bool
+	defer func() {
+		if priority {
+			iapi.inflightLimiter.Unlock()
+			apiLog.Info("Relinquishing prioritized goroutine status.")
+		}
+		final := atomic.AddInt64(&iapi.inflightUTXOs, -inflightUTXOs)
+		apiLog.Debugf("Removing %d inflight UTXOs. New total = %d.", inflightUTXOs, final)
+
+		apiLog.Debugf("getAddressesTxnOutput completed for %d addresses with %d UTXOs in %v.",
+			len(addresses), inflightUTXOs, time.Since(t0))
+	}()
+
+	// Initialize output slice.
+	txnOutputs := make([]*apitypes.AddressTxnOutput, 0)
+	currentHeight := int32(iapi.BlockData.ChainDB.Height())
+
+	for i, address := range addresses {
+		// Unless this goroutine got completion priority on a previous address
+		// and locked out other goroutines, we must wait for the lock to prevent
+		// simultaneous requests from exceeding the inflight UTXO limit.
+		if !priority {
+			iapi.inflightLimiter.Lock()
+		}
+
+		tStart := time.Now()
+
+		// Query for UTXOs for the current address.
 		confirmedTxnOutputs, _, err := iapi.BlockData.ChainDB.AddressUTXO(address)
+
+		apiLog.Debugf("AddressUTXO completed for %s with %d UTXOs in %v.",
+			address, len(confirmedTxnOutputs), time.Since(tStart))
+
+		// Account for in-flight UTXOs before error checking and unlocking.
+		newInflightUTXOs := int64(len(confirmedTxnOutputs))
+		totalInflight := atomic.AddInt64(&iapi.inflightUTXOs, newInflightUTXOs)
+		apiLog.Tracef("Adding %d inflight (confirmed) UTXOs to the total.", newInflightUTXOs)
+		inflightUTXOs += newInflightUTXOs
+
+		// While locked, check in-flight UTXO count. If over the limit, become
+		// the prioritized goroutine and hold the lock until this http handler
+		// completes (and decrements the inflight UTXO count).
+		if !priority {
+			if totalInflight >= inflightUTXOLimit {
+				// Over the limit, but it's our turn to wrap it up.
+				priority = true
+				apiLog.Info("Becoming prioritized getAddressesTxnOutput goroutine"+
+					"with %d total in-flight UTXOs.", totalInflight)
+				// Unblock occurs only when we finish this entire http request.
+			} else {
+				// Otherwise, unlock now that the query and iapi.inflightUTXOs
+				// has been updated.
+				iapi.inflightLimiter.Unlock()
+			}
+		}
+
+		// Check the returned error value from the query now that the limiter is
+		// unlocked or unlocking is deferred.
 		if dbtypes.IsTimeoutErr(err) {
 			apiLog.Errorf("AddressUTXO: %v", err)
 			http.Error(w, "Database timeout.", http.StatusServiceUnavailable)
@@ -339,17 +408,19 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 			continue
 		}
 
-		addressOuts, _, err := iapi.mp.UnconfirmedTxnsForAddress(address)
+		// Unconfirmed UTXOs
+		newInflightUTXOs = 0 // count the unconfirmed UTXOs now
+		unconfirmedTxnOutputs, _, err := iapi.mp.UnconfirmedTxnsForAddress(address)
 		if err != nil {
 			apiLog.Errorf("Error getting unconfirmed transactions: %v", err)
 			continue
 		}
 
-		if addressOuts != nil {
+		if unconfirmedTxnOutputs != nil {
 			// Add any relevant mempool transaction outputs to the UTXO set.
 		FUNDING_TX_DUPLICATE_CHECK:
-			for _, f := range addressOuts.Outpoints {
-				fundingTx, ok := addressOuts.TxnsStore[f.Hash]
+			for _, f := range unconfirmedTxnOutputs.Outpoints {
+				fundingTx, ok := unconfirmedTxnOutputs.TxnsStore[f.Hash]
 				if !ok {
 					apiLog.Errorf("An outpoint's transaction is not available in TxnStore.")
 					continue
@@ -364,40 +435,60 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 				// need to do one more search on utxo and do not add if this is
 				// already in the list as a confirmed tx.
 				for _, utxo := range confirmedTxnOutputs {
-					if utxo.Vout == f.Index && utxo.TxnID == f.Hash.String() {
+					if utxo.Vout == f.Index && utxo.TxHash == f.Hash {
 						continue FUNDING_TX_DUPLICATE_CHECK
 					}
 				}
 
-				txnOutput := apitypes.AddressTxnOutput{
+				newInflightUTXOs++
+
+				txOut := fundingTx.Tx.TxOut[f.Index]
+
+				txnOutputs = append(txnOutputs, &apitypes.AddressTxnOutput{
 					Address:       address,
 					TxnID:         fundingTx.Hash().String(),
 					Vout:          f.Index,
-					ScriptPubKey:  hex.EncodeToString(fundingTx.Tx.TxOut[f.Index].PkScript),
-					Amount:        dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
-					Satoshis:      fundingTx.Tx.TxOut[f.Index].Value,
+					ScriptPubKey:  hex.EncodeToString(txOut.PkScript),
+					Amount:        dcrutil.Amount(txOut.Value).ToCoin(),
+					Satoshis:      txOut.Value,
 					Confirmations: 0,
 					BlockTime:     fundingTx.MemPoolTime,
-				}
-				txnOutputs = append(txnOutputs, txnOutput)
+				})
 			}
 		}
 
 		// If multiple addresses were in the request, enforce a limit on the
 		// number of UTXOs we will return. Do this before appending the latest
 		// confirmed transactions slice.
-		if len(addresses) > 1 && len(confirmedTxnOutputs)+len(txnOutputs) > maxInsightAddrsUTXOs {
+		numOuts := len(confirmedTxnOutputs) + len(txnOutputs)
+		if len(addresses) > 1 && numOuts > maxInsightAddrsUTXOs {
 			writeInsightError(w, "Too many UTXOs in that result. "+
 				"Please request the UTXOs for each address individually.")
 			return
 		}
 
-		txnOutputs = append(txnOutputs, confirmedTxnOutputs...)
+		totalInflight = atomic.AddInt64(&iapi.inflightUTXOs, newInflightUTXOs)
+		apiLog.Tracef("Adding %d inflight (unconfirmed) UTXOs to the total.", newInflightUTXOs)
+		apiLog.Debugf("Total in-flight UTXOs: %v", totalInflight)
+		inflightUTXOs += newInflightUTXOs
+
+		// On the first address, start with a slice of the correct size.
+		if i == 0 {
+			txnOutputs = append(make([]*apitypes.AddressTxnOutput, 0, numOuts),
+				txnOutputs...)
+		}
+
+		//txnOutputs = append(txnOutputs, confirmedTxnOutputs...)
+		for _, out := range confirmedTxnOutputs {
+			txnOutputs = append(txnOutputs, apitypes.TxOutFromDB(out, currentHeight))
+		}
+		//nolint:ineffassign
+		confirmedTxnOutputs = nil // Go GC, go!
 
 		// Search for items in mempool that spend one of these UTXOs and remove
 		// them from the set.
-		for _, f := range addressOuts.PrevOuts {
-			spendingTx, ok := addressOuts.TxnsStore[f.TxSpending]
+		for _, f := range unconfirmedTxnOutputs.PrevOuts {
+			spendingTx, ok := unconfirmedTxnOutputs.TxnsStore[f.TxSpending]
 			if !ok {
 				apiLog.Errorf("An outpoint's transaction is not available in TxnStore.")
 				continue
@@ -406,12 +497,17 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 				apiLog.Errorf("A transaction spending the outpoint of an unconfirmed transaction is unexpectedly confirmed.")
 				continue
 			}
+
+			var garbage []int
 			for g, utxo := range txnOutputs {
 				if utxo.Vout == f.PreviousOutpoint.Index && utxo.TxnID == f.PreviousOutpoint.Hash.String() {
-					// Found a UTXO that is unconfirmed spent. Remove from slice.
-					txnOutputs = append(txnOutputs[:g], txnOutputs[g+1:]...)
+					apiLog.Debug("Removing an unconfirmed spent UTXO.")
+					garbage = append(garbage, g)
 				}
 			}
+
+			// Remove entries from the end to the beginning of the slice.
+			txnOutputs = removeSliceElements(txnOutputs, garbage)
 		}
 	}
 
@@ -425,6 +521,25 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 	})
 
 	writeJSON(w, txnOutputs, iapi.getIndentQuery(r))
+}
+
+// removeSliceElements removes elements of the input slice at the specified
+// indexes. NOTE: The input slice's buffer is modified but the output length
+// will be different if any elements are removed, so this function should be
+// called like `s = removeSliceElements(s, inds)`. Also note that the original
+// order of elements in the input slice may not be maintained.
+func removeSliceElements(txOuts []*apitypes.AddressTxnOutput, inds []int) []*apitypes.AddressTxnOutput {
+	// Remove entries from the end to the beginning of the slice.
+	sort.Slice(inds, func(i, j int) bool { return inds[i] > inds[j] }) // descending indexes
+	for _, g := range inds {
+		if g > len(txOuts)-1 {
+			continue
+		}
+		txOuts[g] = txOuts[len(txOuts)-1] // overwrite element g with last element
+		txOuts[len(txOuts)-1] = nil       // nil out last element
+		txOuts = txOuts[:len(txOuts)-1]
+	}
+	return txOuts
 }
 
 func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) {

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -386,8 +386,8 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 			if totalInflight >= inflightUTXOLimit {
 				// Over the limit, but it's our turn to wrap it up.
 				priority = true
-				apiLog.Info("Becoming prioritized getAddressesTxnOutput goroutine"+
-					"with %d total in-flight UTXOs.", totalInflight)
+				apiLog.Infof("Becoming prioritized getAddressesTxnOutput "+
+					"goroutine with %d total in-flight UTXOs.", totalInflight)
 				// Unblock occurs only when we finish this entire http request.
 			} else {
 				// Otherwise, unlock now that the query and iapi.inflightUTXOs

--- a/api/types/go.mod
+++ b/api/types/go.mod
@@ -8,8 +8,9 @@ require (
 	github.com/Sereal/Sereal v0.0.0-20190416075407-a9d24ede505a // indirect
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrjson/v2 v2.0.0
+	github.com/decred/dcrd/dcrutil v1.2.1-0.20190118223730-3a5281156b73
 	github.com/decred/dcrdata/db/dbtypes v1.0.2-0.20190416155607-25afe5d5e790
-	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790
+	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f
 	github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golang/snappy v0.0.1 // indirect

--- a/api/types/go.sum
+++ b/api/types/go.sum
@@ -50,6 +50,7 @@ github.com/decred/dcrd/dcrec v0.0.0-20180721031028-5369a485acf6/go.mod h1:cRAH1S
 github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
 github.com/decred/dcrd/dcrec v0.0.0-20190130161649-59ed4247a1d5 h1:rz0HmQLuABmKj2fFaeYMpJSG66JrDhU3mQ1tDBeGfQk=
 github.com/decred/dcrd/dcrec v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
+github.com/decred/dcrd/dcrec v0.0.0-20190402182842-879eebce3333 h1:SsHXaZfWwQSq+dGzxKM7BqrrKcr1NbNA6c3qiBNCBZY=
 github.com/decred/dcrd/dcrec v0.0.0-20190402182842-879eebce3333/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec v0.0.0-20190413175304-e69a789183f3 h1:UsOBnj2jml7dVI4DuvJyF97wBMNvK+rZ4Zw53n325QA=
 github.com/decred/dcrd/dcrec v0.0.0-20190413175304-e69a789183f3/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
@@ -58,6 +59,7 @@ github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721031028-5369a485acf6/go.mod h
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20181208004914-a0816cf4301f/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5 h1:qA+q5URxOMLCts1hTsNlXfOOtT2d83b3Z597yupIn5A=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
+github.com/decred/dcrd/dcrec/edwards v0.0.0-20190402182842-879eebce3333 h1:6Z3TuqdknGNISdaxQscCYUzl5fS1lMBF+By4u3xNuWQ=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190402182842-879eebce3333/go.mod h1:HblVh1OfMt7xSxUL1ufjToaEvpbjpWvvTAUx4yem8BI=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190413175304-e69a789183f3 h1:1wv0uKVmJPop93YuyJeornJJVzP0613X5keCU4xLKT0=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190413175304-e69a789183f3/go.mod h1:HblVh1OfMt7xSxUL1ufjToaEvpbjpWvvTAUx4yem8BI=
@@ -105,6 +107,8 @@ github.com/decred/dcrdata/txhelpers v1.0.1/go.mod h1:oZOlm7v82oD5SIy1wlOBG0OT92C
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190415153927-351272ba94ab/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790 h1:hmGinC7kJ0kGjw6fNSfpFPIZaguZqbshDYAnFby8vxM=
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
+github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f h1:UHK/F4XLVGFisd1qbP8ILmJG8AM6ShzgfhCTNH/iExw=
+github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0 h1:FPVohgxZHHwi7qTOBki/Dw9j5cgGsZYiktGSfgqHR0w=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0/go.mod h1:k+IOPnUY0YqlwhSDhczzaUN17NX/gMtztwl3UxKgVZY=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
@@ -170,6 +174,7 @@ golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a h1:Igim7XhdOpBnWPuYJ70XcNpq8q3BCACtVgNfoJxOV7g=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -7,6 +7,7 @@ package types
 import (
 	"encoding/json"
 
+	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrdata/db/dbtypes"
 )
 
@@ -91,6 +92,23 @@ type AddressTxnOutput struct {
 	Atoms         int64   `json:"atoms,omitempty"` // Not Required per Insight spec
 	Satoshis      int64   `json:"satoshis,omitempty"`
 	Confirmations int64   `json:"confirmations"`
+}
+
+// TxOutFromDB converts a dbtypes.AddressTxnOutput to a api/types.AddressTxnOutput.
+func TxOutFromDB(dbTxOut *dbtypes.AddressTxnOutput, currentHeight int32) *AddressTxnOutput {
+	return &AddressTxnOutput{
+		Address:      dbTxOut.Address,
+		TxnID:        dbTxOut.TxHash.String(),
+		Vout:         dbTxOut.Vout,
+		BlockTime:    dbTxOut.BlockTime,
+		ScriptPubKey: dbTxOut.PkScript,
+		Height:       int64(dbTxOut.Height),
+		//BlockHash:    dbTxOut.BlockHash.String(),
+		Amount: dcrutil.Amount(dbTxOut.Atoms).ToCoin(),
+		//Atoms: dbTxOut.Atoms,
+		Satoshis:      dbTxOut.Atoms,
+		Confirmations: int64(currentHeight - dbTxOut.Height + 1),
+	}
 }
 
 // SpendByFundingHash models a return from SpendDetailsForFundingTx.

--- a/blockdata/go.mod
+++ b/blockdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/blockdata
 
-go 1.12
+go 1.11
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 // indirect

--- a/db/cache/addresscache_test.go
+++ b/db/cache/addresscache_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-
 	"github.com/decred/dcrdata/db/dbtypes"
 )
 
@@ -66,7 +65,7 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 		}
 
 		switch rows.(type) {
-		case []dbtypes.AddressRowCompact:
+		case []*dbtypes.AddressRowCompact:
 		default:
 			t.Error("rows type should have been []dbtypes.AddressRowCompact")
 		}
@@ -86,7 +85,7 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 		}
 
 		switch rows.(type) {
-		case []dbtypes.AddressRowMerged:
+		case []*dbtypes.AddressRowMerged:
 		default:
 			t.Error("rows type should have been []dbtypes.AddressRowMerged")
 		}
@@ -95,7 +94,7 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 	// rows cache hit
 
 	txHash, _ := chainhash.NewHashFromStr("05e7195ce139c62a46cb77e0002018a14ebe7e6442cd6c2e39274902a44a2a66")
-	aci.rows = []dbtypes.AddressRowCompact{
+	aci.rows = []*dbtypes.AddressRowCompact{
 		{
 			Address: "Dsnieug5H7Zn3SjUWwbcZ17ox9d3F2TEvZV",
 			TxHash:  *txHash,
@@ -123,7 +122,7 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 
 		if v.merged {
 			switch r := rows.(type) {
-			case []dbtypes.AddressRowMerged:
+			case []*dbtypes.AddressRowMerged:
 				if len(r) != len(aci.rows) {
 					t.Fatalf("number of rows incorrect. Got %d, want %d",
 						len(r), len(aci.rows))
@@ -133,7 +132,7 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 			}
 		} else {
 			switch r := rows.(type) {
-			case []dbtypes.AddressRowCompact:
+			case []*dbtypes.AddressRowCompact:
 				if len(r) != len(aci.rows) {
 					t.Fatalf("number of rows incorrect. Got %d, want %d",
 						len(r), len(aci.rows))

--- a/db/cache/go.mod
+++ b/db/cache/go.mod
@@ -1,15 +1,14 @@
 module github.com/decred/dcrdata/db/cache
 
-go 1.12
+go 1.11
 
 require (
 	github.com/decred/dcrd/chaincfg v1.4.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/decred/dcrdata/api/types v1.0.7-0.20190416202529-23d1eb95ca1b
 	github.com/decred/dcrdata/blockdata v1.0.1
 	github.com/decred/dcrdata/db/dbtypes v1.0.2-0.20190416202529-23d1eb95ca1b
 	github.com/decred/dcrdata/semver v1.0.0
-	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790
+	github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f
 	github.com/decred/slog v1.0.0
 )

--- a/db/cache/go.sum
+++ b/db/cache/go.sum
@@ -50,6 +50,7 @@ github.com/decred/dcrd/dcrec v0.0.0-20180721031028-5369a485acf6/go.mod h1:cRAH1S
 github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
 github.com/decred/dcrd/dcrec v0.0.0-20190130161649-59ed4247a1d5 h1:rz0HmQLuABmKj2fFaeYMpJSG66JrDhU3mQ1tDBeGfQk=
 github.com/decred/dcrd/dcrec v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
+github.com/decred/dcrd/dcrec v0.0.0-20190402182842-879eebce3333 h1:SsHXaZfWwQSq+dGzxKM7BqrrKcr1NbNA6c3qiBNCBZY=
 github.com/decred/dcrd/dcrec v0.0.0-20190402182842-879eebce3333/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec v0.0.0-20190413175304-e69a789183f3 h1:UsOBnj2jml7dVI4DuvJyF97wBMNvK+rZ4Zw53n325QA=
 github.com/decred/dcrd/dcrec v0.0.0-20190413175304-e69a789183f3/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
@@ -58,6 +59,7 @@ github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721031028-5369a485acf6/go.mod h
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20181208004914-a0816cf4301f/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5 h1:qA+q5URxOMLCts1hTsNlXfOOtT2d83b3Z597yupIn5A=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
+github.com/decred/dcrd/dcrec/edwards v0.0.0-20190402182842-879eebce3333 h1:6Z3TuqdknGNISdaxQscCYUzl5fS1lMBF+By4u3xNuWQ=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190402182842-879eebce3333/go.mod h1:HblVh1OfMt7xSxUL1ufjToaEvpbjpWvvTAUx4yem8BI=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190413175304-e69a789183f3 h1:1wv0uKVmJPop93YuyJeornJJVzP0613X5keCU4xLKT0=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190413175304-e69a789183f3/go.mod h1:HblVh1OfMt7xSxUL1ufjToaEvpbjpWvvTAUx4yem8BI=
@@ -109,6 +111,8 @@ github.com/decred/dcrdata/txhelpers v1.0.1/go.mod h1:oZOlm7v82oD5SIy1wlOBG0OT92C
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190415153927-351272ba94ab/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790 h1:hmGinC7kJ0kGjw6fNSfpFPIZaguZqbshDYAnFby8vxM=
 github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416155607-25afe5d5e790/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
+github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f h1:UHK/F4XLVGFisd1qbP8ILmJG8AM6ShzgfhCTNH/iExw=
+github.com/decred/dcrdata/txhelpers v1.0.2-0.20190416204615-70a58657e02f/go.mod h1:IyxuqUxIPrHnOmRy9DCl90oqw7FxYHde/fkIkF21B7w=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0 h1:FPVohgxZHHwi7qTOBki/Dw9j5cgGsZYiktGSfgqHR0w=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0/go.mod h1:k+IOPnUY0YqlwhSDhczzaUN17NX/gMtztwl3UxKgVZY=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
@@ -174,6 +178,7 @@ golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a h1:Igim7XhdOpBnWPuYJ70XcNpq8q3BCACtVgNfoJxOV7g=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -940,6 +940,10 @@ func CountMergedRowsCompact(rows []*AddressRowCompact, txnView AddrTxnViewType) 
 // positive). MergedRows will return a non-nil error of a merged row is detected
 // in the input since only non-merged rows are expected.
 func MergeRows(rows []*AddressRow) ([]*AddressRowMerged, error) {
+	// The number of unique transaction hashes is not known from the input since
+	// an address may have multiple appearances in a given transaction. Still
+	// pre-allocate, since we have an idea of the ballpark size of the result,
+	// but try not to overshoot as space will be wasted.
 	numUniqueHashesGuess := len(rows)*2/3 + 1
 	hashMap := make(map[chainhash.Hash]*AddressRowMerged, numUniqueHashesGuess)
 	mergedRows := make([]*AddressRowMerged, 0, numUniqueHashesGuess)
@@ -999,6 +1003,10 @@ func MergeRows(rows []*AddressRow) ([]*AddressRowMerged, error) {
 // positive or not, although the Value function returns an absolute value
 // (always positive).
 func MergeRowsCompact(rows []*AddressRowCompact) []*AddressRowMerged {
+	// The number of unique transaction hashes is not known from the input since
+	// an address may have multiple appearances in a given transaction. Still
+	// pre-allocate, since we have an idea of the ballpark size of the result,
+	// but try not to overshoot as space will be wasted.
 	numUniqueHashesGuess := len(rows)*2/3 + 1
 	hashMap := make(map[chainhash.Hash]*AddressRowMerged, numUniqueHashesGuess)
 	mergedRows := make([]*AddressRowMerged, 0, numUniqueHashesGuess)

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -896,7 +896,7 @@ func CountMergedRows(rows []*AddressRow, txnView AddrTxnViewType) (numMerged int
 
 // CountMergedRowsCompact counts the number of merged rows that would result
 // from calling MergeRowsCompact (a non-merged row) on the input slice.
-func CountMergedRowsCompact(rows []AddressRowCompact, txnView AddrTxnViewType) (numMerged int, err error) {
+func CountMergedRowsCompact(rows []*AddressRowCompact, txnView AddrTxnViewType) (numMerged int, err error) {
 	var wrongDirection func(funding bool) bool
 	switch txnView {
 	case AddrMergedTxn:
@@ -916,12 +916,12 @@ func CountMergedRowsCompact(rows []AddressRowCompact, txnView AddrTxnViewType) (
 	}
 
 	merged := make(map[chainhash.Hash]struct{})
-	for i := range rows {
-		if wrongDirection(rows[i].IsFunding) {
+	for _, row := range rows {
+		if wrongDirection(row.IsFunding) {
 			continue
 		}
 
-		hash := rows[i].TxHash
+		hash := row.TxHash
 		_, found := merged[hash]
 		if !found {
 			numMerged++
@@ -939,27 +939,25 @@ func CountMergedRowsCompact(rows []AddressRowCompact, txnView AddrTxnViewType) (
 // positive or not, although the Value field is an absolute value (always
 // positive). MergedRows will return a non-nil error of a merged row is detected
 // in the input since only non-merged rows are expected.
-func MergeRows(rows []*AddressRow) ([]AddressRowMerged, error) {
-	hashes := make([]chainhash.Hash, 0, len(rows))
-	merged := make(map[chainhash.Hash]*AddressRowMerged)
+func MergeRows(rows []*AddressRow) ([]*AddressRowMerged, error) {
+	numUniqueHashesGuess := len(rows)*2/3 + 1
+	hashMap := make(map[chainhash.Hash]*AddressRowMerged, numUniqueHashesGuess)
+	mergedRows := make([]*AddressRowMerged, 0, numUniqueHashesGuess)
 	for _, r := range rows {
 		if r.MergedCount != 0 {
 			return nil, fmt.Errorf("MergeRows: merged row found in input; " +
 				"only non-merged rows may be merged")
 		}
-		hash := r.TxHash
 
-		Hash, err := chainhash.NewHashFromStr(hash)
+		Hash, err := chainhash.NewHashFromStr(r.TxHash)
 		if err != nil {
-			fmt.Printf("invalid address: %s", hash)
+			fmt.Printf("invalid address: %s", r.TxHash)
 			continue
 		}
 
 		// New transactions are started with MergedCount = 1.
-		row := merged[*Hash]
+		row := hashMap[*Hash]
 		if row == nil {
-			hashes = append(hashes, *Hash)
-
 			mr := AddressRowMerged{
 				Address:        r.Address,
 				TxBlockTime:    r.TxBlockTime.T.Unix(),
@@ -975,11 +973,12 @@ func MergeRows(rows []*AddressRow) ([]AddressRowMerged, error) {
 				mr.AtomsDebit = r.Value
 			}
 
-			merged[*Hash] = &mr
+			hashMap[*Hash] = &mr
+			mergedRows = append(mergedRows, &mr)
 			continue
 		}
 
-		// Update existing transaction.
+		// Update existing transaction in the mergedRows slice.
 		row.MergedCount++
 		if r.IsFunding {
 			row.AtomsCredit += r.Value
@@ -988,32 +987,25 @@ func MergeRows(rows []*AddressRow) ([]AddressRowMerged, error) {
 		}
 	}
 
-	// Build the slice.
-	mergedRows := make([]AddressRowMerged, 0, len(merged))
-	for i := range hashes {
-		mergedRows = append(mergedRows, *merged[hashes[i]])
-	}
+	//fmt.Printf("MergeRows: guess = %d, actual = %d\n", numUniqueHashesGuess, len(mergedRows))
 
 	return mergedRows, nil
 }
 
-// MergeRowsCompact converts a []AddressRowCompact (non-merged rows) into a
+// MergeRowsCompact converts a []*AddressRowCompact (non-merged rows) into a
 // slice of merged address rows. This involves merging rows with the same
 // transaction hash into a single entry by combining the signed values. The
 // IsFunding function of an AddressRowMerged indicates if the net value is
 // positive or not, although the Value function returns an absolute value
 // (always positive).
-func MergeRowsCompact(rows []AddressRowCompact) []AddressRowMerged {
-	hashes := make([]chainhash.Hash, 0, len(rows))
-	merged := make(map[chainhash.Hash]*AddressRowMerged)
-	for i := range rows {
-		r := &rows[i]
-
+func MergeRowsCompact(rows []*AddressRowCompact) []*AddressRowMerged {
+	numUniqueHashesGuess := len(rows)*2/3 + 1
+	hashMap := make(map[chainhash.Hash]*AddressRowMerged, numUniqueHashesGuess)
+	mergedRows := make([]*AddressRowMerged, 0, numUniqueHashesGuess)
+	for _, r := range rows {
 		// New transactions are started with MergedCount = 1.
-		row := merged[r.TxHash]
+		row := hashMap[r.TxHash]
 		if row == nil {
-			hashes = append(hashes, r.TxHash)
-
 			mr := AddressRowMerged{
 				Address:        r.Address,
 				TxBlockTime:    r.TxBlockTime,
@@ -1029,7 +1021,8 @@ func MergeRowsCompact(rows []AddressRowCompact) []AddressRowMerged {
 				mr.AtomsDebit = r.Value
 			}
 
-			merged[r.TxHash] = &mr
+			hashMap[r.TxHash] = &mr
+			mergedRows = append(mergedRows, &mr)
 			continue
 		}
 
@@ -1042,16 +1035,22 @@ func MergeRowsCompact(rows []AddressRowCompact) []AddressRowMerged {
 		}
 	}
 
-	// Build the slice.
-	mergedRows := make([]AddressRowMerged, 0, len(merged))
-	for i := range hashes {
-		mergedRows = append(mergedRows, *merged[hashes[i]])
-	}
+	//fmt.Printf("MergeRowsCompact: guess = %d, actual = %d\n", numUniqueHashesGuess, len(mergedRows))
 
 	return mergedRows
 }
 
-func MergeRowsCompactRange(rows []AddressRowCompact, N, offset int, txnView AddrTxnViewType) []AddressRowMerged {
+// MergeRowsCompactRange is like MergeRowsCompact except it extracts and
+// converts a range of []*AddressRowCompact (non-merged rows) into a slice of
+// merged address rows. This involves merging rows with the same transaction
+// hash into a single entry by combining the signed values. The IsFunding
+// function of an AddressRowMerged indicates if the net value is positive or
+// not, although the Value function returns an absolute value (always positive).
+// The range is specified by offset (results to skip) and N (number of results
+// to include). Note that offset applies to a hypothetical full results slice
+// where there are no repeated transaction hashes rather than to the input slice
+// where there may be repeated hashes.
+func MergeRowsCompactRange(rows []*AddressRowCompact, N, offset int, txnView AddrTxnViewType) []*AddressRowMerged {
 	// Check for invalid count and offset.
 	if offset < 0 || N < 0 {
 		return nil
@@ -1072,45 +1071,41 @@ func MergeRowsCompactRange(rows []AddressRowCompact, N, offset int, txnView Addr
 	// Quick return when no data requested or provided. This intercepts
 	// rows==nil.
 	if N == 0 || len(rows) == 0 {
-		return []AddressRowMerged{}
+		return []*AddressRowMerged{}
 	}
 
-	// Skip over the first offset tx hashes.
+	// Skip over the first offset unique tx hashes.
 	var skipped int
 	seen := make(map[chainhash.Hash]struct{}, offset)
 
 	// Output has at most N elements, each with a unique hash.
-	hashes := make([]chainhash.Hash, 0, N)
-	merged := make(map[chainhash.Hash]*AddressRowMerged, N)
-	for i := range rows {
-		r := &rows[i]
-
+	hashMap := make(map[chainhash.Hash]*AddressRowMerged, N)
+	mergedRows := make([]*AddressRowMerged, 0, N)
+	for _, r := range rows {
 		if wrongDirection(r.IsFunding) {
 			continue
 		}
 
 		// Newly encountered tx hash starts a new merged row.
-		row := merged[r.TxHash]
+		row := hashMap[r.TxHash]
 		if row == nil {
 			// Do not get beyond N merged rows, but continue looking for more
 			// data to merge.
-			if len(merged) == N {
+			if len(mergedRows) == N {
 				continue
 			}
 
 			// Skip over offset merged rows.
 			if skipped < offset {
 				if _, found := seen[r.TxHash]; !found {
-					// Would create a new merged row. Incremend the skip counter
-					// and register this tx hash.
+					// This new hash would create a new merged row. Increment
+					// the skip counter and register this tx hash.
 					skipped++
 					seen[r.TxHash] = struct{}{}
 				}
 				// Skip this merged row data.
 				continue
 			}
-
-			hashes = append(hashes, r.TxHash)
 
 			mr := AddressRowMerged{
 				Address:        r.Address,
@@ -1127,7 +1122,8 @@ func MergeRowsCompactRange(rows []AddressRowCompact, N, offset int, txnView Addr
 				mr.AtomsDebit = r.Value
 			}
 
-			merged[r.TxHash] = &mr
+			hashMap[r.TxHash] = &mr
+			mergedRows = append(mergedRows, &mr)
 			continue
 		}
 
@@ -1140,19 +1136,12 @@ func MergeRowsCompactRange(rows []AddressRowCompact, N, offset int, txnView Addr
 		}
 	}
 
-	// Build the slice.
-	mergedRows := make([]AddressRowMerged, 0, len(merged))
-	// Range over the hashes slice to keep the same order.
-	for i := range hashes {
-		mergedRows = append(mergedRows, *merged[hashes[i]])
-	}
-
 	return mergedRows
 }
 
-// CompactRows converts a []*AddressRow to a []AddressRowCompact.
-func CompactRows(rows []*AddressRow) []AddressRowCompact {
-	compact := make([]AddressRowCompact, 0, len(rows))
+// CompactRows converts a []*AddressRow to a []*AddressRowCompact.
+func CompactRows(rows []*AddressRow) []*AddressRowCompact {
+	compact := make([]*AddressRowCompact, 0, len(rows))
 	for _, r := range rows {
 		hash, err := chainhash.NewHashFromStr(r.TxHash)
 		if err != nil {
@@ -1160,7 +1149,7 @@ func CompactRows(rows []*AddressRow) []AddressRowCompact {
 			return nil
 		}
 		mhash, _ := chainhash.NewHashFromStr(r.MatchingTxHash) // zero array on error
-		compact = append(compact, AddressRowCompact{
+		compact = append(compact, &AddressRowCompact{
 			Address:        r.Address,
 			TxBlockTime:    r.TxBlockTime.UNIX(),
 			MatchingTxHash: *mhash,
@@ -1178,10 +1167,9 @@ func CompactRows(rows []*AddressRow) []AddressRowCompact {
 // UncompactRows converts (to the extent possible) a []AddressRowCompact to a
 // []*AddressRow. VinVoutDbID is unknown and set to zero. Do not use
 // VinVoutDbID, or insert the AddressRow.
-func UncompactRows(compact []AddressRowCompact) []*AddressRow {
+func UncompactRows(compact []*AddressRowCompact) []*AddressRow {
 	rows := make([]*AddressRow, 0, len(compact))
-	for i := range compact {
-		r := &compact[i]
+	for _, r := range compact {
 		// An unset matching hash is represented by the zero-value array.
 		var matchingHash string
 		if !txhelpers.IsZeroHash(r.MatchingTxHash) {
@@ -1206,10 +1194,9 @@ func UncompactRows(compact []AddressRowCompact) []*AddressRow {
 // UncompactMergedRows converts (to the extent possible) a []AddressRowMerged to
 // a []*AddressRow. VinVoutDbID is unknown and set to zero. Do not use
 // VinVoutDbID, or insert the AddressRow.
-func UncompactMergedRows(merged []AddressRowMerged) []*AddressRow {
+func UncompactMergedRows(merged []*AddressRowMerged) []*AddressRow {
 	rows := make([]*AddressRow, 0, len(merged))
-	for i := range merged {
-		r := &merged[i]
+	for _, r := range merged {
 		rows = append(rows, &AddressRow{
 			Address:        r.Address,
 			ValidMainChain: r.ValidMainChain,
@@ -1225,6 +1212,18 @@ func UncompactMergedRows(merged []AddressRowMerged) []*AddressRow {
 		})
 	}
 	return rows
+}
+
+// AddressTxnOutput is a compact version of api/types.AddressTxnOutput.
+type AddressTxnOutput struct {
+	Address  string
+	PkScript string
+	TxHash   chainhash.Hash
+	//BlockHash chainhash.Hash
+	Vout      uint32
+	Height    int32
+	BlockTime int64
+	Atoms     int64
 }
 
 // AddressMetrics defines address metrics needed to make decisions by which

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -229,13 +229,25 @@ func (pgb *ChainDB) BlockSummaryTimeRange(min, max int64, limit int) ([]dbtypes.
 }
 
 // AddressUTXO returns the unspent transaction outputs (UTXOs) paying to the
-// specified address in a []apitypes.AddressTxnOutput.
-func (pgb *ChainDB) AddressUTXO(address string) ([]apitypes.AddressTxnOutput, bool, error) {
+// specified address in a []*dbtypes.AddressTxnOutput.
+func (pgb *ChainDB) AddressUTXO(address string) ([]*dbtypes.AddressTxnOutput, bool, error) {
 	// Check the cache first.
 	bestHash, height := pgb.BestBlock()
 	utxos, validHeight := pgb.AddressCache.UTXOs(address)
 	if utxos != nil && *bestHash == validHeight.Hash {
 		return utxos, false, nil
+	}
+
+	// Cache is empty or stale.
+
+	// Make the pointed to AddressTxnOutput structs elegible for garbage
+	// collection. pgb.AddressCache.StoreUTXOs sets a new slice retrieved from
+	// the database, so we do not want to hang on to a copy of the old slice.
+	var oldUTXOs bool
+	if utxos != nil {
+		//nolint:ineffassign
+		utxos = nil
+		oldUTXOs = true // flag to clear them from cache if we update them
 	}
 
 	busy, wait, done := pgb.CacheLocks.utxo.TryLock(address)
@@ -257,18 +269,23 @@ func (pgb *ChainDB) AddressUTXO(address string) ([]apitypes.AddressTxnOutput, bo
 	// is clear.
 	defer done()
 
-	// Cache is empty or stale, so query the DB.
+	// Prior to performing the query, clear the old UTXOs to save memory.
+	if oldUTXOs {
+		pgb.AddressCache.ClearUTXOs(address)
+	}
+
+	// Query the DB for the current UTXO set for this address.
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
-	blockHeight := pgb.Height()
-	txnOutput, err := RetrieveAddressUTXOs(ctx, pgb.db, address, blockHeight)
+	txnOutputs, err := RetrieveAddressDbUTXOs(ctx, pgb.db, address)
 	if err != nil {
 		return nil, false, pgb.replaceCancelError(err)
 	}
 
 	// Update the address cache.
-	cacheUpdated := pgb.AddressCache.StoreUTXOs(address, txnOutput, cache.NewBlockID(bestHash, height))
-	return txnOutput, cacheUpdated, nil
+	cacheUpdated := pgb.AddressCache.StoreUTXOs(address, txnOutputs,
+		cache.NewBlockID(bestHash, height))
+	return txnOutputs, cacheUpdated, nil
 }
 
 // SpendDetailsForFundingTx will return the details of any spending transactions

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -240,7 +240,7 @@ func (pgb *ChainDB) AddressUTXO(address string) ([]*dbtypes.AddressTxnOutput, bo
 
 	// Cache is empty or stale.
 
-	// Make the pointed to AddressTxnOutput structs elegible for garbage
+	// Make the pointed to AddressTxnOutput structs eligible for garbage
 	// collection. pgb.AddressCache.StoreUTXOs sets a new slice retrieved from
 	// the database, so we do not want to hang on to a copy of the old slice.
 	var oldUTXOs bool

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1900,7 +1900,7 @@ func (pgb *ChainDB) AddressRowsMerged(address string) ([]*dbtypes.AddressRowMerg
 		return dbtypes.MergeRowsCompact(rowsCompact), nil
 	}
 
-	// Make the pointed to AddressRowMerged structs elegible for garbage
+	// Make the pointed to AddressRowMerged structs eligible for garbage
 	// collection. pgb.updateAddressRows sets a new AddressRowMerged slice
 	// retrieved from the database, so we do not want to hang on to a copy of
 	// the old data.
@@ -1935,7 +1935,7 @@ func (pgb *ChainDB) AddressRowsCompact(address string) ([]*dbtypes.AddressRowCom
 		return rowsCompact, nil
 	}
 
-	// Make the pointed to AddressRowCompact structs elegible for garbage
+	// Make the pointed to AddressRowCompact structs eligible for garbage
 	// collection. pgb.updateAddressRows sets a new AddressRowCompact slice
 	// retrieved from the database, so we do not want to hang on to a copy of
 	// the old data.
@@ -2843,7 +2843,7 @@ func (pgb *ChainDB) TxHistoryData(address string, addrChart dbtypes.HistoryChart
 		return
 	}
 
-	// Make the pointed to ChartsData elegible for garbage collection.
+	// Make the pointed to ChartsData eligible for garbage collection.
 	// pgb.AddressCache.StoreHistoryChart sets a new ChartsData retrieved from
 	// the database, so we do not want to hang on to a copy of the old data.
 	//nolint:ineffassign

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1459,9 +1459,9 @@ func countMerged(ctx context.Context, db *sql.DB, address, query string) (count 
 }
 
 // RetrieveAddressUTXOs gets the unspent transaction outputs (UTXOs) paying to
-// the specified address. The input current block height is used to compute
-// confirmations of the located transactions.
-func RetrieveAddressUTXOs(ctx context.Context, db *sql.DB, address string, currentBlockHeight int64) ([]apitypes.AddressTxnOutput, error) {
+// the specified address as a []*apitypes.AddressTxnOutput. The input current
+// block height is used to compute confirmations of the located transactions.
+func RetrieveAddressUTXOs(ctx context.Context, db *sql.DB, address string, currentBlockHeight int64) ([]*apitypes.AddressTxnOutput, error) {
 	stmt, err := db.Prepare(internal.SelectAddressUnspentWithTxn)
 	if err != nil {
 		log.Error(err)
@@ -1475,12 +1475,12 @@ func RetrieveAddressUTXOs(ctx context.Context, db *sql.DB, address string, curre
 	}
 	defer closeRows(rows)
 
-	var outputs []apitypes.AddressTxnOutput
+	var outputs []*apitypes.AddressTxnOutput
 	for rows.Next() {
 		pkScript := []byte{}
 		var blockHeight, atoms int64
 		var blockTime dbtypes.TimeDef
-		txnOutput := apitypes.AddressTxnOutput{}
+		txnOutput := new(apitypes.AddressTxnOutput)
 		if err = rows.Scan(&txnOutput.Address, &txnOutput.TxnID,
 			&atoms, &blockHeight, &blockTime, &txnOutput.Vout, &pkScript); err != nil {
 			log.Error(err)
@@ -1491,6 +1491,46 @@ func RetrieveAddressUTXOs(ctx context.Context, db *sql.DB, address string, curre
 		txnOutput.Satoshis = atoms
 		txnOutput.Height = blockHeight
 		txnOutput.Confirmations = currentBlockHeight - blockHeight + 1
+		outputs = append(outputs, txnOutput)
+	}
+
+	return outputs, nil
+}
+
+// RetrieveAddressDbUTXOs gets the unspent transaction outputs (UTXOs) paying to
+// the specified address as a []*dbtypes.AddressTxnOutput. The input current
+// block height is used to compute confirmations of the located transactions.
+func RetrieveAddressDbUTXOs(ctx context.Context, db *sql.DB, address string) ([]*dbtypes.AddressTxnOutput, error) {
+	stmt, err := db.Prepare(internal.SelectAddressUnspentWithTxn)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	rows, err := stmt.QueryContext(ctx, address)
+	_ = stmt.Close()
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	defer closeRows(rows)
+
+	var outputs []*dbtypes.AddressTxnOutput
+	for rows.Next() {
+		pkScript := []byte{}
+		var txHash string
+		var blockTime dbtypes.TimeDef
+		txnOutput := new(dbtypes.AddressTxnOutput)
+		if err = rows.Scan(&txnOutput.Address, &txHash,
+			&txnOutput.Atoms, &txnOutput.Height, &blockTime,
+			&txnOutput.Vout, &pkScript); err != nil {
+			log.Error(err)
+		}
+		txnOutput.BlockTime = blockTime.UNIX()
+		err = chainhash.Decode(&txnOutput.TxHash, txHash)
+		if err != nil {
+			log.Error(err)
+		}
+		txnOutput.PkScript = hex.EncodeToString(pkScript)
 		outputs = append(outputs, txnOutput)
 	}
 

--- a/dev/heap_in_use.m
+++ b/dev/heap_in_use.m
@@ -1,0 +1,9 @@
+heapuse=[];
+h=figure;
+ax=axes('parent',h);
+while true,
+  [s,out] = system("dcrps memstats dcrdata | grep heap-in-use | awk '{print $3}' | sed 's/(//'");
+  heapuse(end+1)=str2double(out);
+  plot(ax, heapuse); drawnow
+  pause(0.05)
+end

--- a/dev/heap_in_use.m
+++ b/dev/heap_in_use.m
@@ -1,9 +1,18 @@
-heapuse=[];
-h=figure;
-ax=axes('parent',h);
+% This will continuously plot HeapInUse for a process named "dcrdata". The dcrps
+% binary is required. Install it with "go get github.com/dcrlabs/dcrps".
+
+% Try to get the GOPATH environment variable, but if it is not available
+% Octave/MATLAB, it may be necessary setenv('GOPATH','/path/to/gopath') before
+% calling this script, or to define the dcrps math manually here.
+dcrps = [fullfile(getenv('GOPATH'), '/bin/dcrps')];
+%dcrps = '/path/to/dcrps';
+printf('Using dcrps at \"%s\"\n', dcrps)
+heapuse = [];
+h = figure;
+ax = axes('parent',h);
 while true,
-  [s,out] = system("dcrps memstats dcrdata | grep heap-in-use | awk '{print $3}' | sed 's/(//'");
-  heapuse(end+1)=str2double(out);
-  plot(ax, heapuse); drawnow
+  [s,out] = system([dcrps  ' memstats dcrdata | grep heap-in-use | awk ''{print $3}'' | sed ''s/(//''']);
+  heapuse(end+1) = str2double(out);
+  plot(ax, heapuse, 'linewidth', 2); drawnow
   pause(0.05)
 end


### PR DESCRIPTION
### In-flight address UTXOs

The Insight API's `/addr/{address}/utxo` endpoint can consume excessive memory
for addresses with many UTXOs.  This imposes a limit on the number of "in-flight"
UTXOs to restrict how much memory can be consumed at the request of a client.

The `.../utxo` endpoint is handed by `(*InsightApi).getAddressesTxnOutput`, to which
these edits add in-flight UTXO counting and limiting.  To do this, a new field is added to
`InsightApi` called `inflightUTXOs` that tracks how many UTXOs are currently loaded
from DB queries by the `getAddressesTxnOutput` method.

Limiting is implemented by:
1. Restricting the number of address UTXO queries to one (1) concurrent request with a `Mutex`.
2. Atomically updating the `inflightUTXOs` counter while the lock is still held.
3. Checking if the counter is over a global limit.
   - If the counter is over the limit, hold the lock until the http handler (including JSON
   marshaling) completes. This handler call has gained "priority" status.
   - If the counter is not over the limit, release the lock for other concurrent requests.
4. When the http handler completes, decrement the total in-flight UTXOs by the
  number processed by the returning handler.

### Cache memory management

* Create a new `dbtypes.AddressTxnOutput` type for caching instead of using the `api/types.AddressTxnOutput` type that is very inefficient in several respects. Add the `RetrieveAddressDbUTXOs` function for returning an address' UTXOs in this type.
* Change the cached address rows and UTXOs to slices of pointers to structs instead of slices of structs (e.g. `[]*dbtypes.AddressRowCompact` instead of `[]dbtypes.AddressRowCompact`).  This allows fewer copies in places, particularly in `debitAddressRowsMerged` and `creditAddressRowsMerged`.
* Avoid a second `range map` loop in `MergeRows`, `MergeRowsCompact`, and `MergeRowsCompactRange`.
* In `(*ChainDB).AddressUTXO`, make cached data eligible for garbage collection before performing the update queries that generate data that will just replace the cached data. See the added `(*AddressCache).ClearRows` and `(*AddressCache).ClearUTXOs` functions.
* Also in `AddressUTXO`, set the local copy of the UTXOs slice to `nil` before trying to obtain the update lock (or waiting for another updater goroutine).
* Add a GNU Octave script for live plotting heap-in-use (`runtime.MemStats.HeapInuse`). Uses [`dcrps`](https://github.com/dcrlabs/dcrps) and requires the binary to be called "dcrdata".