### PR TITLE
Run each testutil query individually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ pubsub/democlient/democlient
 dcrrates/rateserver/rateserver
 dcrrates/rateserver/logs/
 *.gob
+pgsql_*.sql
+sqlite_*.sql

--- a/testutil/dbconfig/config.go
+++ b/testutil/dbconfig/config.go
@@ -61,10 +61,18 @@ func scanQueries(data []byte, atEOF bool) (advance int, token []byte, err error)
 
 // Comments start with (--) and end with a new line.
 func deleteComments(a []byte) []byte {
-	re := regexp.MustCompile(`^--[\s*\w*[[:punct:]]*]*$\n`)
+	// delete sql comment
+	re := regexp.MustCompile(`--[^\n]*`)
 	a = re.ReplaceAll(a, []byte{})
 
-	// delete "test_" from all table references.
+	// Remove duplicate tabs and space characters.
+	re = regexp.MustCompile(`[\t\p{Zs}]{2,}`)
+	a = re.ReplaceAll(a, []byte{})
+
+	// delete "test_" from all table name references.
 	re = regexp.MustCompile(`test_`)
-	return re.ReplaceAll(a, []byte{})
+	a = re.ReplaceAll(a, []byte{})
+
+	// delete any leading or trailing spaces left.
+	return bytes.TrimSpace(a)
 }

--- a/testutil/dbconfig/config.go
+++ b/testutil/dbconfig/config.go
@@ -37,7 +37,6 @@ func CustomScanner(m Migrations) error {
 		if len(text) == 0 {
 			continue
 		}
-
 		if err = m.Runner(text); err != nil {
 			return fmt.Errorf("Runner(%s): %v", text, err)
 		}
@@ -51,7 +50,7 @@ func scanQueries(data []byte, atEOF bool) (advance int, token []byte, err error)
 	if atEOF && len(data) == 0 {
 		return 0, nil, bufio.ErrFinalToken
 	}
-	if i := bytes.LastIndex(data, []byte(";\n")); i >= 0 {
+	if i := bytes.Index(data, []byte(";\n")); i >= 0 {
 		return i + 1, deleteComments(data[:i]), nil
 	}
 	if atEOF {

--- a/testutil/dbconfig/config_test.go
+++ b/testutil/dbconfig/config_test.go
@@ -1,0 +1,41 @@
+package dbconfig
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestScanQueries tests if scanQueries can be able to scan an individual query from
+// many queries together as a single token.
+func TestScanQueries(t *testing.T) {
+	testData := []byte(`
+		--
+		-- Data for Name: test_addresses; Type: TABLE DATA; Schema: public; Owner: postgres
+		--
+
+		INSERT INTO public.test_addresses (id, address) VALUES (727, 'DseF2UooQ8R78U6ZkPxEkUfzvyWMS3uVZQk');
+		INSERT INTO public.test_addresses (id, address) VALUES (62, 'DshdKtxhqX6Mi4iyvbYitaUYKE8M1FDyg9L');
+		INSERT INTO public.test_addresses (id, address) VALUES (1976, 'DsosVxMiaBCq8qdaFAMDPFPoYkeXMAYSXME');
+		`)
+
+	isEOF := false
+	val, token, err := scanQueries(testData, isEOF)
+	if err != nil {
+		t.Fatalf("expected no error to be returned but found %v", err)
+	}
+
+	if val <= 10 {
+		t.Fatalf("expected the advance int value to greater than 10 but it was %v ", val)
+	}
+
+	// "test_" table name prefix references were deleted.
+	// SQL comments were deleted.
+	// Any leading or trailing spaces were deleted.
+	// expectedToken shows the first token returned based on the testData input provided.
+	expectedToken := []byte(`INSERT INTO public.addresses (id, address) VALUES (727, 'DseF2UooQ8R78U6ZkPxEkUfzvyWMS3uVZQk')`)
+
+	if !bytes.Equal(token, expectedToken) {
+		t.Fatalf("expected the returned token to be (%v) but found (%v)", string(expectedToken), string(token))
+	}
+
+}


### PR DESCRIPTION
Since the file is scanned several bytes at a time, my custom token scanner using `LastIndex(` function was checking the last occurrence of `;\n` characters in the chunk already scanned.

`Index(` now returns the first occurrence of `;\n` in the scanned chunk thus you can not debug the tests. 