### PR TITLE
tidy: dbload, rateserver, dcrsqlite, dcrpg

### DIFF
--- a/db/dcrpg/go.sum
+++ b/db/dcrpg/go.sum
@@ -86,10 +86,10 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrdata/api/types/v3 v3.0.0 h1:NVw3pDQ0TVckSIegFSYcqPlqKZI6ehJSOEftHIvrOoY=
 github.com/decred/dcrdata/api/types/v3 v3.0.0/go.mod h1:DsZytNKhEESj6LLZatG9sO7cJPOp/ZQhV7nBzfflhpU=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0 h1:/itfTDAYV6bKK+lRbfyLL/O2aLU2QFi/Ija3RkPNKzI=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0/go.mod h1:fqVo7R+cuXGpEPnk4hNobY2MnF0mrCYSd5AsBahuqUE=
-github.com/decred/dcrdata/db/cache/v2 v2.0.0 h1:9ZIEMuqnVIPJjnlQ3UnmJxK0GTfkHqzBqionGZPpPsE=
-github.com/decred/dcrdata/db/cache/v2 v2.0.0/go.mod h1:Y4P8q485x8BpRLS52eXs9Lf+1hQl+5b7G1xnGkqJFHQ=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0 h1:oyNSqXxVzX5TWomjYCBIPh5OCJ4/nbp/llDuZ6gN20o=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0/go.mod h1:GPl6U8Od/5IAriuLt+Irfrz4bqWzzroCf5b2JHrS6YA=
+github.com/decred/dcrdata/db/cache/v2 v2.1.0 h1:QZn9iwHkNEZ3Ta+7xDuCNfCFn6R8yBiDLzxzdECAoEI=
+github.com/decred/dcrdata/db/cache/v2 v2.1.0/go.mod h1:Y4P8q485x8BpRLS52eXs9Lf+1hQl+5b7G1xnGkqJFHQ=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0 h1:1xF6HNNZwz9am2bByX7/89QTAPHcJbGIUQCDIlYFYMk=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0/go.mod h1:/xdvajiQlUnguMo16CNNK4xLvKVSm4veWf65Wq8DSuk=
 github.com/decred/dcrdata/rpcutils v1.2.0 h1:Xy1ogIEBX0kr7Sxe4uBQLw37i6VLPph7UIJQm7/54rc=
@@ -98,8 +98,8 @@ github.com/decred/dcrdata/semver v1.0.0 h1:DBqYU/x+4LqHq/3r4xKdF6xG5ewktG2KDC+g/
 github.com/decred/dcrdata/semver v1.0.0/go.mod h1:z+nQqiAd9fYkHhBLbejysZ2FPHtgkrErWDgMf+JlZWE=
 github.com/decred/dcrdata/stakedb/v2 v2.0.0 h1:drKto5hRxf7F4N08BzUmsxENv8RREOd5G4ZwrfQ9n3w=
 github.com/decred/dcrdata/stakedb/v2 v2.0.0/go.mod h1:DHfLqloW4lX5AcyPVYAyZBVScIdmAknsFb70C/7qnBE=
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1 h1:GpT582PTQ05nU1UHpr6Lz4vbIY94nTz751XYvGxnXe0=
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1/go.mod h1:ULWGbJMk5n/KvPe3/frMWM8BPhU0uLiKKhSYkYb9stE=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0 h1:3VDeqqb4RNDAYCPwe+yhe8WCl9DCtf2BbtRYxx1n6bo=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0/go.mod h1:R3AhuzSGbXK5YG6fst5njhUzDsCtju1+cbAqXsmi11s=
 github.com/decred/dcrdata/txhelpers/v2 v2.0.0 h1:X93e5mH+FhkQ45VroSEAUrb4eNM9KIJm77c9eqMWfNQ=
 github.com/decred/dcrdata/txhelpers/v2 v2.0.0/go.mod h1:u8uiIpoUlcuZSSeOu8geJhz5TxN49PSwuYcuqP7anwA=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0 h1:FPVohgxZHHwi7qTOBki/Dw9j5cgGsZYiktGSfgqHR0w=

--- a/db/dcrsqlite/go.sum
+++ b/db/dcrsqlite/go.sum
@@ -91,10 +91,10 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrdata/api/types/v3 v3.0.0 h1:NVw3pDQ0TVckSIegFSYcqPlqKZI6ehJSOEftHIvrOoY=
 github.com/decred/dcrdata/api/types/v3 v3.0.0/go.mod h1:DsZytNKhEESj6LLZatG9sO7cJPOp/ZQhV7nBzfflhpU=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0 h1:/itfTDAYV6bKK+lRbfyLL/O2aLU2QFi/Ija3RkPNKzI=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0/go.mod h1:fqVo7R+cuXGpEPnk4hNobY2MnF0mrCYSd5AsBahuqUE=
-github.com/decred/dcrdata/db/cache/v2 v2.0.0 h1:9ZIEMuqnVIPJjnlQ3UnmJxK0GTfkHqzBqionGZPpPsE=
-github.com/decred/dcrdata/db/cache/v2 v2.0.0/go.mod h1:Y4P8q485x8BpRLS52eXs9Lf+1hQl+5b7G1xnGkqJFHQ=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0 h1:oyNSqXxVzX5TWomjYCBIPh5OCJ4/nbp/llDuZ6gN20o=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0/go.mod h1:GPl6U8Od/5IAriuLt+Irfrz4bqWzzroCf5b2JHrS6YA=
+github.com/decred/dcrdata/db/cache/v2 v2.1.0 h1:QZn9iwHkNEZ3Ta+7xDuCNfCFn6R8yBiDLzxzdECAoEI=
+github.com/decred/dcrdata/db/cache/v2 v2.1.0/go.mod h1:Y4P8q485x8BpRLS52eXs9Lf+1hQl+5b7G1xnGkqJFHQ=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0 h1:1xF6HNNZwz9am2bByX7/89QTAPHcJbGIUQCDIlYFYMk=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0/go.mod h1:/xdvajiQlUnguMo16CNNK4xLvKVSm4veWf65Wq8DSuk=
 github.com/decred/dcrdata/dcrrates v1.1.0 h1:tbzM5FhqQ0iVUk0PNOH4E0spoiqlDKZNg/4SsZndsEw=
@@ -113,8 +113,8 @@ github.com/decred/dcrdata/semver v1.0.0 h1:DBqYU/x+4LqHq/3r4xKdF6xG5ewktG2KDC+g/
 github.com/decred/dcrdata/semver v1.0.0/go.mod h1:z+nQqiAd9fYkHhBLbejysZ2FPHtgkrErWDgMf+JlZWE=
 github.com/decred/dcrdata/stakedb/v2 v2.0.0 h1:drKto5hRxf7F4N08BzUmsxENv8RREOd5G4ZwrfQ9n3w=
 github.com/decred/dcrdata/stakedb/v2 v2.0.0/go.mod h1:DHfLqloW4lX5AcyPVYAyZBVScIdmAknsFb70C/7qnBE=
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1 h1:GpT582PTQ05nU1UHpr6Lz4vbIY94nTz751XYvGxnXe0=
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1/go.mod h1:ULWGbJMk5n/KvPe3/frMWM8BPhU0uLiKKhSYkYb9stE=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0 h1:3VDeqqb4RNDAYCPwe+yhe8WCl9DCtf2BbtRYxx1n6bo=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0/go.mod h1:R3AhuzSGbXK5YG6fst5njhUzDsCtju1+cbAqXsmi11s=
 github.com/decred/dcrdata/txhelpers/v2 v2.0.0 h1:X93e5mH+FhkQ45VroSEAUrb4eNM9KIJm77c9eqMWfNQ=
 github.com/decred/dcrdata/txhelpers/v2 v2.0.0/go.mod h1:u8uiIpoUlcuZSSeOu8geJhz5TxN49PSwuYcuqP7anwA=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0 h1:FPVohgxZHHwi7qTOBki/Dw9j5cgGsZYiktGSfgqHR0w=

--- a/dcrrates/rateserver/go.sum
+++ b/dcrrates/rateserver/go.sum
@@ -33,8 +33,8 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrdata/dcrrates v1.1.0 h1:tbzM5FhqQ0iVUk0PNOH4E0spoiqlDKZNg/4SsZndsEw=
 github.com/decred/dcrdata/dcrrates v1.1.0/go.mod h1:0YiDI6OS9kpVdkpLlFVo0+EvCLf6U+QY24wrJGf40xg=
-github.com/decred/dcrdata/exchanges/v2 v2.0.0 h1:LNgUH/WuD6wvhjzXJMXtwsE28EjyoKs1ev5iQ6gWtSM=
-github.com/decred/dcrdata/exchanges/v2 v2.0.0/go.mod h1:OQK9FcVspuhnZFlk2jOcGwLuEiMSQM0iXMwsWISFE5Q=
+github.com/decred/dcrdata/exchanges/v2 v2.0.1 h1:gfs5JfobSyuyERVEfo4IOTXbBHd22HJfi7PG9GEYlbY=
+github.com/decred/dcrdata/exchanges/v2 v2.0.1/go.mod h1:OQK9FcVspuhnZFlk2jOcGwLuEiMSQM0iXMwsWISFE5Q=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/pubsub/go.sum
+++ b/pubsub/go.sum
@@ -93,8 +93,8 @@ github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hn
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrdata/api/types/v3 v3.0.0 h1:NVw3pDQ0TVckSIegFSYcqPlqKZI6ehJSOEftHIvrOoY=
 github.com/decred/dcrdata/api/types/v3 v3.0.0/go.mod h1:DsZytNKhEESj6LLZatG9sO7cJPOp/ZQhV7nBzfflhpU=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0 h1:/itfTDAYV6bKK+lRbfyLL/O2aLU2QFi/Ija3RkPNKzI=
-github.com/decred/dcrdata/blockdata/v2 v2.0.0/go.mod h1:fqVo7R+cuXGpEPnk4hNobY2MnF0mrCYSd5AsBahuqUE=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0 h1:oyNSqXxVzX5TWomjYCBIPh5OCJ4/nbp/llDuZ6gN20o=
+github.com/decred/dcrdata/blockdata/v3 v3.0.0/go.mod h1:GPl6U8Od/5IAriuLt+Irfrz4bqWzzroCf5b2JHrS6YA=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0 h1:1xF6HNNZwz9am2bByX7/89QTAPHcJbGIUQCDIlYFYMk=
 github.com/decred/dcrdata/db/dbtypes/v2 v2.0.0/go.mod h1:/xdvajiQlUnguMo16CNNK4xLvKVSm4veWf65Wq8DSuk=
 github.com/decred/dcrdata/dcrrates v1.1.0 h1:tbzM5FhqQ0iVUk0PNOH4E0spoiqlDKZNg/4SsZndsEw=

--- a/testutil/dbload/go.sum
+++ b/testutil/dbload/go.sum
@@ -1,4 +1,4 @@
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1 h1:GpT582PTQ05nU1UHpr6Lz4vbIY94nTz751XYvGxnXe0=
-github.com/decred/dcrdata/testutil/dbconfig v1.0.1/go.mod h1:ULWGbJMk5n/KvPe3/frMWM8BPhU0uLiKKhSYkYb9stE=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0 h1:3VDeqqb4RNDAYCPwe+yhe8WCl9DCtf2BbtRYxx1n6bo=
+github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0/go.mod h1:R3AhuzSGbXK5YG6fst5njhUzDsCtju1+cbAqXsmi11s=
 github.com/lib/pq v1.1.0 h1:/5u4a+KGJptBRqGzPvYQL9p0d/tPR4S31+Tnzj9lEO4=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=


### PR DESCRIPTION
Given the newly tagged modules (blockdata/v3, cache/v2, dbconfig/v2, and exchanges), tidy the dependents.

After this the following modules are ready to tag: pubsub@2.0.1, db/dcrsqlite@v3.0.1 and db/dcrpg@v3.0.2