### PR TITLE
insight: add pageNum middleware and use in /txs endpoint

### DIFF
--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -65,7 +65,7 @@ func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
 		app.ValidatePostCtx, m.PostBroadcastTxCtx).Post("/tx/send", app.broadcastTransactionRaw)
 	mux.With(m.TransactionHashCtx).Get("/tx/{txid}", app.getTransaction)
 	mux.With(m.TransactionHashCtx).Get("/rawtx/{txid}", app.getTransactionHex)
-	mux.With(m.TransactionsCtx).Get("/txs", app.getTransactions)
+	mux.With(m.TransactionsCtx, m.PageNumCtx).Get("/txs", app.getTransactions)
 
 	// Status and Utility
 	mux.With(app.StatusInfoCtx).Get("/status", app.getStatusInfo)

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -72,9 +72,10 @@ func sortTxsByTimeAndHash(txns []txSortable) {
 }
 
 // InsightAddressTransactions performs DB queries to get all transaction hashes
-// for the specified addresses in descending order by time. It also returns a
-// list of recently (defined as greater than recentBlockHeight) confirmed
-// transactions that can be used to validate mempool status.
+// for the specified addresses in descending order by time, then ascending order
+// by hash. It also returns a list of recently (defined as greater than
+// recentBlockHeight) confirmed transactions that can be used to validate
+// mempool status.
 func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight int64) (txs, recentTxs []chainhash.Hash, err error) {
 	// Time of a "recent" block
 	recentBlocktime, err0 := pgb.BlockTimeByHeight(recentBlockHeight)


### PR DESCRIPTION
The `pageNum` URL query param was being ignored with the `/txs` endpoint.
This checks for the `pageNum` parameter and goes to the correct page of
transactions.

This also fixes the computation of the `pagesTotal` JSON response field,
which previously was set to the total number of transactions rather than
than the number of pages.

Resolves https://github.com/decred/dcrdata/issues/1459