### PR TITLE
gov/agendas: do not use compiled ConcensusDeployments

### DIFF
--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1449,7 +1449,8 @@ func (pgb *ChainDB) AgendaVotes(agendaID string, chartType int) (*dbtypes.Agenda
 	return avc, pgb.replaceCancelError(err)
 }
 
-// AgendasVotesSummary fetches the total vote choices count for the provided agenda.
+// AgendasVotesSummary fetches the total vote choices count for the provided
+// agenda.
 func (pgb *ChainDB) AgendasVotesSummary(agendaID string) (summary *dbtypes.AgendaSummary, err error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
@@ -2769,8 +2770,8 @@ func (pgb *ChainDB) AddressTransactionDetails(addr string, count, skip int64,
 
 // UpdateChainState updates the blockchain's state, which includes each of the
 // agenda's VotingDone and Activated heights. If the agenda passed (i.e. status
-// is "lockedIn" or "activated"), Activated is set to the height at which the rule
-// change will take(or took) place.
+// is "lockedIn" or "activated"), Activated is set to the height at which the
+// rule change will take(or took) place.
 func (pgb *ChainDB) UpdateChainState(blockChainInfo *chainjson.GetBlockChainInfoResult) {
 	if pgb == nil {
 		return
@@ -2794,10 +2795,10 @@ func (pgb *ChainDB) UpdateChainState(blockChainInfo *chainjson.GetBlockChainInfo
 		MaxBlockSize:           blockChainInfo.MaxBlockSize,
 	}
 
-	var voteMilestones = make(map[string]dbtypes.MileStone)
+	chainInfo.AgendaMileStones = make(map[string]dbtypes.MileStone, len(blockChainInfo.Deployments))
 
 	for agendaID, entry := range blockChainInfo.Deployments {
-		var agendaInfo = dbtypes.MileStone{
+		agendaInfo := dbtypes.MileStone{
 			Status:     dbtypes.AgendaStatusFromStr(entry.Status),
 			StartTime:  time.Unix(int64(entry.StartTime), 0).UTC(),
 			ExpireTime: time.Unix(int64(entry.ExpireTime), 0).UTC(),
@@ -2824,17 +2825,16 @@ func (pgb *ChainDB) UpdateChainState(blockChainInfo *chainjson.GetBlockChainInfo
 			agendaInfo.Activated = entry.Since
 		}
 
-		agendaInfo.VotingStarted = agendaInfo.VotingDone - ruleChangeInterval
+		if agendaInfo.VotingDone != 0 {
+			agendaInfo.VotingStarted = agendaInfo.VotingDone - ruleChangeInterval
+		}
 
-		voteMilestones[agendaID] = agendaInfo
+		chainInfo.AgendaMileStones[agendaID] = agendaInfo
 	}
 
-	chainInfo.AgendaMileStones = voteMilestones
-
 	pgb.deployments.mtx.Lock()
-	defer pgb.deployments.mtx.Unlock()
-
 	pgb.deployments.chainInfo = &chainInfo
+	pgb.deployments.mtx.Unlock()
 }
 
 // ChainInfo guarantees thread-safe access of the deployment data.

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -121,7 +121,7 @@ type PoliteiaBackend interface {
 type agendaBackend interface {
 	AgendaInfo(agendaID string) (*agendas.AgendaTagged, error)
 	AllAgendas() (agendas []*agendas.AgendaTagged, err error)
-	CheckAgendasUpdates(activeVersions map[uint32][]chaincfg.ConsensusDeployment) error
+	UpdateAgendas() error
 }
 
 // links to be passed with common page data.
@@ -554,7 +554,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			// Update the Agendas DB. Run this asynchronously to avoid
 			// blocking other processes.
 			go func() {
-				err := exp.agendasSource.CheckAgendasUpdates(exp.ChainParams.Deployments)
+				err := exp.agendasSource.UpdateAgendas()
 				if err != nil {
 					log.Error(err)
 				}

--- a/gov/agendas/deployments.go
+++ b/gov/agendas/deployments.go
@@ -8,10 +8,10 @@ package agendas
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/asdine/storm/v3"
-	"github.com/decred/dcrd/chaincfg/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/semver"
@@ -19,9 +19,9 @@ import (
 
 // AgendaDB represents the data for the stored DB.
 type AgendaDB struct {
-	sdb        *storm.DB
-	NumAgendas int
-	rpcClient  DeploymentSource
+	sdb           *storm.DB
+	stakeVersions []uint32
+	deploySource  DeploymentSource
 }
 
 // AgendaTagged has the same fields as chainjson.Agenda plus the VoteVersion
@@ -41,16 +41,16 @@ type AgendaTagged struct {
 }
 
 var (
-	// errDefault defines an error message returned if the agenda db wasn't properly
-	// initialized.
+	// errDefault defines an error message returned if the agenda db wasn't
+	// properly initialized.
 	errDefault = fmt.Errorf("AgendaDB was not initialized correctly")
 
 	// dbVersion is the current required version of the agendas.db.
 	dbVersion = semver.NewSemver(1, 0, 0)
 )
 
-// dbinfo defines the property that holds the db version.
-const dbinfo = "_agendas.db_"
+// dbInfo defines the property that holds the db version.
+const dbInfo = "_agendas.db_"
 
 // DeploymentSource provides a cleaner way to track the rpcclient methods used
 // in this package. It also allows usage of alternative implementations to
@@ -60,9 +60,8 @@ type DeploymentSource interface {
 }
 
 // NewAgendasDB opens an existing database or create a new one using with the
-// specified file name. An initialized agendas db connection is returned.
-// It also checks the db version, Reindexes the db if need be and sets the
-// required db version.
+// specified file name. It also checks the DB version, reindexes the DB if need
+// be, and sets the required DB version.
 func NewAgendasDB(client DeploymentSource, dbPath string) (*AgendaDB, error) {
 	if dbPath == "" {
 		return nil, fmt.Errorf("empty db Path found")
@@ -82,9 +81,9 @@ func NewAgendasDB(client DeploymentSource, dbPath string) (*AgendaDB, error) {
 		return nil, err
 	}
 
-	// Checks if the correct db version has been set.
+	// Check if the correct DB version has been set.
 	var version string
-	err = db.Get(dbinfo, "version", &version)
+	err = db.Get(dbInfo, "version", &version)
 	if err != nil && err != storm.ErrNotFound {
 		return nil, err
 	}
@@ -100,27 +99,90 @@ func NewAgendasDB(client DeploymentSource, dbPath string) (*AgendaDB, error) {
 		}
 
 		// Set the required db version.
-		err = db.Set(dbinfo, "version", dbVersion.String())
+		err = db.Set(dbInfo, "version", dbVersion.String())
 		if err != nil {
 			return nil, err
 		}
 		log.Infof("agendas.db version %v was set", dbVersion)
 	}
 
-	return &AgendaDB{sdb: db, rpcClient: client}, nil
-}
-
-// countProperties fetches the Agendas count and appends it to the AgendaDB
-// receiver.
-func (db *AgendaDB) countProperties() error {
-	numAgendas, err := db.sdb.Count(&AgendaTagged{})
+	// Determine stake versions known by dcrd.
+	stakeVersions, err := listStakeVersions(client)
 	if err != nil {
-		log.Errorf("Agendas count failed: %v\n", err)
-		return err
+		return nil, err
 	}
 
-	db.NumAgendas = numAgendas
-	return nil
+	adb := &AgendaDB{
+		sdb:           db,
+		deploySource:  client,
+		stakeVersions: stakeVersions,
+	}
+	return adb, nil
+}
+
+func listStakeVersions(client DeploymentSource) ([]uint32, error) {
+	// The regexp is needed because dcrd does not currently return
+	// ErrRPCInvalidParameter, instead ErrRPCInternal.
+	re := regexp.MustCompile(`stake version \d+ does not exist`)
+
+	agendaIDs := func(agendas []chainjson.Agenda) (ids []string) {
+		for i := range agendas {
+			ids = append(ids, agendas[i].ID)
+		}
+		return
+	}
+
+	var firstVer uint32
+	for {
+		voteInfo, err := client.GetVoteInfo(firstVer)
+		if err == nil {
+			// That's the first version.
+			log.Debugf("Stake version %d: %v", firstVer, agendaIDs(voteInfo.Agendas))
+			// startTime = voteInfo.Agendas[0].StartTime
+			break
+		}
+
+		if re.MatchString(err.Error()) {
+			// Try again.
+			firstVer++
+			continue
+		}
+		// Something went wrong.
+		return nil, err
+
+		// When dcrd fixes the code, do this instead of regexp:
+		// if jerr, ok := err.(*dcrjson.RPCError); ok {
+		// 	switch jerr.Code {
+		// 	case dcrjson.ErrRPCInvalidParameter:
+		// 		continue
+		// 	default:
+		// 		return nil, err
+		// 	}
+		// } else {
+		// 	return nil, err
+		// }
+		//
+		// firstVer++
+	}
+
+	versions := []uint32{firstVer}
+	for i := firstVer + 1; ; i++ {
+		voteInfo, err := client.GetVoteInfo(i)
+		if err == nil {
+			log.Debugf("Stake version %d: %v", i, agendaIDs(voteInfo.Agendas))
+			versions = append(versions, i)
+			continue
+		}
+
+		if re.MatchString(err.Error()) {
+			// Previous was the highest known stake version.
+			break
+		}
+		// Something went wrong.
+		return nil, err
+	}
+
+	return versions, nil
 }
 
 // Close should be called when you are done with the AgendaDB to close the
@@ -170,15 +232,14 @@ func agendasForVoteVersion(ver uint32, client DeploymentSource) ([]AgendaTagged,
 	return agendas, nil
 }
 
-// updatedb checks if vote versions available in chaincfg.ConsensusDeployment
-// are already updated in the agendas db, if not yet their data is updated.
-// chainjson.GetVoteInfoResult and chaincfg.ConsensusDeployment hold almost similar
-// data contents but chaincfg.Vote does not contain the important vote status
-// field that is found in chainjson.Agenda.
-func (db *AgendaDB) updatedb(activeVersions map[uint32][]chaincfg.ConsensusDeployment) (int, error) {
+// updateDB updates the agenda data for all configured vote versions.
+// chainjson.GetVoteInfoResult and chaincfg.ConsensusDeployment hold almost
+// similar data contents but chaincfg.Vote does not contain the important vote
+// status field that is found in chainjson.Agenda.
+func (db *AgendaDB) updateDB() (int, error) {
 	var agendas []AgendaTagged
-	for voteVersion := range activeVersions {
-		taggedAgendas, err := agendasForVoteVersion(voteVersion, db.rpcClient)
+	for _, voteVersion := range db.stakeVersions {
+		taggedAgendas, err := agendasForVoteVersion(voteVersion, db.deploySource)
 		if err != nil || len(taggedAgendas) == 0 {
 			return -1, fmt.Errorf("vote version %d agendas retrieval failed: %v",
 				voteVersion, err)
@@ -204,28 +265,22 @@ func (db *AgendaDB) storeAgenda(agenda *AgendaTagged) error {
 	return db.sdb.Save(agenda)
 }
 
-// CheckAgendasUpdates checks for update at the start of the process and will
-// proceed to update when necessary.
-func (db *AgendaDB) CheckAgendasUpdates(activeVersions map[uint32][]chaincfg.ConsensusDeployment) error {
+// UpdateAgendas updates agenda data for all configured vote versions.
+func (db *AgendaDB) UpdateAgendas() error {
 	if db == nil || db.sdb == nil {
 		return errDefault
 	}
 
-	if len(activeVersions) == 0 {
-		return nil
-	}
-
-	numRecords, err := db.updatedb(activeVersions)
+	numRecords, err := db.updateDB()
 	if err != nil {
-		return fmt.Errorf("agendas.CheckAgendasUpdates failed: %v", err)
+		return fmt.Errorf("agendas.UpdateAgendas failed: %v", err)
 	}
 
 	log.Infof("%d agenda records (agendas) were updated", numRecords)
-
-	return db.countProperties()
+	return nil
 }
 
-// AgendaInfo fetches an agenda's details given it's agendaID.
+// AgendaInfo fetches an agenda's details given its agendaID.
 func (db *AgendaDB) AgendaInfo(agendaID string) (*AgendaTagged, error) {
 	if db == nil || db.sdb == nil {
 		return nil, errDefault

--- a/gov/agendas/deployments.go
+++ b/gov/agendas/deployments.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/q"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 	"github.com/decred/dcrdata/semver"
@@ -300,7 +301,7 @@ func (db *AgendaDB) AllAgendas() (agendas []*AgendaTagged, err error) {
 		return nil, errDefault
 	}
 
-	err = db.sdb.All(&agendas)
+	err = db.sdb.Select(q.True()).OrderBy("VoteVersion", "ID").Reverse().Find(&agendas)
 	if err != nil {
 		log.Errorf("Failed to fetch data from Agendas DB: %v", err)
 	}

--- a/gov/agendas/deployments_test.go
+++ b/gov/agendas/deployments_test.go
@@ -258,27 +258,27 @@ var activeVersions = map[uint32][]chaincfg.ConsensusDeployment{
 func TestUpdateAndRetrievals(t *testing.T) {
 	var client *testClient
 
-	dbInstance := &AgendaDB{sdb: db, rpcClient: client}
+	voteVersions := []uint32{4, 5, 6, 7}
+	dbInstance := &AgendaDB{sdb: db, rpcClient: client, versions: voteVersions}
 	invalidVersions := map[uint32][]chaincfg.ConsensusDeployment{20: {}}
 
 	type testData struct {
-		db           *AgendaDB
-		voteVersions map[uint32][]chaincfg.ConsensusDeployment
-		errMsg       string
+		db     *AgendaDB
+		errMsg string
 	}
 
 	td := []testData{
-		{nil, nil, "AgendaDB was not initialized correctly"},
-		{&AgendaDB{}, nil, "AgendaDB was not initialized correctly"},
-		{dbInstance, activeVersions, ""},
-		{dbInstance, invalidVersions, `agendas.CheckAgendasUpdates failed: vote ` +
+		{nil, "AgendaDB was not initialized correctly"},
+		{&AgendaDB{}, "AgendaDB was not initialized correctly"},
+		{dbInstance, ""},
+		{dbInstance, `agendas.UpdateAgendas failed: vote ` +
 			`version 20 agendas retrieval failed: invalid vote version 20 found`},
 	}
 
 	// Test saving updates to agendas db.
 	for i, val := range td {
-		t.Run("Test_CheckAgendasUpdates_#"+strconv.Itoa(i), func(t *testing.T) {
-			err := val.db.CheckAgendasUpdates(val.voteVersions)
+		t.Run("Test_UpdateAgendas_#"+strconv.Itoa(i), func(t *testing.T) {
+			err := val.db.UpdateAgendas()
 			if err != nil && val.errMsg != err.Error() {
 				t.Fatalf("expect to find error '%s' but found '%v' ", val.errMsg, err)
 			}

--- a/gov/agendas/deployments_test.go
+++ b/gov/agendas/deployments_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/asdine/storm/v3"
-	"github.com/decred/dcrd/chaincfg/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types"
 	"github.com/decred/dcrdata/db/dbtypes/v2"
 )
@@ -79,7 +78,7 @@ type testClient int
 // GetVoteInfo implementation showing a sample data format expected.
 func (*testClient) GetVoteInfo(version uint32) (*chainjson.GetVoteInfoResult, error) {
 	if version != 5 {
-		return &chainjson.GetVoteInfoResult{}, fmt.Errorf(voteVersionErrMsg, version)
+		return nil, fmt.Errorf("stake version %d does not exist", version)
 	}
 	resp := &chainjson.GetVoteInfoResult{
 		CurrentHeight: 319842,
@@ -176,11 +175,6 @@ func TestNewAgendasDB(t *testing.T) {
 	}
 }
 
-// voteVersionErrMsg is a sample error message that does not imply the format of
-// the actual error rpcclient.GetVoteInfo returns when an invalid votes version
-// is provided.
-var voteVersionErrMsg = "invalid vote version %d found"
-
 var expectedAgenda = &AgendaTagged{
 	ID:             "TestAgenda0001",
 	Description:    "This agenda just shows chainjson.GetVoteInfoResult payload format",
@@ -216,51 +210,17 @@ var expectedAgenda = &AgendaTagged{
 	VoteVersion: 5,
 }
 
-var activeVersions = map[uint32][]chaincfg.ConsensusDeployment{
-	5: {
-		{
-			Vote: chaincfg.Vote{
-				Id:          "TestAgenda0001",
-				Description: "This agenda just shows chainjson.GetVoteInfoResult payload format",
-				Mask:        6,
-				Choices: []chaincfg.Choice{
-					{
-						Id:          "abstain",
-						Description: "abstain voting for change",
-						Bits:        0,
-						IsAbstain:   true,
-						IsNo:        false,
-					},
-					{
-						Id:          "no",
-						Description: "keep the existing consensus rules",
-						Bits:        2,
-						IsAbstain:   false,
-						IsNo:        true,
-					},
-					{
-						Id:          "yes",
-						Description: "change to the new consensus rules",
-						Bits:        4,
-						IsAbstain:   false,
-						IsNo:        false,
-					},
-				},
-			},
-			StartTime:  1548633600,
-			ExpireTime: 1580169600,
-		},
-	},
-}
-
 // TestUpdateAndRetrievals tests the agendas db updating and retrieval of one
 // and many agendas.
 func TestUpdateAndRetrievals(t *testing.T) {
 	var client *testClient
 
-	voteVersions := []uint32{4, 5, 6, 7}
-	dbInstance := &AgendaDB{sdb: db, rpcClient: client, versions: voteVersions}
-	invalidVersions := map[uint32][]chaincfg.ConsensusDeployment{20: {}}
+	voteVersions := []uint32{5}
+	dbInstance := &AgendaDB{
+		sdb:           db,
+		deploySource:  client,
+		stakeVersions: voteVersions,
+	}
 
 	type testData struct {
 		db     *AgendaDB
@@ -271,8 +231,6 @@ func TestUpdateAndRetrievals(t *testing.T) {
 		{nil, "AgendaDB was not initialized correctly"},
 		{&AgendaDB{}, "AgendaDB was not initialized correctly"},
 		{dbInstance, ""},
-		{dbInstance, `agendas.UpdateAgendas failed: vote ` +
-			`version 20 agendas retrieval failed: invalid vote version 20 found`},
 	}
 
 	// Test saving updates to agendas db.
@@ -285,10 +243,6 @@ func TestUpdateAndRetrievals(t *testing.T) {
 
 			if err == nil && val.errMsg != "" {
 				t.Fatalf("expected to find error '%s' but none was returned ", val.errMsg)
-			}
-
-			if err == nil && val.db.NumAgendas != 2 {
-				t.Fatalf("expected to find 2 agendas added but found '%d'", val.db.NumAgendas)
 			}
 		})
 	}

--- a/gov/agendas/tracker.go
+++ b/gov/agendas/tracker.go
@@ -397,8 +397,12 @@ func (tracker *VoteTracker) newVoteSummary() *VoteSummary {
 			}
 		}
 		agendaSummary.VoteCount = agendaSummary.Aye + agendaSummary.Nay
-		agendaSummary.Approval = float32(agendaSummary.Aye) / float32(agendaSummary.VoteCount)
-		agendaSummary.AbstainRate = float32(agendaSummary.Abstain) / float32(agendaSummary.VoteCount+agendaSummary.Abstain)
+		if agendaSummary.VoteCount > 0 {
+			agendaSummary.Approval = float32(agendaSummary.Aye) / float32(agendaSummary.VoteCount)
+		}
+		if agendaSummary.VoteCount+agendaSummary.Abstain > 0 {
+			agendaSummary.AbstainRate = float32(agendaSummary.Abstain) / float32(agendaSummary.VoteCount+agendaSummary.Abstain)
+		}
 		agendaSummary.QuorumProgress = float32(agendaSummary.VoteCount) / float32(agendaSummary.Quorum)
 		agendaSummary.FailThreshold = 1 - agendaSummary.PassThreshold
 

--- a/gov/agendas/tracker_test.go
+++ b/gov/agendas/tracker_test.go
@@ -74,7 +74,7 @@ func (source dataSourceStub) GetStakeVersionInfo(version int32) (*chainjson.GetS
 
 func (source dataSourceStub) GetVoteInfo(version uint32) (*chainjson.GetVoteInfoResult, error) {
 	if version > 6 {
-		return nil, fmt.Errorf(" ")
+		return nil, fmt.Errorf("stake version %d does not exist", version)
 	}
 	h := int64(version * 50000)
 	return &chainjson.GetVoteInfoResult{
@@ -152,10 +152,9 @@ func counter(hash string) (uint32, uint32, uint32, error) {
 }
 
 func TestVoteTracker(t *testing.T) {
-	data := map[uint32][]chaincfg.ConsensusDeployment{4: {{StartTime: 1493164800}}}
-	tracker, err := NewVoteTracker(chaincfg.MainNetParams(), dataSourceStub{}, counter, data)
+	tracker, err := NewVoteTracker(chaincfg.MainNetParams(), dataSourceStub{}, counter)
 	if err != nil {
-		t.Errorf("NewVoteTracker error: %v", err)
+		t.Fatalf("NewVoteTracker error: %v", err)
 	}
 
 	summary := tracker.Summary()

--- a/main.go
+++ b/main.go
@@ -471,7 +471,7 @@ func _main(ctx context.Context) error {
 
 	// A vote tracker tracks current block and stake versions and votes.
 	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient,
-		chainDB.AgendaVoteCounts, activeChain.Deployments)
+		chainDB.AgendaVoteCounts)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize vote tracker: %v", err)
 	}
@@ -993,9 +993,7 @@ func _main(ctx context.Context) error {
 
 	// The proposals and agenda db updates are run after the db indexing.
 	// Retrieve blockchain deployment updates and add them to the agendas db.
-	// activeChain.Deployments contains a list of all agendas supported in the
-	// current environment.
-	if err = agendasInstance.CheckAgendasUpdates(activeChain.Deployments); err != nil {
+	if err = agendasInstance.UpdateAgendas(); err != nil {
 		return fmt.Errorf("updating agendas db failed: %v", err)
 	}
 

--- a/public/js/controllers/agenda_controller.js
+++ b/public/js/controllers/agenda_controller.js
@@ -22,7 +22,7 @@ function agendasLegendFormatter (data) {
     return total + n.y
   }, 0)
   data.series.forEach((series) => {
-    let percentage = ((series.y * 100) / total).toFixed(2)
+    let percentage = total !== 0 ? ((series.y * 100) / total).toFixed(2) : 0
     html = '<span style="color:#2d2d2d;">' + html + '</span>'
     html += `<br>${series.dashHTML}<span style="color: ${series.color};">${series.labelHTML}: ${series.yHTML} (${percentage}%)</span>`
   })
@@ -30,7 +30,7 @@ function agendasLegendFormatter (data) {
 }
 
 function cumulativeVoteChoicesData (d) {
-  if (d == null || !(d.yes instanceof Array)) return [[0, 0, 0]]
+  if (d == null || !(d.yes instanceof Array)) return [[0, 0, 0, 0]]
   return d.yes.map((n, i) => {
     return [
       new Date(d.time[i]),

--- a/public/js/controllers/agenda_controller.js
+++ b/public/js/controllers/agenda_controller.js
@@ -30,7 +30,7 @@ function agendasLegendFormatter (data) {
 }
 
 function cumulativeVoteChoicesData (d) {
-  if (!(d.yes instanceof Array)) return [[0, 0, 0]]
+  if (d == null || !(d.yes instanceof Array)) return [[0, 0, 0]]
   return d.yes.map((n, i) => {
     return [
       new Date(d.time[i]),
@@ -42,7 +42,7 @@ function cumulativeVoteChoicesData (d) {
 }
 
 function voteChoicesByBlockData (d) {
-  if (!(d.yes instanceof Array)) return [[0, 0, 0, 0]]
+  if (d == null || !(d.yes instanceof Array)) return [[0, 0, 0, 0]]
   return d.yes.map((n, i) => {
     return [
       d.height[i],

--- a/public/js/helpers/meters.js
+++ b/public/js/helpers/meters.js
@@ -167,14 +167,14 @@ class Meter {
     var opts = this.options
     var theme = this.activeTheme
     var halfLen = this.norm(opts.meterWidth) * 0.5
-    var start = super.normedPolarToCartesian(this.radius - halfLen, value)
-    var end = super.normedPolarToCartesian(this.radius + halfLen, value)
+    var start = this.normedPolarToCartesian(this.radius - halfLen, value)
+    var end = this.normedPolarToCartesian(this.radius + halfLen, value)
     ctx.lineWidth = 1.5
     ctx.strokeStyle = color
-    super.dot(start, color, opts.dotSize)
-    super.dot(end, color, opts.dotSize)
+    this.dot(start, color, opts.dotSize)
+    this.dot(end, color, opts.dotSize)
     ctx.strokeStyle = theme.text
-    super.line(start, end)
+    this.line(start, end)
   }
 
   async animate (key, target) {

--- a/views/agenda.tmpl
+++ b/views/agenda.tmpl
@@ -48,13 +48,13 @@
                         <tr>
                             <td class="text-right pr-2 lh1rem vam nowrap xs-w117 medium-sans">Voting Start</td>
                             <td class="lh1rem">
-                                <span class="hash break-word"><a href="/block/{{$.VotingStarted}}">{{$.VotingStarted}}</a></span>
+                                <span class="hash break-word">{{if eq $.VotingStarted 0}}N/A{{else}}<a href="/block/{{$.VotingStarted}}">{{$.VotingStarted}}</a>{{end}}</span>
                             </td>
                         </tr>
                          <tr>
                             <td class="text-right pr-2 lh1rem vam nowrap xs-w117 medium-sans">Voting End</td>
                             <td class="lh1rem">
-                                <span class="hash break-word"></a><a href="/block/{{$.LockedIn}}">{{$.LockedIn}}</a></span>
+                                <span class="hash break-word">{{if eq $.LockedIn 0}}N/A{{else}}<a href="/block/{{$.LockedIn}}">{{$.LockedIn}}</a>{{end}}</span>
                             </td>
                         </tr>
                         <tr>

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -19,7 +19,7 @@
 {{define "agendas"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Vote Agendas Page"}}
+    {{template "html-head" printf "Consensus Deployment Agendas"}}
         {{template "navbar" .}}
         <div class="container main pb-5" data-controller="agendas">
 

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -1,7 +1,7 @@
 {{define "proposals"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Vote Proposals Page"}}
+    {{template "html-head" printf "Politeia Proposals"}}
         {{template "navbar" .}}
         <div class="container main" data-controller="pagenavigation">
             <div class="row justify-content-between">


### PR DESCRIPTION
This eliminates the use of `chaincfg.Params.ConsensusDeployments` for determining the range of valid stake versions.  There is no reason to have this be compile time information when it can be figured out via `getvoteinfo`:

```
[DBG] AGDB: Stake version 4: [sdiffalgorithm lnsupport]
[DBG] AGDB: Stake version 5: [lnfeatures]
[DBG] AGDB: Stake version 6: [fixlnseqlocks]
[DBG] AGDB: Stake version 7: [headercommitments]
```

This also fixes a few bugs:
- In the agendas_controller, `Meter.drawIndicator`, and thus `ProgressMeter.draw` were broken because `Meter` was trying to reference `super`.
- The agendas table was in no particular order.  It is now ordered by vote version, then ID.
- Agenda votes in the defined state (yet to begin voting) threw JS errors from cumulativeVoteChoicesData and voteChoicesByBlockData.
- The same defined agendas showed NaN% in the legends, which is confusing.  It says zero now.

The titles of the agendas and proposals pages are renamed:
- Decred Vote Agendas Page => Consensus Deployment Agendas
- Decred Vote Proposals Page => Politeia Proposals
The word "Page" is silly since you're viewing it in a web browser.

The agendas page now:

![image](https://user-images.githubusercontent.com/9373513/67461241-6aa98800-f62c-11e9-88a1-8cef173c5ef3.png)


