### PR TITLE
dcrpg: only count mainchain votes in agenda votes queries

### DIFF
--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -455,7 +455,8 @@ const (
 		FROM agenda_votes
 		INNER JOIN votes ON agenda_votes.votes_row_id = votes.id
 		WHERE agenda_votes.agendas_row_id = (SELECT id from agendas WHERE name = $4)
-		AND votes.height >= $5 AND votes.height <= $6 `
+			AND votes.height >= $5 AND votes.height <= $6
+			AND votes.is_mainchain = TRUE `
 
 	// Proposals Table
 


### PR DESCRIPTION
This constrains the agenda votes retrieval query to only votes in mainchain blocks.

Resolves https://github.com/decred/dcrdata/issues/1627

**Before**

![image](https://user-images.githubusercontent.com/9373513/69645433-c8663100-102b-11ea-8c2d-48a6a642c043.png)

**After**

![image](https://user-images.githubusercontent.com/9373513/69644844-d2d3fb00-102a-11ea-806f-2dbe4f83b3be.png)

