### PR TITLE
Align section heights of the homepage

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -149,7 +149,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blocks := exp.blockData.GetExplorerBlocks(int(height), int(height)-5)
+	blocks := exp.blockData.GetExplorerBlocks(int(height), int(height)-8)
 	var bestBlock *types.BlockBasic
 	if blocks == nil {
 		bestBlock = new(types.BlockBasic)

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -7,7 +7,7 @@
     {{ template "navbar" . }}
     <div class="container main" data-controller="time blocklist homepage">
         <div class="row">
-            <div class="col-md-15 p-0">
+            <div class="d-flex flex-column col-md-15 p-0">
 
                 <div class="bg-white mb-1 py-2 px-3 my-0">
                     <div class="d-inline-block position-relative p-2">
@@ -95,7 +95,7 @@
                     </div>
                 </div> <!-- end blocks card -->
 
-                <div class="py-1 px-2 mb-1 bg-white">
+                <div class="py-1 px-2 mb-1 bg-white flex-grow-1">
 
                     <div class="d-flex align-items-baseline my-2">
                         <div class="position-relative col nowrap">
@@ -202,7 +202,7 @@
                 </div>  <!-- end mempool card -->
             </div> <!-- end column -->
 
-            <div class="col-md-9 p-0">
+            <div class="d-flex flex-column col-md-9 p-0">
                 {{with .Info}}
                 <div class="bg-white mb-1 py-2 px-3 mx-1">
                     <div class="mt-2 my-3 h4">
@@ -365,7 +365,7 @@
                     </div>
                 </div> <!-- end mining card -->
 
-                <div class="bg-white mb-1 p-2 mb-2 px-3 mx-1">
+                <div class="bg-white mb-1 p-2 px-3 mx-1 flex-grow-1">
                     <div class="my-3 h4">
                         <span class="dcricon-tree d-inline-block pr-2 h4"></span>
                         Distribution


### PR DESCRIPTION
Resolves #1457
Resolves #992

- Adds an extra row in Blocks section
- Makes the 2 columns flexbox in order to evenly distribute their content
- Removes bottom margin from Distribution section so it aligns with end of the column

Full desktop width
<img width="1279" alt="Screen Shot 2019-07-08 at 1 27 25 PM" src="https://user-images.githubusercontent.com/2056512/60804361-06021480-a186-11e9-877b-e9fb03d6b942.png">

Width 900
<img width="638" alt="Screen Shot 2019-07-08 at 1 28 45 PM" src="https://user-images.githubusercontent.com/2056512/60804364-07cbd800-a186-11e9-8656-abf7cccf00c1.png">

Width 864
<img width="660" alt="Screen Shot 2019-07-08 at 1 29 25 PM" src="https://user-images.githubusercontent.com/2056512/60804365-07cbd800-a186-11e9-9ad3-bea7c4dcde40.png">
