### PR TITLE
api,pg: faster block range API queries

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -228,6 +228,40 @@ const (
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height = $1;`
 
+	SelectBlockDataRange = `
+		SELECT blocks.hash, blocks.height, blocks.size,
+			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
+			stats.pool_val, blocks.winners, blocks.is_valid
+		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
+		WHERE blocks.height BETWEEN $1 AND $2
+		ORDER BY blocks.height;`
+
+	SelectBlockDataRangeDesc = `
+		SELECT blocks.hash, blocks.height, blocks.size,
+			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
+			stats.pool_val, blocks.winners, blocks.is_valid
+		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
+		WHERE blocks.height BETWEEN $1 AND $2
+		ORDER BY blocks.height DESC;`
+
+	SelectBlockDataRangeWithSkip = `
+		SELECT blocks.hash, blocks.height, blocks.size,
+			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
+			stats.pool_val, blocks.winners, blocks.is_valid
+		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
+		WHERE blocks.height BETWEEN $1 AND $2
+			AND blocks.height %% %d = %d
+		ORDER BY blocks.height;`
+
+	SelectBlockDataRangeWithSkipDesc = `
+		SELECT blocks.hash, blocks.height, blocks.size,
+			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
+			stats.pool_val, blocks.winners, blocks.is_valid
+		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
+		WHERE blocks.height BETWEEN $1 AND $2
+			AND blocks.height %% %d = %d
+		ORDER BY blocks.height DESC;`
+
 	SelectBlockDataByHash = `
 			SELECT blocks.hash, blocks.height, blocks.size,
 				blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -4780,6 +4780,40 @@ func (pgb *ChainDB) BlockSummary(ind int64) (*apitypes.BlockDataBasic, error) {
 	return bd, nil
 }
 
+// GetSummary returns the *apitypes.BlockDataBasic for a range of block heights.
+func (pgb *ChainDB) GetSummaryRange(idx0, idx1 int) []*apitypes.BlockDataBasic {
+	summaries, err := pgb.BlockSummaryRange(int64(idx0), int64(idx1))
+	if err != nil {
+		log.Errorf("Unable to retrieve block summaries: %v", err)
+		return nil
+	}
+	return summaries
+}
+
+// BlockSummaryRange returns the *apitypes.BlockDataBasic for a range of block
+// height.
+func (pgb *ChainDB) BlockSummaryRange(idx0, idx1 int64) ([]*apitypes.BlockDataBasic, error) {
+	return RetrieveBlockSummaryRange(pgb.ctx, pgb.db, idx0, idx1)
+}
+
+// GetSummaryStepped returns the []*apitypes.BlockDataBasic for a given block
+// height.
+func (pgb *ChainDB) GetSummaryRangeStepped(idx0, idx1, step int) []*apitypes.BlockDataBasic {
+	summaries, err := pgb.BlockSummaryRangeStepped(int64(idx0), int64(idx1), int64(step))
+	if err != nil {
+		log.Errorf("Unable to retrieve block summaries: %v", err)
+		return nil
+	}
+
+	return summaries
+}
+
+// BlockSummaryRangeStepped returns the []*apitypes.BlockDataBasic for every
+// step'th block in a specified range.
+func (pgb *ChainDB) BlockSummaryRangeStepped(idx0, idx1, step int64) ([]*apitypes.BlockDataBasic, error) {
+	return RetrieveBlockSummaryRangeStepped(pgb.ctx, pgb.db, idx0, idx1, step)
+}
+
 // GetSummaryByHash returns a *apitypes.BlockDataBasic for a given hex-encoded
 // block hash. If withTxTotals is true, the TotalSent and MiningFee fields will
 // be set, but it's costly because it requires a GetBlockVerboseByHash RPC call.


### PR DESCRIPTION
Uses new queries for selecting ranges of API blocks. The query methods now bypass the block cache, but are much faster. 

Resolves #1523 