### PR TITLE
require at least go 1.12 in each go.mod

### DIFF
--- a/api/types/go.mod
+++ b/api/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/api/types/v4
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/blockdata/go.mod
+++ b/blockdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/blockdata/v4
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/db/cache/go.mod
+++ b/db/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/db/cache/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/db/dbtypes/go.mod
+++ b/db/dbtypes/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/db/dbtypes/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/blockchain/stake/v2 v2.0.1

--- a/db/dcrpg/chkdcrpg/go.mod
+++ b/db/dcrpg/chkdcrpg/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/db/dcrpg/chkdcrpg
 
-go 1.11
+go 1.12
 
 replace (
 	github.com/decred/dcrdata/db/dcrpg/v4 => ../

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/db/dcrpg/v4
 
-go 1.11
+go 1.12
 
 require (
 	github.com/chappjc/trylock v1.0.0

--- a/dcrrates/go.mod
+++ b/dcrrates/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/dcrrates
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/dcrutil/v2 v2.0.0

--- a/exchanges/go.mod
+++ b/exchanges/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/exchanges/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/carterjones/signalr v0.3.5

--- a/explorer/types/go.mod
+++ b/explorer/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/explorer/types/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/v2 v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrdata/v5
 
+go 1.12
+
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb

--- a/gov/go.mod
+++ b/gov/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/gov/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/asdine/storm v2.2.0+incompatible

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/mempool/v4
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/blockchain/stake/v2 v2.0.1

--- a/middleware/go.mod
+++ b/middleware/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/middleware/v3
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/pubsub/v3
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/v2 v2.2.0

--- a/pubsub/types/go.mod
+++ b/pubsub/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/pubsub/types/v3
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/base58 v1.0.0

--- a/rpcutils/go.mod
+++ b/rpcutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/rpcutils/v2
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/semver/go.mod
+++ b/semver/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrdata/semver
 
-go 1.11
+go 1.12

--- a/stakedb/go.mod
+++ b/stakedb/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/stakedb/v3
 
-go 1.11
+go 1.12
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 // indirect

--- a/testutil/dbconfig/go.mod
+++ b/testutil/dbconfig/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrdata/testutil/dbconfig/v2
 
-go 1.11
+go 1.12

--- a/testutil/dbload/go.mod
+++ b/testutil/dbload/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/testutil/dbload
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/dcrdata/testutil/dbconfig/v2 v2.0.0

--- a/txhelpers/go.mod
+++ b/txhelpers/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/txhelpers/v3
 
-go 1.11
+go 1.12
 
 require (
 	github.com/decred/base58 v1.0.0


### PR DESCRIPTION
The reason for keeping these updated with latest-1 is that these version lines in go.mod apparently can also activate certain go features, according to the [Go 1.13 beta release notes](https://tip.golang.org/doc/go1.13#language):

> If your code uses modules and your go.mod files specifies a language version, be sure it is set to at least 1.13 to get access to these language changes. You can do this by editing the go.mod file directly, or you can run go mod edit -go=1.13.

I do not know of any such features that are enabled with `go 1.12`, but updating go.mod in this way should be done on each new release.