### PR TITLE
Piparser: Complete its decoupling the in case of its failure

### DIFF
--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -132,6 +132,10 @@ func mainCore() error {
 		return err
 	}
 
+	// SetPiParserValidity sets the invalid parser flag if a nil parser instance
+	// was found.
+	dcrpg.SetPiParserValidity(parser == nil)
+
 	// Construct a ChainDB without a stakeDB to allow quick dropping of tables.
 	mpChecker := rpcutils.NewMempoolAddressChecker(client, activeChain)
 	db, err := dcrpg.NewChainDB(&dbi, activeChain, nil, false, cfg.HidePGConfig, 0,

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -320,7 +320,7 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 	// Retrieve and update any new proposals created since the previous
 	// proposals were stored in the db.
 	lastProposal, err := db.lastSavedProposal()
-	if err != nil {
+	if err != nil && err != storm.ErrNotFound {
 		return fmt.Errorf("lastSavedProposal failed: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -185,6 +185,10 @@ func _main(ctx context.Context) error {
 		log.Error(err)
 	}
 
+	// SetPiParserValidity sets the invalid parser flag if a nil parser instance
+	// was found.
+	dcrpg.SetPiParserValidity(parser == nil)
+
 	// Auxiliary DB (PostgreSQL)
 	var newPGIndexes, updateAllAddresses, updateAllVotes bool
 	pgHost, pgPort := cfg.PGHost, ""

--- a/public/js/controllers/proposal_controller.js
+++ b/public/js/controllers/proposal_controller.js
@@ -10,6 +10,7 @@ let common = {
   fillGraph: true,
   strokeWidth: 2,
   gridLineColor: '#C4CBD2',
+  labelsUTC: true,
   legendFormatter: legendFormatter
 }
 

--- a/views/agenda.tmpl
+++ b/views/agenda.tmpl
@@ -1,7 +1,7 @@
 {{define "agenda"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Vote Agenda Pages"}}
+    {{template "html-head" printf "Decred Agenda Charts"}}
         {{template "navbar" .}}
         {{with .Ai}}
         <div class="container main">

--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -1,7 +1,7 @@
 {{define "proposal"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Vote Proposal Pages"}}
+    {{template "html-head" printf "Decred Proposal Charts"}}
         {{template "navbar" .}}
         {{with .Data}}
         <div class="container">


### PR DESCRIPTION
Shielding the dcrdata from errors obtained from piparser wasn't fixed conclusively before. When I had some internet outage earlier today, dcrdata crashed because of the nil parser instance value passed though the `ProposalsFetcher` interface.
Instead of using `reflect` package to check if the interface has a nil value, a parser validity flag is set when the parser instance created is nil.

Proposals charts were set to display on the correct UTC time instead of the browser's timezone.
