### PR TITLE
explorer: fix darkmode on firefox

### DIFF
--- a/public/js/controllers/menu_controller.js
+++ b/public/js/controllers/menu_controller.js
@@ -14,12 +14,17 @@ function closest (el, id) {
 
 export default class extends Controller {
   static get targets () {
-    return ['toggle', 'darkModeToggle']
+    return ['toggle', 'darkModeToggle', 'form']
   }
 
   connect () {
     this.clickout = this._clickout.bind(this)
-    document.querySelectorAll('.menu-submit').forEach(button => { button.disabled = true })
+    this.formTargets.forEach(form => {
+      form.addEventListener('submit', e => {
+        e.preventDefault()
+        return false
+      })
+    })
   }
 
   _clickout (e) {

--- a/public/scss/navigation.scss
+++ b/public/scss/navigation.scss
@@ -167,6 +167,10 @@ body.darkBG {
     }
   }
 
+  .menu-form:hover .menu-item {
+    color: #2e75ff;
+  }
+
   .menu-submit {
     border: none;
     text-decoration: none;

--- a/public/scss/themes.scss
+++ b/public/scss/themes.scss
@@ -142,6 +142,10 @@ body.darkBG {
     }
   }
 
+  #menu .menu-form:hover .menu-item {
+    color: $dark-link-hover-color;
+  }
+
   #menu {
     background: #2a2a2a;
     box-shadow: 0 0 0 1px #fff3;

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -111,13 +111,13 @@
 					{{- else}}
 						<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
 					{{- end}}
-						<form action="/set" method="post">
+						<form action="/set" method="post" data-target="menu.form" class="menu-form">
 							<input type="hidden" name="darkmode" value="darkmode">
 							<input type="hidden" name="requestURI" value="{{.RequestURI}}">
-							<button type="submit"
+							<button type="submit" data-action="click->menu#onSunClick"
 									class="menu-submit text-left w-100 p-0"
 									data-keynav-skip>
-									<div class="menu-item" data-action="click->menu#onSunClick">
+									<div class="menu-item">
 									  <span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
 									  Night Mode
 									</div>


### PR DESCRIPTION
Firefox appears not to propagate click and hover events on disabled buttons, so this works around it.