### PR TITLE
deal with invalid module pseudo-versions in transitive deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,14 @@
 module github.com/decred/dcrdata/v5
 
+go 1.12
+
+replace (
+	github.com/go-critic/go-critic v0.0.0-20181204210945-0af0999fabfb => github.com/go-critic/go-critic v0.3.5-0.20190108192714-0af0999fabfb
+	github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
+	github.com/golangci/go-tools v0.0.0-20180109140146-35a9f45a5db0 => github.com/golangci/go-tools v0.0.0-20190124090046-35a9f45a5db0
+	github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
+)
+
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,7 @@ github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJ
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-critic/go-critic v0.0.0-20181204210945-0af0999fabfb/go.mod h1:PSww+HOJZQ3TN2hi6sphNiW1PhwELxbsK8+Jy1sjML8=
 github.com/go-critic/go-critic v0.3.4/go.mod h1:AHR42Lk/E/aOznsrYdMYeIQS5RH10HZHSqP+rD6AJrc=
+github.com/go-critic/go-critic v0.3.5-0.20190108192714-0af0999fabfb/go.mod h1:PSww+HOJZQ3TN2hi6sphNiW1PhwELxbsK8+Jy1sjML8=
 github.com/go-lintpack/lintpack v0.5.1/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
@@ -349,6 +350,7 @@ github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6/go.mod h1:DbHgvL
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/go-tools v0.0.0-20180109140146-35a9f45a5db0/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
 github.com/golangci/go-tools v0.0.0-20180902103155-93eecd106a0b/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
+github.com/golangci/go-tools v0.0.0-20190124090046-35a9f45a5db0/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
 github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3/go.mod h1:JXrF4TWy4tXYn62/9x8Wm/K/dm06p8tCKwFRDPZG/1o=
 github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee/go.mod h1:ozx7R9SIwqmqf5pRP90DhR2Oay2UIjGuKheCBCNwAYU=
 github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d/go.mod h1:ozx7R9SIwqmqf5pRP90DhR2Oay2UIjGuKheCBCNwAYU=


### PR DESCRIPTION
Go 1.13 is more strict when it comes to validating module pseudo-versions.  There are four transitive dependencies with invalid pseudo-versions that must be replaced as described at https://tip.golang.org/doc/go1.13#version-validation

```
go: github.com/decred/dcrdata/gov/v2@v2.0.2 requires
	github.com/decred/politeia@v0.0.0-20190716200512-2a928f2c2084 requires
	github.com/marcopeereboom/sbox@v0.0.0-20190125180204-32a7c85e429a requires
	github.com/golangci/golangci-lint@v1.13.1 requires
	github.com/go-critic/go-critic@v0.0.0-20181204210945-0af0999fabfb: invalid pseudo-version: does not match version-control timestamp (2019-01-08T19:27:14Z)

github.com/golangci/gofmt@v0.0.0-20181105071733-0b8337e80d98: invalid pseudo-version: does not match version-control timestamp (2018-12-22T12:35:16Z)

github.com/golangci/go-tools@v0.0.0-20180109140146-35a9f45a5db0: invalid pseudo-version: does not match version-control timestamp (2019-01-24T09:00:46Z)

github.com/golangci/errcheck@v0.0.0-20181003203344-ef45e06d44b6: invalid pseudo-version: does not match version-control timestamp (2018-12-23T08:41:20Z)
```

These are all coming in through the politeia import and github.com/marcopeereboom/sbox.