### PR TITLE
exchanges: better websocket error handling and reconnect logic

### DIFF
--- a/dcrrates/rateserver/go.mod
+++ b/dcrrates/rateserver/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	google.golang.org/grpc v1.20.0
 )
+
+replace github.com/decred/dcrdata/exchanges/v2 => ../../exchanges

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -761,7 +761,7 @@ func (xc *CommonExchange) wsDepthStatus(connector func()) (tryHttp, initializing
 			var delay time.Duration
 			// wsDepthStatus is only called every DataExpiry, so a delay of zero is ok
 			// until there are a few consecutive errors.
-			switch true {
+			switch {
 			case errCount < 5:
 			case errCount < 20:
 				delay = 10 * time.Minute
@@ -774,7 +774,7 @@ func (xc *CommonExchange) wsDepthStatus(connector func()) (tryHttp, initializing
 				// book over HTTP anyway.
 				connector()
 			} else {
-				log.Errorf("%s websocket disabled. Too many errors. Will attempt to reconnect after %.1f minutes", xc.token, okToTry.Sub(time.Now()).Minutes())
+				log.Errorf("%s websocket disabled. Too many errors. Will attempt to reconnect after %.1f minutes", xc.token, time.Until(okToTry).Minutes())
 			}
 		} else {
 			// Connection has not been initialized. Trigger a silent update, since an

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -631,6 +631,12 @@ func (xc *CommonExchange) setWsFail(err error) {
 	xc.wsSync.fail = time.Now()
 }
 
+func (xc *CommonExchange) wsFailTime() time.Time {
+	xc.wsMtx.RLock()
+	defer xc.wsMtx.RUnlock()
+	return xc.wsSync.fail
+}
+
 // Set the init flag. The websocket is considered failed if the failed flag
 // is later than the init flag.
 func (xc *CommonExchange) wsInitialized() {
@@ -640,11 +646,13 @@ func (xc *CommonExchange) wsInitialized() {
 	xc.wsSync.update = xc.wsSync.init
 }
 
-// Set the updated flag.
+// Set the updated flag. Set the error count to 0 when the client has
+// successfully updated.
 func (xc *CommonExchange) wsUpdated() {
 	xc.wsMtx.Lock()
 	defer xc.wsMtx.Unlock()
 	xc.wsSync.update = time.Now()
+	xc.wsSync.errCount = 0
 }
 
 func (xc *CommonExchange) wsLastUpdate() time.Time {
@@ -681,8 +689,6 @@ func (xc *CommonExchange) connectSignalr(cfg *signalrConfig) (err error) {
 	xc.sr, err = newSignalrConnection(cfg)
 	return
 }
-
-const wsMaxErrors = 5
 
 // An intermediate order representation used to track an orderbook over a
 // websocket connection.
@@ -752,12 +758,23 @@ func (xc *CommonExchange) wsDepthStatus(connector func()) (tryHttp, initializing
 			log.Tracef("using http fallback for %s orderbook data", xc.token)
 			tryHttp = true
 			errCount := xc.wsErrorCount()
-			if errCount < wsMaxErrors {
+			var delay time.Duration
+			// wsDepthStatus is only called every DataExpiry, so a delay of zero is ok
+			// until there are a few consecutive errors.
+			switch true {
+			case errCount < 5:
+			case errCount < 20:
+				delay = 10 * time.Minute
+			default:
+				delay = time.Minute * 60
+			}
+			okToTry := xc.wsFailTime().Add(delay)
+			if time.Now().After(okToTry) {
 				// Try to connect, but don't wait for the response. Grab the order
 				// book over HTTP anyway.
 				connector()
-			} else if errCount == wsMaxErrors {
-				log.Errorf("%s websocket being disabled. Too many errors", xc.token)
+			} else {
+				log.Errorf("%s websocket disabled. Too many errors. Will attempt to reconnect after %.1f minutes", xc.token, okToTry.Sub(time.Now()).Minutes())
 			}
 		} else {
 			// Connection has not been initialized. Trigger a silent update, since an

--- a/exchanges/go.mod
+++ b/exchanges/go.mod
@@ -10,7 +10,6 @@ require (
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2 // indirect
 	golang.org/x/sys v0.0.0-20190416124237-ebb4019f01c9 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190415143225-d1146b9035b9 // indirect
 	google.golang.org/grpc v1.20.0
 )


### PR DESCRIPTION
Adds a progressive reconnection delay, so even persistent errors can be recovered. Fixes a bug where the error counter was not being reset. 