### PR TITLE
[4.1] Change the reverse chronologically sorting url to return new data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/decred/dcrdata/v4
 
-replace github.com/decred/dcrdata/gov/agendas => ./gov/agendas
-
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
@@ -21,8 +19,8 @@ require (
 	github.com/decred/dcrdata/db/dcrsqlite/v2 v2.0.0
 	github.com/decred/dcrdata/exchanges v1.0.0
 	github.com/decred/dcrdata/explorer/types v1.0.1
-	github.com/decred/dcrdata/gov/agendas v1.1.0
-	github.com/decred/dcrdata/gov/politeia v1.1.0
+	github.com/decred/dcrdata/gov/agendas v1.1.1-0.20190519161030-ce42628f6d7c
+	github.com/decred/dcrdata/gov/politeia v1.1.1-0.20190519161030-ce42628f6d7c
 	github.com/decred/dcrdata/mempool/v2 v2.0.0
 	github.com/decred/dcrdata/middleware/v2 v2.0.2-0.20190506145717-84bca771d7bf
 	github.com/decred/dcrdata/pubsub v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -183,10 +183,10 @@ github.com/decred/dcrdata/exchanges v1.0.0 h1:+Wlq8gIsjwbzzNTyMcmm0lf/joP1fYPr8E
 github.com/decred/dcrdata/exchanges v1.0.0/go.mod h1:b34x8boSFo0z0pndmkKS13dEFiRRMzSYU8AHns7W/JM=
 github.com/decred/dcrdata/explorer/types v1.0.1 h1:GAMnVy1KDwq7GqC1AYKaR+Msl70Tv0GYy5TH6bMJpEM=
 github.com/decred/dcrdata/explorer/types v1.0.1/go.mod h1:QPKurkX8v7UshmXgZS3VOzuIrU4hoCBac8Mt4YxgYYs=
-github.com/decred/dcrdata/gov/agendas v1.1.0 h1:XOnA7JgvVtnfq0PTSGn2XkWmjGa6ZWn4PLl8Qi8gUXg=
-github.com/decred/dcrdata/gov/agendas v1.1.0/go.mod h1:wXOs/PT0LzusDzdxRXWaKwE3EIHz9uUUt/0mfC/V6CA=
-github.com/decred/dcrdata/gov/politeia v1.1.0 h1:Dhc97ojB4eCafc99A/DsHMdaSY3NR/mGLNAwoWTl7RM=
-github.com/decred/dcrdata/gov/politeia v1.1.0/go.mod h1:ckcQHZS6Vd1dD5tImwMzBTJa/Hw6GLTNU9km0uw7gH4=
+github.com/decred/dcrdata/gov/agendas v1.1.1-0.20190519161030-ce42628f6d7c h1:XjBwKwvhRdIuAkucnMLJqgHMMaGM8QPFaGokAfTkv2Y=
+github.com/decred/dcrdata/gov/agendas v1.1.1-0.20190519161030-ce42628f6d7c/go.mod h1:wXOs/PT0LzusDzdxRXWaKwE3EIHz9uUUt/0mfC/V6CA=
+github.com/decred/dcrdata/gov/politeia v1.1.1-0.20190519161030-ce42628f6d7c h1:N3wrei8UPraMA5uD1+MSoCIq2copG8WJMP2oo8oFpKg=
+github.com/decred/dcrdata/gov/politeia v1.1.1-0.20190519161030-ce42628f6d7c/go.mod h1:ckcQHZS6Vd1dD5tImwMzBTJa/Hw6GLTNU9km0uw7gH4=
 github.com/decred/dcrdata/mempool/v2 v2.0.0 h1:GZHL8UgsCWiamfCSUQ4DY/aB6m4OXYbylMc0WxOQjc0=
 github.com/decred/dcrdata/mempool/v2 v2.0.0/go.mod h1:FIRHQCgF92I/picVJ4lccrLn/c6IsmHx5hZot1Tok3k=
 github.com/decred/dcrdata/middleware/v2 v2.0.2-0.20190506145717-84bca771d7bf h1:5KyZIq6hC15Qk6e8u0HMt4fUPDoNer74vvQ8JyQ+L8g=

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -119,8 +119,7 @@ func (db *ProposalDB) saveProposals(URLParams string) (int, error) {
 			break
 		}
 
-		copyURLParams = fmt.Sprintf("%s?after=%v", URLParams,
-			data.Data[pageSize-1].Censorship.Token)
+		copyURLParams = fmt.Sprintf("?before=%v", data.Data[pageSize-1].Censorship.Token)
 	}
 
 	// Save all the proposals
@@ -220,7 +219,7 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 
 	var queryParam string
 	if len(lastProposal) > 0 && lastProposal[0].Censorship.Token != "" {
-		queryParam = fmt.Sprintf("?after=%s", lastProposal[0].Censorship.Token)
+		queryParam = fmt.Sprintf("?before=%s", lastProposal[0].Censorship.Token)
 	}
 
 	n, err := db.saveProposals(queryParam)
@@ -237,7 +236,7 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 }
 
 func (db *ProposalDB) lastSavedProposal() (lastP []*pitypes.ProposalInfo, err error) {
-	err = db.dbP.All(&lastP, storm.Limit(1), storm.Reverse())
+	err = db.dbP.Select().Limit(1).OrderBy("Timestamp").Reverse().Find(&lastP)
 	return
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/decred/dcrdata/pull/1352 to 4.1-stable.

It is presently deployed to https://explorer.dcrdata.org/proposals.