### PR TITLE
dcrpg: AddressData should copy the cached AddressBalance

### DIFF
--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -764,7 +764,7 @@ func (ac *AddressCache) ClearAll() (numCleared int) {
 }
 
 // Clear purging cached data for the given addresses. If addrs is nil, all data
-// are cleared. If addresses is non-nil empty slice, no data are cleard.
+// are cleared. If addresses is non-nil empty slice, no data are cleared.
 func (ac *AddressCache) Clear(addrs []string) (numCleared int) {
 	if addrs == nil {
 		return ac.ClearAll()
@@ -791,7 +791,12 @@ func (ac *AddressCache) Balance(addr string) (*dbtypes.AddressBalance, *BlockID)
 		return nil, nil
 	}
 	ac.cacheMetrics.balanceHit()
-	return aci.Balance()
+	balance, blockID := aci.Balance()
+	var bal dbtypes.AddressBalance
+	if balance != nil {
+		bal = *balance // copy balance struct, blockID is already new
+	}
+	return &bal, blockID
 }
 
 // UTXOs attempts to retrieve an []*AddressTxnOutput for the given address. The
@@ -808,7 +813,7 @@ func (ac *AddressCache) UTXOs(addr string) ([]*dbtypes.AddressTxnOutput, *BlockI
 }
 
 // HistoryChart attempts to retrieve ChartsData for the given address, chart
-// type, and grouping inverval. The BlockID for the block at which the cached
+// type, and grouping interval. The BlockID for the block at which the cached
 // data is valid is also returned. In the event of a cache miss, both returned
 // pointers will be nil.
 func (ac *AddressCache) HistoryChart(addr string, addrChart dbtypes.HistoryChart,
@@ -1021,7 +1026,7 @@ func (ac *AddressCache) addCacheItem(addr string, aci *AddressCacheItem) (succes
 }
 
 func (ac *AddressCache) setCacheItemRows(addr string, rows []*dbtypes.AddressRowCompact, block *BlockID) (updated bool) {
-	if ac.cap < 1 || ac.capAddr < 1 {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
 		return false
 	}
 
@@ -1141,7 +1146,7 @@ func (ac *AddressCache) StoreRowsCompact(addr string, rows []*dbtypes.AddressRow
 // StoreBalance stores the AddressBalance for the given address in cache. The
 // current best block data is required to determine cache freshness.
 func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalance, block *BlockID) bool {
-	if ac.cap < 1 || ac.capAddr < 1 {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
 		return false
 	}
 
@@ -1149,15 +1154,16 @@ func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalanc
 	defer ac.mtx.Unlock()
 	aci := ac.a[addr]
 
-	if block != nil && balance == nil {
-		balance = &dbtypes.AddressBalance{
-			Address: addr,
-		}
+	var bal dbtypes.AddressBalance
+	if balance == nil {
+		bal.Address = addr
+	} else {
+		bal = *balance
 	}
 
 	if aci == nil || aci.BlockHash() != block.Hash {
 		return ac.addCacheItem(addr, &AddressCacheItem{
-			balance: balance,
+			balance: &bal,
 			height:  block.Height,
 			hash:    block.Hash,
 		})
@@ -1165,7 +1171,7 @@ func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalanc
 
 	// cache is current, so just set the balance.
 	aci.mtx.Lock()
-	aci.balance = balance
+	aci.balance = &bal
 	aci.mtx.Unlock()
 	return true
 }
@@ -1173,7 +1179,7 @@ func (ac *AddressCache) StoreBalance(addr string, balance *dbtypes.AddressBalanc
 // StoreUTXOs stores the *AddressTxnOutput slice for the given address in cache.
 // The current best block data is required to determine cache freshness.
 func (ac *AddressCache) StoreUTXOs(addr string, utxos []*dbtypes.AddressTxnOutput, block *BlockID) bool {
-	if ac.cap < 1 || ac.capAddr < 1 {
+	if block == nil || ac.cap < 1 || ac.capAddr < 1 {
 		return false
 	}
 
@@ -1186,7 +1192,7 @@ func (ac *AddressCache) StoreUTXOs(addr string, utxos []*dbtypes.AddressTxnOutpu
 	defer ac.mtx.Unlock()
 	aci := ac.a[addr]
 
-	if block != nil && utxos == nil {
+	if utxos == nil {
 		utxos = []*dbtypes.AddressTxnOutput{}
 	}
 

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -792,11 +792,12 @@ func (ac *AddressCache) Balance(addr string) (*dbtypes.AddressBalance, *BlockID)
 	}
 	ac.cacheMetrics.balanceHit()
 	balance, blockID := aci.Balance()
-	var bal dbtypes.AddressBalance
+	var bal *dbtypes.AddressBalance
 	if balance != nil {
-		bal = *balance // copy balance struct, blockID is already new
+		bal = new(dbtypes.AddressBalance)
+		*bal = *balance // copy balance struct, blockID is already new
 	}
-	return &bal, blockID
+	return bal, blockID
 }
 
 // UTXOs attempts to retrieve an []*AddressTxnOutput for the given address. The

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1886,7 +1886,7 @@ func (pgb *ChainDB) AddressBalance(address string) (bal *dbtypes.AddressBalance,
 	// Check the cache first.
 	bestHash, height := pgb.BestBlock()
 	var validHeight *cache.BlockID
-	bal, validHeight = pgb.AddressCache.Balance(address)
+	bal, validHeight = pgb.AddressCache.Balance(address) // bal is a copy
 	if bal != nil && *bestHash == validHeight.Hash {
 		return
 	}
@@ -1921,7 +1921,7 @@ func (pgb *ChainDB) AddressBalance(address string) (bal *dbtypes.AddressBalance,
 
 	// Update the address cache.
 	cacheUpdated = pgb.AddressCache.StoreBalance(address, bal,
-		cache.NewBlockID(bestHash, height))
+		cache.NewBlockID(bestHash, height)) // stores a copy of bal
 	return
 }
 
@@ -2149,7 +2149,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 	// addressRows is now present and current. Proceed to get the balance.
 
 	// Try the address balance cache.
-	balance, validBlock := pgb.AddressCache.Balance(address)
+	balance, validBlock := pgb.AddressCache.Balance(address) // balance is a copy
 	cacheCurrent = validBlock != nil && validBlock.Hash == *hash
 	if cacheCurrent {
 		log.Debugf("Address balance cache HIT for %s.", address)
@@ -2186,7 +2186,7 @@ func (pgb *ChainDB) AddressHistory(address string, N, offset int64,
 		}
 		// Update balance cache.
 		blockID := cache.NewBlockID(hash, height)
-		pgb.AddressCache.StoreBalance(address, balance, blockID)
+		pgb.AddressCache.StoreBalance(address, balance, blockID) // a copy of balance is stored
 	} else {
 		// Count spent/unspent amounts and transactions.
 		log.Debugf("Obtaining balance via DB query.")
@@ -2354,7 +2354,6 @@ FUNDING_TX_DUPLICATE_CHECK:
 		}
 		received += fundingTx.Tx.TxOut[f.Index].Value
 		numReceived++
-
 	}
 
 	// Spending transactions (unconfirmed)


### PR DESCRIPTION
Before updating the balance with unconfirmed transaction information,
the AddressData balance struct should be copied. Previously only the
pointer to the cached balance struct was being copied.

Resolves https://github.com/decred/dcrdata/issues/1475