### PR TITLE
proposal listing: Add tooltip to the vote status

### DIFF
--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -124,23 +124,27 @@
                                     <span class="text-abandoned">
                                         In Discussion
                                     </span>
+                                {{else if eq (len .VoteResults) 0 }}
+                                    <span class="text-progress">
+                                        In Progress
+                                    </span>
                                 {{else}}
                                     {{range $i, $vr := .VoteResults}}
                                         {{if eq $vr.Option.OptionID "yes"}}
                                             {{$votesPercent :=  percentage $vr.VotesReceived $v.TotalVotes}}
                                             {{if lt $.Tip.Height (toInt $v.Endheight)}}
-                                                <span class="text-progress">
+                                                <span class="text-progress position-relative" data-tooltip="Vote Status (approval %)">
                                                     In Progress ({{printf "%.0f" ($votesPercent)}}%)
                                                 </span>
                                             {{else if lt (percentage $v.TotalVotes $v.NumOfEligibleVotes) (toFloat64 $v.QuorumPercentage)}}
                                                 <span class="text-no-quorum">No quorum</span>
                                             {{else}}
                                                 {{if lt $votesPercent (toFloat64 $v.PassPercentage)}}
-                                                    <span class="text-failed">
+                                                    <span class="text-failed position-relative" data-tooltip="Vote Status (approval %)">
                                                         Failed ({{printf "%.0f" ($votesPercent)}}%)
                                                     </span>
                                                 {{else}}
-                                                    <span class="text-green">
+                                                    <span class="text-green position-relative" data-tooltip="Vote Status (approval %)">
                                                         Passed ({{printf "%.0f" ($votesPercent)}}%)
                                                     </span>
                                                 {{end}}


### PR DESCRIPTION
Added a tooltip to the proposal vote status column for the entries showing the approval percentage.

![Screenshot from 2019-06-04 14-50-54](https://user-images.githubusercontent.com/22055953/58877788-55ae7580-86da-11e9-984e-bbe299b4f372.png)

Added the `In Discussion` vote status to include the period when the proposal has been approved but no votes exist yet.