### PR TITLE
[5.2] pubsub,psclient: fix server->client pings and require them in client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/decred/dcrdata/v5
 
 go 1.12
 
+replace (
+	github.com/decred/dcrdata/db/dcrpg/v5 => ./db/dcrpg
+	github.com/decred/dcrdata/pubsub/v4 => ./pubsub
+)
+
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
@@ -48,5 +53,3 @@ require (
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
 )
-
-replace github.com/decred/dcrdata/db/dcrpg/v5 => ./db/dcrpg

--- a/pubsub/democlient/go.mod
+++ b/pubsub/democlient/go.mod
@@ -2,6 +2,8 @@ module github.com/decred/dcrdata/pubsub/democlient
 
 go 1.12
 
+replace github.com/decred/dcrdata/pubsub/v4 => ../
+
 require (
 	github.com/decred/dcrd/chaincfg/v2 v2.3.0
 	github.com/decred/dcrd/dcrutil/v2 v2.0.1

--- a/pubsub/democlient/go.sum
+++ b/pubsub/democlient/go.sum
@@ -81,6 +81,8 @@ github.com/decred/dcrdata/explorer/types/v2 v2.1.1 h1:Ly1XuqH6IvdXEjfdJ9pNMh4Jwm
 github.com/decred/dcrdata/explorer/types/v2 v2.1.1/go.mod h1:tzjXFj7r6Z75n8CoaeiG/1HNJc7PCjpA1+3vh8Ny3sE=
 github.com/decred/dcrdata/mempool/v5 v5.0.1 h1:q5v0L8npGIW3DXhAcCLk9CDI/dOoPreotzLgLsUo608=
 github.com/decred/dcrdata/mempool/v5 v5.0.1/go.mod h1:ZxNwSAxRnrqWk6dhnYIsv/o9xreDVPAMHjcOe7ihd08=
+github.com/decred/dcrdata/mempool/v5 v5.0.2 h1:/1wHd5X9KpXf2SptlnGjWmV/IUFQi9JBoDnSUCcCj30=
+github.com/decred/dcrdata/mempool/v5 v5.0.2/go.mod h1:ZxNwSAxRnrqWk6dhnYIsv/o9xreDVPAMHjcOe7ihd08=
 github.com/decred/dcrdata/pubsub/types/v3 v3.0.5 h1:DTXSmk6adST4mYzaYZw8oHNKqfqYJ+wFdsRCjDotmkc=
 github.com/decred/dcrdata/pubsub/types/v3 v3.0.5/go.mod h1:msVpLMm6G8Qk/KQ/oU+gXphcIJAUXCmxwCegEFDsXl4=
 github.com/decred/dcrdata/pubsub/v4 v4.0.1 h1:4JjoRO3L3VuD7CKqOhlC+3i9B1G/klw//ga6QvVMrac=

--- a/pubsub/democlient/main.go
+++ b/pubsub/democlient/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Create the pubsub client, opening a connection to the URL.
 	ctx, cancel := context.WithCancel(context.Background())
 	opts := psclient.Opts{
-		ReadTimeout:  3 * time.Second,
+		ReadTimeout:  psclient.DefaultReadTimeout,
 		WriteTimeout: 3 * time.Second,
 	}
 	cl, err := psclient.New(cfg.URL, ctx, &opts)

--- a/pubsub/psclient/client.go
+++ b/pubsub/psclient/client.go
@@ -92,7 +92,7 @@ func newPingMsg(reqID int64) []byte {
 	return pingMsg
 }
 
-var defaultTimeout = 10 * time.Second
+const defaultTimeout = pubsub.PingInterval * 10 / 9
 
 // Opts defines the psclient Client options.
 type Opts struct {
@@ -241,9 +241,8 @@ func (c *Client) receiver() {
 
 		resp, err := c.receiveMsg()
 		if err != nil {
-			if pstypes.IsIOTimeoutErr(err) {
-				continue
-			}
+			// Even a timeout should close shutdown the client since that
+			// indicates pings from the server did not arrive in time.
 			log.Errorf("ReceiveMsg failed: %v", err)
 			return
 		}

--- a/pubsub/psclient/client.go
+++ b/pubsub/psclient/client.go
@@ -349,9 +349,15 @@ func (c *Client) deleteRequestID(reqID int64) {
 // after validating it. The response is returned.
 func (c *Client) Subscribe(event string) (*pstypes.ResponseMessage, error) {
 	// Validate the event type.
-	_, _, ok := pstypes.ValidateSubscription(event)
+	sig, _, ok := pstypes.ValidateSubscription(event)
 	if !ok {
 		return nil, fmt.Errorf("invalid subscription %s", event)
+	}
+
+	if sig == pstypes.SigPingAndUserCount {
+		log.Warn("Pings from the server no longer require a subscription. " +
+			"Pings are sent to all clients.")
+		// Let the request go through.
 	}
 
 	respChan, reqID := c.newResponseChan()

--- a/pubsub/psclient/client.go
+++ b/pubsub/psclient/client.go
@@ -92,7 +92,10 @@ func newPingMsg(reqID int64) []byte {
 	return pingMsg
 }
 
-const defaultTimeout = pubsub.PingInterval * 10 / 9
+const (
+	DefaultReadTimeout  = pubsub.PingInterval * 10 / 9
+	DefaultWriteTimeout = 5 * time.Second
+)
 
 // Opts defines the psclient Client options.
 type Opts struct {
@@ -122,7 +125,7 @@ func New(url string, ctx context.Context, opts *Opts) (*Client, error) {
 		return nil, err
 	}
 
-	readTimeout, writeTimeout := defaultTimeout, defaultTimeout
+	readTimeout, writeTimeout := DefaultReadTimeout, DefaultWriteTimeout
 	if opts != nil {
 		readTimeout = opts.ReadTimeout
 		writeTimeout = opts.WriteTimeout
@@ -170,7 +173,7 @@ func NewFromConn(ws *websocket.Conn, ctx context.Context, opts *Opts) *Client {
 		return nil
 	}
 
-	readTimeout, writeTimeout := defaultTimeout, defaultTimeout
+	readTimeout, writeTimeout := DefaultReadTimeout, DefaultWriteTimeout
 	if opts != nil {
 		readTimeout = opts.ReadTimeout
 		writeTimeout = opts.WriteTimeout

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-var version = semver.NewSemver(3, 1, 0)
+var version = semver.NewSemver(3, 2, 0)
 
 // Version indicates the semantic version of the pubsub module.
 func Version() semver.Semver {

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -403,10 +403,15 @@ loop:
 			continue loop
 		}
 
-		if sig.Signal != sigByeNow && !clientData.isSubscribed(sig) {
-			log.Errorf("Client not subscribed for %s events. "+
-				"WebSocketHub should have caught this.", sig)
-			continue loop // break
+		switch sig.Signal {
+		case sigByeNow, sigPingAndUserCount:
+			// These signals are not subscription-based.
+		default:
+			if !clientData.isSubscribed(sig) {
+				log.Errorf("Client not subscribed for %s events. "+
+					"WebSocketHub should have caught this.", sig)
+				continue loop // break
+			}
 		}
 
 		log.Tracef("signaling client %d with %s", clientData.id, sig)

--- a/pubsub/websocket.go
+++ b/pubsub/websocket.go
@@ -17,7 +17,9 @@ import (
 type hubSpoke chan pstypes.HubMessage
 
 const (
-	pingInterval = 45 * time.Second
+	// PingInterval is how frequently the server will ping all clients. The
+	// clients should set their read deadlines to more than this.
+	PingInterval = 30 * time.Second
 
 	tickerSigReset int = iota
 	tickerSigStop
@@ -321,7 +323,7 @@ func (wsh *WebsocketHub) pingClients() chan<- struct{} {
 
 	go func() {
 		// start the client ping ticker
-		ticker := time.NewTicker(pingInterval)
+		ticker := time.NewTicker(PingInterval)
 		defer ticker.Stop()
 
 		for {

--- a/pubsub/websocket.go
+++ b/pubsub/websocket.go
@@ -397,11 +397,11 @@ func (wsh *WebsocketHub) Run() {
 				hubMsg, client.id)
 			wsh.unregisterClient(spoke)
 		case *spoke <- hubMsg:
-			log.Tracef("Sent %s message to client %s.", hubMsg, client.id)
+			log.Tracef("Sent %s message to client %d.", hubMsg, client.id)
 		case <-timer.C:
 			// TODO: remove this case (and timer) once we are
 			// confident there is no change of a deadlock.
-			log.Errorf("Timeout sending %s message to client %s.", hubMsg, client.id)
+			log.Errorf("Timeout sending %s message to client %d.", hubMsg, client.id)
 		}
 	}
 

--- a/pubsub/websocket_test.go
+++ b/pubsub/websocket_test.go
@@ -17,28 +17,33 @@ func Test_client_subscribe(t *testing.T) {
 		cl      *client
 		hubMsg  pstypes.HubMessage
 		wantErr error
+		wantOK  bool
 	}{
-		{"ok newtx", newClient(), pstypes.HubMessage{Signal: sigNewTx}, nil},
+		{"ping not a sub", newClient(), pstypes.HubMessage{Signal: sigPingAndUserCount}, nil, false},
+		{"ok newtx", newClient(), pstypes.HubMessage{Signal: sigNewTx}, nil, true},
 		{"ok addr", newClient(), pstypes.HubMessage{
 			Signal: sigAddressTx,
 			Msg:    &pstypes.AddressMessage{Address: "DsfX4WrSecUwGoRd9B7Lz1JjYssYaVKnjGC"},
-		}, nil},
+		}, nil, true},
 		{"bad addr", newClient(), pstypes.HubMessage{
 			Signal: sigAddressTx,
 			Msg:    pstypes.AddressMessage{Address: "DsfX4WrSecUwGoRd9B7Lz1JjYssYaVKnjGC"},
-		}, errors.New("msg.Msg not a string (SigAddressTx): types.AddressMessage")},
+		}, errors.New("msg.Msg not a string (SigAddressTx): types.AddressMessage"), false},
 		{"bad addr", newClient(), pstypes.HubMessage{
 			Signal: sigAddressTx,
 			Msg:    nil,
-		}, errors.New("msg.Msg not a string (SigAddressTx): <nil>")},
+		}, errors.New("msg.Msg not a string (SigAddressTx): <nil>"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cl.subscribe(tt.hubMsg)
+			ok, err := tt.cl.subscribe(tt.hubMsg)
 			if (err != nil) != (tt.wantErr != nil) ||
 				(err != nil && err.Error() != tt.wantErr.Error()) {
 				t.Errorf(`subscribe() error = "%v", wantErr "%v"`, err, tt.wantErr)
 				return
+			}
+			if ok != tt.wantOK {
+				t.Errorf("Did not subscribe to %v.", tt.hubMsg)
 			}
 		})
 	}


### PR DESCRIPTION
Backport of https://github.com/decred/dcrdata/pull/1645 for 5.2-stable.

The following changes are made, which effectively require the client to receive pings from the server at the interval the server sends them otherwise the client will shutdown assuming the connection has died.  The clients no longer have to `Ping` at the application level to detect when the connection is lost.  And the server's outgoing pings are used to clean up dead clients.

* Fix the server->client pings that were supposed to be sent automatically to all clients since the ping subscription was removed.
* Export `pubsub.PingInterval`, the server's ping interval, and set it to 30 seconds.
* In the client (`psclient`), set the default read time out to `pubsub.PingInterval * 10 / 9`, although this is still configurable by via `psclient.Opts`.
* **A read timeout in the client's receive loop will now SHUTDOWN THE CLIENT.**

