### PR TITLE
dcrpg: add vouts.mixed and vouts.spend_tx_row_id

### DIFF
--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -112,7 +112,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 			MixDenom:         mixDenom,
 			NumVin:           uint32(len(tx.TxIn)),
 			NumVout:          uint32(len(tx.TxOut)),
-			IsValidBlock:     isValid,
+			IsValid:          isValid || tree == wire.TxTreeStake,
 			IsMainchainBlock: isMainchain,
 		}
 
@@ -134,7 +134,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 				BlockHeight: txin.BlockHeight,
 				BlockIndex:  txin.BlockIndex,
 				ScriptHex:   txin.SignatureScript,
-				IsValid:     isValid,
+				IsValid:     dbTx.IsValid,
 				IsMainchain: isMainchain,
 			})
 		}
@@ -153,6 +153,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 				Value:        uint64(txout.Value),
 				Version:      txout.Version,
 				ScriptPubKey: txout.PkScript,
+				Mixed:        mixDenom == txout.Value, // later, check ticket and vote outputs against the spent outputs' mixed status
 			}
 			scriptClass, scriptAddrs, reqSigs, err := txscript.ExtractPkScriptAddrs(
 				vout.Version, vout.ScriptPubKey, chainParams)

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -753,12 +753,15 @@ type Vout struct {
 	Version          uint16           `json:"version"`
 	ScriptPubKey     []byte           `json:"pkScriptHex"`
 	ScriptPubKeyData ScriptPubKeyData `json:"pkScript"`
+	Mixed            bool             `json:"mixed"`
 }
 
 // UTXOData stores an address and value associated with a transaction output.
 type UTXOData struct {
 	Addresses []string
 	Value     int64
+	Mixed     bool
+	VoutDbID  int64
 }
 
 // UTXO represents a transaction output, but it is intended to help track
@@ -1635,7 +1638,7 @@ type Tx struct {
 	VoutDbIds []uint64 `json:"voutdbids"`
 	// NOTE: VoutDbIds may not be needed if there is a vout table since each
 	// vout will have a tx_dbid
-	IsValidBlock     bool `json:"valid_block"`
+	IsValid          bool `json:"valid"`
 	IsMainchainBlock bool `json:"mainchain"`
 }
 

--- a/db/dcrpg/internal/indexes.go
+++ b/db/dcrpg/internal/indexes.go
@@ -21,6 +21,7 @@ const (
 	// vouts table
 
 	IndexOfVoutsTableOnTxHashInd = "uix_vout_txhash_ind"
+	IndexOfVoutsTableOnSpendTxID = "uix_vout_spendtxid_ind"
 
 	// addresses table
 
@@ -84,6 +85,7 @@ var IndexDescriptions = map[string]string{
 	IndexOfVinsTableOnVin:                  "vins on transaction hash and index",
 	IndexOfVinsTableOnPrevOut:              "vins on previous outpoint",
 	IndexOfVoutsTableOnTxHashInd:           "vouts on transaction hash and index",
+	IndexOfVoutsTableOnSpendTxID:           "vouts on spend_tx_row_id",
 	IndexOfAddressTableOnAddress:           "addresses table on address",
 	IndexOfAddressTableOnVoutID:            "addresses table on vout row id, address, and is_funding",
 	IndexOfAddressTableOnBlockTime:         "addresses table on block time",

--- a/db/dcrpg/internal/rewind.go
+++ b/db/dcrpg/internal/rewind.go
@@ -218,7 +218,8 @@ const (
 		WHERE transactions.id = ANY(array_cat(blocks.txdbids, blocks.stxdbids))
 		AND blocks.hash=$1;`
 	DeleteTransactionsSimple = `DELETE FROM transactions
-		WHERE block_hash=$1;`
+		WHERE block_hash=$1
+		RETURNING id;`
 
 	DeleteBlock = `DELETE FROM blocks
 		WHERE hash=$1;`

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -77,9 +77,9 @@ const (
 
 	// IndexTicketsTableOnHashes creates the unique index
 	// uix_ticket_hashes_index on (tx_hash, block_hash).
-	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX ` + IndexOfTicketsTableOnHashes +
+	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX IF NOT EXISTS ` + IndexOfTicketsTableOnHashes +
 		` ON tickets(tx_hash, block_hash);`
-	DeindexTicketsTableOnHashes = `DROP INDEX ` + IndexOfTicketsTableOnHashes + ` CASCADE;`
+	DeindexTicketsTableOnHashes = `DROP INDEX IF EXISTS ` + IndexOfTicketsTableOnHashes + ` CASCADE;`
 
 	// IndexTicketsTableOnTxDbID creates the unique index that ensures only one
 	// row in the tickets table may refer to a certain row of the transactions
@@ -88,13 +88,13 @@ const (
 	// block_hash) that allows a transaction appearing in multiple blocks (e.g.
 	// side chains and/or invalidated blocks) to have multiple rows in the
 	// transactions table.
-	IndexTicketsTableOnTxDbID = `CREATE UNIQUE INDEX ` + IndexOfTicketsTableOnTxRowID +
+	IndexTicketsTableOnTxDbID = `CREATE UNIQUE INDEX IF NOT EXISTS ` + IndexOfTicketsTableOnTxRowID +
 		` ON tickets(purchase_tx_db_id);`
-	DeindexTicketsTableOnTxDbID = `DROP INDEX ` + IndexOfTicketsTableOnTxRowID + ` CASCADE;`
+	DeindexTicketsTableOnTxDbID = `DROP INDEX IF EXISTS ` + IndexOfTicketsTableOnTxRowID + ` CASCADE;`
 
-	IndexTicketsTableOnPoolStatus = `CREATE INDEX ` + IndexOfTicketsTableOnPoolStatus +
+	IndexTicketsTableOnPoolStatus = `CREATE INDEX IF NOT EXISTS ` + IndexOfTicketsTableOnPoolStatus +
 		` ON tickets(pool_status);`
-	DeindexTicketsTableOnPoolStatus = `DROP INDEX ` + IndexOfTicketsTableOnPoolStatus + ` CASCADE;`
+	DeindexTicketsTableOnPoolStatus = `DROP INDEX IF EXISTS ` + IndexOfTicketsTableOnPoolStatus + ` CASCADE;`
 
 	SelectTicketsInBlock        = `SELECT * FROM tickets WHERE block_hash = $1;`
 	SelectTicketsTxDbIDsInBlock = `SELECT purchase_tx_db_id FROM tickets WHERE block_hash = $1;`

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -132,9 +132,9 @@ const (
 		LIMIT 1;`
 
 	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time,
-		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry,
-		size, spent, sent, fees, mix_count, mix_denom, num_vin, vin_db_ids,
-		num_vout, vout_db_ids, is_valid, is_mainchain
+			time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry,
+			size, spent, sent, fees, mix_count, mix_denom, num_vin, vin_db_ids,
+			num_vout, vout_db_ids, is_valid, is_mainchain
 		FROM transactions WHERE tx_hash = $1
 		ORDER BY is_mainchain DESC, is_valid DESC, block_time DESC
 		LIMIT 1;`

--- a/db/dcrpg/pgblockchain_fullpgdb_test.go
+++ b/db/dcrpg/pgblockchain_fullpgdb_test.go
@@ -3,12 +3,45 @@
 package dcrpg
 
 import (
+	"encoding/csv"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/db/dcrpg/v5/internal"
 )
+
+func TestMixedUtxosByHeight(t *testing.T) {
+	heights, utxoCountReg, utxoValueReg, utxoCountStk, utxoValueStk, err := db.MixedUtxosByHeight()
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+
+	csvfile, err := os.Create("utxos.csv")
+	if err != nil {
+		t.Fatalf("error creating utxos file: %s", err)
+	}
+	defer csvfile.Close()
+
+	csvwriter := csv.NewWriter(csvfile)
+	defer csvwriter.Flush()
+
+	for i := range heights {
+		err = csvwriter.Write([]string{
+			fmt.Sprint(heights[i]),
+			fmt.Sprint(utxoCountReg[i]),
+			fmt.Sprint(utxoValueReg[i] / 1e8),
+			fmt.Sprint(utxoCountStk[i]),
+			fmt.Sprint(utxoValueStk[i] / 1e8),
+		})
+		if err != nil {
+			t.Fatalf("csvwriter.Write: %s", err)
+		}
+	}
+
+}
 
 func TestAddressRows(t *testing.T) {
 	rows, err := db.AddressRowsMerged("Dsh6khiGjTuyExADXxjtDgz1gRr9C5dEUf6")

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1057,11 +1057,7 @@ func TxIsRegular(txType int) bool {
 // IsStakeTx indicates if the input MsgTx is a stake transaction.
 func IsStakeTx(msgTx *wire.MsgTx) bool {
 	switch stake.DetermineTxType(msgTx) {
-	case stake.TxTypeSSGen:
-		fallthrough
-	case stake.TxTypeSStx:
-		fallthrough
-	case stake.TxTypeSSRtx:
+	case stake.TxTypeSSGen, stake.TxTypeSStx, stake.TxTypeSSRtx:
 		return true
 	default:
 		return false


### PR DESCRIPTION
This upgrades the database scheme from 5 to 6 (specifically, v1.5.1 -> v1.6.0).
- add `vouts.mixed` (BOOLEAN), true for outputs of mix transactions, and the stake transactions that spend them.
- add `vouts.spend_tx_row_id` (INT8) referencing the row ID (PK) in the transactions table, of the spending transaction, default is NULL