### PR TITLE
dcrpg: unconfirmed txs funding an address were not labeled funding

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2326,6 +2326,7 @@ FUNDING_TX_DUPLICATE_CHECK:
 				FormattedSize: humanize.Bytes(uint64(fundingTx.Tx.SerializeSize())),
 				Total:         txhelpers.TotalOutFromMsgTx(fundingTx.Tx).ToCoin(),
 				ReceivedTotal: dcrutil.Amount(fundingTx.Tx.TxOut[f.Index].Value).ToCoin(),
+				IsFunding:     true,
 			}
 			addrData.Transactions = append(addrData.Transactions, addrTx)
 		}


### PR DESCRIPTION
On the /address page, unconfirmed transactions "funding" the address were not set as `IsFunding=true`, causing the incorrect display when the "All" or "Credits" views were selected.

Before (oops, definitely not an sstxcommitment)

![image](https://user-images.githubusercontent.com/9373513/59389730-96536200-8d5e-11e9-92e1-0387dfb3618f.png)

After

![image](https://user-images.githubusercontent.com/9373513/59389734-9bb0ac80-8d5e-11e9-8d3a-d52b53406d53.png)
