### PR TITLE
use our logger with the cors middleware v1.7.0

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -284,6 +284,12 @@ func NewFileRouter(app *appContext, useRealIP bool) fileMux {
 	return fileMux{mux}
 }
 
+type loggerFunc func(string, ...interface{})
+
+func (lw loggerFunc) Printf(str string, args ...interface{}) {
+	lw(str, args...)
+}
+
 // Stacks some middleware common to both file and api router.
 func stackedMux(useRealIP bool) *chi.Mux {
 	mux := chi.NewRouter()
@@ -293,6 +299,7 @@ func stackedMux(useRealIP bool) *chi.Mux {
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
 	corsMW := cors.Default()
+	corsMW.Log = loggerFunc(apiLog.Infof)
 	mux.Use(corsMW.Handler)
 	return mux
 }

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -299,7 +299,7 @@ func stackedMux(useRealIP bool) *chi.Mux {
 	mux.Use(middleware.Logger)
 	mux.Use(middleware.Recoverer)
 	corsMW := cors.Default()
-	corsMW.Log = loggerFunc(apiLog.Infof)
+	corsMW.Log = loggerFunc(apiLog.Tracef)
 	mux.Use(corsMW.Handler)
 	return mux
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -603,7 +603,7 @@ func (exp *explorerUI) addRoutes() {
 	exp.Mux.Use(middleware.Logger)
 	exp.Mux.Use(middleware.Recoverer)
 	corsMW := cors.Default()
-	corsMW.Log = loggerFunc(log.Infof)
+	corsMW.Log = loggerFunc(log.Tracef)
 	exp.Mux.Use(corsMW.Handler)
 
 	redirect := func(url string) http.HandlerFunc {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -593,10 +593,17 @@ func (exp *explorerUI) updateDevFundBalance() {
 	}
 }
 
+type loggerFunc func(string, ...interface{})
+
+func (lw loggerFunc) Printf(str string, args ...interface{}) {
+	lw(str, args...)
+}
+
 func (exp *explorerUI) addRoutes() {
 	exp.Mux.Use(middleware.Logger)
 	exp.Mux.Use(middleware.Recoverer)
 	corsMW := cors.Default()
+	corsMW.Log = loggerFunc(log.Infof)
 	exp.Mux.Use(corsMW.Handler)
 
 	redirect := func(url string) http.HandlerFunc {

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/rs/cors v1.6.0
+	github.com/rs/cors v1.7.0
 	github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644
 	github.com/sirupsen/logrus v1.3.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d h1:1VUlQbCfkoSGv
 github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
-github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 h1:X+yvsM2yrEktyI+b2qND5gpH8YhURn0k8OCaeRnkINo=
 github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 h1:80VN+vGkqM773Br/uNNTSheo3KatTgV8IpjIKjvVLng=


### PR DESCRIPTION
github.com/rs/cors v1.7.0 allows specifying a custom logger.  This updates to cors v1.7.0 and uses our loggers in both the api and explorer routers.