### PR TITLE
views: remove the Explore Block chain div that wastes space

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -330,7 +330,6 @@
 {{define "blocksBanner"}}
 <div class="bg-white block-banner">
 	<div class="container px-0">
-		<div class="h3 text-blueish pt-4 pb-2">Explore Blockchain</div>
 		<div>
 			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/blocks">
 				<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>


### PR DESCRIPTION
This was live-demoed for a while, but not committed.  This gets rid of the "Explore Blockchain" div that wastes so much space.

Resolves issue https://github.com/decred/dcrdata/issues/1607