### PR TITLE
doc and naming cleanup

### DIFF
--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -698,7 +698,7 @@ func (ac *AddressCache) BalanceStats() (hits, misses int) {
 	return ac.cacheMetrics.balanceStats()
 }
 
-// rowStats reports the row hit/miss stats.
+// RowStats reports the row hit/miss stats.
 func (ac *AddressCache) RowStats() (hits, misses int) {
 	return ac.cacheMetrics.rowStats()
 }

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -415,7 +415,7 @@ type ChartData struct {
 	updaters     []ChartUpdater
 }
 
-// Check that the length of all arguments is equal.
+// ValidateLengths checks that the length of all arguments is equal.
 func ValidateLengths(lens ...lengther) (int, error) {
 	lenLen := len(lens)
 	if lenLen == 0 {

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -666,13 +666,13 @@ func (pgb *ChainDB) DeindexAddressTable() error {
 	return err
 }
 
-// IndexAddressTableOnVoutID creates the index for the addresses table over
-// vout row ID.
+// IndexStatsTableOnHeight creates the index for the stats table over height.
 func IndexStatsTableOnHeight(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.IndexStatsOnHeight)
 	return
 }
 
+// DeindexStatsTableOnHeight drops the index for the stats table over height.
 func DeindexStatsTableOnHeight(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexStatsOnHeight)
 	return

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2767,36 +2767,6 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 	}, nil
 }
 
-// TODO: finish
-func (pgb *ChainDB) AddressTransactionRawDetails(addr string, count, skip int64,
-	txnType dbtypes.AddrTxnViewType) ([]*apitypes.AddressTxRaw, error) {
-	addrData, _, err := pgb.addressInfo(addr, count, skip, txnType)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert each dbtypes.AddressTx to apitypes.AddressTxRaw
-	txs := addrData.Transactions
-	txsRaw := make([]*apitypes.AddressTxRaw, 0, len(txs))
-	for i := range txs {
-		txsRaw = append(txsRaw, &apitypes.AddressTxRaw{
-			Size: int32(txs[i].Size),
-			TxID: txs[i].TxID,
-			// Version
-			// LockTime
-			// Vin
-			// Vout
-			//
-			Confirmations: int64(txs[i].Confirmations),
-			//BlockHash: txs[i].
-			Time: apitypes.TimeAPI{S: txs[i].Time},
-			//Blocktime:
-		})
-	}
-
-	return txsRaw, nil
-}
-
 // UpdateChainState updates the blockchain's state, which includes each of the
 // agenda's VotingDone and Activated heights. If the agenda passed (i.e. status
 // is "lockedIn" or "activated"), Activated is set to the height at which the rule
@@ -4471,7 +4441,8 @@ func (pgb *ChainDB) GetPoolInfo(idx int) *apitypes.TicketPoolInfo {
 	return ticketPoolInfo
 }
 
-// GetPoolInfo retrieves the ticket pool statistics at the specified block hash.
+// GetPoolInfoByHash retrieves the ticket pool statistics at the specified block
+// hash.
 func (pgb *ChainDB) GetPoolInfoByHash(hash string) *apitypes.TicketPoolInfo {
 	ticketPoolInfo, err := RetrievePoolInfoByHash(pgb.ctx, pgb.db, hash)
 	if err != nil {
@@ -4481,7 +4452,7 @@ func (pgb *ChainDB) GetPoolInfoByHash(hash string) *apitypes.TicketPoolInfo {
 	return ticketPoolInfo
 }
 
-// GetPoolInfo retrieves the ticket pool statistics for a range of block
+// GetPoolInfoRange retrieves the ticket pool statistics for a range of block
 // heights, as a slice.
 func (pgb *ChainDB) GetPoolInfoRange(idx0, idx1 int) []apitypes.TicketPoolInfo {
 	ind0 := int64(idx0)
@@ -5020,8 +4991,8 @@ func (pgb *ChainDB) GetMempoolSSTxFeeRates(N int) *apitypes.MempoolTicketFees {
 	return &mpTicketFees
 }
 
-// returns the current mempool ticket info for tickets above height N in the
-// mempool cache.
+// GetMempoolSSTxDetails returns the current mempool ticket info for tickets
+// above height N in the mempool cache.
 func (pgb *ChainDB) GetMempoolSSTxDetails(N int) *apitypes.MempoolTicketDetails {
 	height, timestamp, totalSSTx, details := pgb.MPC.GetTicketsDetails(N)
 	mpTicketDetails := apitypes.MempoolTicketDetails{

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2433,31 +2433,6 @@ func RetrieveFundingTxByVinDbID(ctx context.Context, db *sql.DB, vinDbID uint64)
 	return
 }
 
-// TODO: this does not appear correct.
-func RetrieveFundingTxsByTx(db *sql.DB, txHash string) ([]uint64, []*dbtypes.Tx, error) {
-	var ids []uint64
-	var txs []*dbtypes.Tx
-	rows, err := db.Query(internal.SelectFundingTxsByTx, txHash)
-	if err != nil {
-		return ids, txs, err
-	}
-	defer closeRows(rows)
-
-	for rows.Next() {
-		var id uint64
-		var tx dbtypes.Tx
-		err = rows.Scan(&id, &tx)
-		if err != nil {
-			break
-		}
-
-		ids = append(ids, id)
-		txs = append(txs, &tx)
-	}
-
-	return ids, txs, err
-}
-
 // RetrieveSpendingTxByVinID gets the spending transaction input (hash, vin
 // number, and tx tree) for the transaction input specified by row ID in the
 // vins table.

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -255,6 +255,9 @@ func (pgb *ChainDB) DeleteDuplicates(barLoad chan *dbtypes.ProgressBarLoad) erro
 	return nil
 }
 
+// DeleteDuplicatesRecovery attempts to delete "duplicate" rows in all tables
+// where unique indexes are to be created.  This is like DeleteDuplicates, but
+// it also includes transactions, tickets, votes, and misses.
 func (pgb *ChainDB) DeleteDuplicatesRecovery(barLoad chan *dbtypes.ProgressBarLoad) error {
 	allDuplicates := []dropDuplicatesInfo{
 		// Remove duplicate vins

--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -1852,7 +1852,7 @@ func (list DragonExCandlestickList) getFloat(idx int) (float64, error) {
 	return val, nil
 }
 
-// DragonExCandlestickLists is a list of DragonExCandlestickList
+// DragonExCandlestickPts is a list of DragonExCandlestickList.
 type DragonExCandlestickPts []DragonExCandlestickList
 
 // DragonExCandlestickData models the Data field of DragonExCandlestickResponse.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -230,8 +230,8 @@ func (t *TxInfo) IsImmatureCoinbase() bool {
 	return t.Type == CoinbaseTypeStr && t.Mature == "False"
 }
 
-// IsImmatureCoinbase verifies the conditions: 1. is a revocation,
-// 2. is not mature.
+// IsImmatureRevocation verifies the conditions: 1. is a revocation, 2. is not
+// mature.
 func (t *TxInfo) IsImmatureRevocation() bool {
 	return t.Type == RevTypeStr && t.Mature == "False"
 }

--- a/gov/politeia/types/types.go
+++ b/gov/politeia/types/types.go
@@ -204,13 +204,13 @@ func VotesStatuses() map[VoteStatusType]string {
 // IsEqual compares CensorshipRecord, Name, State, NumComments, StatusChangeMsg,
 // Timestamp, CensoredDate, AbandonedDate, PublishedDate, Token, VoteStatus,
 // TotalVotes and count of VoteResults between the two ProposalsInfo structs passed.
-func (a *ProposalInfo) IsEqual(b *ProposalInfo) bool {
-	if a.CensorshipRecord != b.CensorshipRecord || a.Name != b.Name || a.State != b.State ||
-		a.NumComments != b.NumComments || a.StatusChangeMsg != b.StatusChangeMsg ||
-		a.Status != b.Status || a.Timestamp != b.Timestamp || a.Token != b.Token ||
-		a.CensoredDate != b.CensoredDate || a.AbandonedDate != b.AbandonedDate ||
-		a.VoteStatus != b.VoteStatus || a.TotalVotes != b.TotalVotes ||
-		a.PublishedDate != b.PublishedDate || len(a.VoteResults) != len(b.VoteResults) {
+func (pi *ProposalInfo) IsEqual(b *ProposalInfo) bool {
+	if pi.CensorshipRecord != b.CensorshipRecord || pi.Name != b.Name || pi.State != b.State ||
+		pi.NumComments != b.NumComments || pi.StatusChangeMsg != b.StatusChangeMsg ||
+		pi.Status != b.Status || pi.Timestamp != b.Timestamp || pi.Token != b.Token ||
+		pi.CensoredDate != b.CensoredDate || pi.AbandonedDate != b.AbandonedDate ||
+		pi.VoteStatus != b.VoteStatus || pi.TotalVotes != b.TotalVotes ||
+		pi.PublishedDate != b.PublishedDate || len(pi.VoteResults) != len(b.VoteResults) {
 		return false
 	}
 	return true
@@ -240,14 +240,14 @@ type ProposalMetadata struct {
 // prepare figures for display. Many of these manipulations require a tip height
 // and a target block time for the network, so those must be provided as
 // arguments.
-func (pinfo *ProposalInfo) Metadata(tip, targetBlockTime int64) *ProposalMetadata {
+func (pi *ProposalInfo) Metadata(tip, targetBlockTime int64) *ProposalMetadata {
 	meta := new(ProposalMetadata)
-	desc := pinfo.VoteStatus.ShortDesc()
+	desc := pi.VoteStatus.ShortDesc()
 	switch desc {
 	case "Started", "Finished":
-		endHeight, _ := strconv.ParseInt(pinfo.ProposalVotes.Endheight, 10, 64)
+		endHeight, _ := strconv.ParseInt(pi.ProposalVotes.Endheight, 10, 64)
 		meta.StartHeight = endHeight - windowSize
-		for _, count := range pinfo.VoteResults {
+		for _, count := range pi.VoteResults {
 			switch count.Option.OptionID {
 			case "yes":
 				meta.Yes = count.VotesReceived
@@ -256,10 +256,10 @@ func (pinfo *ProposalInfo) Metadata(tip, targetBlockTime int64) *ProposalMetadat
 			}
 		}
 		meta.VoteCount = meta.Yes + meta.No
-		quorumPct := float32(pinfo.QuorumPercentage) / 100
-		meta.QuorumCount = int64(quorumPct * float32(pinfo.NumOfEligibleVotes))
-		meta.PassPercent = float32(pinfo.PassPercentage) / 100
-		pctVoted := float32(meta.VoteCount) / float32(pinfo.NumOfEligibleVotes)
+		quorumPct := float32(pi.QuorumPercentage) / 100
+		meta.QuorumCount = int64(quorumPct * float32(pi.NumOfEligibleVotes))
+		meta.PassPercent = float32(pi.PassPercentage) / 100
+		pctVoted := float32(meta.VoteCount) / float32(pi.NumOfEligibleVotes)
 		meta.QuorumAchieved = pctVoted > quorumPct
 		if meta.VoteCount > 0 {
 			meta.Approval = float32(meta.Yes) / float32(meta.VoteCount)

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -89,7 +89,7 @@ func NewLimiter(max float64) *Limiter {
 	return &Limiter{tollbooth.NewLimiter(max, nil)}
 }
 
-// Tollboth creates a new rate limiter middleware using the provided Limiter.
+// Tollbooth creates a new rate limiter middleware using the provided Limiter.
 func Tollbooth(l *Limiter) func(http.Handler) http.Handler {
 	// Create a middleware, capturing the Limiter.
 	return func(next http.Handler) http.Handler {
@@ -973,7 +973,7 @@ func RetrieveExchangeTokenCtx(r *http.Request) string {
 	return token
 }
 
-// ExchangeTokenContext pulls the bin width from the URL.
+// StickWidthContext pulls the bin width from the URL.
 func StickWidthContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bin := chi.URLParam(r, "bin")

--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -32,7 +32,8 @@ import (
 	"github.com/decred/dcrdata/txhelpers/v3"
 )
 
-// A hard deadline for handlers to finish handling before an error is logged.
+// SyncHandlerDeadline is a hard deadline for handlers to finish handling before
+// an error is logged.
 const SyncHandlerDeadline = time.Minute * 5
 
 // BranchTips describes the old and new chain tips involved in a reorganization.

--- a/notification/notifier_test.go
+++ b/notification/notifier_test.go
@@ -54,14 +54,14 @@ func (node *dummyNode) GetBlockHeaderVerbose(hash *chainhash.Hash) (*chainjson.G
 	return nil, nil
 }
 
-var callCounter int = 0
+var callCounter int
 
-// test_TxHandler will be tested async
+// testTxHandler will be tested async
 var mtx sync.RWMutex
 var wg = new(sync.WaitGroup)
 var notifier *Notifier
 
-func test_TxHandler(_ *chainjson.TxRawResult) error {
+func testTxHandler(_ *chainjson.TxRawResult) error {
 	mtx.Lock()
 	defer mtx.Unlock()
 	defer wg.Done()
@@ -69,19 +69,19 @@ func test_TxHandler(_ *chainjson.TxRawResult) error {
 	return nil
 }
 
-var test_TxHandler_2 = test_TxHandler
+var testTxHandler2 = testTxHandler
 
-func test_BlockHandler(_ *wire.BlockHeader) error {
+func testBlockHandler(_ *wire.BlockHeader) error {
 	defer wg.Done()
 	callCounter++
 	return nil
 }
-func test_BlockHandlerLite(_ uint32, _ string) error {
+func testBlockHandlerLite(_ uint32, _ string) error {
 	defer wg.Done()
 	callCounter++
 	return nil
 }
-func test_ReorgHandler(reorg *txhelpers.ReorgData) error {
+func testReorgHandler(reorg *txhelpers.ReorgData) error {
 	defer wg.Done()
 	callCounter++
 	notifier.SetPreviousBlock(reorg.NewChainHead, uint32(reorg.NewChainHeight))
@@ -92,10 +92,10 @@ func TestNotifier(t *testing.T) {
 	ctx, shutdown := context.WithCancel(context.Background())
 	notifier = NewNotifier(ctx)
 	signals := notifier.DcrdHandlers()
-	notifier.RegisterTxHandlerGroup(test_TxHandler, test_TxHandler_2)
-	notifier.RegisterBlockHandlerGroup(test_BlockHandler)
-	notifier.RegisterBlockHandlerLiteGroup(test_BlockHandlerLite)
-	notifier.RegisterReorgHandlerGroup(test_ReorgHandler)
+	notifier.RegisterTxHandlerGroup(testTxHandler, testTxHandler2)
+	notifier.RegisterBlockHandlerGroup(testBlockHandler)
+	notifier.RegisterBlockHandlerLiteGroup(testBlockHandlerLite)
+	notifier.RegisterReorgHandlerGroup(testReorgHandler)
 	wg.Add(5)
 
 	notifier.Listen(&dummyNode{})


### PR DESCRIPTION
In addition to lots of docs clean up, this PR removes two exported functions from the `dcrpg` package:

- `RetrieveFundingTxsByTx`, unused internally and documented with `// TODO: this does not appear correct.`
- `(*ChainDB).AddressTransactionRawDetails`, unused internally and documented with `// TODO: finish`.