### PR TITLE
insight: DcrToInsightTxns can RPC for prevout addresses

### DIFF
--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -117,14 +117,13 @@ func (pgb *ChainDB) InsightAddressTransactions(addr []string, recentBlockHeight 
 }
 
 // AddressIDsByOutpoint fetches all address row IDs for a given outpoint
-// (txHash:voutIndex). TODO: Update the vin due to the issue with amountin
-// invalid for unconfirmed txns.
+// (txHash:voutIndex).
 func (pgb *ChainDB) AddressIDsByOutpoint(txHash string, voutIndex uint32) ([]uint64, []string, int64, error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 	ids, addrs, val, err := RetrieveAddressIDsByOutpoint(ctx, pgb.db, txHash, voutIndex)
 	return ids, addrs, val, pgb.replaceCancelError(err)
-} // Update Vin due to DCRD AMOUNTIN - END
+}
 
 // InsightSearchRPCAddressTransactions performs a searchrawtransactions for the
 // specified address, max number of transactions, and offset into the transaction

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2024,9 +2024,8 @@ func scanAddressQueryRows(rows *sql.Rows, queryType int) (addressRows []*dbtypes
 	return
 }
 
-// RetrieveAddressIDsByOutpoint fetches all address row IDs for a given outpoint
-// (hash:index).
-// Update Vin due to DCRD AMOUNTIN - START - DO NOT MERGE CHANGES IF DCRD FIXED
+// RetrieveAddressIDsByOutpoint gets all address row IDs, addresses, and values
+// for a given outpoint.
 func RetrieveAddressIDsByOutpoint(ctx context.Context, db *sql.DB, txHash string, voutIndex uint32) ([]uint64, []string, int64, error) {
 	var ids []uint64
 	var addresses []string
@@ -2049,7 +2048,7 @@ func RetrieveAddressIDsByOutpoint(ctx context.Context, db *sql.DB, txHash string
 		addresses = append(addresses, addr)
 	}
 	return ids, addresses, value, err
-} // Update Vin due to DCRD AMOUNTIN - END
+}
 
 // retrieveOldestTxBlockTime helps choose the most appropriate address page
 // graph grouping to load by default depending on when the first transaction to


### PR DESCRIPTION
For non-coinbase/stakebase inputs, the previous outpoint itself may be
in mempool, in which case it is necessary to retrieve the inputs' txns
and decode the pkScript.

In addition to the above fix, which uses `txhelpers.OutPointAddressesFromString`,
amount summation is performed in integers rather than floats, and fee computation
is now correct for both coinbase and stakebase (vote) transactions.