### PR TITLE
mod updates

### DIFF
--- a/api/insight/socket.io.go
+++ b/api/insight/socket.io.go
@@ -13,7 +13,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/txhelpers/v2"
 	socketio "github.com/googollee/go-socket.io"
 )

--- a/blockdata/go.mod
+++ b/blockdata/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrdata/blockdata/v2
+module github.com/decred/dcrdata/blockdata/v3
 
 go 1.11
 

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrdata/db/dcrpg/v3
 
 go 1.11
 
-replace github.com/decred/dcrdata/testutil/dbconfig => ../../testutil/dbconfig
+replace github.com/decred/dcrdata/testutil/dbconfig/v2 => ../../testutil/dbconfig
 
 require (
 	github.com/chappjc/trylock v1.0.0

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/decred/dcrd/txscript v1.0.3-0.20190613214542-d0a6bf024dfc
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types/v3 v3.0.0
-	github.com/decred/dcrdata/blockdata/v2 v2.0.0
-	github.com/decred/dcrdata/db/cache/v2 v2.0.0
+	github.com/decred/dcrdata/blockdata/v3 v3.0.0
+	github.com/decred/dcrdata/db/cache/v2 v2.1.0
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/semver v1.0.0
 	github.com/decred/dcrdata/stakedb/v2 v2.0.0
-	github.com/decred/dcrdata/testutil/dbconfig v1.0.1
+	github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0
 	github.com/decred/slog v1.0.0
 	github.com/dmigwi/go-piparser/proposals v0.0.0-20190426030541-8412e0f44f55

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -27,7 +27,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v2"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types/v3"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/cache/v2"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/db/dcrpg/v3/internal"

--- a/db/dcrpg/pgblockchain_common_test.go
+++ b/db/dcrpg/pgblockchain_common_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrdata/db/cache/v2"
-	"github.com/decred/dcrdata/testutil/dbconfig"
+	"github.com/decred/dcrdata/testutil/dbconfig/v2"
 	"github.com/decred/slog"
 	pitypes "github.com/dmigwi/go-piparser/proposals/types"
 )

--- a/db/dcrsqlite/apisource_charts_test.go
+++ b/db/dcrsqlite/apisource_charts_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrdata/db/cache/v2"
-	tc "github.com/decred/dcrdata/testutil/dbconfig"
+	tc "github.com/decred/dcrdata/testutil/dbconfig/v2"
 	_ "github.com/mattn/go-sqlite3"
 )
 

--- a/db/dcrsqlite/chainmonitor.go
+++ b/db/dcrsqlite/chainmonitor.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/txhelpers/v2"
 )
 

--- a/db/dcrsqlite/go.mod
+++ b/db/dcrsqlite/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types/v3 v3.0.0
-	github.com/decred/dcrdata/blockdata/v2 v2.0.0
-	github.com/decred/dcrdata/db/cache/v2 v2.0.0
+	github.com/decred/dcrdata/blockdata/v3 v3.0.0
+	github.com/decred/dcrdata/db/cache/v2 v2.1.0
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/explorer/types v1.1.0
 	github.com/decred/dcrdata/mempool/v3 v3.0.1
 	github.com/decred/dcrdata/rpcutils v1.2.0
 	github.com/decred/dcrdata/stakedb/v2 v2.0.0
-	github.com/decred/dcrdata/testutil/dbconfig v1.0.1
+	github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0
 	github.com/decred/dcrdata/txhelpers/v2 v2.0.0
 	github.com/decred/slog v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	apitypes "github.com/decred/dcrdata/api/types/v3"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/cache/v2"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/slog"

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -14,7 +14,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
 	apitypes "github.com/decred/dcrdata/api/types/v3"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/rpcutils"
 	"github.com/decred/dcrdata/txhelpers/v2"

--- a/dcrrates/rateserver/go.mod
+++ b/dcrrates/rateserver/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrdata/dcrrates/rateserver
 require (
 	github.com/decred/dcrd/certgen v1.0.2
 	github.com/decred/dcrdata/dcrrates v1.1.0
-	github.com/decred/dcrdata/exchanges/v2 v2.0.0
+	github.com/decred/dcrdata/exchanges/v2 v2.0.1
 	github.com/decred/slog v1.0.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0

--- a/exchanges/go.mod
+++ b/exchanges/go.mod
@@ -10,7 +10,6 @@ require (
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2 // indirect
 	golang.org/x/sys v0.0.0-20190416124237-ebb4019f01c9 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190415143225-d1146b9035b9 // indirect
 	google.golang.org/grpc v1.20.0
 )

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -23,7 +23,7 @@ import (
 	"github.com/decred/dcrd/dcrjson/v2"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/exchanges/v2"
 	"github.com/decred/dcrdata/explorer/types"

--- a/go.mod
+++ b/go.mod
@@ -13,16 +13,16 @@ require (
 	github.com/decred/dcrd/txscript v1.0.3-0.20190613214542-d0a6bf024dfc
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrdata/api/types/v3 v3.0.0
-	github.com/decred/dcrdata/blockdata/v2 v2.0.0
-	github.com/decred/dcrdata/db/cache/v2 v2.0.0
+	github.com/decred/dcrdata/blockdata/v3 v3.0.0
+	github.com/decred/dcrdata/db/cache/v2 v2.1.0
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/db/dcrpg/v3 v3.0.0
 	github.com/decred/dcrdata/db/dcrsqlite/v3 v3.0.0
-	github.com/decred/dcrdata/exchanges/v2 v2.0.0
+	github.com/decred/dcrdata/exchanges/v2 v2.0.1
 	github.com/decred/dcrdata/explorer/types v1.1.0
-	github.com/decred/dcrdata/gov v1.0.0
+	github.com/decred/dcrdata/gov v1.0.1
 	github.com/decred/dcrdata/mempool/v3 v3.0.1
-	github.com/decred/dcrdata/middleware/v2 v2.1.0
+	github.com/decred/dcrdata/middleware/v2 v2.2.0
 	github.com/decred/dcrdata/pubsub/types/v2 v2.0.0
 	github.com/decred/dcrdata/pubsub/v2 v2.0.0
 	github.com/decred/dcrdata/rpcutils v1.2.0
@@ -56,7 +56,7 @@ require (
 
 replace (
 	github.com/decred/dcrdata/api/types/v3 => ./api/types
-	github.com/decred/dcrdata/blockdata/v2 => ./blockdata
+	github.com/decred/dcrdata/blockdata/v3 => ./blockdata
 	github.com/decred/dcrdata/db/cache/v2 => ./db/cache
 	github.com/decred/dcrdata/db/dbtypes/v2 => ./db/dbtypes
 	github.com/decred/dcrdata/db/dcrpg/v3 => ./db/dcrpg

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,6 @@ replace (
 	github.com/decred/dcrdata/rpcutils => ./rpcutils
 	github.com/decred/dcrdata/semver => ./semver
 	github.com/decred/dcrdata/stakedb/v2 => ./stakedb
-	github.com/decred/dcrdata/testutil/dbconfig => ./testutil/dbconfig
+	github.com/decred/dcrdata/testutil/dbconfig/v2 => ./testutil/dbconfig
 	github.com/decred/dcrdata/txhelpers/v2 => ./txhelpers
 )

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/decred/dcrd/wire v1.1.0 h1:G+3CugtxNbToUN8RKWqm74yLfzJJ2BKMOr2RgWc4Ty
 github.com/decred/dcrd/wire v1.1.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hng=
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
+github.com/decred/dcrdata v2.1.3+incompatible h1:DLzrqgOOgHwrUSbuOVDAUzfQePhCGl9UsjEgZI1D0Kg=
 github.com/decred/dcrdata/api/types v1.0.6 h1:ipZ7bN/9RE1rOKa2IYXe7yVoxs6e6Bfs8bCNzsJzMOY=
 github.com/decred/dcrdata/api/types v1.0.6/go.mod h1:BuRGiCMg2EhpvAWp8ezLZ+mbLC8fcfKMX/q3PYfUgHk=
 github.com/decred/dcrdata/api/types/v3 v3.0.0 h1:NVw3pDQ0TVckSIegFSYcqPlqKZI6ehJSOEftHIvrOoY=
@@ -163,6 +164,7 @@ github.com/decred/dcrdata/gov v1.0.0 h1:5LPFqrj+icNP5rPFPfE6nPVihUjdR6r0UShARkBj
 github.com/decred/dcrdata/gov v1.0.0/go.mod h1:wiF36SkIuwTPD5/sVLYNWqn+hEOMZ6PKZkTDYmFyCkM=
 github.com/decred/dcrdata/mempool/v3 v3.0.1 h1:MtlBOeaOxl3PIw7YjQKyCehQw8/588fPGPr3Fyky97E=
 github.com/decred/dcrdata/mempool/v3 v3.0.1/go.mod h1:2nEki72AlJbXl5ypQhrcI0gcWkmX2fZcbJ0XgbAL2qw=
+github.com/decred/dcrdata/middleware v1.0.1 h1:UE93rW1OaTyjp6ey0R9oXy2rK6TghnM79RA6HzGyJ2w=
 github.com/decred/dcrdata/middleware/v2 v2.1.0 h1:oMjy+Sws7WwkjAY0r+ZXeS5Tl/uRPsH9tyKC75pE5nM=
 github.com/decred/dcrdata/middleware/v2 v2.1.0/go.mod h1:Zd96+65ZHWtchjYZDYBA6HcM1snigFeubwxRngu7i6M=
 github.com/decred/dcrdata/pubsub/types/v2 v2.0.0 h1:7UBWEITNpUmJKq8TPJatDns1+eWbGUgnLMTVSxpvKrM=

--- a/log.go
+++ b/log.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/decred/dcrd/rpcclient/v2"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/dcrpg/v3"
 	"github.com/decred/dcrdata/db/dcrsqlite/v3"
 	"github.com/decred/dcrdata/exchanges/v2"

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/rpcclient/v2"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/cache/v2"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/db/dcrpg/v3"

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -772,6 +772,12 @@ func AgendaIdCtx(next http.Handler) http.Handler {
 	})
 }
 
+// AgendIdCtx returns a http.HandlerFunc that embeds the value at the url part
+// {agendaId} into the request context. This is here for backward compatibility.
+func AgendIdCtx(next http.Handler) http.Handler {
+	return AgendaIdCtx(next)
+}
+
 // GetAgendaIdCtx retrieves the ctxAgendaId data from the request context.
 // If not set, the return value is an empty string.
 func GetAgendaIdCtx(r *http.Request) string {

--- a/pubsub/democlient/go.mod
+++ b/pubsub/democlient/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrdata/pubsub/democlient
 
 replace (
 	github.com/decred/dcrdata/api/types/v3 => ../../api/types
-	github.com/decred/dcrdata/blockdata/v2 => ../../blockdata
+	github.com/decred/dcrdata/blockdata/v3 => ../../blockdata
 	github.com/decred/dcrdata/db/cache/v2 => ../../db/cache
 	github.com/decred/dcrdata/db/dbtypes/v2 => ../../db/dbtypes
 	github.com/decred/dcrdata/db/dcrpg/v3 => ../../db/dcrpg

--- a/pubsub/democlient/go.mod
+++ b/pubsub/democlient/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/decred/dcrdata/rpcutils => ../../rpcutils
 	github.com/decred/dcrdata/semver => ../../semver
 	github.com/decred/dcrdata/stakedb/v2 => ../../stakedb
-	github.com/decred/dcrdata/testutil/dbconfig => ../../testutil/dbconfig
+	github.com/decred/dcrdata/testutil/dbconfig/v2 => ../../testutil/dbconfig
 	github.com/decred/dcrdata/txhelpers/v2 => ../../txhelpers
 )
 

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/decred/dcrd/dcrutil v1.3.0
 	github.com/decred/dcrd/txscript v1.0.3-0.20190613214542-d0a6bf024dfc
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/decred/dcrdata/blockdata/v2 v2.0.0
+	github.com/decred/dcrdata/blockdata/v3 v3.0.0
 	github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0
 	github.com/decred/dcrdata/explorer/types v1.1.0
 	github.com/decred/dcrdata/mempool/v3 v3.0.1

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrdata/blockdata/v2"
+	"github.com/decred/dcrdata/blockdata/v3"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/explorer/types"
 	exptypes "github.com/decred/dcrdata/explorer/types"

--- a/testutil/dbconfig/go.mod
+++ b/testutil/dbconfig/go.mod
@@ -1,3 +1,3 @@
-module github.com/decred/dcrdata/testutil/dbconfig
+module github.com/decred/dcrdata/testutil/dbconfig/v2
 
 go 1.11

--- a/testutil/dbload/go.mod
+++ b/testutil/dbload/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrdata/testutil/dbload
 
 go 1.11
 
-replace github.com/decred/dcrdata/testutil/dbconfig => ../dbconfig
+replace github.com/decred/dcrdata/testutil/dbconfig/v2 => ../dbconfig
 
 require (
 	github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0

--- a/testutil/dbload/go.mod
+++ b/testutil/dbload/go.mod
@@ -5,6 +5,6 @@ go 1.11
 replace github.com/decred/dcrdata/testutil/dbconfig => ../dbconfig
 
 require (
-	github.com/decred/dcrdata/testutil/dbconfig v1.0.1
+	github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0
 	github.com/lib/pq v1.1.0
 )

--- a/testutil/dbload/main.go
+++ b/testutil/dbload/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	tc "github.com/decred/dcrdata/testutil/dbconfig"
+	tc "github.com/decred/dcrdata/testutil/dbconfig/v2"
 	_ "github.com/lib/pq"
 )
 


### PR DESCRIPTION
After merge, tag the following:
- gov v1.0.1
- middleware v2.2.0
- exchanges v2.0.1 - NOTE: only updated dcrdata and rateserver deps!
- blockdata - v3.0.0 (major from v2 to v3)
- testutil/dbconfig - v2.0.0 (major from v1 to v2)
- cache - v2.1.0 - before dcrpg

After this commit is merged, update and tag:
- pubsub v2.0.1 (updated for blockdata major bump)
- db/dcrpg v3.0.2
- db/dcrsqlite v3.0.1