### PR TITLE
fix stake participation data scale

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -252,8 +252,8 @@ function poolSizeFunc (data) {
 
 function percentStakedFunc (data) {
   rawCoinSupply = data.circulation.map(v => v * atomsToDCR)
-  rawPoolValue = data.poolval
-  var ys = data.poolval.map((v, i) => [v / rawCoinSupply[i] * 100])
+  rawPoolValue = data.poolval.map(v => v * atomsToDCR)
+  var ys = rawPoolValue.map((v, i) => [v / rawCoinSupply[i] * 100])
   if (data.axis === 'height') {
     if (data.bin === 'block') return zipIvY(ys)
     return zipHvY(data.h, ys)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/9373513/68127606-1c3e9800-ff0e-11e9-86bd-e9cff3012834.png)

After:

![image](https://user-images.githubusercontent.com/9373513/68127716-5740cb80-ff0e-11e9-8bbe-c063fdb17e92.png)

Note that this also fixes the legend, which had ticket pool value *1e8, and the huge percentage:

![image](https://user-images.githubusercontent.com/9373513/68127803-793a4e00-ff0e-11e9-92b1-67d26009fbdd.png)
