### PR TITLE
restore replace statements for dcrdata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,25 @@ require (
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 )
+
+replace (
+	github.com/decred/dcrdata/api/types/v4 => ./api/types
+	github.com/decred/dcrdata/blockdata/v4 => ./blockdata
+	github.com/decred/dcrdata/db/cache/v2 => ./db/cache
+	github.com/decred/dcrdata/db/dbtypes/v2 => ./db/dbtypes
+	github.com/decred/dcrdata/db/dcrpg/v4 => ./db/dcrpg
+	github.com/decred/dcrdata/db/dcrsqlite/v4 => ./db/dcrsqlite
+	github.com/decred/dcrdata/dcrrates => ./dcrrates
+	github.com/decred/dcrdata/exchanges/v2 => ./exchanges
+	github.com/decred/dcrdata/explorer/types/v2 => ./explorer/types
+	github.com/decred/dcrdata/gov/v2 => ./gov
+	github.com/decred/dcrdata/mempool/v4 => ./mempool
+	github.com/decred/dcrdata/middleware/v3 => ./middleware
+	github.com/decred/dcrdata/pubsub/types/v3 => ./pubsub/types
+	github.com/decred/dcrdata/pubsub/v3 => ./pubsub
+	github.com/decred/dcrdata/rpcutils/v2 => ./rpcutils
+	github.com/decred/dcrdata/semver => ./semver
+	github.com/decred/dcrdata/stakedb/v3 => ./stakedb
+	github.com/decred/dcrdata/testutil/dbconfig/v2 => ./testutil/dbconfig
+	github.com/decred/dcrdata/txhelpers/v3 => ./txhelpers
+)


### PR DESCRIPTION
Most of the modules had a major version bump to use the new `jsonrpc/types` dcrd package.

See the diff for the following commit range to see what was changed before this: https://github.com/decred/dcrdata/compare/2ca45e7c17e6962d4a0aff3c3fd35d6f10bdbe85..d6b240d52b934a13f00718eef6cbf8a63d2305ff