### PR TITLE
dcrpg: create the vouts.spend_tx_row_id index

### DIFF
--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -2886,7 +2886,6 @@ func InsertSpendingAddressRow(db *sql.DB, fundingTxHash string,
 func updateSpendTxInfoInAllVouts(db SqlExecutor) (int64, error) {
 	// Set vouts.spend_tx_row_id using vouts.tx_hash, vins.prev_tx_hash, and
 	// transactions.tx_hash.
-	log.Infof("Setting vouts.spend_tx_row_id (INT8) column. This will take a while...")
 	res, err := db.Exec(`UPDATE vouts SET spend_tx_row_id = transactions.id
 			FROM vins, transactions
 			WHERE vouts.tx_hash=vins.prev_tx_hash

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -31,7 +31,7 @@ const (
 	// This includes changes such as creating tables, adding/deleting columns,
 	// adding/deleting indexes or any other operations that create, delete, or
 	// modify the definition of any database relation.
-	schemaVersion = 6
+	schemaVersion = 7
 
 	// maintVersion indicates when certain maintenance operations should be
 	// performed for the same compatVersion and schemaVersion. Such operations

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -345,7 +345,22 @@ func (u *Upgrader) compatVersion1Upgrades(current, target DatabaseVersion) (bool
 		fallthrough
 
 	case 6:
-		// Perform schema v6 maintenance.
+		err = u.upgrade160to170()
+		if err != nil {
+			return false, fmt.Errorf("failed to upgrade 1.6.0 to 1.7.0: %v", err)
+		}
+		current.schema++
+		if err = updateSchemaVersion(u.db, current.schema); err != nil {
+			return false, fmt.Errorf("failed to update schema version: %v", err)
+		}
+		current.maint = 0
+		if err = updateMaintVersion(u.db, current.maint); err != nil {
+			return false, fmt.Errorf("failed to update maintenance version: %v", err)
+		}
+		fallthrough
+
+	case 7:
+		// Perform schema v7 maintenance.
 
 		// No further upgrades.
 		return upgradeCheck()
@@ -365,6 +380,11 @@ func removeTableComments(db *sql.DB) {
 			log.Errorf(`Failed to remove comment on table %s.`, tableName)
 		}
 	}
+}
+
+func (u *Upgrader) upgrade160to170() error {
+	// Create the missing vouts.spend_tx_row_id index.
+	return IndexVoutTableOnSpendTxID(u.db)
 }
 
 func (u *Upgrader) upgrade151to160() error {


### PR DESCRIPTION
The index on vouts.spend_tx_row_id should have been created as part of a previous upgrade.  Instead, the startup index check detected that it was missing and reindexed everything.  This change just creates the index, if it does not already exist.