### PR TITLE
speed up new block ntfn and storage handling

### DIFF
--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v2"
@@ -76,7 +77,7 @@ func (p *chainMonitor) collect(hash *chainhash.Hash) (*wire.MsgBlock, *BlockData
 	return msgBlock, blockData, nil
 }
 
-// ConnectBlock is a sychronous version of BlockConnectedHandler that collects
+// ConnectBlock is a synchronous version of BlockConnectedHandler that collects
 // and stores data for a block specified by the given hash. ConnectBlock
 // satisfies notification.BlockHandler, and is registered as a handler in
 // main.go.
@@ -95,11 +96,14 @@ func (p *chainMonitor) ConnectBlock(header *wire.BlockHeader) error {
 	// Store block data with each saver.
 	for _, s := range p.dataSavers {
 		if s != nil {
+			tStart := time.Now()
 			// Save data to wherever the saver wants to put it.
 			if err0 := s.Store(blockData, msgBlock); err0 != nil {
 				log.Errorf("(%v).Store failed: %v", reflect.TypeOf(s), err0)
 				err = err0
 			}
+			log.Tracef("(*chainMonitor).ConnectBlock: Completed %s.Store in %v.",
+				reflect.TypeOf(s), time.Since(tStart))
 		}
 	}
 	return err

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -80,6 +80,11 @@ func IndexBlockTableOnHeight(db *sql.DB) (err error) {
 	return
 }
 
+func IndexBlockTableOnTime(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexBlocksTableOnTime)
+	return
+}
+
 func DeindexBlockTableOnHash(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexBlockTableOnHash)
 	return
@@ -87,6 +92,11 @@ func DeindexBlockTableOnHash(db *sql.DB) (err error) {
 
 func DeindexBlockTableOnHeight(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexBlocksTableOnHeight)
+	return
+}
+
+func DeindexBlockTableOnTime(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexBlocksTableOnTime)
 	return
 }
 
@@ -486,6 +496,7 @@ func (pgb *ChainDB) IndexAll(barLoad chan *dbtypes.ProgressBarLoad) error {
 		// blocks table
 		{Msg: "blocks table on hash", IndexFunc: IndexBlockTableOnHash},
 		{Msg: "blocks table on height", IndexFunc: IndexBlockTableOnHeight},
+		{Msg: "blocks table on time", IndexFunc: IndexBlockTableOnTime},
 
 		// transactions table
 		{Msg: "transactions table on tx/block hashes", IndexFunc: IndexTransactionTableOnHashes},

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -90,6 +90,11 @@ const (
 	IndexBlocksTableOnHeight   = `CREATE INDEX ` + IndexOfBlocksTableOnHeight + ` ON blocks(height);`
 	DeindexBlocksTableOnHeight = `DROP INDEX ` + IndexOfBlocksTableOnHeight + ` CASCADE;`
 
+	// IndexBlocksTableOnHeight creates the index uix_block_time on (time).
+	// This is not unique because of side chains.
+	IndexBlocksTableOnTime   = `CREATE INDEX ` + IndexOfBlocksTableOnTime + ` ON blocks("time");`
+	DeindexBlocksTableOnTime = `DROP INDEX ` + IndexOfBlocksTableOnTime + ` CASCADE;`
+
 	SelectBlockByTimeRangeSQL = `SELECT hash, height, size, time, numtx
 		FROM blocks WHERE time BETWEEN $1 and $2 ORDER BY time DESC LIMIT $3;`
 	SelectBlockByTimeRangeSQLNoLimit = `SELECT hash, height, size, time, numtx

--- a/db/dcrpg/internal/indexes.go
+++ b/db/dcrpg/internal/indexes.go
@@ -6,6 +6,7 @@ const (
 
 	IndexOfBlocksTableOnHash   = "uix_block_hash"
 	IndexOfBlocksTableOnHeight = "uix_block_height"
+	IndexOfBlocksTableOnTime   = "uix_block_time"
 
 	// transactions table
 

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -73,9 +73,9 @@ func DropTables(db *sql.DB) {
 	for i := range createTableStatements {
 		pair := createTableStatements[lastIndex-i]
 		tableName := pair[0]
-		log.Infof("DROPPING the \"%s\" table.", tableName)
+		log.Infof("DROPPING the %q table.", tableName)
 		if err := dropTable(db, tableName); err != nil {
-			log.Errorf(`DROP TABLE "%s" failed.`, tableName)
+			log.Errorf("DROP TABLE %q; failed.", tableName)
 		}
 	}
 }

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -103,7 +103,7 @@ func (t *templates) execWithReload(name string, data interface{}) (string, error
 	if err != nil {
 		return "", fmt.Errorf("execWithReload: %v", err)
 	}
-	log.Debugf("reloaded HTML template \"%s\"", name)
+	log.Debugf("reloaded HTML template %q", name)
 	return t.execTemplateToString(name, data)
 }
 

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -401,7 +401,7 @@ func (db *ProposalDB) CheckProposalsUpdates() error {
 	// Add the sum of the newly added proposals.
 	numRecords += n
 
-	log.Infof("%d proposal records (politeia proposals-storm) were updated", numRecords)
+	log.Infof("%d politeia proposal DB records were updated", numRecords)
 
 	return nil
 }


### PR DESCRIPTION
**WARNING: This PR now updates the dcrpg table scheme from 1.2.0 to 1.3.0.**

This PR is meant to address a number of inefficiencies with new block handling.
`Notifier.processBlock()` has been taking between 10-20 seconds on production
servers, which is far too long.  For reference, on my workstation it took about 1.6
seconds, which is also longer than I would expect.

- Put `PubSubHub`'s `Store` before `explorerUI`'s since `explorerUI` launches
many computationally expensive tasks, which aren't required for downstream
block update handling.

- Make chart's `TriggerUpdate` run async.  `blockdata.BlockTrigger` now has an
`Async` `bool` field for this purpose.

- Log timing of each `Store` call in `(*chainMonitor).ConnectBlock`.

- Prevent concurrent calls to `(*ChartData).Update()`, which could happen
now that `TriggerUpdate` is run async by the chain monitor.

- Add to `ChainDB` a `lastExplorerBlock` field to cache the last
`exptypes.BlockInfo` retrieved with `GetExplorerBlock` and the latest
difficulties retrieved since the last call to `GetExplorerBlock`. This is
done because both `explorerUI.Store` and `PubSubHub.Store` run the same
costly queries back to back.  This cache struct now also holds the difficulties
retrieved by related function calls.

- Index the `blocks` table on `"time"`.  This practically eliminates the delay
from the SQL query for difficult on time, which was significant.

- In `(*explorerUI).Store`, make ASR simulation async so as not to block
subsequent `BlockDataSavers` any longer than needed.  Prevent dev fund
balance refresh and vote tracker refresh from running during DB sync.

Before (but with added logging)

```
[DBG] NTFN: OnBlockConnected: 391949 / 000000000000000020135202f994c196ad08dae13c332eb6466a2ea053185bfa (previous: 000000000000000007a06ce62ce6c503e7e66cfe3711c823324a7ea9e1ba1a17)
[INF] NTFN: superQueue: Processing new block 000000000000000020135202f994c196ad08dae13c332eb6466a2ea053185bfa (height 391949).
[INF] SKDB: Connected block 391949 to stake DB.
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/stakedb/v3.(*ChainMonitor).ConnectBlock-fm completed in 963ns
[INF] BLKD: Block height 391949 connected. Collecting data...
[DBG] BLKD: Collector.Collect() completed in 44.91208ms
[DBG] PSQL: Cleared cache for 88 addresses.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *dcrpg.ChainDB.Store in 161.292912ms.
[INF] PSQL: Pre-fetching project fund data at height 391949...
[DBG] PSQL: Address rows (view=all) cache MISS for Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx.
[DBG] EXPR: Got new block 391949 for the explorer.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *explorer.explorerUI.Store in 276.673326ms.
[DBG] PUBS: Got new block 391949 for the pubsubhub.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *pubsub.PubSubHub.Store in 287.384776ms.
[DBG] IAPI: Sending new websocket block 000000000000000020135202f994c196ad08dae13c332eb6466a2ea053185bfa
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *insight.SocketServer.Store in 19.849µs.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed blockdata.BlockTrigger.Store in 756.527654ms.
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/blockdata/v4.(*chainMonitor).ConnectBlock-fm completed in 403ns
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/v5/notification.(*Notifier).RegisterBlockHandlerLiteGroup.func1 completed in 898ns
[DBG] MEMP: New block at height 391949 - starting CollectAndStore...
[DBG] MEMP: MempoolDataCollector.Collect() completed in 61.207008ms
[DBG] MEMP: 26 addresses in mempool pertaining to 38 transactions
[DBG] MEMP: New Block at height 391949 - sending SigMempoolUpdate to hub relay...
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/v5/notification.(*Notifier).RegisterBlockHandlerLiteGroup.func1 completed in 1.029µs
[DBG] NTFN: handlers of Notifier.processBlock() completed in 1.597832355s
```

After

```
[DBG] NTFN: OnBlockConnected: 392015 / 000000000000000019570cd6f05f1fad514a811994fcbdcd2b44b227a37eb8d0 (previous: 000000000000000003e87db5c9b8d8a5dc82507a9c0f333d7f3d39f74a680170)
[INF] NTFN: superQueue: Processing new block 000000000000000019570cd6f05f1fad514a811994fcbdcd2b44b227a37eb8d0 (height 392015).
[INF] SKDB: Connected block 392015 to stake DB.
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/stakedb/v3.(*ChainMonitor).ConnectBlock-fm completed in 804ns
[INF] BLKD: Block height 392015 connected. Collecting data...
[DBG] BLKD: Collector.Collect() completed in 42.796822ms
[DBG] PSQL: The previous block 000000000000000003e87db5c9b8d8a5dc82507a9c0f333d7f3d39f74a680170 for block 000000000000000019570cd6f05f1fad514a811994fcbdcd2b44b227a37eb8d0 not found in cache, looking it up.
[DBG] PSQL: Cleared cache for 14 addresses.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *dcrpg.ChainDB.Store in 49.019286ms.
[INF] PSQL: Pre-fetching project fund data at height 392015...
[DBG] PSQL: Address rows (view=all) cache MISS for Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx.
[DBG] PUBS: Got new block 392015 for the pubsubhub.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *pubsub.PubSubHub.Store in 5.597748ms.
[DBG] EXPR: Got new block 392015 for the explorer.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *explorer.explorerUI.Store in 412.57µs.
[DBG] IAPI: Sending new websocket block 000000000000000019570cd6f05f1fad514a811994fcbdcd2b44b227a37eb8d0
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed *insight.SocketServer.Store in 30.575µs.
[DBG] BLKD: (*chainMonitor).ConnectBlock: Completed blockdata.BlockTrigger.Store in 1.449µs.
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/blockdata/v4.(*chainMonitor).ConnectBlock-fm completed in 800ns
[DBG] MEMP: New block at height 392015 - starting CollectAndStore...
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/v5/notification.(*Notifier).RegisterBlockHandlerLiteGroup.func1 completed in 761ns
[INF] AGDB: 5 agenda records (agendas) were updated
[DBG] MEMP: MempoolDataCollector.Collect() completed in 10.099462ms
[DBG] MEMP: 24 addresses in mempool pertaining to 15 transactions
[DBG] MEMP: New Block at height 392015 - sending SigMempoolUpdate to hub relay...
[DBG] NTFN: Notifier: BlockHandler github.com/decred/dcrdata/v5/notification.(*Notifier).RegisterBlockHandlerLiteGroup.func1 completed in 469ns
[DBG] NTFN: handlers of Notifier.processBlock() completed in 111.640904ms
                                           
```

Note that there are several new goroutines still running at this point, but `processBlock()` is done.  The websocket clients (both pubsub and insight) and the explorer pages get their updates more promptly.  And more importantly, /api/status/happy is happy much sooner.