### PR TITLE
Onion v2 address configuration option and footer link

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,8 +79,9 @@ var (
 	defaultDisabledExchanges = "huobi,dragonex"
 	defaultRateCertFile      = filepath.Join(defaultHomeDir, "rpc.cert")
 
-	defaultMainnetLink = "https://explorer.dcrdata.org/"
-	defaultTestnetLink = "https://testnet.dcrdata.org/"
+	defaultMainnetLink  = "https://explorer.dcrdata.org/"
+	defaultTestnetLink  = "https://testnet.dcrdata.org/"
+	defaultOnionAddress = ""
 
 	maxSyncStatusLimit = 5000
 )
@@ -167,8 +168,9 @@ type config struct {
 	RateCertificate   string `long:"ratecert" description:"File containing DCRRates TLS certificate file." env:"DCRDATA_RATE_MASTER"`
 
 	// Links
-	MainnetLink string `long:"mainnet-link" description:"When dcrdata is on testnet, this address will be used to direct a user to a dcrdata on mainnet when appropriate." env:"DCRDATA_MAINNET_LINK"`
-	TestnetLink string `long:"testnet-link" description:"When dcrdata is on mainnet, this address will be used to direct a user to a dcrdata on testnet when appropriate." env:"DCRDATA_TESTNET_LINK"`
+	MainnetLink  string `long:"mainnet-link" description:"When dcrdata is on testnet, this address will be used to direct a user to a dcrdata on mainnet when appropriate." env:"DCRDATA_MAINNET_LINK"`
+	TestnetLink  string `long:"testnet-link" description:"When dcrdata is on mainnet, this address will be used to direct a user to a dcrdata on testnet when appropriate." env:"DCRDATA_TESTNET_LINK"`
+	OnionAddress string `long:"onion-address" description:"Hidden service address" env:"DCRDATA_ONION_ADDRESS"`
 }
 
 var (
@@ -205,6 +207,7 @@ var (
 		RateCertificate:     defaultRateCertFile,
 		MainnetLink:         defaultMainnetLink,
 		TestnetLink:         defaultTestnetLink,
+		OnionAddress:        defaultOnionAddress,
 	}
 )
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -139,6 +139,7 @@ type links struct {
 	Mainnet       string
 	TestnetSearch string
 	MainnetSearch string
+	OnionURL      string
 }
 
 var explorerLinks = &links{
@@ -277,6 +278,7 @@ type ExplorerConfig struct {
 	PoliteiaURL     string
 	MainnetLink     string
 	TestnetLink     string
+	OnionAddress    string
 	ReloadHTML      bool
 }
 
@@ -299,6 +301,10 @@ func New(cfg *ExplorerConfig) *explorerUI {
 	explorerLinks.Testnet = cfg.TestnetLink
 	explorerLinks.MainnetSearch = cfg.MainnetLink + "search?search="
 	explorerLinks.TestnetSearch = cfg.TestnetLink + "search?search="
+
+	if cfg.OnionAddress != "" {
+		explorerLinks.OnionURL = fmt.Sprintf("http://%s/", cfg.OnionAddress)
+	}
 
 	// explorerDataSource is an interface that could have a value of pointer type.
 	if exp.dataSource == nil || reflect.ValueOf(exp.dataSource).IsNil() {

--- a/main.go
+++ b/main.go
@@ -491,6 +491,7 @@ func _main(ctx context.Context) error {
 		MainnetLink:     cfg.MainnetLink,
 		TestnetLink:     cfg.TestnetLink,
 		ReloadHTML:      cfg.ReloadHTML,
+		OnionAddress:    cfg.OnionAddress,
 	})
 	// TODO: allow views config
 	if explore == nil {

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -94,3 +94,6 @@
 ; Maximum number of comma-separated addresses allowed in certain Insight API
 ; endpoints, such as /insight/api/addrs/{addr0,..,addrN}
 ;max-api-addrs=3
+
+; TOR hidden service address.  When specified, it will be displayed in the footer.
+;onion-address=

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -136,6 +136,15 @@
 				target="_blank"
 				rel="noopener noreferrer"
 			>dcrdata v{{.Version}}</a>
+			{{- if ne .Links.OnionURL "" }}
+			<a
+				class="text-nowrap d-none d-md-inline-block pr-3"
+				href="{{.Links.OnionURL}}"
+				title="Access dcrdata over Tor"
+				target="_blank"
+				rel="noopener noreferrer"
+			>Tor site</a>
+			{{ end }}
 			<a
 				class="text-nowrap"
 				href="{{.Links.License}}"


### PR DESCRIPTION
Display configurable Onion link in the footer.
Solves #1624 