### PR TITLE
proposals: add voting not started status

### DIFF
--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -148,8 +148,8 @@
                                         In Discussion
                                     </span>
                                 {{else if eq (len .VoteResults) 0 }}
-                                    <span class="text-progress position-relative" data-tooltip="Voting in progress">
-                                        In Progress
+                                    <span class="text-progress position-relative" data-tooltip="Waiting for administrator approval to start voting">
+                                        Vote pending
                                     </span>
                                 {{else}}
                                     {{range $i, $vr := .VoteResults}}


### PR DESCRIPTION
Resolves #1510

Not sure about the dark mode tooltip text color though

<img width="1249" alt="Screen Shot 2019-08-12 at 2 04 42 PM" src="https://user-images.githubusercontent.com/2056512/62860936-7f070580-bd0a-11e9-8258-cf3aa5dc0798.png">

