### PR TITLE
prepare for rpcutils v1.2.0

### DIFF
--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/decred/dcrdata/blockdata v1.0.1
 	github.com/decred/dcrdata/db/cache/v2 v2.0.0
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
-	github.com/decred/dcrdata/rpcutils v1.0.2-0.20190416204615-70a58657e02f
+	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/stakedb v1.0.1
 	github.com/decred/dcrdata/testutil/dbconfig v1.0.1

--- a/db/dcrsqlite/go.mod
+++ b/db/dcrsqlite/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/explorer/types v1.1.0
 	github.com/decred/dcrdata/mempool v1.0.0
-	github.com/decred/dcrdata/rpcutils v1.0.2-0.20190416163815-b92d2b40c258
+	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/stakedb v1.0.1
 	github.com/decred/dcrdata/testutil/dbconfig v1.0.1
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/decred/dcrdata/middleware/v2 v2.1.0
 	github.com/decred/dcrdata/pubsub v1.0.1-0.20190416165439-dcbde78387e2
 	github.com/decred/dcrdata/pubsub/types/v2 v2.0.0
-	github.com/decred/dcrdata/rpcutils v1.0.2-0.20190416204615-70a58657e02f
+	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/stakedb v1.0.1
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0
@@ -62,6 +62,5 @@ replace (
 	github.com/decred/dcrdata/db/dcrsqlite => ./db/dcrsqlite
 	github.com/decred/dcrdata/mempool => ./mempool
 	github.com/decred/dcrdata/pubsub => ./pubsub
-	github.com/decred/dcrdata/rpcutils => ./rpcutils
 	github.com/decred/dcrdata/stakedb => ./stakedb
 )

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/explorer/types v1.1.0
 	github.com/decred/dcrdata/pubsub/types/v2 v2.0.0
-	github.com/decred/dcrdata/rpcutils v1.0.2-0.20190416204615-70a58657e02f
+	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0
 	github.com/decred/slog v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/stakedb/go.mod
+++ b/stakedb/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types/v3 v3.0.0
-	github.com/decred/dcrdata/rpcutils v1.0.1
+	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0
 	github.com/decred/slog v1.0.0
 	github.com/dgraph-io/badger v1.5.5-0.20190214192501-3196cc1d7a5f


### PR DESCRIPTION
To be tagged as rpcutils/v1.2.0 as per https://github.com/decred/dcrdata/issues/1379