### PR TITLE
pubsub/explorer: leave the HubRelay channels opened

### DIFF
--- a/pubsub/websocket.go
+++ b/pubsub/websocket.go
@@ -283,10 +283,7 @@ func (wsh *WebsocketHub) pingClients() chan<- struct{} {
 			select {
 			case <-ticker.C:
 				wsh.HubRelay <- pstypes.HubMessage{Signal: sigPingAndUserCount}
-			case _, ok := <-stopPing:
-				if ok {
-					log.Errorf("Do not send on stopPing channel, only close it.")
-				}
+			case <-stopPing:
 				return
 			}
 		}
@@ -298,10 +295,9 @@ func (wsh *WebsocketHub) pingClients() chan<- struct{} {
 // Stop kills the run() loop and unregisters all clients (connections).
 func (wsh *WebsocketHub) Stop() {
 	// End the run() loop, allowing in progress operations to complete.
-	wsh.quitWSHandler <- struct{}{}
-	// Lastly close the hub relay channel sine the quitWSHandler signal is
-	// handled in the Run loop.
-	close(wsh.HubRelay)
+	close(wsh.quitWSHandler)
+	// Do not close HubRelay since there are multiple senders; Run() is the
+	// receiver.
 }
 
 // Run starts the main event loop, which handles the following: 1. receiving
@@ -429,13 +425,7 @@ func (wsh *WebsocketHub) Run() {
 		case c := <-wsh.Unregister:
 			wsh.unregisterClient(c)
 
-		case _, ok := <-wsh.quitWSHandler:
-			if !ok {
-				log.Error("close channel already closed. This should not happen.")
-				return
-			}
-			close(wsh.quitWSHandler)
-
+		case <-wsh.quitWSHandler:
 			// End the buffer interval send loop,
 			wsh.bufferTickerChan <- tickerSigStop
 


### PR DESCRIPTION
This resolves shutdown races that could cause panics in rare cases.

There are multiple goroutines that send to `HubRelay` in both the pubsub
and explorer packages.  The `WebsocketHub` is the receiver, but there are
other senders. Closing the channel is not necessary to terminate the run
loops.  Since the senders have alternate select cases to prevent indefinitely
blocking, the solution is to not close the channel.

Also, to quit the run loops, `Stop()` now closes `quitWSHandler` instead of
sending on it.  There are NO senders, only a receiver.