### PR TITLE
insight: also check URL queries for params in PostAddrsTxsCtx middleware

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -735,7 +735,8 @@ func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) 
 			txsOld = append(txsOld, txOld)
 		}
 
-		// Convert to dcrjson transaction to Insight tx type.
+		// Convert to dcrjson transaction to Insight tx type. TxConverter also
+		// retrieves previous outpoint addresses.
 		txsNew, err := iapi.TxConverter(txsOld)
 		if err != nil {
 			apiLog.Error("getTransactions: Error processing transactions: %v", err)


### PR DESCRIPTION
The PostAddrsTxsCtx middleware processes parameters given in the POST
request body for an addrs endpoint. While the addresses list, "addrs",
must be in the POST body JSON, the other parameters may be specified
as URL queries. POST body values take priority.

e.g. `curl -s -X POST "http://127.0.0.1:7777/insight/api/addrs/txs?noScriptSig=0&noAsm=0&noSpent=0&from=0&to=25" -H 'Cache-Control: no-cache' -H 'Content-Type: application/json' -d '{"addrs":"DsTxcEnumw212AEjG2tfKoPA5nXBfWng2VG"}'`