### PR TITLE
explorer: charts: custom keyed chart responses. refactor controller

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -928,8 +928,9 @@ var chartMakers = map[string]ChartMaker{
 	PercentStaked:   stakedCoinsChart,
 }
 
-// Chart will return a JSON-encoded chartResponse of the provided type
-// and BinLevel.
+// Chart will return a JSON-encoded chartResponse of the provided chart,
+// binLevel, and axis (TimeAxis, HeightAxis). binString is ignored for
+// window-binned charts.
 func (charts *ChartData) Chart(chartID, binString, axisString string) ([]byte, error) {
 	if isWindowBin(chartID) {
 		binString = string(WindowBin)
@@ -957,7 +958,7 @@ func (charts *ChartData) Chart(chartID, binString, axisString string) ([]byte, e
 }
 
 // Encode the data sets. Optionally add arbitrary additional data as part of the
-// chartRespnse seed. A nil seed is allowed.
+// chartResponse seed. A nil seed is allowed.
 func encode(sets lengtherMap, seed chartResponse) ([]byte, error) {
 	if len(sets) == 0 {
 		return nil, fmt.Errorf("encode called without arguments")
@@ -972,7 +973,7 @@ func encode(sets lengtherMap, seed chartResponse) ([]byte, error) {
 		}
 	}
 	if len(seed) == 0 {
-		seed = make(chartResponse)
+		seed = make(chartResponse, len(sets))
 	}
 	for k, v := range sets {
 		seed[k] = v.Truncate(smaller)
@@ -1223,7 +1224,7 @@ func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 	}
 	t := make(ChartUints, 0, hrLen)
 	y := make(ChartUints, 0, hrLen)
-	rotator := make([]uint64, HashrateAvgLength)
+	var rotator [HashrateAvgLength]uint64
 	for i, work := range chainwork {
 		idx := i % HashrateAvgLength
 		rotator[idx] = work
@@ -1239,7 +1240,7 @@ func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 	return t, y
 }
 
-// dailyHashrate provides the provided daily chainwork data to hashrate data.
+// dailyHashrate converts the provided daily chainwork data to hashrate data.
 // Since hashrates are based on a difference, the returned arrays will be 1
 // element fewer than the number of days. A truncated time slice with the same
 // length as the hashrate slice is returned.

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -1250,11 +1250,19 @@ func dailyHashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 	}
 	times := make([]uint64, 0, len(time)-1)
 	rates := make([]uint64, 0, len(time)-1)
+	var dupes int
 	for i, t := range time[1:] {
 		tDiff := t - time[i]
+		if tDiff <= 0 {
+			tDiff = aDay
+			dupes += 1
+		}
 		workDiff := chainwork[i+1] - chainwork[i]
 		rates = append(rates, (workDiff)*1e6/tDiff)
 		times = append(times, t)
+	}
+	if dupes > 0 {
+		log.Warnf("charts: dailyHashrate: %d duplicate timestamp(s) found")
 	}
 	return times, rates
 }

--- a/db/cache/charts_test.go
+++ b/db/cache/charts_test.go
@@ -185,7 +185,7 @@ func TestChartsCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error getting fresh chart: %v", err)
 		}
-		if string(chart) != `{"x":[1,86402,86403,172804,172805,259206],"y":[1,2,3,4,5,6]}` {
+		if string(chart) != `{"axis":"time","bin":"block","size":[1,2,3,4,5,6],"t":[1,86402,86403,172804,172805,259206]}` {
 			t.Fatalf("unexpected chart json")
 		}
 		ck := cacheKey(BlockSize, BlockBin, TimeAxis)

--- a/db/dcrpg/pgblockchain_charts_test.go
+++ b/db/dcrpg/pgblockchain_charts_test.go
@@ -37,7 +37,7 @@ func registerDummyFeeAndPoolInfo(charts *cache.ChartData) {
 // No difference between the two should exist otherwise this test should fail.
 // It also checks the order and duplicates in the x-axis dataset.
 func TestPgCharts(t *testing.T) {
-	charts := cache.NewChartData(context.Background(), 0, &chaincfg.MainNetParams)
+	charts := cache.NewChartData(context.Background(), 0, chaincfg.MainNetParams())
 	// Spoof the interval to enable more points with a smaller test db.
 	charts.DiffInterval = 9
 


### PR DESCRIPTION
Changes the /api/chart responses from JSON object keys of x,y,z to custom keys. Updates the charts controller to use the new scheme. Removed that time array from block-binned data with axis=height, cutting half off of those response sizes.