### PR TITLE
pubsub: fix possible dropped messages

### DIFF
--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-var version = semver.NewSemver(3, 0, 0)
+var version = semver.NewSemver(3, 1, 0)
 
 // Version indicates the semantic version of the pubsub module.
 func Version() semver.Semver {
@@ -36,8 +36,8 @@ func Version() semver.Semver {
 }
 
 const (
-	wsWriteTimeout = 10 * time.Second
-	wsReadTimeout  = 20 * time.Second
+	wsWriteTimeout = 5 * time.Second
+	wsReadTimeout  = 7 * time.Second
 )
 
 // wsDataSource defines the interface for collecting required data.
@@ -394,7 +394,7 @@ func (psh *PubSubHub) sendLoop(conn *connection) {
 
 loop:
 	for sig := range updateSigChan {
-		log.Tracef("(*PubSubHub)sendLoop: updateSigChan received %v for client %s",
+		log.Tracef("(*PubSubHub)sendLoop: updateSigChan received %v for client %d",
 			sig, clientData.id)
 		// If the update channel is closed, the loop terminates.
 
@@ -522,7 +522,7 @@ loop:
 			}
 			// If the send failed, the client is probably gone, quit the
 			// send loop, unregistering the client from the websocket hub.
-			log.Errorf("websocket.JSON.Send of %v failed: %v", pushMsg, err)
+			log.Errorf("websocket.JSON.Send of %v type message failed: %v", sig, err)
 			return
 		}
 	} // for range { a.k.a. loop:

--- a/pubsub/websocket.go
+++ b/pubsub/websocket.go
@@ -5,8 +5,6 @@
 package pubsub
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -228,13 +226,10 @@ type clientHubSpoke struct {
 	c  *hubSpoke
 }
 
+var idCounter uint64
+
 func newClientID() uint64 {
-	var id [8]byte
-	n, err := rand.Read(id[:])
-	if n != 8 || err != nil {
-		panic("newClientID: rand.Read failed!")
-	}
-	return binary.LittleEndian.Uint64(id[:])
+	return atomic.AddUint64(&idCounter, 1)
 }
 
 // NewClientHubSpoke registers a connection with the hub, and returns a pointer

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -4,7 +4,7 @@
 ; For all logging subsystems:
 ;debuglevel=debug
 ; Set per-subsystem:
-;debuglevel=DATD=debug,SQLT=debug,MEMP=debug,RPCC=info,JAPI=debug,PSQL=debug,IAPI=debug,NTFN=debug,SKDB=debug,BLKD=debug,EXPR=debug,PUBS=debug,XBOT=debug
+;debuglevel=DATD=debug,MEMP=debug,RPCC=info,JAPI=debug,PSQL=debug,IAPI=debug,NTFN=debug,SKDB=debug,BLKD=debug,EXPR=debug,PUBS=trace,XBOT=debug
 
 ; Authentication information for dcrd RPC (must set, no default)
 ;dcrduser=duser


### PR DESCRIPTION
When sending a signal to a pubsub client (i.e. `*spoke <- hubMsg`) and
the channel buffer is full, that does not mean the client is dead.
Instead, block the send unless `client.killed` is closed (when its
`WebSocketHandler` returns after both send and receive loops have
returned). There is no longer a `default` case.

Assign each client a random id, and add more logging around address messages.

Remove `SQLT` log subsystem from sample-dcrdata.conf

Add timeout for sends on the `hubSpoke` message channel send to
catch programmer error that could lead to deadlock.