### PR TITLE
piparser: Add piparser disable flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -124,6 +124,7 @@ type config struct {
 	ChartsCacheDump    string `long:"chartscache" description:"Defines the file name that holds the charts cache data on system exit."`
 	PiPropRepoOwner    string `long:"piproposalsowner" description:"Defines the owner to the github repo where Politeia's proposals are pushed."`
 	PiPropRepoName     string `long:"piproposalsrepo" description:"Defines the name of the github repo where Politeia's proposals are pushed."`
+	DisablePiParser    bool   `long:"disable-piparser" description:"Disables the piparser tool from running."`
 
 	PurgeNBestBlocks int  `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
 	FastSQLitePurge  bool `long:"fast-sqlite-purge" description:"Purge all data for the blocks above the specified height."`

--- a/config.go
+++ b/config.go
@@ -519,6 +519,9 @@ func loadConfig() (*config, error) {
 	if cfg.SimNet {
 		activeNet = &netparams.SimNetParams
 		activeChain = &chaincfg.SimNetParams
+
+		// If on simnet, disable piparser tool automatically.
+		cfg.DisablePiParser = true
 		numNets++
 	}
 	if numNets > 1 {

--- a/config_test.go
+++ b/config_test.go
@@ -234,6 +234,19 @@ func TestDefaultConfigTestNetWithEnvAndBadValue(t *testing.T) {
 	}
 }
 
+func TestDisablePiparserValueOnSimnet(t *testing.T) {
+	os.Args = append(os.Args, "--simnet")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Errorf("expected to find no error but found: %v", err)
+	}
+
+	if !cfg.DisablePiParser {
+		t.Fatal("expected DisablePiParser value to be activated but it wasn't")
+	}
+}
+
 func TestRetrieveRootPath(t *testing.T) {
 	type testData struct {
 		RawURL   string

--- a/db/dbtypes/go.sum
+++ b/db/dbtypes/go.sum
@@ -97,6 +97,7 @@ github.com/decred/dcrdata/db/cache v1.0.1/go.mod h1:WPkmV72Cal2OOjt4bG35XrjzSqsp
 github.com/decred/dcrdata/db/dbtypes v1.0.1/go.mod h1:d9qVcMl+l5rOEY7zJB5nqQ0WDEHof9vWlW/9hpK0xpc=
 github.com/decred/dcrdata/db/dbtypes v1.0.2-0.20190416155607-25afe5d5e790/go.mod h1:yPNF/Tsj3pLBxofu2Pr70hqejMYpCZHvcudkexvq0hQ=
 github.com/decred/dcrdata/db/dbtypes v1.0.2-0.20190416204615-70a58657e02f/go.mod h1:yPNF/Tsj3pLBxofu2Pr70hqejMYpCZHvcudkexvq0hQ=
+github.com/decred/dcrdata/db/dcrpg v1.0.0/go.mod h1:b1YmLNZH2p7evVJU6hapsW5Mup5Xtvx3OK48jQa6PYE=
 github.com/decred/dcrdata/rpcutils v1.0.1 h1:6QRdrsD71sfhQbDp6wMt3tgsck+0MW0N7bB4ZnWL7mA=
 github.com/decred/dcrdata/rpcutils v1.0.1/go.mod h1:ZQ3lZzgIiyE75+4CL3d8rDGJZLxd+ftbgWX1jAPSco8=
 github.com/decred/dcrdata/rpcutils v1.0.2-0.20190416204615-70a58657e02f h1:nXVy/hPkQdOl6T/ZbuK+nJPsQrYQZMSEzjK7zNHYQWk=

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1180,9 +1180,9 @@ func (pgb *ChainDB) VotesInBlock(hash string) (int16, error) {
 // proposalsUpdateHandler runs in the background asynchronous to retrieve the
 // politeia proposal updates that the piparser tool signaled.
 func (pgb *ChainDB) proposalsUpdateHandler() {
-	// Do not initiate the async update if invalid piparser instance was found.
+	// Do not initiate the async update if invalid or disabled piparser instance was found.
 	if pgb.piparser == nil {
-		log.Error("invalid piparser instance was found: async update stopped")
+		log.Error("invalid or disabled piparser instance found: proposals async update stopped")
 		return
 	}
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -112,8 +112,8 @@ type explorerDataSource interface {
 	LastPiParserSync() time.Time
 }
 
-// politeiaBackend implements methods that manage proposals db data.
-type politeiaBackend interface {
+// PoliteiaBackend implements methods that manage proposals db data.
+type PoliteiaBackend interface {
 	LastProposalsSync() int64
 	CheckProposalsUpdates() error
 	AllProposals(offset, rowsCount int, filterByVoteStatus ...int) (proposals []*pitypes.ProposalInfo, totalCount int, err error)
@@ -202,7 +202,7 @@ type explorerUI struct {
 	explorerSource   explorerDataSource
 	agendasSource    agendaBackend
 	voteTracker      *agendas.VoteTracker
-	proposalsSource  politeiaBackend
+	proposalsSource  PoliteiaBackend
 	dbsSyncing       atomic.Value
 	devPrefetch      bool
 	templates        templates
@@ -281,7 +281,7 @@ type ExplorerConfig struct {
 	XcBot             *exchanges.ExchangeBot
 	AgendasSource     agendaBackend
 	Tracker           *agendas.VoteTracker
-	ProposalsSource   politeiaBackend
+	ProposalsSource   PoliteiaBackend
 	PoliteiaURL       string
 	MainnetLink       string
 	TestnetLink       string
@@ -544,7 +544,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		// Politeia updates happen hourly thus if every blocks takes an average
 		// of 5 minutes to mine then 12 blocks take approximately 1hr.
 		// https://docs.decred.org/advanced/navigating-politeia-data/#voting-and-comment-data
-		if newBlockData.Height%12 == 0 {
+		if newBlockData.Height%12 == 0 && exp.proposalsSource != nil {
 			// Update the proposal DB. This is run asynchronously since it involves
 			// a query to Politeia (a remote system) and we do not want to block
 			// execution.

--- a/mempool/go.sum
+++ b/mempool/go.sum
@@ -122,6 +122,7 @@ github.com/decred/dcrdata/semver v1.0.0 h1:DBqYU/x+4LqHq/3r4xKdF6xG5ewktG2KDC+g/
 github.com/decred/dcrdata/semver v1.0.0/go.mod h1:z+nQqiAd9fYkHhBLbejysZ2FPHtgkrErWDgMf+JlZWE=
 github.com/decred/dcrdata/stakedb v1.0.1 h1:ncEsHgYrlGQAkza/RIGJQUuNsmFn4jdLlOt0w/Z7D0c=
 github.com/decred/dcrdata/stakedb v1.0.1/go.mod h1:zEJ8qEtmxJLRK3IAfbpleAW2qvpWuldeBrLpz/amQjE=
+github.com/decred/dcrdata/txhelpers v1.0.1/go.mod h1:oZOlm7v82oD5SIy1wlOBG0OT92CMfmKg05wk+2qaSaM=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0 h1:FPVohgxZHHwi7qTOBki/Dw9j5cgGsZYiktGSfgqHR0w=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0/go.mod h1:k+IOPnUY0YqlwhSDhczzaUN17NX/gMtztwl3UxKgVZY=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=


### PR DESCRIPTION
A new flag to disable Piparser and Politea API query is added.

 `--disable-piparser` ensures that `/proposals` and `/proposal` page returns:

![Screenshot from 2019-06-07 15-04-50](https://user-images.githubusercontent.com/22055953/59102912-1da36e80-8936-11e9-8af9-4fac6ccf11f6.png)

The API returns:
```bash
$ curl http://localhost:7777/api/proposal/a4f2a91c8589b2e5a955798d6c0f4f77f2eec13b62063c5f4102c21913dcaf32 
piparser is disabled.
```

Fixes #1374