### PR TITLE
when time remaining is 0, show "imminent"

### DIFF
--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -400,6 +400,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"threeSigFigs": threeSigFigs,
 		"remaining": func(idx int, max, t int64) string {
 			x := (max - int64(idx)) * t
+			if x == 0 {
+				return "imminent"
+			}
 			allsecs := int(time.Duration(x).Seconds())
 			str := ""
 			if allsecs > 604799 {


### PR DESCRIPTION
Previously the home page would just say "remaining" when the ticket price window count reached 144 of 144.  This is the number of blocks mined in the current ticket price window.  This could be changed to stop at 143, proceeding to 0 next, but for now this fixes the time remaining when the entire ticket price window has been mined.

![image](https://user-images.githubusercontent.com/9373513/69559617-e1a9a780-0f6f-11ea-89fd-67b4778ba710.png)

