### PR TITLE
gov: fix simnet agenda db and vote tracking

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -559,7 +559,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	}
 
 	// Trigger a vote info refresh.
-	go exp.voteTracker.Refresh()
+	if exp.voteTracker != nil {
+		go exp.voteTracker.Refresh()
+	}
 
 	// Politeia updates happen hourly. Thus, if blocks take 5 minutes on average
 	// to mine, then 12 blocks take approximately 1hr.

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1771,9 +1771,15 @@ func (exp *explorerUI) AgendaPage(w http.ResponseWriter, r *http.Request) {
 
 // AgendasPage is the page handler for the "/agendas" path.
 func (exp *explorerUI) AgendasPage(w http.ResponseWriter, r *http.Request) {
+	if exp.voteTracker == nil {
+		log.Warnf("Agendas requested with nil voteTracker")
+		exp.StatusPage(w, "", "agendas disabled on simnet", "", ExpStatusPageDisabled)
+		return
+	}
+
 	agenda, err := exp.agendasSource.AllAgendas()
 	if err != nil {
-		log.Errorf("Template execute failure: %v", err)
+		log.Errorf("Error fetching agendas: %v", err)
 		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
 		return
 	}

--- a/gov/agendas/deployments_test.go
+++ b/gov/agendas/deployments_test.go
@@ -154,7 +154,7 @@ func TestNewAgendasDB(t *testing.T) {
 	}
 
 	for i, val := range td {
-		results, err := NewAgendasDB(val.rpc, val.dbPath, false)
+		results, err := NewAgendasDB(val.rpc, val.dbPath)
 		if err == nil && val.errMsg != "" {
 			t.Fatalf("expected no error but found '%v' ", err)
 		}

--- a/gov/agendas/deployments_test.go
+++ b/gov/agendas/deployments_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"testing"
 
 	"github.com/asdine/storm/v3"
@@ -155,7 +154,7 @@ func TestNewAgendasDB(t *testing.T) {
 	}
 
 	for i, val := range td {
-		results, err := NewAgendasDB(val.rpc, val.dbPath)
+		results, err := NewAgendasDB(val.rpc, val.dbPath, false)
 		if err == nil && val.errMsg != "" {
 			t.Fatalf("expected no error but found '%v' ", err)
 		}
@@ -224,29 +223,9 @@ func TestUpdateAndRetrievals(t *testing.T) {
 		stakeVersions: voteVersions,
 	}
 
-	type testData struct {
-		db     *AgendaDB
-		errMsg string
-	}
-
-	td := []testData{
-		{nil, "AgendaDB was not initialized correctly"},
-		{&AgendaDB{}, "AgendaDB was not initialized correctly"},
-		{dbInstance, ""},
-	}
-
-	// Test saving updates to agendas db.
-	for i, val := range td {
-		t.Run("Test_UpdateAgendas_#"+strconv.Itoa(i), func(t *testing.T) {
-			err := val.db.UpdateAgendas()
-			if err != nil && val.errMsg != err.Error() {
-				t.Fatalf("expect to find error '%s' but found '%v' ", val.errMsg, err)
-			}
-
-			if err == nil && val.errMsg != "" {
-				t.Fatalf("expected to find error '%s' but none was returned ", val.errMsg)
-			}
-		})
+	err := dbInstance.UpdateAgendas()
+	if err != nil {
+		t.Fatalf("agenda update error: %v", err)
 	}
 
 	// Test retrieval of all agendas.

--- a/main.go
+++ b/main.go
@@ -458,7 +458,7 @@ func _main(ctx context.Context) error {
 	// is found, its deleted pending the data update that restores valid data.
 	var agendaDB *agendas.AgendaDB
 	agendaDB, err = agendas.NewAgendasDB(
-		dcrdClient, filepath.Join(cfg.DataDir, cfg.AgendasDBFileName), cfg.SimNet)
+		dcrdClient, filepath.Join(cfg.DataDir, cfg.AgendasDBFileName))
 	if err != nil {
 		return fmt.Errorf("failed to create new agendas db instance: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -456,8 +456,9 @@ func _main(ctx context.Context) error {
 	// store and retrieves agendas data. Agendas votes are On-Chain
 	// transactions that appear in the decred blockchain. If corrupted data is
 	// is found, its deleted pending the data update that restores valid data.
-	agendasInstance, err := agendas.NewAgendasDB(dcrdClient,
-		filepath.Join(cfg.DataDir, cfg.AgendasDBFileName))
+	var agendaDB *agendas.AgendaDB
+	agendaDB, err = agendas.NewAgendasDB(
+		dcrdClient, filepath.Join(cfg.DataDir, cfg.AgendasDBFileName), cfg.SimNet)
 	if err != nil {
 		return fmt.Errorf("failed to create new agendas db instance: %v", err)
 	}
@@ -479,11 +480,16 @@ func _main(ctx context.Context) error {
 		log.Info("Piparser is disabled. Proposals API has been disabled too")
 	}
 
-	// A vote tracker tracks current block and stake versions and votes.
-	tracker, err := agendas.NewVoteTracker(activeChain, dcrdClient,
-		chainDB.AgendaVoteCounts)
-	if err != nil {
-		return fmt.Errorf("Unable to initialize vote tracker: %v", err)
+	// A vote tracker tracks current block and stake versions and votes. Only
+	// initialize the vote tracker if not on simnet. nil tracker is a sentinel
+	// value throughout.
+	var tracker *agendas.VoteTracker
+	if !cfg.SimNet {
+		tracker, err = agendas.NewVoteTracker(activeChain, dcrdClient,
+			chainDB.AgendaVoteCounts)
+		if err != nil {
+			return fmt.Errorf("Unable to initialize vote tracker: %v", err)
+		}
 	}
 
 	// Create the explorer system.
@@ -494,7 +500,7 @@ func _main(ctx context.Context) error {
 		DevPrefetch:     !cfg.NoDevPrefetch,
 		Viewsfolder:     "views",
 		XcBot:           xcBot,
-		AgendasSource:   agendasInstance,
+		AgendasSource:   agendaDB,
 		Tracker:         tracker,
 		ProposalsSource: proposalsInstance,
 		PoliteiaURL:     cfg.PoliteiaAPIURL,
@@ -650,7 +656,7 @@ func _main(ctx context.Context) error {
 		DataSource:         chainDB,
 		JsonIndent:         cfg.IndentJSON,
 		XcBot:              xcBot,
-		AgendasDBInstance:  agendasInstance,
+		AgendasDBInstance:  agendaDB,
 		MaxAddrs:           cfg.MaxCSVAddrs,
 		Charts:             charts,
 		IsPiparserDisabled: cfg.DisablePiParser,
@@ -1014,7 +1020,7 @@ func _main(ctx context.Context) error {
 
 	// The proposals and agenda db updates are run after the db indexing.
 	// Retrieve blockchain deployment updates and add them to the agendas db.
-	if err = agendasInstance.UpdateAgendas(); err != nil {
+	if err = agendaDB.UpdateAgendas(); err != nil {
 		return fmt.Errorf("updating agendas db failed: %v", err)
 	}
 


### PR DESCRIPTION
Disables `VoteTracker` and `AgendaDB` when simnet is in use. `VoteTracker` is not initialized, and `AgendaDB` has reasonable return values from exported functions.