### PR TITLE
api/types: do not omit zero-value InsightVin.Vout

### DIFF
--- a/api/insight/converter.go
+++ b/api/insight/converter.go
@@ -35,13 +35,13 @@ func (iapi *InsightApi) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noSc
 			Size:          uint32(len(tx.Hex) / 2),
 		}
 
-		// Vins fill
+		// Vins
 		var vInSum float64
 		for vinID, vin := range tx.Vin {
 			InsightVin := &apitypes.InsightVin{
 				Txid:     vin.Txid,
-				Vout:     vin.Vout,
-				Sequence: vin.Sequence,
+				Vout:     newUint32Ptr(vin.Vout),
+				Sequence: newUint32Ptr(vin.Sequence),
 				N:        vinID,
 				Value:    vin.AmountIn,
 				CoinBase: vin.Coinbase,
@@ -80,7 +80,7 @@ func (iapi *InsightApi) DcrToInsightTxns(txs []*dcrjson.TxRawResult, noAsm, noSc
 
 		}
 
-		// Vout fill
+		// Vouts
 		var vOutSum float64
 		for _, v := range tx.Vout {
 			InsightVout := &apitypes.InsightVout{

--- a/api/types/insightapitypes.go
+++ b/api/types/insightapitypes.go
@@ -141,13 +141,13 @@ type InsightTx struct {
 
 type InsightVin struct {
 	Txid      string            `json:"txid,omitempty"`
-	Vout      uint32            `json:"vout,omitempty"`
-	Sequence  uint32            `json:"sequence,omitempty"`
+	Vout      *uint32           `json:"vout,omitempty"`
+	Sequence  *uint32           `json:"sequence,omitempty"`
 	N         int               `json:"n"`
 	ScriptSig *InsightScriptSig `json:"scriptSig,omitempty"`
 	Addr      string            `json:"addr,omitempty"`
-	ValueSat  int64             `json:"valueSat,omitempty"`
-	Value     float64           `json:"value,omitempty"`
+	ValueSat  int64             `json:"valueSat"`
+	Value     float64           `json:"value"`
 	CoinBase  string            `json:"coinbase,omitempty"`
 }
 


### PR DESCRIPTION
`Vout` and `Sequence` should not be omitted when zero. Instead, use a nil
pointer to omit them.
`Value` and `ValueSat` never need be omitted.

These changes require a *major* version bump to the api/types module.