### PR TITLE
Fix Style Lint & Update Readme 

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,3 @@
 public/scss/_variables.scss
 public/scss/_variables_reference.scss
+node_modules

--- a/README.md
+++ b/README.md
@@ -372,6 +372,25 @@ cp sample-dcrdata.conf ~/.dcrdata/dcrdata.conf
 Then edit dcrdata.conf with your dcrd RPC settings. See the output of `dcrdata
 --help` for a list of all options and their default values.
 
+### Note: Edit postgresql settings in drcdata.conf file. 
+```
+-- Enable or Disable the pg support by default its false
+pg=true 
+pgdbname=<<DB_NAME>> e.g dcrdata_mainnet
+pguser=<<DB_OWNER>> e.g dcrdata
+pgpass=<<PASSWORD>>
+pghost=<<PG_HOST>> e.g 127.0.0.1:5432
+```
+
+#### (Optional): Disable the TLS connection with dcrd
+Run the `dcrd` with no `--notls` option
+
+```
+-- Edit dcrdata.conf to disable TLS for the connection 
+nodaemontls=1
+```
+
+
 ### Using Environment Variables for Configuration
 
 Almost all configuration items are available to set via environment variables.

--- a/README.md
+++ b/README.md
@@ -372,24 +372,14 @@ cp sample-dcrdata.conf ~/.dcrdata/dcrdata.conf
 Then edit dcrdata.conf with your dcrd RPC settings. See the output of `dcrdata
 --help` for a list of all options and their default values.
 
-### Note: Edit postgresql settings in drcdata.conf file. 
-```
--- Enable or Disable the pg support by default its false
-pg=true 
+### Edit postgresql settings in drcdata.conf file. 
+
+```ini
 pgdbname=<<DB_NAME>> e.g dcrdata_mainnet
-pguser=<<DB_OWNER>> e.g dcrdata
-pgpass=<<PASSWORD>>
-pghost=<<PG_HOST>> e.g 127.0.0.1:5432
+pguser=<<DB_USER>> e.g dcrdata
+pgpass=<<DB_PASS>>  # or comment out if no password (e.g. UNIX socket for pghost)
+pghost=<<PG_HOST>> e.g 127.0.0.1:5432 or /var/run/postgres
 ```
-
-#### (Optional): Disable the TLS connection with dcrd
-Run the `dcrd` with no `--notls` option
-
-```
--- Edit dcrdata.conf to disable TLS for the connection 
-nodaemontls=1
-```
-
 
 ### Using Environment Variables for Configuration
 


### PR DESCRIPTION
1. Wepack was generating warning regarding the sass files found in the node_modules.
   Add the node_modules to the .stylelintignore file.

2.Add the postgresql instruction in the readme file for deploying the dcrdata locally.
3.Add the optional instruction to run dcrd and dcrdata in notls mode.