### PR TITLE
views/explorer: improve address page memory utilization

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -53,7 +53,7 @@ const (
 
 	// MaxAddressRows is an upper limit on the number of rows that may be shown
 	// on the address page table.
-	MaxAddressRows int64 = 1000
+	MaxAddressRows int64 = 160
 
 	testnetNetName = "Testnet"
 )

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1289,6 +1289,9 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Debugf(`"address" template HTML size: %.2f kiB (%s, %v, %d)`,
+		float64(len(str))/1024.0, address, txnType, addrData.NumTransactions)
+
 	w.Header().Set("Content-Type", "text/html")
 	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
 	w.WriteHeader(http.StatusOK)
@@ -1333,10 +1336,8 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// jsonBytes, err := json.Marshal(response)
-	// if err != nil {
-	// 	jsonBytes = []byte("JSON error")
-	// }
+	log.Debugf(`"addresstable" template HTML size: %.2f kiB (%s, %v, %d)`,
+		float64(len(response.HTML))/1024.0, address, txnType, addrData.NumTransactions)
 
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
@@ -1345,7 +1346,6 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Debug(err)
 	}
-	//w.Write(jsonBytes)
 }
 
 // parseAddressParams is used by both /address and /addresstable.

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -5,7 +5,6 @@
 package explorer
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 	"html/template"
@@ -86,7 +85,7 @@ func (t *templates) execTemplateToString(name string, data interface{}) (string,
 		return "", fmt.Errorf("Template %s not known", name)
 	}
 
-	var page bytes.Buffer
+	var page strings.Builder
 	err := temp.template.ExecuteTemplate(&page, name, data)
 	return page.String(), err
 }

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -12,6 +12,7 @@ import txInBlock from '../helpers/block_helper'
 import { fadeIn, animationFrame } from '../helpers/animation_helper'
 
 const blockDuration = 5 * 60000
+const maxAddrRows = 160
 let Dygraph // lazy loaded on connect
 
 function txTypesFunc (d, binSize) {
@@ -342,10 +343,10 @@ export default class extends Controller {
       if (option.value > 100) {
         if (rowMax > 100) {
           option.disabled = false
-          option.text = option.value = Math.min(rowMax, 1000)
+          option.text = option.value = Math.min(rowMax, maxAddrRows)
         } else {
           option.disabled = true
-          option.text = option.value = 1000
+          option.text = option.value = maxAddrRows
         }
       } else {
         option.disabled = rowMax <= option.value

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -4,9 +4,9 @@
 
 {{template "html-head" printf "Decred Address %s" .Data.Address}}
     {{template "navbar" . }}
-    {{with .Data}}
-    {{$TxnCount := add .TxnCount .NumUnconfirmed}}
-    {{$txType := .TxnType}}
+    {{- with .Data}}
+    {{- $TxnCount := add .TxnCount .NumUnconfirmed}}
+    {{- $txType := .TxnType -}}
     <div class="container main"
       data-controller="address newblock"
       data-address-offset="{{.Offset}}"
@@ -16,11 +16,11 @@
     >
     <div class="row pb-4 px-2">
       <div class="col-24 col-xl-10 bg-white px-3 py-3 position-relative">
-          {{if eq .Address $.DevAddress}}
+          {{- if eq .Address $.DevAddress}}
               <div class="fs22 pb-3">Decred Treasury</div>
-          {{else}}
+          {{- else}}
               <div class="fs22 pb-3">Address</div>
-          {{end}}
+          {{- end}}
           <div class="text-left d-flex align-items-start flex-wrap">
             <div class="fs15 font-weight-bold break-word d-inline-block hash-box mb-3" data-target="address.addr">{{.Address}}</div>
             <a
@@ -40,41 +40,40 @@
               <span class="text-secondary fs13">Balance</span>
               <br>
               <span class="lh1rem d-inline-block pt-1 fs18 fs14-decimal font-weight-bold">
-                {{if .Balance}}
+                {{- if .Balance}}
                     {{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span class="text-secondary fs14">DCR</span>
-                {{else}}
+                {{- else}}
                 <span class="fs18">0</span> <span class="text-secondary fs14">DCR</span>
-                {{end}}
+                {{- end}}
               </span>
               <br>
-              {{if $.FiatBalance}}
+              {{- if $.FiatBalance}}
                 <span class="text-secondary fs16 lh1rem">{{threeSigFigs $.FiatBalance.Value}} <span class="fs14">{{$.FiatBalance.Index}}</span></span>
-              {{end}}
+              {{- end}}
             </div>
             <div class="d-inline-block text-left pr-2 pb-3">
               <span class="text-secondary fs13">Received</span>
-              <br>
+                <br>
                 <span class="lh1rem d-inline-block pt-1 fs18 fs14-decimal font-weight-bold">
-                    {{if .Balance}}
-                        {{$received := add .Balance.TotalSpent .Balance.TotalUnspent}}
-                        {{template "decimalParts" (amountAsDecimalParts $received true)}} <span class="text-secondary fs14">DCR</span>
-                    {{else}}
+                    {{- if .Balance}}
+                        {{- $received := add .Balance.TotalSpent .Balance.TotalUnspent}}
+                        {{- template "decimalParts" (amountAsDecimalParts $received true)}} <span class="text-secondary fs14">DCR</span>
+                    {{- else}}
                         <span class="fs18">0</span> <span class="text-secondary fs14">DCR</span>
-                    {{end}}
+                    {{- end}}
                 </span>
                 <br>
                 <span class="text-secondary fs16 lh1rem">{{intComma (add .Balance.NumSpent .Balance.NumUnspent)}} outputs</span>
-              </span>
             </div>
             <div class="d-inline-block text-left pr-2 pb-3">
               <span class="text-secondary fs13">Spent</span>
               <br>
                 <span class="lh1rem d-inline-block pt-1 fs18 fs14-decimal font-weight-bold">
-                {{if .Balance}}
-                    {{template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}} <span class="text-secondary fs14">DCR</span>
-                {{else}}
+                {{- if .Balance}}
+                    {{- template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}} <span class="text-secondary fs14">DCR</span>
+                {{- else}}
                     <span class="fs18">0</span> <span class="text-secondary fs14">DCR</span>
-                {{end}}
+                {{- end}}
                 </span>
                 <br>
                 <span class="text-secondary fs16 lh1rem">{{intComma .Balance.NumSpent}} inputs</span>
@@ -82,21 +81,21 @@
             <span></span>
           </div>
           <div class="row pb-2">
-              {{if ne .NumUnconfirmed 0}}
+              {{- if ne .NumUnconfirmed 0}}
                 <div class="col-12 pb-2 fs14 text-secondary text-left" data-target="address.numUnconfirmed">
                     <span class="font-weight-bold">Unconfirmed</span>: <span class="addr-unconfirmed-count">{{.NumUnconfirmed}}</span>
                 </div>
-              {{end}}
-              {{if .Balance.HasStakeOutputs}}
+              {{- end}}
+              {{- if .Balance.HasStakeOutputs}}
                 <div class="col-12 pb-2 fs14 text-secondary text-left">
                     <span class="font-weight-bold">Stake spending</span>: {{printf "%.1f" (x100 .Balance.FromStake)}}%
                 </div>
-              {{end}}
-              {{if .Balance.HasStakeInputs}}
+              {{- end}}
+              {{- if .Balance.HasStakeInputs}}
                 <div class="col-12 pb-2 fs14 text-secondary text-left">
                     <span class="font-weight-bold">Stake income</span>: {{printf "%.1f" (x100 .Balance.ToStake)}}%
                 </div>
-              {{end}}
+              {{- end}}
           </div>
           <div class="row pb-3 fs16">
             <span class="col-24"><a href="{{$.Links.DownloadLink}}" title="Decred downloads" target="_blank" rel="noopener noreferrer">Get Decrediton</a>, the official desktop wallet.</span>
@@ -226,9 +225,10 @@
         <div
             class="d-flex align-items-center justify-content-between"
         >
-          {{if gt $TxnCount 0}}<a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>{{end}}
-          <!-- This dummy span ensures left/right alignment of the buttons, even if one is hidden -->
-          <span></span>
+          {{- if gt $TxnCount 0}}
+          <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
+          {{- end}}
+          <span></span>{{/*This dummy span ensures left/right alignment of the buttons, even if one is hidden.*/}}
           <div class="d-inline-block text-right">
             <label class="mb-0 mr-1" for="txntype">Type</label>
             <select
@@ -246,9 +246,7 @@
             </select>
           </div>
         </div>
-        <div
-            class="hidden d-flex align-items-center justify-content-end"
-        >
+        <div class="hidden d-flex align-items-center justify-content-end">
             <label class="my-2 mr-1" for="pagesize">Page size</label>
             <select
                 name="pagesize"
@@ -256,25 +254,25 @@
                 data-target="address.pagesize"
                 data-action="change->address#changePageSize"
                 class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}}"
-                {{if lt $TxnCount 20}}disabled{{end}}
+                {{- if lt $TxnCount 20}} disabled{{end}}
             >
-            {{$Txlen := len .Transactions}}
-            <option {{if eq $Txlen 20}}selected{{end}} value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
-            <option {{if eq $Txlen 40}}selected{{end}} value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
-            <option {{if eq $Txlen 80}}selected{{end}} value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
-              {{if lt $TxnCount 160}}
-                  <option{{if eq $Txlen $TxnCount}} selected{{end}} value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
-              {{else}}
-                  <option{{if eq $Txlen 160}} selected{{end}} value="160">160</option>
-              {{end}}
+            {{- $Txlen := len .Transactions}}
+              <option {{if eq $Txlen 20}}selected {{end}}value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
+              <option {{if eq $Txlen 40}}selected {{end}}value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
+              <option {{if eq $Txlen 80}}selected {{end}}value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
+            {{- if lt $TxnCount 160}}
+              <option {{if eq $Txlen $TxnCount}}selected {{end}}value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
+            {{- else}}
+              <option {{if ge $Txlen 160}}selected {{end}}value="160">160</option>
+            {{- end}}
+            </select>
             </select>
         </div>
     </div>
-    {{end}} {{/* if not .IsDummyAddress */}}
-  </div> <!-- container main -->
-  {{end}} {{/* with .Data */}}
-  {{ template "footer" . }}
-
+    {{- end}}{{/* if not .IsDummyAddress */}}
+  </div>{{/* container main */}}
+  {{- end}} {{/* with .Data */}}
+  {{template "footer" . }}
 </body>
 </html>
-{{end}}
+{{- end}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -260,11 +260,12 @@
             >
             {{$Txlen := len .Transactions}}
             <option {{if eq $Txlen 20}}selected{{end}} value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
-            <option {{if eq $Txlen 100}}selected{{end}} value="100"{{if lt $TxnCount 100}} disabled{{end}}>100</option>
-              {{if lt $TxnCount 1000}}
-                  <option{{if eq $Txlen $TxnCount}} selected{{end}} value="{{$TxnCount}}"{{if le $TxnCount 100}} disabled{{end}}>{{$TxnCount}}</option>
+            <option {{if eq $Txlen 40}}selected{{end}} value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
+            <option {{if eq $Txlen 80}}selected{{end}} value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
+              {{if lt $TxnCount 160}}
+                  <option{{if eq $Txlen $TxnCount}} selected{{end}} value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
               {{else}}
-                  <option{{if eq $Txlen 1000}} selected{{end}} value="1000">1000</option>
+                  <option{{if eq $Txlen 160}} selected{{end}} value="160">160</option>
               {{end}}
             </select>
         </div>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -105,11 +105,11 @@
 						<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
 						<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
 						<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
-						{{if eq .NetName "Mainnet"}}
-							<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
-						{{else}}
-							<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
-						{{end}}
+					{{- if eq .NetName "Mainnet"}}
+						<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
+					{{- else}}
+						<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
+					{{- end}}
 						<form action="/set" method="post">
 							<input type="hidden" name="darkmode" value="darkmode">
 							<input type="hidden" name="requestURI" value="{{.RequestURI}}">
@@ -122,7 +122,7 @@
 									</div>
 							</button>
 						</form>
-						<a class="menu-item" data-keynav-skip data-turbolinks="false" href="#" class="jsonly" id="keynav-toggle">
+						<a class="menu-item jsonly" data-keynav-skip data-turbolinks="false" href="#" id="keynav-toggle">
 							<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
 						</a>
 						<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
@@ -179,24 +179,32 @@
 </footer>
 {{end}}
 
-{{define "decimalParts"}}
+{{define "decimalParts" -}}
 <div class="decimal-parts d-inline-block">
-	{{if eq (len .) 4}}
-		<span class="int">{{ index . 0 }}.{{ index . 1 }}</span
-		>{{if gt (len (index . 2)) 0}}<span class="decimal">{{ index . 2 }}</span
-		><span class="decimal trailing-zeroes">{{ index . 3 }}</span>{{end}}
-	{{else}}
-		<span class="int">{{index . 0}}</span
-		>{{if gt (len (index . 1)) 0}}<span class="decimal dot">.</span
-		><span class="decimal">{{index . 1 }}</span
-		><span class="decimal trailing-zeroes">{{index . 2}}</span>{{end}}
-	{{end}}
+	{{- if eq (len .) 4 -}}
+		<span class="int">{{ index . 0 }}.{{ index . 1 }}</span>
+		{{- if gt (len (index . 2)) 0 -}}
+		<span class="decimal">{{ index . 2 }}</span>
+		{{- /* trailing zeros  */ -}}
+		<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
+		{{- end}}
+	{{- else -}}
+		<span class="int">{{index . 0}}</span>
+		{{- if gt (len (index . 1)) 0 -}}
+		<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
+		{{- /* trailing zeros  */ -}}
+		<span class="decimal trailing-zeroes">{{index . 2}}</span>
+		{{- end}}
+	{{- end -}}
 	</div>
-{{end}}
+{{- end}}
 
 {{define "fmtPercentage"}}
-	{{if gt . 0.0}}<span class="text-green">+{{printf "%.2f" .}} %</span>
-	{{else}}<span class="text-danger">{{printf "%.2f" .}} %</span>{{end}}
+  {{- if gt . 0.0 -}}
+    <span class="text-green">+{{printf "%.2f" .}} %</span>
+  {{- else -}}
+    <span class="text-danger">{{printf "%.2f" .}} %</span>
+  {{- end -}}
 {{end}}
 
 {{define "listViewRouting"}}
@@ -206,154 +214,128 @@
 		  data-target="pagenavigation.listview"
 		  data-action="change->pagenavigation#setListView"
 		  >
-			<option {{if eq . "years"}}selected{{end}} value="years">Years</option>
-			<option {{if eq . "months"}}selected{{end}} value="months">Months</option>
-			<option {{if eq . "weeks"}}selected{{end}} value="weeks">Weeks</option>
-			<option {{if eq . "days"}}selected{{end}} value="days">Days</option>
-			<option {{if eq . "windows"}}selected{{end}} value="ticketpricewindows">Windows</option>
-			<option {{if eq . "blocks"}}selected{{end}} value="blocks">Blocks</option>
+			<option {{if eq . "years"}}selected {{end}}value="years">Years</option>
+			<option {{if eq . "months"}}selected {{end}}value="months">Months</option>
+			<option {{if eq . "weeks"}}selected {{end}}value="weeks">Weeks</option>
+			<option {{if eq . "days"}}selected {{end}}value="days">Days</option>
+			<option {{if eq . "windows"}}selected {{end}}value="ticketpricewindows">Windows</option>
+			<option {{if eq . "blocks"}}selected {{end}}value="blocks">Blocks</option>
 		</select>
 	</div>
 {{end}}
 
 {{define "hashElide"}}
-  {{$hash := (index . 0)}}
-  {{$link := (index . 1)}}
-  {{if eq $link ""}}
+  {{- $hash := (index . 0) -}}
+  {{- $link := (index . 1) -}}
+  {{- if eq $link "" -}}
 	<div
-  {{else}}
+  {{- else -}}
 	<a href="{{$link}}"
-  {{end}}
-	data-keynav-priority
-	class="elidedhash mono"
-	data-head="{{hashStart $hash}}"
-	data-tail="{{hashEnd $hash}}"
-	>{{$hash}}{{if eq $link ""}}</div>{{else}}</a>{{end}}
+  {{- end}} data-keynav-priority class="elidedhash mono" data-head="{{hashStart $hash}}" data-tail="{{hashEnd $hash}}">
+  {{- $hash}}
+  {{- if eq $link ""}}</div>{{else}}</a>{{end -}}
 {{end}}
 
 {{define "addressTable"}}
-	{{$txType := .TxnType}}
-	{{if .Transactions}}
-	<table class="table table-mono-cells table-responsive-sm">
-		<thead>
-			<th class="d-none d-sm-table-cell">Tx Type</th>
-			<th class="text-left">Input/&#8203;Output ID</th>
-		{{if eq $txType "merged_debit"}}
-			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
-				><span class="d-none d-sm-inline">Inputs</span>
-			</th>
-			<th class="text-right">Debit DCR</th>
-		{{else if eq $txType "merged_credit" }}
-			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
-				><span class="d-none d-sm-inline">Outputs</span>
-			</th>
-			<th class="text-right">Credit DCR</th>
-		{{else if eq $txType "merged" }}
-			<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
-			<th class="text-right">Credit DCR</th>
-			<th class="text-right">Debit DCR</th>
-		{{else}}
-			<th class="text-right">Credit DCR</th>
-			<th class="text-right">Debit DCR</th>
-		{{end}}
-			<th class="d-none d-sm-table-cell text-right">Time</th>
-			<th class="text-right">Age</th>
-			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
-			<th class="d-none d-sm-table-cell text-right">Size</th>
-		</thead>
-		<tbody>
-		{{range .Transactions}}
-			<tr {{if eq .Confirmations 0}}data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
-				<td class="d-none d-sm-table-cell">{{.TxType}}</td>
-				<td>{{template "hashElide" (hashlink .TxID .Link)}}</td>
-
-			{{if eq $txType "merged_debit"}}
-				<td class="text-right">{{.MergedTxnCount}}</td>
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-				</td>
-
-			{{else if eq $txType "merged_credit"}}
-				<td class="text-right">{{.MergedTxnCount}}</td>
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-				</td>
-
-			{{else if eq $txType "merged"}}
-				<td class="text-right">{{.MergedTxnCount}}</td>
-				{{if .IsFunding}}
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-				</td>
-				<td class="text-right">&mdash;</td>
-				{{else}}
-				<td class="text-right">&mdash;</td>
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-				</td>
-				{{end}}
-
-			{{else if or (eq $txType "credit") .IsFunding}}  <!-- .IsFunding = true && txType = "all" is a credit -->
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-				</td>
-				{{if ne .MatchedTx ""}}
-				<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
-					data-txid="{{.MatchedTx}}"
-					data-action="mouseover->address#hashOver mouseout->address#hashOut"
-					>spent</a></td>
-				{{else}}
-				<td class="text-right">unspent</td>
-				{{end}}
-
-			{{else}} <!-- either "debit", or "all" with .IsFunding = false -->
-				{{if eq .SentTotal 0.0}}
-				<td class="text-right">sstxcommitment</td>
-				{{else if ne .MatchedTx ""}}
-				<td class="text-right"><a
-					href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}"
-					data-action="mouseover->address#hashOver mouseout->address#hashOut"
-					>source</a></td>
-				{{else}}
-				<td class="text-right">N/A</td>
-				{{end}}
-
-				<td class="text-right fs15">
-					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-				</td>
-			{{end}}
-
-				<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time}}{{end}}</td>
-				<td class="addr-tx-age text-right">
-				{{if eq (.Time.T.Unix) 0}}
-					N/A
-				{{else}}
-					<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
-				{{end}}
-				</td>
-
-				<td class="addr-tx-confirms text-right"
-					data-target="newblock.confirmations"
-					data-confirmations="{{.Confirmations}}"
-					data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}"
-					data-yes="#"
-					data-no="(unconfirmed)"
-			  	>{{.Confirmations}}</td>
-				<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
-			</tr>
-			{{end}}
-		</tbody>
-	</table>
-	{{else}}
-	<table class="table table-mono-cells">
-		<tr>
-			<td>
-				No transactions found for this address.
+{{- $txType := .TxnType}}
+{{- if .Transactions}}
+<table class="table table-mono-cells table-responsive-sm">
+	<thead>
+		<th class="d-none d-sm-table-cell">Tx Type</th>
+		<th class="text-left">Input/&#8203;Output ID</th>
+	{{- if eq $txType "merged_debit"}}
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
+			><span class="d-none d-sm-inline">Inputs</span>
+		</th>
+		<th class="text-right">Debit DCR</th>
+	{{- else if eq $txType "merged_credit" }}
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
+			><span class="d-none d-sm-inline">Outputs</span>
+		</th>
+		<th class="text-right">Credit DCR</th>
+	{{- else if eq $txType "merged" }}
+		<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
+		<th class="text-right">Credit DCR</th>
+		<th class="text-right">Debit DCR</th>
+	{{- else}}
+		<th class="text-right">Credit DCR</th>
+		<th class="text-right">Debit DCR</th>
+	{{- end}}
+		<th class="d-none d-sm-table-cell text-right">Time</th>
+		<th class="text-right">Age</th>
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
+		<th class="d-none d-sm-table-cell text-right">Size</th>
+	</thead>
+	<tbody>
+	{{- range .Transactions}}
+		<tr{{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
+			<td class="d-none d-sm-table-cell">{{.TxType}}</td>
+			<td>{{template "hashElide" (hashlink .TxID .Link)}}</td>
+		{{- if eq $txType "merged_debit"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+		{{- else if eq $txType "merged_credit"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+		{{- else if eq $txType "merged"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			{{- if .IsFunding}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+			<td class="text-right">&mdash;</td>
+			{{- else}}
+			<td class="text-right">&mdash;</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+			{{- end}}
+		{{- else if or (eq $txType "credit") .IsFunding}}{{/* .IsFunding = true && txType = "all" is a credit */}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+			{{- if ne .MatchedTx ""}}
+			<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
+				data-txid="{{.MatchedTx}}"
+				data-action="mouseover->address#hashOver mouseout->address#hashOut"
+				>spent</a></td>
+			{{- else}}
+			<td class="text-right">unspent</td>
+			{{- end}}
+		{{- else}}{{/* either "debit", or "all" with .IsFunding = false */ -}}
+			{{- if eq .SentTotal 0.0}}
+			<td class="text-right">sstxcommitment</td>
+			{{- else if ne .MatchedTx ""}}
+			<td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" data-action="mouseover->address#hashOver mouseout->address#hashOut">source</a></td>
+			{{- else}}
+			<td class="text-right">N/A</td>
+			{{- end}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+		{{- end}}
+			<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time}}{{end}}</td>
+			<td class="addr-tx-age text-right">
+			{{- if eq (.Time.T.Unix) 0}}
+				N/A
+			{{- else}}
+				<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
+			{{- end}}
 			</td>
+			<td class="addr-tx-confirms text-right"	{{/*Update confirmations with Stimulus*/ -}} 
+				data-target="newblock.confirmations" {{/*trim*/ -}} 
+				data-confirmations="{{.Confirmations}}" {{/*trim*/ -}} 
+				data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}" {{/*trim*/ -}} 
+				data-yes="#" {{/*trim*/ -}} 
+				data-no="(unconfirmed)" {{/*trim*/ -}} 
+			>{{.Confirmations}}</td>
+			<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
 		</tr>
-	</table>
-	{{end}}
-{{end}}
+	{{- end}}
+	</tbody>
+</table>
+{{- else}}
+<table class="table table-mono-cells">
+	<tr>
+		<td>
+			No transactions found for this address.
+		</td>
+	</tr>
+</table>
+{{- end}}
+{{- end}}
 
 {{define "mempoolDump"}}
   {{$likely := .LikelyMineable}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -1,368 +1,358 @@
 {{define "html-head"}}
 <head data-turbolinks-eval="false">
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
-    <meta name="author" content="The Decred developers">
-    <meta name="application-name"           content="Decred - Autonomous Digital Currency">
-    <meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
-    <!--  Custom favicon  -->
-        <!-- Apple PWA -->
-        <link rel="apple-touch-icon" sizes="57x57"   href="/images/favicon/apple-touch-icon-57x57.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="60x60"   href="/images/favicon/apple-touch-icon-60x60.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="72x72"   href="/images/favicon/apple-touch-icon-72x72.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="76x76"   href="/images/favicon/apple-touch-icon-76x76.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="114x114" href="/images/favicon/apple-touch-icon-114x114.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="120x120" href="/images/favicon/apple-touch-icon-120x120.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-touch-icon-144x144.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon-152x152.png?v=yHh3NA">
-        <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon-180x180.png?v=yHh3NA">
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+	<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
+	<meta name="author" content="The Decred developers">
+	<meta name="application-name"           content="Decred - Autonomous Digital Currency">
+	<meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
+	<!--  Custom favicon  -->
+		<!-- Apple PWA -->
+		<link rel="apple-touch-icon" sizes="57x57"   href="/images/favicon/apple-touch-icon-57x57.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="60x60"   href="/images/favicon/apple-touch-icon-60x60.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="72x72"   href="/images/favicon/apple-touch-icon-72x72.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="76x76"   href="/images/favicon/apple-touch-icon-76x76.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="114x114" href="/images/favicon/apple-touch-icon-114x114.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="120x120" href="/images/favicon/apple-touch-icon-120x120.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-touch-icon-144x144.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon-152x152.png?v=yHh3NA">
+		<link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon-180x180.png?v=yHh3NA">
 
-        <!-- Browser -->
-        <link rel="icon" href="/images/favicon/favicon.ico?v=yHh3NA">
-        <link rel="icon" href="/images/favicon/favicon-32x32.png?v=yHh3NA" type="image/png" sizes="32x32">
-        <link rel="icon" href="/images/favicon/favicon-16x16.png?v=yHh3NA" type="image/png" sizes="16x16">
+		<!-- Browser -->
+		<link rel="icon" href="/images/favicon/favicon.ico?v=yHh3NA">
+		<link rel="icon" href="/images/favicon/favicon-32x32.png?v=yHh3NA" type="image/png" sizes="32x32">
+		<link rel="icon" href="/images/favicon/favicon-16x16.png?v=yHh3NA" type="image/png" sizes="16x16">
 
-        <!-- Android PWA -->
-        <link rel="manifest" href="/images/favicon/manifest.json?v=yHh3NA">
+		<!-- Android PWA -->
+		<link rel="manifest" href="/images/favicon/manifest.json?v=yHh3NA">
 
-        <!-- Safari -->
-        <link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=yHh3NA" color="#091440">
+		<!-- Safari -->
+		<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=yHh3NA" color="#091440">
 
-        <!-- Windows PWA -->
-        <meta name="msapplication-TileColor" content="#091440">
-        <meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
-        <meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
-    <!-- End custom favicon -->
+		<!-- Windows PWA -->
+		<meta name="msapplication-TileColor" content="#091440">
+		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
+		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
+	<!-- End custom favicon -->
 
-    <meta name="turbolinks-cache-control" content="no-cache">
-    <title>{{.}}</title>
-    <link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
-    <link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
-    <link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
-    <link rel="preload" href="/images/connecting.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="/images/themes/light/logo.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="/images/connected.svg" as="image" type="image/svg+xml" />
-    <link rel="preload" href="/images/disconnected.svg" as="image" type="image/svg+xml" />
-    <link href="/dist/css/style.css" rel="stylesheet">
+	<meta name="turbolinks-cache-control" content="no-cache">
+	<title>{{.}}</title>
+	<link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff" as="font" type="font/woff" crossorigin="anonymous" />
+	<link rel="preload" href="/images/connecting.svg" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/themes/light/logo.svg" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/connected.svg" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/disconnected.svg" as="image" type="image/svg+xml" />
+	<link href="/dist/css/style.css" rel="stylesheet">
 
-    <script src="/js/vendor/turbolinks.min.js"></script>
+	<script src="/js/vendor/turbolinks.min.js"></script>
 </head>
 {{end}}
 
 {{define "navbar"}}
 <body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
 <header class="top-nav"
-        id="navBar"
-        data-blocktime="{{.BlockTimeUnix}}">
-    <div class="container">
-        <div class="d-flex align-items-center flex-wrap">
-            <div class="d-flex align-items-center">
-                <div class="col-sm-auto" style="padding: 0 2px">
-                    <a href="/" class="no-underline d-block home-link">
-                        <div class="dcrdata-logo"></div>
-                    </a>
-                </div>
-            </div>
-            <div class="col px-4 text-right">
-                <form
-                    class="search-form"
-                    role="search"
-                    id="search-form"
-                    action="/search"
-                    data-controller="search"
-                    data-action="submit->search#execute"
-                >
-                    <input
-                        tabindex="0"
-                        type="text"
-                        name="search"
-                        id="search"
-                        class="top-search mousetrap"
-                        placeholder="Search for blocks, addresses, transactions or proposal tokens"
-                        spellcheck="false"
-                    />
-                    <button class="search-bttn"><span class="dcricon-search"></span></button>
-                </form>
-            </div>
-            <nav role="navigation" id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
-                <div id="menuToggle">
-                    <input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
-                    <span class="patty"></span>
-                    <span class="patty"></span>
-                    <span class="patty short"></span>
-                    <div id="menu">
-                        <a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
-                        <a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
-                        <a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
-                        <a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
-                        <a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
-                        <a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
-                        <a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
-                        <a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
-                        <a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
-                        <a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
-                        <a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
-                        {{if eq .NetName "Mainnet"}}
-                            <a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
-                        {{else}}
-                            <a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
-                        {{end}}
-                        <form action="/set" method="post">
-                            <input type="hidden" name="darkmode" value="darkmode">
-                            <input type="hidden" name="requestURI" value="{{.RequestURI}}">
-                            <button type="submit"
-                                    class="menu-submit text-left w-100 p-0"
-                                    data-keynav-skip>
-                                    <div class="menu-item" data-action="click->menu#onSunClick">
-                                      <span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
-                                      Night Mode
-                                    </div>
-                            </button>
-                        </form>
-                        <a class="menu-item" data-keynav-skip data-turbolinks="false" href="#" class="jsonly" id="keynav-toggle">
-                            <span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
-                        </a>
-                        <a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
-                    </div>
-                </div>
-            </nav>
-        </div>
-    </div>
+		id="navBar"
+		data-blocktime="{{.BlockTimeUnix}}">
+	<div class="container">
+		<div class="d-flex align-items-center flex-wrap">
+			<div class="d-flex align-items-center">
+				<div class="col-sm-auto" style="padding: 0 2px">
+					<a href="/" class="no-underline d-block home-link">
+						<div class="dcrdata-logo"></div>
+					</a>
+				</div>
+			</div>
+			<div class="col px-4 text-right">
+				<form
+					class="search-form"
+					role="search"
+					id="search-form"
+					action="/search"
+					data-controller="search"
+					data-action="submit->search#execute"
+				>
+					<input
+						tabindex="0"
+						type="text"
+						name="search"
+						id="search"
+						class="top-search mousetrap"
+						placeholder="Search for blocks, addresses, transactions or proposal tokens"
+						spellcheck="false"
+					/>
+					<button class="search-bttn"><span class="dcricon-search"></span></button>
+				</form>
+			</div>
+			<nav role="navigation" id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
+				<div id="menuToggle">
+					<input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
+					<span class="patty"></span>
+					<span class="patty"></span>
+					<span class="patty short"></span>
+					<div id="menu">
+						<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
+						<a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
+						<a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
+						<a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
+						<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
+						<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
+						<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
+						<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
+						<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
+						<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
+						<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
+						{{if eq .NetName "Mainnet"}}
+							<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
+						{{else}}
+							<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
+						{{end}}
+						<form action="/set" method="post">
+							<input type="hidden" name="darkmode" value="darkmode">
+							<input type="hidden" name="requestURI" value="{{.RequestURI}}">
+							<button type="submit"
+									class="menu-submit text-left w-100 p-0"
+									data-keynav-skip>
+									<div class="menu-item" data-action="click->menu#onSunClick">
+									  <span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
+									  Night Mode
+									</div>
+							</button>
+						</form>
+						<a class="menu-item" data-keynav-skip data-turbolinks="false" href="#" class="jsonly" id="keynav-toggle">
+							<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
+						</a>
+						<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
+					</div>
+				</div>
+			</nav>
+		</div>
+	</div>
 </header>
 {{end}}
 
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
-    <div class="container d-flex justify-content-between align-items-center">
-        <span>
-            <span data-controller="time" data-target="time.blocktime" data-stamp="{{$.Tip.Time}}"></span> <span class="d-none d-sm-inline">since last block</span>
-        </span>
-        <span>
-            <a
-                class="text-nowrap d-none d-md-inline-block pr-3"
-                href="{{.Links.Github}}"
-                title="dcrdata on GitHub"
-                target="_blank"
-                rel="noopener noreferrer"
-            >dcrdata v{{.Version}}</a>
-            <a
-                class="text-nowrap"
-                href="{{.Links.License}}"
-                target="_blank"
-                rel="noopener noreferrer"
-            >© 2019 The Decred developers (ISC)</a>
-        </span>
-        <span
-            id="connection"
-            class="text-nowrap align-items-center clickable d-inline-block"
-            data-turbolinks-permanent
-            data-controller="connection"
-            data-target="connection.indicator"
-            data-action="click->connection#requestNotifyPermission"
-            title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
-            ><span class="d-none d-sm-inline" data-target="connection.status">Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
-        </span>
-    </div>
-    <script
-        src="/dist/js/vendors~app.bundle.js"
-        data-turbolinks-eval="false"
-        data-turbolinks-suppress-warning
-    ></script>
-    <script
-        src="/dist/js/app.bundle.js"
-        data-turbolinks-eval="false"
-        data-turbolinks-suppress-warning
-    ></script>
+	<div class="container d-flex justify-content-between align-items-center">
+		<span>
+			<span data-controller="time" data-target="time.blocktime" data-stamp="{{$.Tip.Time}}"></span> <span class="d-none d-sm-inline">since last block</span>
+		</span>
+		<span>
+			<a
+				class="text-nowrap d-none d-md-inline-block pr-3"
+				href="{{.Links.Github}}"
+				title="dcrdata on GitHub"
+				target="_blank"
+				rel="noopener noreferrer"
+			>dcrdata v{{.Version}}</a>
+			<a
+				class="text-nowrap"
+				href="{{.Links.License}}"
+				target="_blank"
+				rel="noopener noreferrer"
+			>© 2019 The Decred developers (ISC)</a>
+		</span>
+		<span
+			id="connection"
+			class="text-nowrap align-items-center clickable d-inline-block"
+			data-turbolinks-permanent
+			data-controller="connection"
+			data-target="connection.indicator"
+			data-action="click->connection#requestNotifyPermission"
+			title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
+			><span class="d-none d-sm-inline" data-target="connection.status">Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
+		</span>
+	</div>
+	<script
+		src="/dist/js/vendors~app.bundle.js"
+		data-turbolinks-eval="false"
+		data-turbolinks-suppress-warning
+	></script>
+	<script
+		src="/dist/js/app.bundle.js"
+		data-turbolinks-eval="false"
+		data-turbolinks-suppress-warning
+	></script>
 </footer>
 {{end}}
 
 {{define "decimalParts"}}
 <div class="decimal-parts d-inline-block">
-    {{if eq (len .) 4}}
-        <span class="int">{{ index . 0 }}.{{ index . 1 }}</span
-        >{{if gt (len (index . 2)) 0}}<span class="decimal">{{ index . 2 }}</span
-        ><span class="decimal trailing-zeroes">{{ index . 3 }}</span>{{end}}
-    {{else}}
-        <span class="int">{{index . 0}}</span
-        >{{if gt (len (index . 1)) 0}}<span class="decimal dot">.</span
-        ><span class="decimal">{{index . 1 }}</span
-        ><span class="decimal trailing-zeroes">{{index . 2}}</span>{{end}}
-    {{end}}
-    </div>
+	{{if eq (len .) 4}}
+		<span class="int">{{ index . 0 }}.{{ index . 1 }}</span
+		>{{if gt (len (index . 2)) 0}}<span class="decimal">{{ index . 2 }}</span
+		><span class="decimal trailing-zeroes">{{ index . 3 }}</span>{{end}}
+	{{else}}
+		<span class="int">{{index . 0}}</span
+		>{{if gt (len (index . 1)) 0}}<span class="decimal dot">.</span
+		><span class="decimal">{{index . 1 }}</span
+		><span class="decimal trailing-zeroes">{{index . 2}}</span>{{end}}
+	{{end}}
+	</div>
 {{end}}
 
 {{define "fmtPercentage"}}
-    {{if gt . 0.0}}<span class="text-green">+{{printf "%.2f" .}} %</span>
-    {{else}}<span class="text-danger">{{printf "%.2f" .}} %</span>{{end}}
+	{{if gt . 0.0}}<span class="text-green">+{{printf "%.2f" .}} %</span>
+	{{else}}<span class="text-danger">{{printf "%.2f" .}} %</span>{{end}}
 {{end}}
 
 {{define "listViewRouting"}}
-    <div class="fs12 nowrap text-left" style="margin:auto auto auto 0px;">
-        <select
-          class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
-          data-target="pagenavigation.listview"
-          data-action="change->pagenavigation#setListView"
-          >
-            <option {{if eq . "years"}}selected{{end}} value="years">Years</option>
-            <option {{if eq . "months"}}selected{{end}} value="months">Months</option>
-            <option {{if eq . "weeks"}}selected{{end}} value="weeks">Weeks</option>
-            <option {{if eq . "days"}}selected{{end}} value="days">Days</option>
-            <option {{if eq . "windows"}}selected{{end}} value="ticketpricewindows">Windows</option>
-            <option {{if eq . "blocks"}}selected{{end}} value="blocks">Blocks</option>
-        </select>
-    </div>
+	<div class="fs12 nowrap text-left" style="margin:auto auto auto 0px;">
+		<select
+		  class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
+		  data-target="pagenavigation.listview"
+		  data-action="change->pagenavigation#setListView"
+		  >
+			<option {{if eq . "years"}}selected{{end}} value="years">Years</option>
+			<option {{if eq . "months"}}selected{{end}} value="months">Months</option>
+			<option {{if eq . "weeks"}}selected{{end}} value="weeks">Weeks</option>
+			<option {{if eq . "days"}}selected{{end}} value="days">Days</option>
+			<option {{if eq . "windows"}}selected{{end}} value="ticketpricewindows">Windows</option>
+			<option {{if eq . "blocks"}}selected{{end}} value="blocks">Blocks</option>
+		</select>
+	</div>
 {{end}}
 
 {{define "hashElide"}}
   {{$hash := (index . 0)}}
   {{$link := (index . 1)}}
   {{if eq $link ""}}
-    <div
+	<div
   {{else}}
-    <a href="{{$link}}"
+	<a href="{{$link}}"
   {{end}}
-    data-keynav-priority
-    class="elidedhash mono"
-    data-head="{{hashStart $hash}}"
-    data-tail="{{hashEnd $hash}}"
-    >{{$hash}}{{if eq $link ""}}</div>{{else}}</a>{{end}}
+	data-keynav-priority
+	class="elidedhash mono"
+	data-head="{{hashStart $hash}}"
+	data-tail="{{hashEnd $hash}}"
+	>{{$hash}}{{if eq $link ""}}</div>{{else}}</a>{{end}}
 {{end}}
 
 {{define "addressTable"}}
-  {{$TxnCount := .TxnCount}}
-  {{$txType := .TxnType}}
-  {{$isMerged := .IsMerged}}
-  {{if .Transactions}}
-  <table class="table table-mono-cells table-responsive-sm">
-      <thead>
-          <th class="d-none d-sm-table-cell">Tx Type</th>
-          <th class="text-left">Input/&#8203;Output ID</th>
-          {{if eq $txType "merged_debit"}}
-              <th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
-                ><span class="d-none d-sm-inline">Inputs</span>
-              </th>
-              <th class="text-right">Debit DCR</th>
-          {{else if eq $txType "merged_credit" }}
-              <th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
-                ><span class="d-none d-sm-inline">Outputs</span>
-              </th>
-              <th class="text-right">Credit DCR</th>
-          {{else if eq $txType "merged" }}
-              <th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
-              <th class="text-right">Credit DCR</th>
-              <th class="text-right">Debit DCR</th>
-          {{else}}
-              <th class="text-right">Credit DCR</th>
-              <th class="text-right">Debit DCR</th>
-          {{end}}
-          <th class="d-none d-sm-table-cell text-right">Time</th>
-          <th class="text-right">Age</th>
-          <th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
-          <th class="d-none d-sm-table-cell text-right">Size</th>
-      </thead>
-      <tbody>
-          {{range $i, $v := .Transactions}}
-          <tr {{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}" {{end}}>
-              {{with $v}}
-              <td class="d-none d-sm-table-cell">{{.TxType}}</td>
-              <td>{{template "hashElide" (hashlink .TxID .Link)}}</td>
+	{{$txType := .TxnType}}
+	{{if .Transactions}}
+	<table class="table table-mono-cells table-responsive-sm">
+		<thead>
+			<th class="d-none d-sm-table-cell">Tx Type</th>
+			<th class="text-left">Input/&#8203;Output ID</th>
+		{{if eq $txType "merged_debit"}}
+			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
+				><span class="d-none d-sm-inline">Inputs</span>
+			</th>
+			<th class="text-right">Debit DCR</th>
+		{{else if eq $txType "merged_credit" }}
+			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
+				><span class="d-none d-sm-inline">Outputs</span>
+			</th>
+			<th class="text-right">Credit DCR</th>
+		{{else if eq $txType "merged" }}
+			<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
+			<th class="text-right">Credit DCR</th>
+			<th class="text-right">Debit DCR</th>
+		{{else}}
+			<th class="text-right">Credit DCR</th>
+			<th class="text-right">Debit DCR</th>
+		{{end}}
+			<th class="d-none d-sm-table-cell text-right">Time</th>
+			<th class="text-right">Age</th>
+			<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
+			<th class="d-none d-sm-table-cell text-right">Size</th>
+		</thead>
+		<tbody>
+		{{range .Transactions}}
+			<tr {{if eq .Confirmations 0}}data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
+				<td class="d-none d-sm-table-cell">{{.TxType}}</td>
+				<td>{{template "hashElide" (hashlink .TxID .Link)}}</td>
 
-              {{if eq $txType "merged_debit"}}
-                <td class="text-right">{{.MergedTxnCount}}</td>
-                <td class="text-right fs15">
-                  {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-                </td>
+			{{if eq $txType "merged_debit"}}
+				<td class="text-right">{{.MergedTxnCount}}</td>
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+				</td>
 
-              {{else if eq $txType "merged_credit"}}
-                <td class="text-right">{{.MergedTxnCount}}</td>
-                <td class="text-right fs15">
-                  {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-                </td>
+			{{else if eq $txType "merged_credit"}}
+				<td class="text-right">{{.MergedTxnCount}}</td>
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+				</td>
 
-              {{else if eq $txType "merged"}}
-                <td class="text-right">{{.MergedTxnCount}}</td>
-                {{if .IsFunding}}
-                  <td class="text-right fs15">
-                    {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-                  </td>
-                  <td class="text-right">&mdash;</td>
-                {{else}}
-                  <td class="text-right">&mdash;</td>
-                  <td class="text-right fs15">
-                    {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-                  </td>
-                {{end}}
+			{{else if eq $txType "merged"}}
+				<td class="text-right">{{.MergedTxnCount}}</td>
+				{{if .IsFunding}}
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+				</td>
+				<td class="text-right">&mdash;</td>
+				{{else}}
+				<td class="text-right">&mdash;</td>
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+				</td>
+				{{end}}
 
-              {{else if or (eq $txType "credit") .IsFunding}}  <!-- .IsFunding = true && txType = "all" is a credit -->
-                <td class="text-right fs15">
-                  {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
-                </td>
-                {{if ne .MatchedTx ""}}
-                    <td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
-                      data-txid="{{.MatchedTx}}"
-                      data-action="mouseover->address#hashOver mouseout->address#hashOut"
-                      >spent</a></td>
-                {{else}}
-                    <td class="text-right">unspent</td>
-                {{end}}
+			{{else if or (eq $txType "credit") .IsFunding}}  <!-- .IsFunding = true && txType = "all" is a credit -->
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+				</td>
+				{{if ne .MatchedTx ""}}
+				<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
+					data-txid="{{.MatchedTx}}"
+					data-action="mouseover->address#hashOver mouseout->address#hashOut"
+					>spent</a></td>
+				{{else}}
+				<td class="text-right">unspent</td>
+				{{end}}
 
-              {{else}} <!-- either "credit", or "all" with .IsFunding = false -->
-                {{if eq .SentTotal 0.0}}
-                  <td class="text-right">sstxcommitment</td>
-                {{else if ne .MatchedTx ""}}
-                  <td class="text-right"><a
-                    href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}"
-                    data-action="mouseover->address#hashOver mouseout->address#hashOut"
-                    >source</a></td>
-                {{else}}
-                  <td class="text-right">N/A</td>
-                {{end}}
-                <td class="text-right fs15">
-                  {{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
-                </td>
-              {{end}}
+			{{else}} <!-- either "debit", or "all" with .IsFunding = false -->
+				{{if eq .SentTotal 0.0}}
+				<td class="text-right">sstxcommitment</td>
+				{{else if ne .MatchedTx ""}}
+				<td class="text-right"><a
+					href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}"
+					data-action="mouseover->address#hashOver mouseout->address#hashOut"
+					>source</a></td>
+				{{else}}
+				<td class="text-right">N/A</td>
+				{{end}}
 
-              <td class="addr-tx-time d-none d-sm-table-cell text-right">
-                  {{if eq .Confirmations 0}}
-                      Unconfirmed
-                  {{else}}
-                      {{.Time}}
-                  {{end}}
-              </td>
-              <td class="addr-tx-age text-right">
-              {{if eq (.Time.T.Unix) 0}}
-                  N/A
-              {{else}}
-                  <span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
-              {{end}}
-              </td>
+				<td class="text-right fs15">
+					{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}
+				</td>
+			{{end}}
 
-              <td class="addr-tx-confirms text-right"
-                  data-target="newblock.confirmations"
-                  data-confirmations="{{.Confirmations}}"
-                  data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}"
-                  data-yes="#"
-                  data-no="(unconfirmed)"
-              >{{.Confirmations}}</td>
+				<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time}}{{end}}</td>
+				<td class="addr-tx-age text-right">
+				{{if eq (.Time.T.Unix) 0}}
+					N/A
+				{{else}}
+					<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
+				{{end}}
+				</td>
 
-              <td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
-              {{end}}
-          </tr>
-          {{end}}
-      </tbody>
-  </table>
-  {{else}}
-  <table class="table table-mono-cells">
-      <tr>
-          <td>
-              No transactions found for this address.
-          </td>
-      </tr>
-  </table>
-  {{end}}
+				<td class="addr-tx-confirms text-right"
+					data-target="newblock.confirmations"
+					data-confirmations="{{.Confirmations}}"
+					data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}"
+					data-yes="#"
+					data-no="(unconfirmed)"
+			  	>{{.Confirmations}}</td>
+				<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
+			</tr>
+			{{end}}
+		</tbody>
+	</table>
+	{{else}}
+	<table class="table table-mono-cells">
+		<tr>
+			<td>
+				No transactions found for this address.
+			</td>
+		</tr>
+	</table>
+	{{end}}
 {{end}}
 
 {{define "mempoolDump"}}


### PR DESCRIPTION
Three main chainges:

* views: Reduce byte size of `addressTable` template html.

Also avoid the unneeded template if and range variables.

* explorer: reduce max address rows

* explorer: use `strings.Builder` instead of `bytes.Buffer`

In `(*templates).execTemplateToString`, use `strings.Builder` instead of
`bytes.Buffer` to avoid an unnecessary copy when calling `String()`.
TODO: look into preallocating its buffer.