### PR TITLE
dcrpg: InsightAddressTransactions should include spending

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -547,7 +547,9 @@ func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) 
 	addresses, addrerr := m.GetAddressCtx(r, iapi.params, 1)
 
 	if blockerr != nil && addrerr != nil {
-		writeInsightError(w, "Required query parameters (address or block) not present.")
+		msg := fmt.Sprintf(`Required query parameters (address or block) not present. `+
+			`address error: "%v" / block error: "%v"`, addrerr, blockerr)
+		writeInsightError(w, msg)
 		return
 	}
 	if addrerr == nil && len(addresses) > 1 {

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -71,10 +71,10 @@ func sortTxsByTimeAndHash(txns []txSortable) {
 	})
 }
 
-// InsightAddressTransactions performs a db query to pull all txids for the
-// specified addresses ordered desc by time. It also returns a list of recently
-// (defined as greater than recentBlockHeight) confirmed transactions that can
-// be used to validate mempool status.
+// InsightAddressTransactions performs DB queries to get all transaction hashes
+// for the specified addresses in descending order by time. It also returns a
+// list of recently (defined as greater than recentBlockHeight) confirmed
+// transactions that can be used to validate mempool status.
 func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight int64) (txs, recentTxs []chainhash.Hash, err error) {
 	// Time of a "recent" block
 	recentBlocktime, err0 := pgb.BlockTimeByHeight(recentBlockHeight)
@@ -90,12 +90,7 @@ func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight 
 		if err != nil {
 			return nil, nil, err
 		}
-		// merged credit rows
-		// rows = cache.AllCreditAddressRows(rows)
 		for _, r := range rows {
-			if !r.IsFunding() {
-				continue
-			}
 			//txns = append(txns, txSortable{r.TxHash, r.TxBlockTime})
 			txns = append(txns, r.TxHash)
 			// Count the number of "recent" txns.
@@ -107,13 +102,6 @@ func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight 
 
 	// Sort by block time (DESC) then hash (ASC).
 	//sortTxsByTimeAndHash(txns)
-	// wasSorted := sort.SliceIsSorted(txns, func(i, j int) bool {
-	// 	if txns[i].Time == txns[j].Time {
-	// 		return txns[i].Hash < txns[j].Hash
-	// 	}
-	// 	return txns[i].Time > txns[j].Time
-	// })
-	// fmt.Println(wasSorted)
 
 	txs = make([]chainhash.Hash, 0, len(txns))
 	recentTxs = make([]chainhash.Hash, 0, numRecent)
@@ -126,13 +114,6 @@ func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight 
 	}
 
 	return
-
-	// Perform the DB query in the absence of all cached data.
-	// ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
-	// defer cancel()
-	// txs, recentTxs, err = RetrieveAddressTxnsOrdered(ctx, pgb.db, addr, recentBlocktime)
-	// err = pgb.replaceCancelError(err)
-	// return
 }
 
 // AddressIDsByOutpoint fetches all address row IDs for a given outpoint

--- a/db/dcrpg/pgblockchain_fullpgdb_test.go
+++ b/db/dcrpg/pgblockchain_fullpgdb_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/decred/dcrdata/db/dcrpg/v3/internal"
 )
 
+func TestAddressRows(t *testing.T) {
+	rows, err := db.AddressRowsMerged("Dsh6khiGjTuyExADXxjtDgz1gRr9C5dEUf6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	neededTxns := []string{"23c329675052915d326c8048b16105a25002478c247c815b314d04b349fc8bea",
+		"53bb28bce5bde2b75825f5dc9cbe4c310fe04d8447ef48df20815f1079633c11"}
+	for _, r := range rows {
+		for i := range neededTxns {
+			if neededTxns[i] == r.TxHash.String() {
+				// remove
+				neededTxns[i] = neededTxns[len(neededTxns)-1]
+				neededTxns = neededTxns[:len(neededTxns)-1]
+				break
+			}
+		}
+	}
+	if len(neededTxns) > 0 {
+		t.Error("Some expected transactions not found:", neededTxns)
+	}
+}
+
 func TestMissingIndexes(t *testing.T) {
 	missing, descs, err := db.MissingIndexes()
 	if err != nil {


### PR DESCRIPTION
The Insight API endpoints `/api/addr[s]/{address}[/txs]` should include spending transactions as well as funding.

Also include a test for `(*ChainDB).AddressRowsMerged` to ensure it includes both funding and spending.