### PR TITLE
set server header

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ var (
 	defaultCacheControlMaxAge  = 86400
 	defaultInsightReqRateLimit = 20.0
 	defaultMaxCSVAddrs         = 25
+	defaultServerHeader        = "dcrdata"
 
 	defaultMempoolMinInterval = 2
 	defaultMempoolMaxInterval = 120
@@ -113,6 +114,7 @@ type config struct {
 	InsightReqRateLimit float64 `long:"insight-limit-rps" description:"Requests/second per client IP for the Insight API's rate limiter." env:"DCRDATA_INSIGHT_RATE_LIMIT"`
 	MaxCSVAddrs         int     `long:"max-api-addrs" description:"Maximum allowed comma-separated addresses for endpoints that accept multiple addresses."`
 	CompressAPI         bool    `long:"compress-api" description:"Use compression for a number of endpoints with commonly large responses."`
+	ServerHeader        string  `long:"server-http-header" description:"Set the HTTP response header Server key value. Valid values are \"off\", \"version\", or a custom string."`
 
 	// Data I/O
 	MempoolMinInterval int    `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`
@@ -190,6 +192,7 @@ var (
 		CacheControlMaxAge:  defaultCacheControlMaxAge,
 		InsightReqRateLimit: defaultInsightReqRateLimit,
 		MaxCSVAddrs:         defaultMaxCSVAddrs,
+		ServerHeader:        defaultServerHeader,
 		DcrdCert:            defaultDaemonRPCCertFile,
 		MempoolMinInterval:  defaultMempoolMinInterval,
 		MempoolMaxInterval:  defaultMempoolMaxInterval,
@@ -645,6 +648,13 @@ func loadConfig() (*config, error) {
 	cfg.APIListen, err = normalizeNetworkAddress(cfg.APIListen, defaultHost, defaultAPIPort)
 	if err != nil {
 		return loadConfigError(err)
+	}
+
+	switch cfg.ServerHeader {
+	case "off":
+		cfg.ServerHeader = ""
+	case "version":
+		cfg.ServerHeader = version.AppName + "-" + version.Version()
 	}
 
 	// Expand some additional paths.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/decred/dcrdata/v5
 
 go 1.12
 
+replace github.com/decred/dcrdata/middleware/v3 => ./middleware
+
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb

--- a/main.go
+++ b/main.go
@@ -661,7 +661,10 @@ func _main(ctx context.Context) error {
 
 	// Configure the explorer web pages router.
 	webMux := chi.NewRouter()
-	webMux.Use(m.Server(version.AppName + "-" + version.Version()))
+	if cfg.ServerHeader != "" {
+		log.Debugf("Using Server HTTP response header %q", cfg.ServerHeader)
+		webMux.Use(m.Server(cfg.ServerHeader))
+	}
 	webMux.With(explore.SyncStatusPageIntercept).Group(func(r chi.Router) {
 		r.Get("/", explore.Home)
 		r.Get("/visualblocks", explore.VisualBlocks)

--- a/main.go
+++ b/main.go
@@ -661,6 +661,7 @@ func _main(ctx context.Context) error {
 
 	// Configure the explorer web pages router.
 	webMux := chi.NewRouter()
+	webMux.Use(m.Server(version.AppName + "-" + version.Version()))
 	webMux.With(explore.SyncStatusPageIntercept).Group(func(r chi.Router) {
 		r.Get("/", explore.Home)
 		r.Get("/visualblocks", explore.VisualBlocks)

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -516,6 +516,16 @@ func CacheControl(maxAge int64) func(http.Handler) http.Handler {
 	}
 }
 
+// Server sets the Server header element.
+func Server(server string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Server", server)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // BlockStepPathCtx returns a http.HandlerFunc that embeds the value at the url
 // part {step} into the request context.
 func BlockStepPathCtx(next http.Handler) http.Handler {

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -23,6 +23,12 @@ http {
     access_log  /var/log/nginx/access.log  main;
     error_log /var/log/nginx/error.log;
 
+    # Do not include the exact nginx version in the Server header. With extra
+    # modules or a commercial nginx subscription, the Server header may be set
+    # to anything.
+    # https://stackoverflow.com/questions/246227/how-do-you-change-the-server-header-returned-by-nginx
+    server_tokens off;
+
     sendfile            on;
     tcp_nopush          on;
     tcp_nodelay         on;
@@ -106,6 +112,10 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
+
+            # Use the Server header set by the backend.
+            # https://stackoverflow.com/questions/246227/how-do-you-change-the-server-header-returned-by-nginx
+            proxy_pass_header Server;
 
             # When the realip module is working, it sets the $remote_addr
             # variable to the client IP picked out of the X-Forwarded-For


### PR DESCRIPTION
This adds a middleware to set Server in the HTTP response header. This is helpful to deal with reverse proxies like nginx that just set `Server: nginx` (or worse, with the entire version string).