### PR TITLE
51% attack cost page

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -354,7 +354,7 @@ func New(cfg *ExplorerConfig) *explorerUI {
 		"rawtx", "status", "parameters", "agenda", "agendas", "charts",
 		"sidechains", "disapproved", "ticketpool", "visualblocks", "statistics",
 		"windows", "timelisting", "addresstable", "proposals", "proposal",
-		"market", "insight_root"}
+		"market", "insight_root", "attackcost"}
 
 	for _, name := range tmpls {
 		if err := exp.templates.addTemplate(name); err != nil {

--- a/main.go
+++ b/main.go
@@ -778,6 +778,7 @@ func _main(ctx context.Context) error {
 		// MenuFormParser will typically redirect, but going to the homepage as a
 		// fallback.
 		r.With(explorer.MenuFormParser).Post("/set", explore.Home)
+		r.Get("/attack-cost", explore.AttackCost)
 	})
 
 	// Configure a page for the bare "/insight" path. This mounts the static

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -98,6 +98,7 @@ export default class extends Controller {
       'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
       'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
       'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
+      'externalAttackPosText', 'additionalTickets', 'newTicketPoolValue', 'internalAttackPosText',
       'additionalHashRate', 'targetPos', 'targetPow',
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
@@ -294,7 +295,7 @@ export default class extends Controller {
 
     switch (this.settings.attack_type) {
       case 1:
-        this.targetHashRate = hashrate / (1 - parseFloat(this.targetPowTarget.value) / 100)
+        this.targetHashRate = hashrate / (1 - parseFloat(this.targetPowTarget.value) / 100) - hashrate
         this.projectedPriceDivTarget.style.display = 'block'
         this.internalAttackTextTarget.classList.add('d-none')
         this.externalAttackTextTarget.classList.remove('d-none')
@@ -323,6 +324,16 @@ export default class extends Controller {
     this.targetPowTarget.value = Math.floor(randomVal * 100) / 100
     this.internalHashTarget.innerHTML = digitformat((rate * this.targetHashRate), 4) + ' Ph/s '
     this.ticketsTarget.innerHTML = digitformat(val * tpSize) + ' tickets '
+    switch (this.settings.attack_type) {
+      case 1:
+        this.hideAll(this.internalAttackPosTextTarget)
+        this.showAll(this.externalAttackPosTextTargets)
+        break
+      case 0:
+      default:
+        this.hideAll(this.externalAttackPosTextTargets)
+        this.showAll(this.internalAttackPosTextTarget)
+    }
 
     this.calculate(true)
   }
@@ -339,8 +350,16 @@ export default class extends Controller {
     var totalElectricity = totalKwh * parseFloat(this.kwhRateTarget.value)
     var extraCostsRate = 1 + parseFloat(this.otherCostsTarget.value) / 100
     var totalPow = extraCostsRate * totalDeviceCost + totalElectricity
-    var ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
-    var DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
+    var ticketAttackSize, DCRNeed
+    if (this.settings.attack_type === 1) {
+      ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
+      this.additionalTicketsTarget.innerHTML = digitformat(ticketAttackSize - tpSize, 2)
+      this.newTicketPoolValueTarget.innerHTML = digitformat(ticketAttackSize, 2)
+      DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
+    } else {
+      ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
+      DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
+    }
     var projectedTicketPrice = DCRNeed / tpSize
     this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
     this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
@@ -381,5 +400,13 @@ export default class extends Controller {
 
   setAllValues (targets, data) {
     targets.map((n) => { n.innerHTML = data })
+  }
+
+  hideAll (targets) {
+    targets.map(el => el.classList.add('d-none'))
+  }
+
+  showAll (targets) {
+    targets.map(el => el.classList.remove('d-none'))
   }
 }

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -112,7 +112,7 @@ export default class extends Controller {
       'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
       'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
       'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
-      'externalAttackPosText', 'additionalTickets', 'newTicketPoolValue', 'internalAttackPosText',
+      'externalAttackPosText', 'additionalTickets', 'internalAttackPosText',
       'additionalHashRate', 'targetPos', 'targetPow', 'operatorSign',
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
@@ -376,7 +376,7 @@ export default class extends Controller {
       ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
       DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
       this.setAllValues(this.additionalTicketsTargets, digitformat(ticketAttackSize - tpSize, 0))
-      this.setAllValues(this.newTicketPoolValueTargets, digitformat(ticketAttackSize, 0))
+      // this.setAllValues(this.newTicketPoolValueTargets, digitformat(ticketAttackSize, 0))
       this.setAllValues(this.operatorSignTargets, '+')
     } else {
       ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -71,6 +71,9 @@ const deviceList = {
   }
 }
 
+const externalAttackType = 'external'
+const internalAttackType = 'internal'
+
 function legendFormatter (data) {
   var html = ''
   if (data.x == null) {
@@ -118,7 +121,7 @@ export default class extends Controller {
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
       'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
       'totalPos', 'totalPow', 'graph', 'labels', 'projectedTicketPrice', 'projectedTicketPriceIncrease', 'attackType',
-      'attackPosPercentNeededLabel', 'attackPosPercentAmountLabel', 'dcrPriceLabel', 'totalDCRPosLabel',
+      'attackPosPercentAmountLabel', 'dcrPriceLabel', 'totalDCRPosLabel',
       'projectedPriceDiv'
     ]
   }
@@ -146,11 +149,11 @@ export default class extends Controller {
     if (this.settings.target_pos) this.setAllInputs(this.targetPosTargets, parseFloat(this.settings.target_pos))
     if (this.settings.price) this.priceDCRTarget.value = parseFloat(this.settings.price)
     if (this.settings.device) this.setDevice(this.settings.device)
-    if (this.settings.attack_type) this.attackTypeTarget.value = parseInt(this.settings.attack_type)
+    if (this.settings.attack_type) this.attackTypeTarget.value = this.settings.attack_type
     if (this.settings.target_pos) this.attackPercentTarget.value = parseInt(this.targetPosTarget.value) / 100
 
-    if (this.settings.attack_type !== 1) {
-      this.settings.attack_type = 0
+    if (this.settings.attack_type !== internalAttackType) {
+      this.settings.attack_type = externalAttackType
     }
     this.setDevicesDesc()
     this.updateSliderData()
@@ -278,8 +281,7 @@ export default class extends Controller {
   selectedDevice () { return this.deviceTarget.value }
 
   selectedAttackType () {
-    // TurboQuery parses the attack_type from the url as int
-    return parseInt(this.attackTypeTarget.value)
+    return this.attackTypeTarget.value
   }
 
   selectOption (options) {
@@ -318,7 +320,7 @@ export default class extends Controller {
     this.targetPowTarget.value = digitformat(powPercentage, 2, true)
     this.setAllValues(this.internalHashTargets, digitformat((this.targetHashRate), 4) + ' Ph/s ')
     switch (this.settings.attack_type) {
-      case 0:
+      case externalAttackType:
         this.targetHashRate += hashrate
         this.projectedPriceDivTarget.style.display = 'block'
         this.internalAttackTextTarget.classList.add('d-none')
@@ -326,7 +328,7 @@ export default class extends Controller {
         this.externalAttackTextTarget.classList.remove('d-none')
         this.externalAttackPosTextTarget.classList.remove('d-node')
         break
-      case 1:
+      case internalAttackType:
       default:
         this.projectedPriceDivTarget.style.display = 'none'
         this.externalAttackTextTarget.classList.add('d-none')
@@ -348,11 +350,11 @@ export default class extends Controller {
 
     this.ticketsTarget.innerHTML = digitformat(val * tpSize) + ' tickets '
     switch (this.settings.attack_type) {
-      case 0:
+      case externalAttackType:
         this.hideAll(this.internalAttackPosTextTargets)
         this.showAll(this.externalAttackPosTextTargets)
         break
-      case 1:
+      case internalAttackType:
       default:
         this.hideAll(this.externalAttackPosTextTargets)
         this.showAll(this.internalAttackPosTextTargets)
@@ -373,7 +375,7 @@ export default class extends Controller {
     var extraCost = parseFloat(this.otherCostsTarget.value) / 100 * (totalDeviceCost + totalElectricity)
     var totalPow = extraCost + totalDeviceCost + totalElectricity
     var ticketAttackSize, DCRNeed
-    if (this.settings.attack_type === 0) {
+    if (this.settings.attack_type === externalAttackType) {
       DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
       this.setAllValues(this.newTicketPoolValueTargets, digitformat(DCRNeed, 2))
       this.setAllValues(this.additionalDcrTargets, digitformat(DCRNeed - tpValue, 2))
@@ -386,7 +388,7 @@ export default class extends Controller {
     this.projectedTicketPriceIncreaseTarget.innerHTML = digitformat(100 * (projectedTicketPrice - tpPrice) / tpPrice, 2)
     this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
 
-    var totalDCRPos = this.settings.attack_type === 0 ? DCRNeed - tpValue : ticketAttackSize * projectedTicketPrice
+    var totalDCRPos = this.settings.attack_type === externalAttackType ? DCRNeed - tpValue : ticketAttackSize * projectedTicketPrice
     var totalPos = totalDCRPos * dcrPrice
     var timeStr = this.attackPeriodTarget.value
     timeStr = this.attackPeriodTarget.value > 1 ? timeStr + ' hours' : timeStr + ' hour'
@@ -414,7 +416,7 @@ export default class extends Controller {
     this.blockHeightTarget.innerHTML = digitformat(height)
     this.totalTarget.innerHTML = digitformat(totalPow + totalPos, 2)
     this.projectedTicketPriceTarget.innerHTML = digitformat(projectedTicketPrice, 2)
-    this.attackPosPercentNeededLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
+    // this.attackPosPercentNeededLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
     this.attackPosPercentAmountLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
     this.setAllValues(this.totalDCRPosLabelTargets, digitformat(totalDCRPos, 2))
     this.setAllValues(this.dcrPriceLabelTargets, digitformat(dcrPrice, 2))

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -1,0 +1,385 @@
+import { Controller } from 'stimulus'
+import TurboQuery from '../helpers/turbolinks_helper'
+import { getDefault } from '../helpers/module_helper'
+import globalEventBus from '../services/event_bus_service'
+import { nightModeOptions } from '../helpers/chart_helper'
+import dompurify from 'dompurify'
+
+function digitformat (amount, decimalPlaces, noComma) {
+  if (!amount) return 0
+
+  if (noComma) return amount.toFixed(decimalPlaces)
+
+  decimalPlaces = decimalPlaces || 0
+  let result = parseFloat(amount).toLocaleString(undefined, { minimumFractionDigits: decimalPlaces, maximumFractionDigits: decimalPlaces }).replace(/\.0*$/, '')
+  if (result.indexOf('.') > -1 && result.endsWith('0')) {
+    return removeTrailingZeros(result)
+  }
+
+  return result
+}
+
+function removeTrailingZeros (value) {
+  value = value.toString()
+  if (value.indexOf('.') === -1) {
+    return value
+  }
+
+  let cutFrom = value.length - 1
+  do {
+    if (value[cutFrom] === '0') {
+      cutFrom--
+    }
+  } while (value[cutFrom] === '0')
+
+  if (value[cutFrom] === '.') {
+    cutFrom--
+  }
+
+  return value.substr(0, cutFrom + 1)
+}
+
+let Dygraph // lazy loaded on connect
+var height, dcrPrice, hashrate, tpSize, tpValue, tpPrice, graphData, currentPoint
+
+function rateCalculation (y) {
+  y = y || 0.99 // 0.99 TODO confirm why 0.99 is used as default instead of 1
+  let x = 1 - y
+
+  // equation to determine hashpower requirement based on percentage of live stake
+  // https://medium.com/decred/decreds-hybrid-protocol-a-superior-deterrent-to-majority-attacks-9421bf486292
+  // (6 (1-f_s)⁵ -15(1-f_s) + 10(1-f_s)³) / (6f_s⁵-15f_s⁴ + 10f_s³)
+  // (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) where y = this.value and x = 1-y
+  return ((6 * Math.pow(x, 5)) - (15 * Math.pow(x, 4)) + (10 * Math.pow(x, 3))) / ((6 * Math.pow(y, 5)) - (15 * Math.pow(y, 4)) + (10 * Math.pow(y, 3)))
+}
+
+const deviceList = {
+  '0': {
+    hashrate: 34, // Th/s
+    units: 'Th/s',
+    power: 1610, // W
+    cost: 1282, // $
+    name: 'DCR5',
+    link: 'https://www.cryptocompare.com/mining/bitmain/antminer-dr5-blake256r14-34ths/'
+  },
+  '1': {
+    hashrate: 44, // Th/s
+    units: 'Th/s',
+    power: 2200, // W
+    cost: 4199, // $
+    name: 'D1',
+    link: 'https://www.cryptocompare.com/mining/crypto-drilling/microbt-whatsminer-d1-plus-psu-dcr-44ths/'
+  }
+}
+
+function legendFormatter (data) {
+  var html = ''
+  if (data.x == null) {
+    let dashLabels = data.series.reduce((nodes, series) => {
+      return `${nodes} <span>${series.labelHTML}</span>`
+    }, '')
+    html = `<span>${this.getLabels()[0]}: N/A</span>${dashLabels}`
+  } else {
+    let yVals = data.series.reduce((nodes, series) => {
+      if (!series.isVisible) return nodes
+      let precession = series.y >= 1 ? 2 : 6
+      return `${nodes} <span class="ml-3">${series.labelHTML}:</span> &nbsp;${digitformat(series.y, precession)}x`
+    }, '<br>')
+
+    html = `<span>${this.getLabels()[0]}: ${digitformat(data.x, 1)}</span>${yVals}`
+  }
+  dompurify.sanitize(html)
+  return html
+}
+
+export default class extends Controller {
+  static get targets () {
+    return [
+      'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
+      'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
+      'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
+      'additionalHashRate', 'targetPos', 'targetPow',
+      'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
+      'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
+      'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
+      'totalPos', 'totalPow', 'graph', 'labels', 'projectedTicketPrice', 'attackType',
+      'attackPosPercentNeededLabel', 'attackPosPercentAmountLabel', 'dcrPriceLabel', 'totalDCRPosLabel',
+      'projectedPriceDiv'
+    ]
+  }
+
+  async connect () {
+    this.query = new TurboQuery()
+    this.settings = TurboQuery.nullTemplate([
+      'attack_time', 'target_pow', 'kwh_rate', 'other_costs', 'target_pos', 'price', 'device', 'attack_type'
+    ])
+
+    // Get initial view settings from the url
+    this.query.update(this.settings)
+
+    height = parseInt(this.data.get('height'))
+    hashrate = parseInt(this.data.get('hashrate'))
+    dcrPrice = parseFloat(this.data.get('dcrprice'))
+    tpPrice = parseFloat(this.data.get('ticketPrice'))
+    tpValue = parseFloat(this.data.get('ticketPoolValue'))
+    tpSize = parseInt(this.data.get('ticketPoolSize'))
+
+    if (this.settings.attack_time) this.attackPeriodTarget.value = parseInt(this.settings.attack_time)
+    if (this.settings.target_pow) this.targetPowTarget.value = parseFloat(this.settings.target_pow)
+    if (this.settings.kwh_rate) this.kwhRateTarget.value = parseFloat(this.settings.kwh_rate)
+    if (this.settings.other_costs) this.otherCostsTarget.value = parseFloat(this.settings.other_cost)
+    if (this.settings.target_pos) this.targetPosTarget.value = parseFloat(this.settings.target_pos)
+    if (this.settings.price) this.priceDCRTarget.value = parseFloat(this.settings.price)
+    if (this.settings.device) this.setDevice(this.settings.device)
+    if (this.settings.attack_type) this.attackTypeTarget.value = parseInt(this.settings.attack_type)
+    if (this.settings.target_pos || this.settings.target_pow) this.attackPercentTarget.value = (this.targetPowTarget.value || this.targetPosTarget.value) / 100
+
+    this.setDevicesDesc()
+    this.updateSliderData()
+
+    Dygraph = await getDefault(
+      import(/* webpackChunkName: "dygraphs" */ '../vendor/dygraphs.min.js')
+    )
+
+    Dygraph.prototype.doZoomY_ = function (lowY, highY) {}
+
+    this.plotGraph()
+    this.processNightMode = (params) => {
+      this.chartsView.updateOptions(
+        nightModeOptions(params.nightMode)
+      )
+    }
+    globalEventBus.on('NIGHT_MODE', this.processNightMode)
+  }
+
+  disconnect () {
+    globalEventBus.off('NIGHT_MODE', this.processNightMode)
+    if (this.chartsView !== undefined) {
+      this.chartsView.destroy()
+    }
+  }
+
+  plotGraph () {
+    const that = this
+    graphData = []
+
+    // populate graphData
+    // to avoid javascript decimal math issue, the iteration is done over whole number and reduced to the expected decimal value within the loop
+    for (let i = 10; i <= 1000; i += 5) {
+      const y = i / 1000
+      graphData.push([y * tpSize, rateCalculation(y)])
+    }
+
+    let options = {
+      ...nightModeOptions(false),
+      labels: ['Attackers Tickets', 'Hash Power Multiplier'],
+      ylabel: 'Hash Power Multiplier',
+      xlabel: 'Attackers Tickets',
+      axes: {
+        y: {
+          axisLabelWidth: 70
+        }
+      },
+      highlightSeriesOpts: { strokeWidth: 2 },
+      legendFormatter: legendFormatter,
+      hideOverlayOnMouseOut: false,
+      labelsDiv: this.labelsTarget,
+      labelsSeparateLines: true,
+      showRangeSelector: false,
+      labelsKMB: true,
+      legend: 'always',
+      logscale: true,
+      interactionModel: {
+        'click': function (e) {
+          that.attackPercentTarget.value = currentPoint.x
+          that.updateSliderData()
+        }
+      },
+      highlightCallback: function (event, x, p) {
+        currentPoint = p[0]
+      }
+    }
+
+    this.chartsView = new Dygraph(this.graphTarget, graphData, options)
+    this.chartsView.setAnnotations([{
+      series: 'Hashpower multiplier',
+      x: 0.51,
+      shortText: 'L',
+      text: '51% Attack'
+    }])
+    this.setActivePoint()
+  }
+
+  updateAttackTime () {
+    this.settings.attack_time = this.attackPeriodTarget.value
+    this.updateSliderData()
+  }
+
+  updateTargetPow () {
+    // todo use the inverse of (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) where y = this.value and x = 1-y to get the
+    //  appropriate multiplier for the selected attack percentage
+    // this.updateSliderData()
+  }
+
+  chooseDevice () {
+    this.settings.device = this.selectedDevice()
+    this.updateSliderData()
+  }
+
+  chooseAttackType () {
+    this.settings.attack_type = this.selectedAttackType()
+    this.updateSliderData()
+  }
+
+  updateKwhRate () {
+    this.settings.kwh_rate = this.kwhRateTarget.value
+    this.updateSliderData()
+  }
+
+  updateOtherCosts () {
+    this.settings.other_costs = this.otherCostsTarget.value
+    this.updateSliderData()
+  }
+
+  updateTargetPos () {
+    this.settings.target_pos = this.targetPosTarget.value
+    this.attackPercentTarget.value = parseFloat(this.targetPosTarget.value) / 100
+    this.updateSliderData()
+  }
+
+  updatePrice () {
+    this.settings.price = this.priceDCRTarget.value
+    dcrPrice = this.priceDCRTarget.value
+    this.updateSliderData()
+  }
+
+  selectedDevice () { return this.deviceTarget.value }
+
+  selectedAttackType () {
+    // TurboQuery parses the attack_type from the url as int
+    return parseInt(this.attackTypeTarget.value)
+  }
+
+  selectOption (options) {
+    let val = '0'
+    options.map((n) => { if (n.selected) val = n.value })
+    return val
+  }
+
+  setDevicesDesc () {
+    this.deviceDescTargets.map((n) => {
+      let info = deviceList[n.value]
+      if (!info) return
+      n.innerHTML = `${info.name}, ${info.hashrate} ${info.units}, ${info.power}w, $${digitformat(info.cost)} per unit`
+    })
+  }
+
+  setDevice (selectedVal) { return this.setOption(this.deviceTargets, selectedVal) }
+
+  setOption (options, selectedVal) {
+    options.map((n) => { n.selected = n.value === selectedVal })
+  }
+
+  setActivePoint () {
+    // Shows point whose details appear on the legend.
+    if (this.chartsView !== undefined) {
+      let val = Math.min(parseFloat(this.attackPercentTarget.value) || 0, 0.99)
+      let row = this.chartsView.getRowForX(val * tpSize)
+      this.chartsView.setSelection(row)
+    }
+  }
+
+  updateTargetHashRate (newTargetPow) {
+    this.targetPowTarget.value = newTargetPow || this.targetPowTarget.value
+
+    switch (this.settings.attack_type) {
+      case 1:
+        this.targetHashRate = hashrate / (1 - parseFloat(this.targetPowTarget.value) / 100)
+        this.projectedPriceDivTarget.style.display = 'block'
+        this.internalAttackTextTarget.classList.add('d-none')
+        this.externalAttackTextTarget.classList.remove('d-none')
+        return
+      case 0:
+      default:
+        this.targetHashRate = hashrate * parseFloat(this.targetPowTarget.value) / 100
+        this.projectedPriceDivTarget.style.display = 'none'
+        this.externalAttackTextTarget.classList.add('d-none')
+        this.internalAttackTextTarget.classList.remove('d-none')
+    }
+  }
+
+  updateSliderData () {
+    var val = Math.min(parseFloat(this.attackPercentTarget.value) || 0, 0.99)
+    // Makes PoS to be affected by the slider
+    // Target PoS value increases when slider moves to the right
+    this.targetPosTarget.value = val * 100
+
+    this.updateTargetHashRate(val * 100)
+    this.setActivePoint()
+
+    var rate = rateCalculation(val)
+    var randomVal = (rate * this.targetHashRate) / parseFloat(hashrate) * 100
+
+    this.targetPowTarget.value = Math.floor(randomVal * 100) / 100
+    this.internalHashTarget.innerHTML = digitformat((rate * this.targetHashRate), 4) + ' Ph/s '
+    this.ticketsTarget.innerHTML = digitformat(val * tpSize) + ' tickets '
+
+    this.calculate(true)
+  }
+
+  calculate (disableHashRateUpdate) {
+    if (!disableHashRateUpdate) this.updateTargetHashRate()
+
+    this.targetHashRate *= rateCalculation(this.targetPosTarget.value / 100)
+    this.query.replace(this.settings)
+    var deviceInfo = deviceList[this.selectedDevice()]
+    var deviceCount = Math.ceil((this.targetHashRate * 1000) / deviceInfo.hashrate)
+    var totalDeviceCost = deviceCount * deviceInfo.cost
+    var totalKwh = deviceCount * deviceInfo.power * parseFloat(this.attackPeriodTarget.value) / 1000
+    var totalElectricity = totalKwh * parseFloat(this.kwhRateTarget.value)
+    var extraCostsRate = 1 + parseFloat(this.otherCostsTarget.value) / 100
+    var totalPow = extraCostsRate * totalDeviceCost + totalElectricity
+    var ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
+    var DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
+    var projectedTicketPrice = DCRNeed / tpSize
+    this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
+    this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
+
+    var totalDCRPos = ticketAttackSize * projectedTicketPrice
+    var totalPos = totalDCRPos * dcrPrice
+    var timeStr = this.attackPeriodTarget.value
+    timeStr = this.attackPeriodTarget.value > 1 ? timeStr + ' hours' : timeStr + ' hour'
+    this.ticketPoolSizeLabelTarget.innerHTML = digitformat(tpSize, 2)
+
+    this.setAllValues(this.actualHashRateTargets, digitformat(hashrate, 4))
+    this.priceDCRTarget.value = digitformat(dcrPrice, 2)
+    this.targetPowTarget.value = digitformat(parseFloat(this.targetPowTarget.value), 2, true)
+    this.targetPosTarget.value = digitformat(parseFloat(this.targetPosTarget.value), 2)
+    this.ticketPriceTarget.innerHTML = digitformat(tpPrice, 4)
+    this.setAllValues(this.targetHashRateTargets, digitformat(this.targetHashRate, 4))
+    this.setAllValues(this.additionalHashRateTargets, digitformat(this.targetHashRate - hashrate, 4))
+    this.setAllValues(this.durationLongDescTargets, timeStr)
+    this.setAllValues(this.countDeviceTargets, digitformat(deviceCount))
+    this.setAllValues(this.deviceNameTargets, `<a href="${deviceInfo.link}">${deviceInfo.name}</a>s`)
+    this.setAllValues(this.totalDeviceCostTargets, digitformat(totalDeviceCost))
+    this.setAllValues(this.totalKwhTargets, digitformat(totalKwh, 2))
+    this.setAllValues(this.totalElectricityTargets, digitformat(totalElectricity, 2))
+    this.setAllValues(this.totalPowTargets, digitformat(totalPow, 2))
+    this.setAllValues(this.ticketSizeAttackTargets, digitformat(ticketAttackSize))
+    this.setAllValues(this.totalDCRPosTargets, digitformat(totalDCRPos, 2))
+    this.setAllValues(this.totalPosTargets, digitformat(totalPos))
+    this.setAllValues(this.ticketPoolValueTargets, digitformat(tpValue))
+    this.setAllValues(this.ticketPoolSizeTargets, digitformat(tpSize))
+    this.blockHeightTarget.innerHTML = digitformat(height)
+    this.totalTarget.innerHTML = digitformat(totalPow + totalPos, 2)
+    this.projectedTicketPriceTarget.innerHTML = digitformat(projectedTicketPrice, 2)
+    this.attackPosPercentNeededLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
+    this.attackPosPercentAmountLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
+    this.totalDCRPosLabelTarget.innerHTML = digitformat(totalDCRPos, 2)
+    this.dcrPriceLabelTarget.innerHTML = digitformat(dcrPrice, 2)
+  }
+
+  setAllValues (targets, data) {
+    targets.map((n) => { n.innerHTML = data })
+  }
+}

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -2,7 +2,6 @@ import { Controller } from 'stimulus'
 import TurboQuery from '../helpers/turbolinks_helper'
 import { getDefault } from '../helpers/module_helper'
 import globalEventBus from '../services/event_bus_service'
-import { nightModeOptions } from '../helpers/chart_helper'
 import dompurify from 'dompurify'
 
 function digitformat (amount, decimalPlaces, noComma) {
@@ -92,6 +91,21 @@ function legendFormatter (data) {
   return html
 }
 
+function nightModeOptions (nightModeOn) {
+  if (nightModeOn) {
+    return {
+      rangeSelectorAlpha: 0.3,
+      gridLineColor: '#596D81',
+      colors: ['#2DD8A3', '#2970FF', '#FFC84E']
+    }
+  }
+  return {
+    rangeSelectorAlpha: 0.4,
+    gridLineColor: '#C4CBD2',
+    colors: ['#2970FF', '#006600', '#FF0090']
+  }
+}
+
 export default class extends Controller {
   static get targets () {
     return [
@@ -142,6 +156,8 @@ export default class extends Controller {
       import(/* webpackChunkName: "dygraphs" */ '../vendor/dygraphs.min.js')
     )
 
+    // dygraph does not provide a way to disable zoom on y-axis https://code.google.com/archive/p/dygraphs/issues/384
+    // this is a hack as doZoomY_ is marked as private
     Dygraph.prototype.doZoomY_ = function (lowY, highY) {}
 
     this.plotGraph()

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -99,7 +99,7 @@ export default class extends Controller {
       'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
       'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
       'externalAttackPosText', 'additionalTickets', 'newTicketPoolValue', 'internalAttackPosText',
-      'additionalHashRate', 'targetPos', 'targetPow',
+      'additionalHashRate', 'targetPos', 'targetPow', 'operatorSign',
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
       'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
@@ -298,14 +298,19 @@ export default class extends Controller {
         this.targetHashRate = hashrate / (1 - parseFloat(this.targetPowTarget.value) / 100) - hashrate
         this.projectedPriceDivTarget.style.display = 'block'
         this.internalAttackTextTarget.classList.add('d-none')
+        this.internalAttackPosTextTarget.classList.add('d-none')
         this.externalAttackTextTarget.classList.remove('d-none')
+        this.externalAttackPosTextTarget.classList.remove('d-node')
+        console.log(this.externalAttackPosTextTarget)
         return
       case 0:
       default:
         this.targetHashRate = hashrate * parseFloat(this.targetPowTarget.value) / 100
         this.projectedPriceDivTarget.style.display = 'none'
         this.externalAttackTextTarget.classList.add('d-none')
+        this.externalAttackPosTextTarget.classList.add('d-node')
         this.internalAttackTextTarget.classList.remove('d-none')
+        this.internalAttackPosTextTarget.classList.remove('d-none')
     }
   }
 
@@ -326,13 +331,13 @@ export default class extends Controller {
     this.ticketsTarget.innerHTML = digitformat(val * tpSize) + ' tickets '
     switch (this.settings.attack_type) {
       case 1:
-        this.hideAll(this.internalAttackPosTextTarget)
+        this.hideAll(this.internalAttackPosTextTargets)
         this.showAll(this.externalAttackPosTextTargets)
         break
       case 0:
       default:
         this.hideAll(this.externalAttackPosTextTargets)
-        this.showAll(this.internalAttackPosTextTarget)
+        this.showAll(this.internalAttackPosTextTargets)
     }
 
     this.calculate(true)
@@ -353,12 +358,14 @@ export default class extends Controller {
     var ticketAttackSize, DCRNeed
     if (this.settings.attack_type === 1) {
       ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
-      this.additionalTicketsTarget.innerHTML = digitformat(ticketAttackSize - tpSize, 2)
-      this.newTicketPoolValueTarget.innerHTML = digitformat(ticketAttackSize, 2)
       DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
+      this.setAllValues(this.additionalTicketsTargets, digitformat(ticketAttackSize - tpSize, 0))
+      this.setAllValues(this.newTicketPoolValueTargets, digitformat(ticketAttackSize, 0))
+      this.setAllValues(this.operatorSignTargets, '+')
     } else {
       ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
       DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
+      this.setAllValues(this.operatorSignTargets, '*')
     }
     var projectedTicketPrice = DCRNeed / tpSize
     this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
@@ -399,14 +406,14 @@ export default class extends Controller {
   }
 
   setAllValues (targets, data) {
-    targets.map((n) => { n.innerHTML = data })
+    targets.forEach((n) => { n.innerHTML = data })
   }
 
   hideAll (targets) {
-    targets.map(el => el.classList.add('d-none'))
+    targets.forEach(el => el.classList.add('d-none'))
   }
 
   showAll (targets) {
-    targets.map(el => el.classList.remove('d-none'))
+    targets.forEach(el => el.classList.remove('d-none'))
   }
 }

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -370,10 +370,9 @@ export default class extends Controller {
     var totalKwh = deviceCount * deviceInfo.power * parseFloat(this.attackPeriodTarget.value) / 1000
     var totalElectricity = totalKwh * parseFloat(this.kwhRateTarget.value)
     var extraCost = parseFloat(this.otherCostsTarget.value) / 100 * (totalDeviceCost + totalElectricity)
-    var totalPow = extraCost * totalDeviceCost + totalElectricity
+    var totalPow = extraCost + totalDeviceCost + totalElectricity
     var ticketAttackSize, DCRNeed
     if (this.settings.attack_type === 1) {
-      // ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
       DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
       this.setAllValues(this.newTicketPoolValueTargets, digitformat(DCRNeed, 2))
       this.setAllValues(this.additionalDcrTargets, digitformat(DCRNeed - tpValue, 2))

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -307,26 +307,26 @@ export default class extends Controller {
   }
 
   updateTargetHashRate (newTargetPow) {
-    this.targetPowTarget.value = newTargetPow || this.targetPowTarget.value
-
+    let ticketPercentage = newTargetPow || this.targetPosTargets.value
+    this.targetHashRate = hashrate * rateCalculation(ticketPercentage / 100)
+    this.targetPowTarget.value = digitformat(100 * this.targetHashRate / hashrate, 2)
     switch (this.settings.attack_type) {
       case 1:
-        this.targetHashRate = hashrate / (1 - parseFloat(this.targetPowTarget.value) / 100) - hashrate
+        this.targetHashRate += hashrate
         this.projectedPriceDivTarget.style.display = 'block'
         this.internalAttackTextTarget.classList.add('d-none')
         this.internalAttackPosTextTarget.classList.add('d-none')
         this.externalAttackTextTarget.classList.remove('d-none')
         this.externalAttackPosTextTarget.classList.remove('d-node')
-        console.log(this.externalAttackPosTextTarget)
         return
       case 0:
       default:
-        this.targetHashRate = hashrate * parseFloat(this.targetPowTarget.value) / 100
         this.projectedPriceDivTarget.style.display = 'none'
         this.externalAttackTextTarget.classList.add('d-none')
         this.externalAttackPosTextTarget.classList.add('d-node')
         this.internalAttackTextTarget.classList.remove('d-none')
         this.internalAttackPosTextTarget.classList.remove('d-none')
+        this.internalHashTarget.innerHTML = digitformat((this.targetHashRate), 4) + ' Ph/s '
     }
   }
 
@@ -339,11 +339,6 @@ export default class extends Controller {
     this.updateTargetHashRate(val * 100)
     this.setActivePoint()
 
-    var rate = rateCalculation(val)
-    var randomVal = (rate * this.targetHashRate) / parseFloat(hashrate) * 100
-
-    this.targetPowTarget.value = Math.floor(randomVal * 100) / 100
-    this.internalHashTarget.innerHTML = digitformat((rate * this.targetHashRate), 4) + ' Ph/s '
     this.ticketsTarget.innerHTML = digitformat(val * tpSize) + ' tickets '
     switch (this.settings.attack_type) {
       case 1:
@@ -362,7 +357,7 @@ export default class extends Controller {
   calculate (disableHashRateUpdate) {
     if (!disableHashRateUpdate) this.updateTargetHashRate()
 
-    this.targetHashRate *= rateCalculation(this.targetPosTarget.value / 100)
+    // this.targetHashRate *= rateCalculation(this.targetPosTarget.value / 100)
     this.query.replace(this.settings)
     var deviceInfo = deviceList[this.selectedDevice()]
     var deviceCount = Math.ceil((this.targetHashRate * 1000) / deviceInfo.hashrate)

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -117,7 +117,7 @@ export default class extends Controller {
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
       'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
-      'totalPos', 'totalPow', 'graph', 'labels', 'projectedTicketPrice', 'attackType',
+      'totalPos', 'totalPow', 'graph', 'labels', 'projectedTicketPrice', 'projectedTicketPriceIncrease', 'attackType',
       'attackPosPercentNeededLabel', 'attackPosPercentAmountLabel', 'dcrPriceLabel', 'totalDCRPosLabel',
       'projectedPriceDiv'
     ]
@@ -377,6 +377,7 @@ export default class extends Controller {
       this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
     }
     var projectedTicketPrice = DCRNeed / tpSize
+    this.projectedTicketPriceIncreaseTarget.innerHTML = digitformat(100 * (projectedTicketPrice - tpPrice) / tpPrice, 2)
     this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
 
     var totalDCRPos = this.settings.attack_type === 1 ? DCRNeed - tpValue : ticketAttackSize * projectedTicketPrice

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -111,7 +111,7 @@ export default class extends Controller {
     return [
       'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
       'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
-      'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
+      'kwhRate', 'kwhRateLabel', 'otherCosts', 'otherCostsValue', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
       'externalAttackPosText', 'additionalDcr', 'newTicketPoolValue', 'internalAttackPosText',
       'additionalHashRate', 'targetPos', 'targetPow',
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
@@ -369,8 +369,8 @@ export default class extends Controller {
     var totalDeviceCost = deviceCount * deviceInfo.cost
     var totalKwh = deviceCount * deviceInfo.power * parseFloat(this.attackPeriodTarget.value) / 1000
     var totalElectricity = totalKwh * parseFloat(this.kwhRateTarget.value)
-    var extraCostsRate = 1 + parseFloat(this.otherCostsTarget.value) / 100
-    var totalPow = extraCostsRate * totalDeviceCost + totalElectricity
+    var extraCost = parseFloat(this.otherCostsTarget.value) / 100 * (totalDeviceCost + totalElectricity)
+    var totalPow = extraCost * totalDeviceCost + totalElectricity
     var ticketAttackSize, DCRNeed
     if (this.settings.attack_type === 1) {
       // ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
@@ -404,6 +404,7 @@ export default class extends Controller {
     this.setAllValues(this.totalDeviceCostTargets, digitformat(totalDeviceCost))
     this.setAllValues(this.totalKwhTargets, digitformat(totalKwh, 2))
     this.setAllValues(this.totalElectricityTargets, digitformat(totalElectricity, 2))
+    this.setAllValues(this.otherCostsValueTargets, digitformat(extraCost, 2))
     this.setAllValues(this.totalPowTargets, digitformat(totalPow, 2))
     this.setAllValues(this.ticketSizeAttackTargets, digitformat(ticketAttackSize))
     this.setAllValues(this.totalDCRPosTargets, digitformat(totalDCRPos, 2))

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -143,7 +143,7 @@ export default class extends Controller {
     if (this.settings.target_pow) this.targetPowTarget.value = parseFloat(this.settings.target_pow)
     if (this.settings.kwh_rate) this.kwhRateTarget.value = parseFloat(this.settings.kwh_rate)
     if (this.settings.other_costs) this.otherCostsTarget.value = parseFloat(this.settings.other_cost)
-    if (this.settings.target_pos) this.targetPosTarget.value = parseFloat(this.settings.target_pos)
+    if (this.settings.target_pos) this.setAllInputs(this.targetPosTargets, parseFloat(this.settings.target_pos))
     if (this.settings.price) this.priceDCRTarget.value = parseFloat(this.settings.price)
     if (this.settings.device) this.setDevice(this.settings.device)
     if (this.settings.attack_type) this.attackTypeTarget.value = parseInt(this.settings.attack_type)
@@ -334,7 +334,7 @@ export default class extends Controller {
     var val = Math.min(parseFloat(this.attackPercentTarget.value) || 0, 0.99)
     // Makes PoS to be affected by the slider
     // Target PoS value increases when slider moves to the right
-    this.targetPosTarget.value = val * 100
+    this.setAllInputs(this.targetPosTargets, val * 100)
 
     this.updateTargetHashRate(val * 100)
     this.setActivePoint()
@@ -394,7 +394,7 @@ export default class extends Controller {
     this.setAllValues(this.actualHashRateTargets, digitformat(hashrate, 4))
     this.priceDCRTarget.value = digitformat(dcrPrice, 2)
     this.targetPowTarget.value = digitformat(parseFloat(this.targetPowTarget.value), 2, true)
-    this.targetPosTarget.value = digitformat(parseFloat(this.targetPosTarget.value), 2)
+    this.setAllInputs(this.targetPosTargets, digitformat(parseFloat(this.targetPosTarget.value), 2))
     this.ticketPriceTarget.innerHTML = digitformat(tpPrice, 4)
     this.setAllValues(this.targetHashRateTargets, digitformat(this.targetHashRate, 4))
     this.setAllValues(this.additionalHashRateTargets, digitformat(this.targetHashRate - hashrate, 4))
@@ -421,6 +421,10 @@ export default class extends Controller {
 
   setAllValues (targets, data) {
     targets.forEach((n) => { n.innerHTML = data })
+  }
+
+  setAllInputs (targets, data) {
+    targets.forEach((n) => { n.value = data })
   }
 
   hideAll (targets) {

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -112,8 +112,8 @@ export default class extends Controller {
       'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
       'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
       'kwhRate', 'kwhRateLabel', 'otherCosts', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
-      'externalAttackPosText', 'additionalTickets', 'internalAttackPosText',
-      'additionalHashRate', 'targetPos', 'targetPow', 'operatorSign',
+      'externalAttackPosText', 'additionalDcr', 'newTicketPoolValue', 'internalAttackPosText',
+      'additionalHashRate', 'targetPos', 'targetPow',
       'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
       'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
       'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
@@ -373,21 +373,19 @@ export default class extends Controller {
     var totalPow = extraCostsRate * totalDeviceCost + totalElectricity
     var ticketAttackSize, DCRNeed
     if (this.settings.attack_type === 1) {
-      ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
+      // ticketAttackSize = tpSize / (1 - parseFloat(this.targetPosTarget.value) / 100)
       DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
-      this.setAllValues(this.additionalTicketsTargets, digitformat(ticketAttackSize - tpSize, 0))
-      // this.setAllValues(this.newTicketPoolValueTargets, digitformat(ticketAttackSize, 0))
-      this.setAllValues(this.operatorSignTargets, '+')
+      this.setAllValues(this.newTicketPoolValueTargets, digitformat(DCRNeed, 2))
+      this.setAllValues(this.additionalDcrTargets, digitformat(DCRNeed - tpValue, 2))
     } else {
       ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
       DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
-      this.setAllValues(this.operatorSignTargets, '*')
+      this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
     }
     var projectedTicketPrice = DCRNeed / tpSize
-    this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
     this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
 
-    var totalDCRPos = ticketAttackSize * projectedTicketPrice
+    var totalDCRPos = this.settings.attack_type === 1 ? DCRNeed - tpValue : ticketAttackSize * projectedTicketPrice
     var totalPos = totalDCRPos * dcrPrice
     var timeStr = this.attackPeriodTarget.value
     timeStr = this.attackPeriodTarget.value > 1 ? timeStr + ' hours' : timeStr + ' hour'
@@ -417,8 +415,8 @@ export default class extends Controller {
     this.projectedTicketPriceTarget.innerHTML = digitformat(projectedTicketPrice, 2)
     this.attackPosPercentNeededLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
     this.attackPosPercentAmountLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
-    this.totalDCRPosLabelTarget.innerHTML = digitformat(totalDCRPos, 2)
-    this.dcrPriceLabelTarget.innerHTML = digitformat(dcrPrice, 2)
+    this.setAllValues(this.totalDCRPosLabelTargets, digitformat(totalDCRPos, 2))
+    this.setAllValues(this.dcrPriceLabelTargets, digitformat(dcrPrice, 2))
   }
 
   setAllValues (targets, data) {

--- a/public/js/helpers/chart_helper.js
+++ b/public/js/helpers/chart_helper.js
@@ -230,18 +230,3 @@ export function synchronize (dygraphs, syncOptions) {
     })
   })
 }
-
-export function nightModeOptions (nightModeOn) {
-  if (nightModeOn) {
-    return {
-      rangeSelectorAlpha: 0.3,
-      gridLineColor: '#596D81',
-      colors: ['#2DD8A3', '#2970FF', '#FFC84E']
-    }
-  }
-  return {
-    rangeSelectorAlpha: 0.4,
-    gridLineColor: '#C4CBD2',
-    colors: ['#2970FF', '#006600', '#FF0090']
-  }
-}

--- a/public/js/helpers/chart_helper.js
+++ b/public/js/helpers/chart_helper.js
@@ -230,3 +230,18 @@ export function synchronize (dygraphs, syncOptions) {
     })
   })
 }
+
+export function nightModeOptions (nightModeOn) {
+  if (nightModeOn) {
+    return {
+      rangeSelectorAlpha: 0.3,
+      gridLineColor: '#596D81',
+      colors: ['#2DD8A3', '#2970FF', '#FFC84E']
+    }
+  }
+  return {
+    rangeSelectorAlpha: 0.4,
+    gridLineColor: '#C4CBD2',
+    colors: ['#2970FF', '#006600', '#FF0090']
+  }
+}

--- a/public/scss/application.scss
+++ b/public/scss/application.scss
@@ -62,3 +62,4 @@
 @import "./responsive.scss";
 @import "./home.scss";
 @import "./cards.scss";
+@import "./attackcost.scss";

--- a/public/scss/attackcost.scss
+++ b/public/scss/attackcost.scss
@@ -1,7 +1,8 @@
 input[type=number] {
   -moz-appearance: textfield;
   font-size: 0.95rem;
-  border-radius: 5px;
+  border-radius: 3px;
+  border: 1px solid #ced4da;
   padding: 0 0.2rem 0 0.3rem;
 }
 

--- a/public/scss/attackcost.scss
+++ b/public/scss/attackcost.scss
@@ -1,0 +1,149 @@
+input[type=number] {
+  -moz-appearance: textfield;
+  font-size: 0.95rem;
+  border-radius: 5px;
+  padding: 0 0.2rem 0 0.3rem;
+}
+
+input[type=number]::-webkit-outer-spin-button,
+input[type=number]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.slider {
+  max-width: 500px;
+  width: 100%;
+  height: calc(1rem + 0.4rem);
+  padding: 0;
+  background-color: transparent;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.slider:focus {
+  outline: 0;
+}
+
+.slider::-webkit-slider-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.25rem;
+  background-color: #2970ff;
+  border: 0;
+  border-radius: 1rem;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.slider:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.slider::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  background-color: #2970ff;
+  border: 0;
+  border-radius: 1rem;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.slider:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.slider::-ms-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0;
+  margin-right: 0.2rem;
+  margin-left: 0.2rem;
+  background-color: #2970ff;
+  border: 0;
+  border-radius: 1rem;
+  appearance: none;
+}
+
+.slider:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.slider::-webkit-slider-thumb:active {
+  background-color: #b3d7ff;
+}
+
+.slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem;
+}
+
+.slider::-moz-range-thumb:active {
+  background-color: #b3d7ff;
+}
+
+.slider::-moz-range-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem;
+}
+
+.slider::-ms-thumb:active {
+  background-color: #b3d7ff;
+}
+
+.slider::-ms-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: transparent;
+  border-color: transparent;
+  border-width: 0.5rem;
+}
+
+.slider::-ms-fill-lower {
+  background-color: #dee2e6;
+  border-radius: 1rem;
+}
+
+.slider::-ms-fill-upper {
+  margin-right: 15px;
+  background-color: #dee2e6;
+  border-radius: 1rem;
+}
+
+.slider:disabled::-webkit-slider-thumb {
+  background-color: #adb5bd;
+}
+
+.slider:disabled::-webkit-slider-runnable-track {
+  cursor: default;
+}
+
+.slider:disabled::-moz-range-thumb {
+  background-color: #adb5bd;
+}
+
+.slider:disabled::-moz-range-track {
+  cursor: default;
+}
+
+.slider:disabled::-ms-thumb {
+  background-color: #adb5bd;
+}
+
+.b-radius {
+  border-radius: 2px;
+}

--- a/public/scss/charts.scss
+++ b/public/scss/charts.scss
@@ -347,7 +347,7 @@ body.darkBG .chartview .dygraph-y2label {
 }
 
 .chart-form-control {
-  width: 250px;
+  width: fit-content;
   font-size: 0.9rem !important;
   height: calc(1.5em + 0.5rem + 2px) !important;
 }

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -267,7 +267,7 @@
                 min="1"
                 max="100"
                 value="5"
-              >% of the cost of the miners. The additional ficility cost is <span data-target="attackcost.otherCostsValue">0</span>
+              >% of the cost of the miners. The additional facility cost is $<span data-target="attackcost.otherCostsValue">0</span>.
             </div>
             <div class="mt-1 ml-2">
               Total PoW attack cost is

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -1,0 +1,378 @@
+{{define "attackcost"}}
+<!DOCTYPE html>
+<html lang="en">
+{{ template "html-head" "Majority Attack Cost Calculator"}}
+{{template "navbar" . }}
+
+   <div
+      class="container py-1 mb-5"
+      data-controller="attackcost"
+      data-attackcost-height="{{.Height}}"
+      data-attackcost-hashrate="{{.HashRate}}"
+      data-attackcost-dcrprice="{{.DCRPrice}}"
+      data-attackcost-ticket-price="{{.TicketPrice}}"
+      data-attackcost-ticket-pool-value="{{.TicketPoolValue}}"
+      data-attackcost-ticket-pool-size="{{.TicketPoolSize}}"
+    >
+    <div class="col-md-24 p-0">
+      <div class="bg-white mb-1 py-2 px-3 my-0">
+        <div class="d-inline-block position-relative p-2">
+          <span class="card-icon dcricon-two blocks h1 mr-2"></span>
+          <span class="h4 my-3">Majority Attack Cost Calculator</span>
+        </div>
+
+        <div class="row mx-0 my-2">
+          <div class="col-24 col-sm-12 col-md-24 col-lg-18 px-3 position-relative">
+            <div class="pl-1">
+              <span class="h6 d-inline-block pl-2 font-weight-bold">Chart</span>
+            </div>
+            <div class="d-flex justify-content-center">
+              <div class="legend d-flex b-radius" data-target="attackcost.labels"></div>
+            </div>
+            <div class="justify-content-center align-items-center" data-target="attackcost.graph" data-action="mouseleave->attackcost#updateSliderData" style="width:100%; height:200px;"></div>
+          </div>
+          <div class="col-24 col-sm-12 col-md-24 col-lg-6 bg-grey px-3 position-relative fs13">
+            <div>
+              <div class="pl-1">
+                  <span class="h6 d-inline-block pl-2">Description</span>
+              </div>
+              <div>
+                <input
+                  class="slider"
+                  data-target="attackcost.attackPercent"
+                  data-action="input->attackcost#updateSliderData"
+                  type="range"
+                  min="0.01"
+                  max="0.99"
+                  step="0.005"
+                  value="0.51"
+                >
+                <span>If an attacker has in their control
+                  <span class="font-weight-bold" data-target="attackcost.tickets">0</span> and
+                  <span class="font-weight-bold" data-target="attackcost.internalHash">0</span> (HashRate)
+                  they will be able to generate blocks at the same average speed as the honest network.
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mx-0 my-2 bg-white">
+        <div class="col-24 col-sm-12 col-md-24 col-lg-13 px-3 position-relative pt-3 pb-3">
+          <div class="pl-1">
+            <span class="h6 d-inline-block pl-2 font-weight-bold">Current Mainnet Parameters</span>
+          </div>
+          <div class="row">
+            <div class="col-24 col-md-12 col-lg-24 col-xl-14 row pb-2 pb-sm-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+              <div class="col-11 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Best Block</span>
+                  <br>
+                  <span class="h4" data-target="attackcost.blockHeight">0</span>
+                </div>
+              </div>
+
+              <div class="col-13 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">HashRate</span>
+                  <br>
+                  <span class="h4" data-target="attackcost.actualHashRate"></span> <span class="text-secondary">Ph/s</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-24 col-md-12 col-lg-24 col-xl-11 row pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+              <div class="col-10 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Ticket Pool size</span>
+                  <br>
+                  <span class="h4" data-target="attackcost.ticketPoolSizeLabel">0</span>
+                </div>
+              </div>
+
+              <div class="col-12 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Ticket Price</span>
+                  <br>
+                  <span class="h4" data-target="attackcost.ticketPrice">0</span>
+                  <span class="text-secondary">DCR</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-24 col-sm-12 col-md-24 col-lg-11 secondary-card pt-3 pb-3 px-3">
+          <div class="pl-1">
+            <span class="h6 d-inline-block pl-2 font-weight-bold">Adjustable Parameters</span>
+          </div>
+
+          <div class="row mt-1">
+              <div class="col-24 col-md-12 col-lg-24 col-xl-14 row pb-3">
+              <div class="col-12 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Attack Time</span>
+                  <br>
+                  <span class="h4">
+                    <input
+                      type="number"
+                      data-target="attackcost.attackPeriod"
+                      data-action="change->attackcost#updateAttackTime"
+                      step="1"
+                      min="1"
+                      value="1"
+                      max="1000"
+                    >
+                  </span>
+                  <span class="text-secondary">hrs</span>
+                </div>
+              </div>
+
+              <div class="col-12 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Electricity Cost</span>
+                  <br>
+                  <span class="h4">
+                    <input
+                      type="number"
+                      data-target="attackcost.kwhRate"
+                      data-action="change->attackcost#updateKwhRate"
+                      step="0.1"
+                      min="0.1"
+                      value="0.1"
+                      max="1000"
+                    >
+                  </span>
+                  <span class="text-secondary">USD/kWh</span>
+                </div>
+              </div>
+            </div>
+            <div class="col-24 col-md-12 col-lg-24 col-xl-10 row pb-3">
+              <div class="col-12 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">USD-DCR Rate</span>
+                  <br>
+                  <span class="h4">
+                    <input
+                      type="number"
+                      data-target="attackcost.priceDCR"
+                      data-action="change->attackcost#UpdatePrice"
+                      step="0.1"
+                      min="0.01"
+                      value="20"
+                      max="1000"
+                    >
+                  </span> <span class="text-secondary">USD/DCR</span>
+                </div>
+              </div>
+              <div class="col-12 text-center">
+                <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
+                  <span class="text-secondary fs13">Attack Type</span>
+                  <br>
+                  <select
+                    class="form-control chart-form-control mr-5"
+                    data-action="attackcost#chooseAttackType"
+                    data-target="attackcost.attackType">
+                    <option data-target="attackcost.attackTypeDesc" value="0">Internal</option>
+                    <option data-target="attackcost.attackTypeDesc" value="1">External</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mx-0 my-2 bg-white">
+        <div class="col-24 col-sm-12 col-md-24 col-lg-13 px-3 position-relative pt-3 pb-3">
+          <div class="pl-1">
+              <span class="h6 d-inline-block pl-2 font-weight-bold">PoW Attack</span>
+          </div>
+          <div class="ml-4">
+              <div class="mt-1 ml-2">
+                <div class="row">
+                  <span class="mr-1">Mining Device:</span>
+                  <select
+                    class="form-control chart-form-control mr-5"
+                    data-action="attackcost#chooseDevice"
+                    data-target="attackcost.device"
+                  >
+                    <option data-target="attackcost.deviceDesc" value="0">DCR5</option>
+                    <option data-target="attackcost.deviceDesc" value="1">D1</option>
+                  </select>
+                </div>
+              </div>
+            </row>
+            <div class="mt-1 ml-2">
+                A
+                <input
+                  readonly {{/*target PoW is set to readonly as the inverse (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) not yet gotten */}}
+                  type="number"
+                  data-target="attackcost.targetPow"
+                  data-action="change->attackcost#updateTargetPow"
+                  step="1"
+                  min="1"
+                  max="1000000"
+                  {{/*autofocus*/}}
+                >%
+                <span data-target="attackcost.internalAttackText">
+                  PoW attack would need <span class="font-weight-bold" data-target="attackcost.targetHashRate">0</span>
+                  <span class="pl-1 unit lh15rem">Ph/s</span>.
+                </span>
+              <span data-target="attackcost.externalAttackText" class="d-none">
+                PoW attack requires adding <span class="font-weight-bold" data-target="attackcost.additionalHashRate">0</span>
+                <span class="pl-1 unit lh15rem">Ph/s</span> to the existing <span class="font-weight-bold" data-target="attackcost.actualHashRate">0</span>
+                <span class="pl-1 unit lh15rem">Ph/s</span> network hashrate. New network hashrate will be
+                <span class="font-weight-bold" data-target="attackcost.targetHashRate">0</span>
+                <span class="pl-1 unit lh15rem">Ph/s</span>.
+              </span>
+            </div>
+
+            <div class="mt-1 ml-2">
+              In order to aquire a <span class="font-weight-bold" data-target="attackcost.targetHashRate">0</span> Ph/s
+              hashrate, it would take
+              <span class="font-weight-bold" data-target="attackcost.countDevice">0</span>
+              <span class="fs11" data-target="attackcost.deviceName">&mdash;</span>
+              at a cost of $<span class="font-weight-bold" data-target="attackcost.totalDeviceCost">0</span>
+              <span class="fs11">USD</span> to buy them.
+            </div>
+            <div class="mt-1 ml-2">
+              Total kWh attack for <span data-target="attackcost.durationLongDesc">0</span> :
+              <span class="position-relative text-secondary font-weight-bold">
+              <span class="font-weight-bold" data-target="attackcost.totalKwh">0</span> <span class="fs11">kWh</span>
+              </span>
+            </div>
+            <div class="mt-1 ml-2">
+              Costs of <span data-target="attackcost.durationLongDesc">0</span>
+              electricity consumption for
+              <span class="font-weight-bold" data-target="attackcost.countDevice">0</span>
+              <span class="fs11" data-target="attackcost.deviceName">&mdash;</span> :
+              <span class="position-relative text-secondary font-weight-bold">
+                $<span class="font-weight-bold" data-target="attackcost.totalElectricity">0</span>
+                <span class="fs11">USD</span>
+              </span>
+            </div>
+            <div class="mt-1 ml-2">
+              To carry out the attack, additional costs for facilities and cooling are estimated at
+              <input
+                type="number"
+                data-action="change->attackcost#updateOtherCosts"
+                data-target="attackcost.otherCosts"
+                step="1"
+                min="1"
+                max="100"
+                value="0"
+              >% of the cost of the miners.
+            </div>
+            <div class="mt-1 ml-2">
+              Total PoW attack cost:
+              <span class="position-relative text-secondary font-weight-bold">
+                $<span class="font-weight-bold" data-target="attackcost.totalPow">0</span>
+                <span class="fs11">USD</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="col-24 col-sm-12 col-md-24 col-lg-11 secondary-card pt-3 pb-3 px-3">
+          <div class="pl-1">
+            <span class="h6 d-inline-block pl-2 font-weight-bold">PoS Attack</span>
+          </div>
+
+          <div class="ml-4">
+            <div class="mt-1 ml-2">
+              A <input
+                type="number"
+                data-target="attackcost.targetPos"
+                data-action="change->attackcost#updateTargetPos"
+                step="1"
+                min="1"
+                max="100"
+                value="60"
+                autofocus
+              >%
+              PoS attack would need
+              <span class="position-relative text-secondary font-weight-bold">
+                <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
+                <span> tickets</span>
+              </span>.
+            </div>
+            <div class="mt-1 ml-2">
+              Total staked is
+              <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>
+            </div>
+            <div class="mt-1 ml-2">
+              <span class="position-relative text-secondary font-weight-bold">
+                <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
+                <span> tickets</span>
+              </span>
+              needed for the attack
+              (<span class="position-relative text-secondary font-weight-bold">
+                <span data-target="attackcost.ticketPoolSize">0</span><span class="fs11"> tickets</span>
+                <span> * </span>
+                <span data-target="attackcost.attackPosPercentNeededLabel">0</span><span class="fs11">%</span>
+              </span>)
+            </div>
+            <div class="mt-1 ml-2">
+              <span class="position-relative text-secondary font-weight-bold">
+                <span class="font-weight-bold" data-target="attackcost.ticketPoolAttack">0</span>
+                <span class="fs11">DCR</span>.
+              </span>
+              needed for the attack
+              (<span class="position-relative text-secondary font-weight-bold">
+                <span data-target="attackcost.ticketPoolValue">0</span><span class="fs11"> DCR</span>
+                <span> * </span>
+                <span data-target="attackcost.attackPosPercentAmountLabel">0</span><span class="fs11">%</span>
+              </span>)
+            </div>
+            <div class="mt-1 ml-2">
+              <span class="position-relative text-secondary font-weight-bold">
+                <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
+              </span>
+              total attack cost
+              (<span class="position-relative text-secondary font-weight-bold">
+                <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
+                <span> * </span>
+                <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
+              </span>)
+            </div>
+            <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
+              The projected ticket price
+              <span class="position-relative text-secondary font-weight-bold">
+              <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
+              <span class="fs11">DCR</span>.
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-center h4 mb-3 mt-3">
+        PoS attack cost:
+        <span class="position-relative text-secondary font-weight-bold">
+          $<span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
+          <span class="fs11">USD</span>
+        </span>
+        <br/>
+
+        PoW attack cost:
+        <span class="position-relative text-secondary font-weight-bold">
+          $<span class="font-weight-bold" data-target="attackcost.totalPow">0</span>
+          <span class="fs11">USD</span>
+        </span>
+        <br/>
+
+        Total attack cost:
+        <span class="position-relative text-secondary font-weight-bold">
+          $<span class="font-weight-bold" data-target="attackcost.total">0</span>
+          <span class="fs11">USD</span>
+        </span>
+      </div>
+    </div>
+    </div>
+  </div>
+ {{ template "footer" . }}
+</body>
+</html>
+{{end}}
+

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -77,7 +77,7 @@
 
               <div class="col-13 text-center">
                 <div class="d-inline-block text-center text-md-left text-lg-center text-xl-left">
-                  <span class="text-secondary fs13">HashRate</span>
+                  <span class="text-secondary fs13">Hash Rate</span>
                   <br>
                   <span class="h4" data-target="attackcost.actualHashRate"></span> <span class="text-secondary">Ph/s</span>
                 </div>
@@ -125,7 +125,6 @@
                       step="1"
                       min="1"
                       value="1"
-                      max="1000"
                     >
                   </span>
                   <span class="text-secondary">hrs</span>
@@ -370,7 +369,8 @@
               The projected ticket price is
               <span class="position-relative font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
-              <span class="fs11">DCR</span>.
+                <span class="fs11">DCR</span>
+                (A <span class="font-weight-bold" data-target="attackcost.projectedTicketPriceIncrease">0</span>% increase).
               </span>
             </div>
 

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -46,7 +46,7 @@
                   min="0.01"
                   max="0.99"
                   step="0.005"
-                  value="0.51"
+                  value="0.5"
                 >
                 <span>If an attacker has in their control
                   <span class="font-weight-bold" data-target="attackcost.tickets">0</span> and
@@ -242,7 +242,7 @@
               <span class="fs11">USD</span> to buy them.
             </div>
             <div class="mt-1 ml-2">
-              Total kWh attack for <span data-target="attackcost.durationLongDesc">0</span> :
+              Total kWh attack for <span data-target="attackcost.durationLongDesc">0</span> is
               <span class="position-relative font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.totalKwh">0</span> <span class="fs11">kWh</span>
               </span>
@@ -251,7 +251,7 @@
               Costs of <span data-target="attackcost.durationLongDesc">0</span>
               electricity consumption for
               <span class="font-weight-bold" data-target="attackcost.countDevice">0</span>
-              <span class="fs11" data-target="attackcost.deviceName">&mdash;</span> :
+              <span class="fs11" data-target="attackcost.deviceName">&mdash;</span> is
               <span class="position-relative font-weight-bold">
                 $<span class="font-weight-bold" data-target="attackcost.totalElectricity">0</span>
                 <span class="fs11">USD</span>
@@ -267,10 +267,10 @@
                 min="1"
                 max="100"
                 value="5"
-              >% of the cost of the miners.
+              >% of the cost of the miners. The additional ficility cost is <span data-target="attackcost.otherCostsValue">0</span>
             </div>
             <div class="mt-1 ml-2">
-              Total PoW attack cost:
+              Total PoW attack cost is
               <span class="position-relative font-weight-bold">
                 $<span class="font-weight-bold" data-target="attackcost.totalPow">0</span>
                 <span class="fs11">USD</span>
@@ -293,7 +293,7 @@
                 step="1"
                 min="1"
                 max="100"
-                value="60"
+                value="50"
                 autofocus
               >%
               PoS attack would need

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -124,6 +124,7 @@
                       data-action="change->attackcost#updateAttackTime"
                       step="1"
                       min="1"
+                      max="1000"
                       value="1"
                     >
                   </span>
@@ -176,8 +177,8 @@
                     class="form-control chart-form-control mr-5"
                     data-action="attackcost#chooseAttackType"
                     data-target="attackcost.attackType">
-                    <option data-target="attackcost.attackTypeDesc" value="0">Internal</option>
-                    <option data-target="attackcost.attackTypeDesc" value="1">External</option>
+                    <option data-target="attackcost.attackTypeDesc" value="0">External</option>
+                    <option data-target="attackcost.attackTypeDesc" value="1">Internal</option>
                   </select>
                 </div>
               </div>
@@ -354,7 +355,7 @@
                       step="1"
                       min="1"
                       max="100"
-                      value="60"
+                      value="50"
                       autofocus
               >% PoS attack would add
               <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span><span class="fs11"> DCR</span>
@@ -370,8 +371,8 @@
               <span class="position-relative font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
                 <span class="fs11">DCR</span>
-                (A <span class="font-weight-bold" data-target="attackcost.projectedTicketPriceIncrease">0</span>% increase).
               </span>
+              (A <span class="font-weight-bold" data-target="attackcost.projectedTicketPriceIncrease">0</span>% increase).
             </div>
 
             <div class="mt-1 ml-2">

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -299,8 +299,8 @@
               PoS attack would need
               <span class="position-relative font-weight-bold">
                   <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
-                  <span> tickets</span>
-                </span>.
+                  <span> tickets.</span>
+                </span>
             </div>
             <div class="mt-1 ml-2">
               Total staked is

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -345,6 +345,9 @@
 
           <div class="ml-4 d-none" data-target="attackcost.externalAttackPosText">
             <div class="mt-1 ml-2">
+              Current total staked is <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>.
+            </div>
+            <div class="mt-1 ml-2">
               An external <input
                       type="number"
                       data-target="attackcost.targetPos"
@@ -354,22 +357,21 @@
                       max="100"
                       value="60"
                       autofocus
-              >%
-              PoS attack would raise the value of the ticket pool by
-              <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span><span class="fs11"> DCR</span>,
-              from <span class="font-weight-bold" data-target="attackcost.ticketPoolValue">0</span> <span class="fs11"> DCR</span>
-              to <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span> <span class="fs11"> DCR</span>.
+              >% PoS attack would add
+              <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span><span class="fs11"> DCR</span>
+              to the total staked.
             </div>
+
             <div class="mt-1 ml-2">
-              Total staked is
-              <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>
+              New total staked will be <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span> <span class="fs11"> DCR</span>.
             </div>
-            <div class="mt-1 ml-2">
+
+            <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
+              The projected ticket price is
               <span class="position-relative text-secondary font-weight-bold">
-                <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span>
-                <span class="fs11">DCR</span>
+              <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
+              <span class="fs11">DCR</span>.
               </span>
-              is needed for the attack
             </div>
 
             <div class="mt-1 ml-2">
@@ -382,14 +384,6 @@
                 <span> * </span>
                 <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
               </span>)
-            </div>
-
-            <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
-              The projected ticket price is
-              <span class="position-relative text-secondary font-weight-bold">
-              <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
-              <span class="fs11">DCR</span>.
-              </span>
             </div>
 
           </div>

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -21,6 +21,7 @@
           <span class="h4 my-3">Majority Attack Cost Calculator</span>
         </div>
 
+        {{- /* ATTACKCOST CHART */ -}}
         <div class="row mx-0 my-2">
           <div class="col-24 col-sm-12 col-md-24 col-lg-18 px-3 position-relative">
             <div class="pl-1">
@@ -59,6 +60,7 @@
       </div>
 
       <div class="row mx-0 my-2 bg-white">
+        {{- /* NETWORK PARAMETERS */ -}}
         <div class="col-24 col-sm-12 col-md-24 col-lg-13 px-3 position-relative pt-3 pb-3">
           <div class="pl-1">
             <span class="h6 d-inline-block pl-2 font-weight-bold">Current Mainnet Parameters</span>
@@ -103,6 +105,7 @@
           </div>
         </div>
 
+        {{- /* ADJUSTABLE PARAMETERS */ -}}
         <div class="col-24 col-sm-12 col-md-24 col-lg-11 secondary-card pt-3 pb-3 px-3">
           <div class="pl-1">
             <span class="h6 d-inline-block pl-2 font-weight-bold">Adjustable Parameters</span>
@@ -185,6 +188,7 @@
       </div>
 
       <div class="row mx-0 my-2 bg-white">
+        {{- /* POW ATTACK */ -}}
         <div class="col-24 col-sm-12 col-md-24 col-lg-13 px-3 position-relative pt-3 pb-3">
           <div class="pl-1">
               <span class="h6 d-inline-block pl-2 font-weight-bold">PoW Attack</span>
@@ -274,6 +278,7 @@
             </div>
           </div>
         </div>
+        {{- /* POS ATTACK */ -}}
         <div class="col-24 col-sm-12 col-md-24 col-lg-11 secondary-card pt-3 pb-3 px-3">
           <div class="pl-1">
             <span class="h6 d-inline-block pl-2 font-weight-bold">PoS Attack</span>
@@ -358,6 +363,7 @@
         </div>
       </div>
 
+      {{- /* CALCULATION SUMMARY */ -}}
       <div class="text-center h4 mb-3 mt-3">
         PoS attack cost:
         <span class="position-relative text-secondary font-weight-bold">

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -177,8 +177,8 @@
                     class="form-control chart-form-control mr-5"
                     data-action="attackcost#chooseAttackType"
                     data-target="attackcost.attackType">
-                    <option data-target="attackcost.attackTypeDesc" value="0">External</option>
-                    <option data-target="attackcost.attackTypeDesc" value="1">Internal</option>
+                    <option data-target="attackcost.attackTypeDesc" value="external">External</option>
+                    <option data-target="attackcost.attackTypeDesc" value="internal">Internal</option>
                   </select>
                 </div>
               </div>
@@ -305,18 +305,6 @@
             <div class="mt-1 ml-2">
               Total staked is
               <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>
-            </div>
-            <div class="mt-1 ml-2">
-              <span class="position-relative font-weight-bold">
-                <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
-                <span> tickets</span>
-              </span>
-              needed for the attack
-              (<span class="position-relative font-weight-bold">
-                <span data-target="attackcost.ticketPoolSize">0</span><span class="fs11"> tickets</span>
-                <span data-target="attackcost.operatorSign"> * </span>
-                <span data-target="attackcost.attackPosPercentNeededLabel">0</span><span class="fs11">%</span>
-              </span>)
             </div>
             <div class="mt-1 ml-2">
               <span class="position-relative font-weight-bold">

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -284,7 +284,7 @@
             <span class="h6 d-inline-block pl-2 font-weight-bold">PoS Attack</span>
           </div>
 
-          <div class="ml-4">
+          <div class="ml-4 d-none" data-target="attackcost.internalAttackPosText">
             <div class="mt-1 ml-2">
               A <input
                 type="number"
@@ -296,20 +296,11 @@
                 value="60"
                 autofocus
               >%
-              <span data-target="attackcost.internalAttackPosText">
-                PoS attack would need
-                <span class="position-relative text-secondary font-weight-bold">
+              PoS attack would need
+              <span class="position-relative text-secondary font-weight-bold">
                   <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
                   <span> tickets</span>
                 </span>.
-              </span>
-
-              <span data-target="attackcost.externalAttackPosText" class="d-none">
-                PoS attack requires adding <span class="font-weight-bold" data-target="attackcost.additionalTickets">0</span>
-                <span class="pl-1 unit lh15rem">tickets</span> to the existing <span class="font-weight-bold" data-target="attackcost.ticketPoolSize">0</span>
-                <span class="pl-1 unit lh15rem">tickets</span>.
-              </span>
-
             </div>
             <div class="mt-1 ml-2">
               Total staked is
@@ -330,9 +321,9 @@
             <div class="mt-1 ml-2">
               <span class="position-relative text-secondary font-weight-bold">
                 <span class="font-weight-bold" data-target="attackcost.ticketPoolAttack">0</span>
-                <span class="fs11">DCR</span>.
+                <span class="fs11">DCR</span>
               </span>
-              needed for the attack
+              is needed for the attack
               (<span class="position-relative text-secondary font-weight-bold">
                 <span data-target="attackcost.ticketPoolValue">0</span><span class="fs11"> DCR</span>
                 <span data-target="attackcost.operatorSign"> * </span>
@@ -350,14 +341,59 @@
                 <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
               </span>)
             </div>
+          </div>
+
+          <div class="ml-4 d-none" data-target="attackcost.externalAttackPosText">
+            <div class="mt-1 ml-2">
+              An external <input
+                      type="number"
+                      data-target="attackcost.targetPos"
+                      data-action="change->attackcost#updateTargetPos"
+                      step="1"
+                      min="1"
+                      max="100"
+                      value="60"
+                      autofocus
+              >%
+              PoS attack would raise the value of the ticket pool by
+              <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span><span class="fs11"> DCR</span>,
+              from <span class="font-weight-bold" data-target="attackcost.ticketPoolValue">0</span> <span class="fs11"> DCR</span>
+              to <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span> <span class="fs11"> DCR</span>.
+            </div>
+            <div class="mt-1 ml-2">
+              Total staked is
+              <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>
+            </div>
+            <div class="mt-1 ml-2">
+              <span class="position-relative text-secondary font-weight-bold">
+                <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span>
+                <span class="fs11">DCR</span>
+              </span>
+              is needed for the attack
+            </div>
+
+            <div class="mt-1 ml-2">
+              <span class="position-relative text-secondary font-weight-bold">
+                <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
+              </span>
+              total attack cost
+              (<span class="position-relative text-secondary font-weight-bold">
+                <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
+                <span> * </span>
+                <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
+              </span>)
+            </div>
+
             <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
-              The projected ticket price
+              The projected ticket price is
               <span class="position-relative text-secondary font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
               <span class="fs11">DCR</span>.
               </span>
             </div>
+
           </div>
+
         </div>
       </div>
 

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -307,8 +307,6 @@
               <span data-target="attackcost.externalAttackPosText" class="d-none">
                 PoS attack requires adding <span class="font-weight-bold" data-target="attackcost.additionalTickets">0</span>
                 <span class="pl-1 unit lh15rem">tickets</span> to the existing <span class="font-weight-bold" data-target="attackcost.ticketPoolSize">0</span>
-                <span class="pl-1 unit lh15rem">tickets</span>. New pool size will be
-                <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span>
                 <span class="pl-1 unit lh15rem">tickets</span>.
               </span>
 

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -320,7 +320,7 @@
               needed for the attack
               (<span class="position-relative text-secondary font-weight-bold">
                 <span data-target="attackcost.ticketPoolSize">0</span><span class="fs11"> tickets</span>
-                <span> * </span>
+                <span data-target="attackcost.operatorSign"> * </span>
                 <span data-target="attackcost.attackPosPercentNeededLabel">0</span><span class="fs11">%</span>
               </span>)
             </div>
@@ -332,7 +332,7 @@
               needed for the attack
               (<span class="position-relative text-secondary font-weight-bold">
                 <span data-target="attackcost.ticketPoolValue">0</span><span class="fs11"> DCR</span>
-                <span> * </span>
+                <span data-target="attackcost.operatorSign"> * </span>
                 <span data-target="attackcost.attackPosPercentAmountLabel">0</span><span class="fs11">%</span>
               </span>)
             </div>

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -243,7 +243,7 @@
             </div>
             <div class="mt-1 ml-2">
               Total kWh attack for <span data-target="attackcost.durationLongDesc">0</span> :
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.totalKwh">0</span> <span class="fs11">kWh</span>
               </span>
             </div>
@@ -252,7 +252,7 @@
               electricity consumption for
               <span class="font-weight-bold" data-target="attackcost.countDevice">0</span>
               <span class="fs11" data-target="attackcost.deviceName">&mdash;</span> :
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 $<span class="font-weight-bold" data-target="attackcost.totalElectricity">0</span>
                 <span class="fs11">USD</span>
               </span>
@@ -271,7 +271,7 @@
             </div>
             <div class="mt-1 ml-2">
               Total PoW attack cost:
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 $<span class="font-weight-bold" data-target="attackcost.totalPow">0</span>
                 <span class="fs11">USD</span>
               </span>
@@ -297,7 +297,7 @@
                 autofocus
               >%
               PoS attack would need
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                   <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
                   <span> tickets</span>
                 </span>.
@@ -307,35 +307,35 @@
               <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>
             </div>
             <div class="mt-1 ml-2">
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
                 <span> tickets</span>
               </span>
               needed for the attack
-              (<span class="position-relative text-secondary font-weight-bold">
+              (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.ticketPoolSize">0</span><span class="fs11"> tickets</span>
                 <span data-target="attackcost.operatorSign"> * </span>
                 <span data-target="attackcost.attackPosPercentNeededLabel">0</span><span class="fs11">%</span>
               </span>)
             </div>
             <div class="mt-1 ml-2">
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 <span class="font-weight-bold" data-target="attackcost.ticketPoolAttack">0</span>
                 <span class="fs11">DCR</span>
               </span>
               is needed for the attack
-              (<span class="position-relative text-secondary font-weight-bold">
+              (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.ticketPoolValue">0</span><span class="fs11"> DCR</span>
                 <span data-target="attackcost.operatorSign"> * </span>
                 <span data-target="attackcost.attackPosPercentAmountLabel">0</span><span class="fs11">%</span>
               </span>)
             </div>
             <div class="mt-1 ml-2">
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
               </span>
               total attack cost
-              (<span class="position-relative text-secondary font-weight-bold">
+              (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
                 <span> * </span>
                 <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
@@ -368,18 +368,18 @@
 
             <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
               The projected ticket price is
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
               <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
               <span class="fs11">DCR</span>.
               </span>
             </div>
 
             <div class="mt-1 ml-2">
-              <span class="position-relative text-secondary font-weight-bold">
+              <span class="position-relative font-weight-bold">
                 <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
               </span>
               total attack cost
-              (<span class="position-relative text-secondary font-weight-bold">
+              (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
                 <span> * </span>
                 <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -262,7 +262,7 @@
                 step="1"
                 min="1"
                 max="100"
-                value="0"
+                value="5"
               >% of the cost of the miners.
             </div>
             <div class="mt-1 ml-2">
@@ -291,11 +291,22 @@
                 value="60"
                 autofocus
               >%
-              PoS attack would need
-              <span class="position-relative text-secondary font-weight-bold">
-                <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
-                <span> tickets</span>
-              </span>.
+              <span data-target="attackcost.internalAttackPosText">
+                PoS attack would need
+                <span class="position-relative text-secondary font-weight-bold">
+                  <span class="font-weight-bold" data-target="attackcost.ticketSizeAttack">0</span>
+                  <span> tickets</span>
+                </span>.
+              </span>
+
+              <span data-target="attackcost.externalAttackPosText" class="d-none">
+                PoS attack requires adding <span class="font-weight-bold" data-target="attackcost.additionalTickets">0</span>
+                <span class="pl-1 unit lh15rem">tickets</span> to the existing <span class="font-weight-bold" data-target="attackcost.ticketPoolSize">0</span>
+                <span class="pl-1 unit lh15rem">tickets</span>. New pool size will be
+                <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span>
+                <span class="pl-1 unit lh15rem">tickets</span>.
+              </span>
+
             </div>
             <div class="mt-1 ml-2">
               Total staked is

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -393,20 +393,6 @@
 
       {{- /* CALCULATION SUMMARY */ -}}
       <div class="text-center h4 mb-3 mt-3">
-        PoS attack cost:
-        <span class="position-relative text-secondary font-weight-bold">
-          $<span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
-          <span class="fs11">USD</span>
-        </span>
-        <br/>
-
-        PoW attack cost:
-        <span class="position-relative text-secondary font-weight-bold">
-          $<span class="font-weight-bold" data-target="attackcost.totalPow">0</span>
-          <span class="fs11">USD</span>
-        </span>
-        <br/>
-
         Total attack cost:
         <span class="position-relative text-secondary font-weight-bold">
           $<span class="font-weight-bold" data-target="attackcost.total">0</span>

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -211,7 +211,6 @@
             <div class="mt-1 ml-2">
                 A
                 <input
-                  readonly {{/*target PoW is set to readonly as the inverse (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) not yet gotten */}}
                   type="number"
                   data-target="attackcost.targetPow"
                   data-action="change->attackcost#updateTargetPow"
@@ -228,7 +227,7 @@
                 PoW attack requires adding <span class="font-weight-bold" data-target="attackcost.additionalHashRate">0</span>
                 <span class="pl-1 unit lh15rem">Ph/s</span> to the existing <span class="font-weight-bold" data-target="attackcost.actualHashRate">0</span>
                 <span class="pl-1 unit lh15rem">Ph/s</span> network hashrate. New network hashrate will be
-                <span class="font-weight-bold" data-target="attackcost.targetHashRate">0</span>
+                <span class="font-weight-bold" data-target="attackcost.newHashRate">0</span>
                 <span class="pl-1 unit lh15rem">Ph/s</span>.
               </span>
             </div>
@@ -267,7 +266,7 @@
                 min="1"
                 max="100"
                 value="5"
-              >% of the cost of the miners. The additional facility cost is $<span data-target="attackcost.otherCostsValue">0</span>.
+              >% of the cost of the miners. The additional facility cost is $<span class="font-weight-bold" data-target="attackcost.otherCostsValue">0</span>.
             </div>
             <div class="mt-1 ml-2">
               Total PoW attack cost is
@@ -322,7 +321,7 @@
               <span class="position-relative font-weight-bold">
                 <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
               </span>
-              total attack cost
+              total PoS attack cost
               (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
                 <span> * </span>
@@ -367,7 +366,7 @@
               <span class="position-relative font-weight-bold">
                 <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
               </span>
-              total attack cost
+              total PoS attack cost
               (<span class="position-relative font-weight-bold">
                 <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
                 <span> * </span>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -1,13 +1,13 @@
 {{define "html-head"}}
-	<head data-turbolinks-eval="false">
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-		<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
-		<meta name="author" content="The Decred developers">
-		<meta name="application-name"           content="Decred - Autonomous Digital Currency">
-		<meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
-		<!--  Custom favicon  -->
+<head data-turbolinks-eval="false">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+	<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
+	<meta name="author" content="The Decred developers">
+	<meta name="application-name"           content="Decred - Autonomous Digital Currency">
+	<meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
+	<!--  Custom favicon  -->
 		<!-- Apple PWA -->
 		<link rel="apple-touch-icon" sizes="57x57"   href="/images/favicon/apple-touch-icon-57x57.png?v=yHh3NA">
 		<link rel="apple-touch-icon" sizes="60x60"   href="/images/favicon/apple-touch-icon-60x60.png?v=yHh3NA">
@@ -34,347 +34,347 @@
 		<meta name="msapplication-TileColor" content="#091440">
 		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=55tv3">
 		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=55tv3">
-		<!-- End custom favicon -->
+	<!-- End custom favicon -->
 
-		<meta name="turbolinks-cache-control" content="no-cache">
-		<title>{{.}}</title>
-		<link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
-		<link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-		<link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-		<link rel="preload" href="/fonts/source-sans-pro-semibold.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-		<link rel="preload" href="/images/connecting.svg?x=55tv3" as="image" type="image/svg+xml" />
-		<link rel="preload" href="/images/themes/light/logo.svg?x=55tv3" as="image" type="image/svg+xml" />
-		<link rel="preload" href="/images/connected.svg?x=55tv3" as="image" type="image/svg+xml" />
-		<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
-		<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
+	<meta name="turbolinks-cache-control" content="no-cache">
+	<title>{{.}}</title>
+	<link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/source-sans-pro-semibold.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+	<link rel="preload" href="/images/connecting.svg?x=55tv3" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/themes/light/logo.svg?x=55tv3" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/connected.svg?x=55tv3" as="image" type="image/svg+xml" />
+	<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
+	<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
 
-		<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
-	</head>
+	<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
+</head>
 {{end}}
 
 {{define "navbar"}}
-	<body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
-	<header class="top-nav d-flex align-items-center" id="navBar" data-blocktime="{{.BlockTimeUnix}}">
-		<div class="container d-flex justify-content-between align-items-center">
-			<a class="no-underline d-block home-link dcrdata-logo" href="/"></a>
-			<form
-					class="search-form"
-					role="search"
-					id="search-form"
-					action="/search"
-					data-controller="search"
-					data-action="submit->search#execute"
-			>
-				<input
-						tabindex="0"
-						type="text"
-						name="search"
-						id="search"
-						class="top-search mousetrap"
-						placeholder="Search for blocks, addresses, transactions or proposal tokens"
-						spellcheck="false"
-						autocomplete="off"
-				/>
-				<button class="search-bttn" type="submit"><span class="dcricon-search"></span></button>
-			</form>
-			<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
-				<div id="menuToggle">
-					<input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
-					<span class="patty"></span>
-					<span class="patty"></span>
-					<span class="patty short"></span>
-					<div id="menu">
-						<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
-						<a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
-						<a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
-						<a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
-						<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
-						<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
-						<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
-						<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
-						<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
-						<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
-						<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
-						<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
-						{{- if eq .NetName "Mainnet"}}
-							<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
-						{{- else}}
-							<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
-						{{- end}}
-						<form action="/set" method="post" data-target="menu.form" class="menu-form">
-							<input type="hidden" name="darkmode" value="darkmode">
-							<input type="hidden" name="requestURI" value="{{.RequestURI}}">
-							<button type="submit" data-action="click->menu#onSunClick"
-									class="menu-submit text-left w-100 p-0"
-									data-keynav-skip>
+<body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
+<header class="top-nav d-flex align-items-center" id="navBar" data-blocktime="{{.BlockTimeUnix}}">
+	<div class="container d-flex justify-content-between align-items-center">
+		<a class="no-underline d-block home-link dcrdata-logo" href="/"></a>
+		<form
+			class="search-form"
+			role="search"
+			id="search-form"
+			action="/search"
+			data-controller="search"
+			data-action="submit->search#execute"
+		>
+			<input
+				tabindex="0"
+				type="text"
+				name="search"
+				id="search"
+				class="top-search mousetrap"
+				placeholder="Search for blocks, addresses, transactions or proposal tokens"
+				spellcheck="false"
+				autocomplete="off"
+			/>
+			<button class="search-bttn" type="submit"><span class="dcricon-search"></span></button>
+		</form>
+		<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
+			<div id="menuToggle">
+				<input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
+				<span class="patty"></span>
+				<span class="patty"></span>
+				<span class="patty short"></span>
+				<div id="menu">
+					<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
+					<a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
+					<a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
+					<a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
+					<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
+					<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
+					<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
+					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
+					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
+					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
+					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
+					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
+				{{- if eq .NetName "Mainnet"}}
+					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
+				{{- else}}
+					<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
+				{{- end}}
+					<form action="/set" method="post" data-target="menu.form" class="menu-form">
+						<input type="hidden" name="darkmode" value="darkmode">
+						<input type="hidden" name="requestURI" value="{{.RequestURI}}">
+						<button type="submit" data-action="click->menu#onSunClick"
+								class="menu-submit text-left w-100 p-0"
+								data-keynav-skip>
 								<div class="menu-item">
-									<span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
-									Night Mode
+								  <span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
+								  Night Mode
 								</div>
-							</button>
-						</form>
-						<a class="menu-item jsonly" data-keynav-skip data-turbolinks="false" href="#" id="keynav-toggle">
-							<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
-						</a>
-						<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
-					</div>
+						</button>
+					</form>
+					<a class="menu-item jsonly" data-keynav-skip data-turbolinks="false" href="#" id="keynav-toggle">
+						<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
+					</a>
+					<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
 				</div>
-			</nav>
-		</div>
-	</header>
+			</div>
+		</nav>
+	</div>
+</header>
 {{end}}
 
 {{define "footer"}}
-	<footer class="navbar-fixed-bottom">
-		<div class="container d-flex justify-content-between align-items-center">
+<footer class="navbar-fixed-bottom">
+	<div class="container d-flex justify-content-between align-items-center">
 		<span>
 			<span data-controller="time" data-target="time.blocktime" data-stamp="{{$.Tip.Time}}"></span> <span class="d-none d-sm-inline">since last block</span>
 		</span>
-			<span>
+		<span>
 			<a
-					class="text-nowrap d-none d-md-inline-block pr-3"
-					href="{{.Links.Github}}"
-					title="dcrdata on GitHub"
-					target="_blank"
-					rel="noopener noreferrer"
+				class="text-nowrap d-none d-md-inline-block pr-3"
+				href="{{.Links.Github}}"
+				title="dcrdata on GitHub"
+				target="_blank"
+				rel="noopener noreferrer"
 			>dcrdata v{{.Version}}</a>
 			{{- if ne .Links.OnionURL "" }}
-				<a
-						class="text-nowrap d-none d-md-inline-block pr-3"
-						href="{{.Links.OnionURL}}"
-						title="Access dcrdata over Tor"
-						target="_blank"
-						rel="noopener noreferrer"
-				>Tor site</a>
+			<a
+				class="text-nowrap d-none d-md-inline-block pr-3"
+				href="{{.Links.OnionURL}}"
+				title="Access dcrdata over Tor"
+				target="_blank"
+				rel="noopener noreferrer"
+			>Tor site</a>
 			{{ end }}
 			<a
-					class="text-nowrap"
-					href="{{.Links.License}}"
-					target="_blank"
-					rel="noopener noreferrer"
+				class="text-nowrap"
+				href="{{.Links.License}}"
+				target="_blank"
+				rel="noopener noreferrer"
 			>© 2020 The Decred developers (ISC)</a>
 		</span>
-			<span
-					id="connection"
-					class="text-nowrap align-items-center clickable d-inline-block"
-					data-turbolinks-permanent
-					data-controller="connection"
-					data-target="connection.indicator"
-					data-action="click->connection#requestNotifyPermission"
-					title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
+		<span
+			id="connection"
+			class="text-nowrap align-items-center clickable d-inline-block"
+			data-turbolinks-permanent
+			data-controller="connection"
+			data-target="connection.indicator"
+			data-action="click->connection#requestNotifyPermission"
+			title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
 			><span class="d-none d-sm-inline" data-target="connection.status">Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
 		</span>
-		</div>
-		<script
-				src="/dist/js/vendors~app.bundle.js?x=55tv3"
-				data-turbolinks-eval="false"
-				data-turbolinks-suppress-warning
-		></script>
-		<script
-				src="/dist/js/app.bundle.js?x=55tv3"
-				data-turbolinks-eval="false"
-				data-turbolinks-suppress-warning
-		></script>
-	</footer>
+	</div>
+	<script
+		src="/dist/js/vendors~app.bundle.js?x=55tv3"
+		data-turbolinks-eval="false"
+		data-turbolinks-suppress-warning
+	></script>
+	<script
+		src="/dist/js/app.bundle.js?x=55tv3"
+		data-turbolinks-eval="false"
+		data-turbolinks-suppress-warning
+	></script>
+</footer>
 {{end}}
 
 {{define "decimalParts" -}}
-	<div class="decimal-parts d-inline-block">
-		{{- if eq (len .) 4 -}}
-			<span class="int">{{ index . 0 }}.{{ index . 1 }}</span>
-			{{- if gt (len (index . 2)) 0 -}}
-				<span class="decimal">{{ index . 2 }}</span>
-				{{- /* trailing zeros  */ -}}
-				<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
-			{{- end}}
-		{{- else -}}
-			<span class="int">{{index . 0}}</span>
-			{{- if gt (len (index . 1)) 0 -}}
-				<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
-				{{- /* trailing zeros  */ -}}
-				<span class="decimal trailing-zeroes">{{index . 2}}</span>
-			{{- end}}
-		{{- end -}}
+<div class="decimal-parts d-inline-block">
+	{{- if eq (len .) 4 -}}
+		<span class="int">{{ index . 0 }}.{{ index . 1 }}</span>
+		{{- if gt (len (index . 2)) 0 -}}
+		<span class="decimal">{{ index . 2 }}</span>
+		{{- /* trailing zeros  */ -}}
+		<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
+		{{- end}}
+	{{- else -}}
+		<span class="int">{{index . 0}}</span>
+		{{- if gt (len (index . 1)) 0 -}}
+		<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
+		{{- /* trailing zeros  */ -}}
+		<span class="decimal trailing-zeroes">{{index . 2}}</span>
+		{{- end}}
+	{{- end -}}
 	</div>
 {{- end}}
 
 {{define "fmtPercentage"}}
-	{{- if gt . 0.0 -}}
-		<span class="text-green">+{{printf "%.2f" .}} %</span>
-	{{- else -}}
-		<span class="text-danger">{{printf "%.2f" .}} %</span>
-	{{- end -}}
+  {{- if gt . 0.0 -}}
+    <span class="text-green">+{{printf "%.2f" .}} %</span>
+  {{- else -}}
+    <span class="text-danger">{{printf "%.2f" .}} %</span>
+  {{- end -}}
 {{end}}
 
 {{define "hashElide"}}
-	{{- $hash := (index . 0) -}}
-	{{- $link := (index . 1) -}}
-	{{- if eq $link "" -}}
-		<div
-	{{- else -}}
-		<a href="{{$link}}"
-	{{- end}} data-keynav-priority class="elidedhash mono" data-head="{{hashStart $hash}}" data-tail="{{hashEnd $hash}}">
-	{{- $hash}}
-	{{- if eq $link ""}}</div>{{else}}</a>{{template "copyTextIcon"}}{{end -}}
+  {{- $hash := (index . 0) -}}
+  {{- $link := (index . 1) -}}
+  {{- if eq $link "" -}}
+	<div
+  {{- else -}}
+	<a href="{{$link}}"
+  {{- end}} data-keynav-priority class="elidedhash mono" data-head="{{hashStart $hash}}" data-tail="{{hashEnd $hash}}">
+  {{- $hash}}
+  {{- if eq $link ""}}</div>{{else}}</a>{{template "copyTextIcon"}}{{end -}}
 {{end}}
 
 {{define "addressTable"}}
-	{{- $txType := .TxnType}}
-	{{- if .Transactions}}
-		<table class="table table-mono-cells table-responsive-sm">
-			<thead>
-			<tr>
-				<th class="d-none d-sm-table-cell">Tx Type</th>
-				<th class="text-left">Input/&#8203;Output ID</th>
-				{{- if eq $txType "merged_debit"}}
-					<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
-						><span class="d-none d-sm-inline">Inputs</span>
-					</th>
-					<th class="text-right">Debit DCR</th>
-				{{- else if eq $txType "merged_credit" }}
-					<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
-						><span class="d-none d-sm-inline">Outputs</span>
-					</th>
-					<th class="text-right">Credit DCR</th>
-				{{- else if eq $txType "merged" }}
-					<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
-					<th class="text-right">Credit DCR</th>
-					<th class="text-right">Debit DCR</th>
-				{{- else}}
-					<th class="text-right">Credit DCR</th>
-					<th class="text-right">Debit DCR</th>
-				{{- end}}
-				<th class="d-none d-sm-table-cell text-right">Time (UTC)</th>
-				<th class="text-right">Age</th>
-				<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
-				<th class="d-none d-sm-table-cell text-right">Size</th>
-			</tr>
-			</thead>
-			<tbody>
-			{{- range .Transactions}}
-				<tr{{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
-					<td class="d-none d-sm-table-cell">{{.TxType}}</td>
-					<td class="clipboard">{{template "hashElide" (hashlink .TxID .Link)}}</td>
-					{{- if eq $txType "merged_debit"}}
-						<td class="text-right">{{.MergedTxnCount}}</td>
-						<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-					{{- else if eq $txType "merged_credit"}}
-						<td class="text-right">{{.MergedTxnCount}}</td>
-						<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-					{{- else if eq $txType "merged"}}
-						<td class="text-right">{{.MergedTxnCount}}</td>
-						{{- if .IsFunding}}
-							<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-							<td class="text-right">&mdash;</td>
-						{{- else}}
-							<td class="text-right">&mdash;</td>
-							<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-						{{- end}}
-					{{- else if or (eq $txType "credit") .IsFunding}}{{/* .IsFunding = true && txType = "all" is a credit */}}
-					<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-					{{- if ne .MatchedTx ""}}
-						<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
-												  data-txid="{{.MatchedTx}}"
-												  data-action="mouseover->address#hashOver mouseout->address#hashOut"
-							>spent</a></td>
-					{{- else}}
-						<td class="text-right">unspent</td>
-					{{- end}}
-					{{- else}}{{/* either "debit", or "all" with .IsFunding = false */ -}}
-					{{- if eq .SentTotal 0.0}}
-						<td class="text-right">sstxcommitment</td>
-					{{- else if ne .MatchedTx ""}}
-						<td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" data-action="mouseover->address#hashOver mouseout->address#hashOut">source</a></td>
-					{{- else}}
-						<td class="text-right">N/A</td>
-					{{- end}}
-					<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-					{{- end}}
-					<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time.DatetimeWithoutTZ}}{{end}}</td>
-					<td class="addr-tx-age text-right">
-						{{- if eq (.Time.T.Unix) 0}}
-							N/A
-						{{- else}}
-							<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
-						{{- end}}
-					</td>
-					<td class="addr-tx-confirms text-right"	{{/*Update confirmations with Stimulus*/ -}}
-						data-target="newblock.confirmations" {{/*trim*/ -}}
-						data-confirmations="{{.Confirmations}}" {{/*trim*/ -}}
-						data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}" {{/*trim*/ -}}
-						data-yes="#" {{/*trim*/ -}}
-						data-no="(unconfirmed)" {{/*trim*/ -}}
-					>{{.Confirmations}}</td>
-					<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
-				</tr>
-			{{- end}}
-			</tbody>
-		</table>
+{{- $txType := .TxnType}}
+{{- if .Transactions}}
+<table class="table table-mono-cells table-responsive-sm">
+	<thead>
+		<tr>
+		<th class="d-none d-sm-table-cell">Tx Type</th>
+		<th class="text-left">Input/&#8203;Output ID</th>
+	{{- if eq $txType "merged_debit"}}
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
+			><span class="d-none d-sm-inline">Inputs</span>
+		</th>
+		<th class="text-right">Debit DCR</th>
+	{{- else if eq $txType "merged_credit" }}
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
+			><span class="d-none d-sm-inline">Outputs</span>
+		</th>
+		<th class="text-right">Credit DCR</th>
+	{{- else if eq $txType "merged" }}
+		<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
+		<th class="text-right">Credit DCR</th>
+		<th class="text-right">Debit DCR</th>
 	{{- else}}
-		<table class="table table-mono-cells">
-			<tr>
-				<td>
-					No transactions found for this address.
-				</td>
-			</tr>
-		</table>
+		<th class="text-right">Credit DCR</th>
+		<th class="text-right">Debit DCR</th>
 	{{- end}}
+		<th class="d-none d-sm-table-cell text-right">Time (UTC)</th>
+		<th class="text-right">Age</th>
+		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
+		<th class="d-none d-sm-table-cell text-right">Size</th>
+		</tr>
+	</thead>
+	<tbody>
+	{{- range .Transactions}}
+		<tr{{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
+			<td class="d-none d-sm-table-cell">{{.TxType}}</td>
+			<td class="clipboard">{{template "hashElide" (hashlink .TxID .Link)}}</td>
+		{{- if eq $txType "merged_debit"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+		{{- else if eq $txType "merged_credit"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+		{{- else if eq $txType "merged"}}
+			<td class="text-right">{{.MergedTxnCount}}</td>
+			{{- if .IsFunding}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+			<td class="text-right">&mdash;</td>
+			{{- else}}
+			<td class="text-right">&mdash;</td>
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+			{{- end}}
+		{{- else if or (eq $txType "credit") .IsFunding}}{{/* .IsFunding = true && txType = "all" is a credit */}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+			{{- if ne .MatchedTx ""}}
+			<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
+				data-txid="{{.MatchedTx}}"
+				data-action="mouseover->address#hashOver mouseout->address#hashOut"
+				>spent</a></td>
+			{{- else}}
+			<td class="text-right">unspent</td>
+			{{- end}}
+		{{- else}}{{/* either "debit", or "all" with .IsFunding = false */ -}}
+			{{- if eq .SentTotal 0.0}}
+			<td class="text-right">sstxcommitment</td>
+			{{- else if ne .MatchedTx ""}}
+			<td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" data-action="mouseover->address#hashOver mouseout->address#hashOut">source</a></td>
+			{{- else}}
+			<td class="text-right">N/A</td>
+			{{- end}}
+			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+		{{- end}}
+			<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time.DatetimeWithoutTZ}}{{end}}</td>
+			<td class="addr-tx-age text-right">
+			{{- if eq (.Time.T.Unix) 0}}
+				N/A
+			{{- else}}
+				<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
+			{{- end}}
+			</td>
+			<td class="addr-tx-confirms text-right"	{{/*Update confirmations with Stimulus*/ -}}
+				data-target="newblock.confirmations" {{/*trim*/ -}}
+				data-confirmations="{{.Confirmations}}" {{/*trim*/ -}}
+				data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}" {{/*trim*/ -}}
+				data-yes="#" {{/*trim*/ -}}
+				data-no="(unconfirmed)" {{/*trim*/ -}}
+			>{{.Confirmations}}</td>
+			<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
+		</tr>
+	{{- end}}
+	</tbody>
+</table>
+{{- else}}
+<table class="table table-mono-cells">
+	<tr>
+		<td>
+			No transactions found for this address.
+		</td>
+	</tr>
+</table>
+{{- end}}
 {{- end}}
 
 {{define "mempoolDump"}}
-	{{$likely := .LikelyMineable}}
-	data-id="{{.Ident}}"
-	data-total="{{$likely.Total}}"
-	data-size="{{$likely.Size}}"
-	data-count="{{$likely.Count}}"
-	data-reg-total="{{$likely.RegularTotal}}"
-	data-reg-count="{{.NumRegular}}"
-	data-vote-total="{{$likely.VoteTotal}}"
-	data-vote-count="{{.VotingInfo.TicketsVoted}}"
-	data-ticket-total="{{$likely.TicketTotal}}"
-	data-ticket-count="{{.NumTickets}}"
-	data-rev-total="{{$likely.RevokeTotal}}"
-	data-rev-count="{{.NumRevokes}}"
+  {{$likely := .LikelyMineable}}
+  data-id="{{.Ident}}"
+  data-total="{{$likely.Total}}"
+  data-size="{{$likely.Size}}"
+  data-count="{{$likely.Count}}"
+  data-reg-total="{{$likely.RegularTotal}}"
+  data-reg-count="{{.NumRegular}}"
+  data-vote-total="{{$likely.VoteTotal}}"
+  data-vote-count="{{.VotingInfo.TicketsVoted}}"
+  data-ticket-total="{{$likely.TicketTotal}}"
+  data-ticket-count="{{.NumTickets}}"
+  data-rev-total="{{$likely.RevokeTotal}}"
+  data-rev-count="{{.NumRevokes}}"
 {{end}}
 
 {{define "blocksBanner"}}
-	<div class="bg-white block-banner">
-		<div class="container px-0">
-			<div>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/blocks">
-					<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>
-					<div class="blocks-selector{{if eq .TimeGrouping "Blocks"}} active{{end}}"></div>
-				</a>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/ticketpricewindows">
-					<span class="separator pl-2 pr-5{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
-					<div class="separator blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
-				</a>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
-					<span class="pr-2 pl-3{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
-					<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
-				</a>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
-					<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
-					<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
-				</a>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/weeks">
-					<span class="px-2{{if eq .TimeGrouping "Weeks"}} unstyled-link{{else}} text-secondary{{end}}">Weeks</span>
-					<div class="blocks-selector{{if eq .TimeGrouping "Weeks"}} active{{end}}"></div>
-				</a>
-				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
-					<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
-					<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
-				</a>
-			</div>
+<div class="bg-white block-banner">
+	<div class="container px-0">
+		<div>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/blocks">
+				<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Blocks"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/ticketpricewindows">
+				<span class="separator pl-2 pr-5{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
+				<div class="separator blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
+				<span class="pr-2 pl-3{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
+				<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/weeks">
+				<span class="px-2{{if eq .TimeGrouping "Weeks"}} unstyled-link{{else}} text-secondary{{end}}">Weeks</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Weeks"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
+				<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
+			</a>
 		</div>
 	</div>
+</div>
 {{end}}
 
 {{define "copyTextIcon"}}
-	<span class="dcricon-copy clickable"
-		  data-controller="clipboard"
-		  data-action="click->clipboard#copyTextToClipboard"
-	></span>
-	<span class="alert alert-success alert-copy">
+  <span class="dcricon-copy clickable"
+  data-controller="clipboard"
+  data-action="click->clipboard#copyTextToClipboard"
+  ></span>
+  <span class="alert alert-success alert-copy">
   </span>
 {{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -1,6 +1,7 @@
 {{define "html-head"}}
 <head data-turbolinks-eval="false">
 	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 	<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
@@ -25,15 +26,15 @@
 		<link rel="icon" href="/images/favicon/favicon-16x16.png?v=yHh3NA" type="image/png" sizes="16x16">
 
 		<!-- Android PWA -->
-		<link rel="manifest" href="/images/favicon/site.webmanifest?v=yHh3NA">
+		<link rel="manifest" href="/images/favicon/manifest.json?v=yHh3NA">
 
 		<!-- Safari -->
 		<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=yHh3NA" color="#091440">
 
 		<!-- Windows PWA -->
 		<meta name="msapplication-TileColor" content="#091440">
-		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=55tv3">
-		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=55tv3">
+		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
+		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
 	<!-- End custom favicon -->
 
 	<meta name="turbolinks-cache-control" content="no-cache">
@@ -48,7 +49,7 @@
 	<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
 	<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
 
-	<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
+	<script src="/js/vendor/turbolinks.min.js"></script>
 </head>
 {{end}}
 
@@ -73,9 +74,8 @@
 				class="top-search mousetrap"
 				placeholder="Search for blocks, addresses, transactions or proposal tokens"
 				spellcheck="false"
-				autocomplete="off"
 			/>
-			<button class="search-bttn" type="submit"><span class="dcricon-search"></span></button>
+			<button class="search-bttn"><span class="dcricon-search"></span></button>
 		</form>
 		<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
 			<div id="menuToggle">
@@ -92,6 +92,7 @@
 					<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
 					<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
 					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
+					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
 					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
@@ -165,12 +166,12 @@
 		</span>
 	</div>
 	<script
-		src="/dist/js/vendors~app.bundle.js?x=55tv3"
+		src="/dist/js/vendors~app.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.bundle.js?x=55tv3"
+		src="/dist/js/app.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>
@@ -203,6 +204,23 @@
   {{- else -}}
     <span class="text-danger">{{printf "%.2f" .}} %</span>
   {{- end -}}
+{{end}}
+
+{{define "listViewRouting"}}
+	<div class="fs12 nowrap text-left" style="margin:auto auto auto 0px;">
+		<select
+		  class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
+		  data-target="pagenavigation.listview"
+		  data-action="change->pagenavigation#setListView"
+		  >
+			<option {{if eq . "years"}}selected {{end}}value="years">Years</option>
+			<option {{if eq . "months"}}selected {{end}}value="months">Months</option>
+			<option {{if eq . "weeks"}}selected {{end}}value="weeks">Weeks</option>
+			<option {{if eq . "days"}}selected {{end}}value="days">Days</option>
+			<option {{if eq . "windows"}}selected {{end}}value="ticketpricewindows">Windows</option>
+			<option {{if eq . "blocks"}}selected {{end}}value="blocks">Blocks</option>
+		</select>
+	</div>
 {{end}}
 
 {{define "hashElide"}}
@@ -345,24 +363,24 @@
 				<div class="blocks-selector{{if eq .TimeGrouping "Blocks"}} active{{end}}"></div>
 			</a>
 			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/ticketpricewindows">
-				<span class="separator pl-2 pr-5{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
-				<div class="separator blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
+				<span class="px-2{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
 			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
-				<span class="pr-2 pl-3{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
-				<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
+				<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
 			</a>
 			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/weeks">
 				<span class="px-2{{if eq .TimeGrouping "Weeks"}} unstyled-link{{else}} text-secondary{{end}}">Weeks</span>
 				<div class="blocks-selector{{if eq .TimeGrouping "Weeks"}} active{{end}}"></div>
 			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
-				<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
+				<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
+			</a>
+			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
+				<span class="px-2{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
+				<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
 			</a>
 		</div>
 	</div>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -1,14 +1,13 @@
 {{define "html-head"}}
-<head data-turbolinks-eval="false">
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
-	<meta name="author" content="The Decred developers">
-	<meta name="application-name"           content="Decred - Autonomous Digital Currency">
-	<meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
-	<!--  Custom favicon  -->
+	<head data-turbolinks-eval="false">
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+		<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
+		<meta name="author" content="The Decred developers">
+		<meta name="application-name"           content="Decred - Autonomous Digital Currency">
+		<meta name="apple-mobile-web-app-title" content="Decred - Autonomous Digital Currency">
+		<!--  Custom favicon  -->
 		<!-- Apple PWA -->
 		<link rel="apple-touch-icon" sizes="57x57"   href="/images/favicon/apple-touch-icon-57x57.png?v=yHh3NA">
 		<link rel="apple-touch-icon" sizes="60x60"   href="/images/favicon/apple-touch-icon-60x60.png?v=yHh3NA">
@@ -26,372 +25,356 @@
 		<link rel="icon" href="/images/favicon/favicon-16x16.png?v=yHh3NA" type="image/png" sizes="16x16">
 
 		<!-- Android PWA -->
-		<link rel="manifest" href="/images/favicon/manifest.json?v=yHh3NA">
+		<link rel="manifest" href="/images/favicon/site.webmanifest?v=yHh3NA">
 
 		<!-- Safari -->
 		<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=yHh3NA" color="#091440">
 
 		<!-- Windows PWA -->
 		<meta name="msapplication-TileColor" content="#091440">
-		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
-		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
-	<!-- End custom favicon -->
+		<meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=55tv3">
+		<meta name="msapplication-config" content="/images/favicon/browserconfig.xml?v=55tv3">
+		<!-- End custom favicon -->
 
-	<meta name="turbolinks-cache-control" content="no-cache">
-	<title>{{.}}</title>
-	<link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
-	<link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-	<link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-	<link rel="preload" href="/fonts/source-sans-pro-semibold.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
-	<link rel="preload" href="/images/connecting.svg?x=55tv3" as="image" type="image/svg+xml" />
-	<link rel="preload" href="/images/themes/light/logo.svg?x=55tv3" as="image" type="image/svg+xml" />
-	<link rel="preload" href="/images/connected.svg?x=55tv3" as="image" type="image/svg+xml" />
-	<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
-	<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
+		<meta name="turbolinks-cache-control" content="no-cache">
+		<title>{{.}}</title>
+		<link rel="preload" href="/fonts/icomoon.ttf?g003m6" as="font" type="font/ttf" crossorigin="anonymous" />
+		<link rel="preload" href="/fonts/inconsolata-v15-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+		<link rel="preload" href="/fonts/source-sans-pro-v9-latin-regular.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+		<link rel="preload" href="/fonts/source-sans-pro-semibold.woff?x=55tv3" as="font" type="font/woff" crossorigin="anonymous" />
+		<link rel="preload" href="/images/connecting.svg?x=55tv3" as="image" type="image/svg+xml" />
+		<link rel="preload" href="/images/themes/light/logo.svg?x=55tv3" as="image" type="image/svg+xml" />
+		<link rel="preload" href="/images/connected.svg?x=55tv3" as="image" type="image/svg+xml" />
+		<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
+		<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
 
-	<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
-</head>
+		<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
+	</head>
 {{end}}
 
 {{define "navbar"}}
-<body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
-<header class="top-nav d-flex align-items-center" id="navBar" data-blocktime="{{.BlockTimeUnix}}">
-	<div class="container d-flex justify-content-between align-items-center">
-		<a class="no-underline d-block home-link dcrdata-logo" href="/"></a>
-		<form
-			class="search-form"
-			role="search"
-			id="search-form"
-			action="/search"
-			data-controller="search"
-			data-action="submit->search#execute"
-		>
-			<input
-				tabindex="0"
-				type="text"
-				name="search"
-				id="search"
-				class="top-search mousetrap"
-				placeholder="Search for blocks, addresses, transactions or proposal tokens"
-				spellcheck="false"
-			/>
-			<button class="search-bttn"><span class="dcricon-search"></span></button>
-		</form>
-		<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
-			<div id="menuToggle">
-				<input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
-				<span class="patty"></span>
-				<span class="patty"></span>
-				<span class="patty short"></span>
-				<div id="menu">
-					<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
-					<a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
-					<a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
-					<a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
-					<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
-					<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
-					<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
-					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
-					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
-					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
-					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
-					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
-				{{- if eq .NetName "Mainnet"}}
-					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
-				{{- else}}
-					<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
-				{{- end}}
-					<form action="/set" method="post" data-target="menu.form" class="menu-form">
-						<input type="hidden" name="darkmode" value="darkmode">
-						<input type="hidden" name="requestURI" value="{{.RequestURI}}">
-						<button type="submit" data-action="click->menu#onSunClick"
-								class="menu-submit text-left w-100 p-0"
-								data-keynav-skip>
+	<body class="{{ theme }}{{if .Cookies.DarkMode}} darkBG{{end}}">
+	<header class="top-nav d-flex align-items-center" id="navBar" data-blocktime="{{.BlockTimeUnix}}">
+		<div class="container d-flex justify-content-between align-items-center">
+			<a class="no-underline d-block home-link dcrdata-logo" href="/"></a>
+			<form
+					class="search-form"
+					role="search"
+					id="search-form"
+					action="/search"
+					data-controller="search"
+					data-action="submit->search#execute"
+			>
+				<input
+						tabindex="0"
+						type="text"
+						name="search"
+						id="search"
+						class="top-search mousetrap"
+						placeholder="Search for blocks, addresses, transactions or proposal tokens"
+						spellcheck="false"
+						autocomplete="off"
+				/>
+				<button class="search-bttn" type="submit"><span class="dcricon-search"></span></button>
+			</form>
+			<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
+				<div id="menuToggle">
+					<input type="checkbox" data-target="menu.toggle" data-action="change->menu#toggle"/>
+					<span class="patty"></span>
+					<span class="patty"></span>
+					<span class="patty short"></span>
+					<div id="menu">
+						<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
+						<a class="menu-item" data-keynav-skip href="/blocks" title="Decred blocks">Blocks</a>
+						<a class="menu-item" data-keynav-skip href="/mempool" title="Decred mempool">Mempool</a>
+						<a class="menu-item" data-keynav-skip href="/ticketpool" title="Decred ticket pool">Ticket Pool</a>
+						<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
+						<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
+						<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
+						<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
+						<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
+						<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
+						<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
+						<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
+						{{- if eq .NetName "Mainnet"}}
+							<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
+						{{- else}}
+							<a class="menu-item" data-keynav-skip href="{{.Links.Mainnet}}" title="Home">Switch To Mainnet</a>
+						{{- end}}
+						<form action="/set" method="post" data-target="menu.form" class="menu-form">
+							<input type="hidden" name="darkmode" value="darkmode">
+							<input type="hidden" name="requestURI" value="{{.RequestURI}}">
+							<button type="submit" data-action="click->menu#onSunClick"
+									class="menu-submit text-left w-100 p-0"
+									data-keynav-skip>
 								<div class="menu-item">
-								  <span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
-								  Night Mode
+									<span id="sun-icon" class="dcricon-sun-fill no-underline pr-2"></span>
+									Night Mode
 								</div>
-						</button>
-					</form>
-					<a class="menu-item jsonly" data-keynav-skip data-turbolinks="false" href="#" id="keynav-toggle">
-						<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
-					</a>
-					<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
+							</button>
+						</form>
+						<a class="menu-item jsonly" data-keynav-skip data-turbolinks="false" href="#" id="keynav-toggle">
+							<span class="text">Enable Hot Keys</span><span class="keys-hint">(&nbsp;&nbsp;<span class="arrows"> &#8592;<br>&#8594;</span>&nbsp;&nbsp;enter&nbsp;&nbsp;\&nbsp;&nbsp;=&nbsp;&nbsp;)</span>
+						</a>
+						<a class="menu-item" data-keynav-skip href="{{.Links.APIDocs}}" title="API Endpoints" target="_blank" rel="noopener noreferrer">JSON API Docs</a>
+					</div>
 				</div>
-			</div>
-		</nav>
-	</div>
-</header>
+			</nav>
+		</div>
+	</header>
 {{end}}
 
 {{define "footer"}}
-<footer class="navbar-fixed-bottom">
-	<div class="container d-flex justify-content-between align-items-center">
+	<footer class="navbar-fixed-bottom">
+		<div class="container d-flex justify-content-between align-items-center">
 		<span>
 			<span data-controller="time" data-target="time.blocktime" data-stamp="{{$.Tip.Time}}"></span> <span class="d-none d-sm-inline">since last block</span>
 		</span>
-		<span>
+			<span>
 			<a
-				class="text-nowrap d-none d-md-inline-block pr-3"
-				href="{{.Links.Github}}"
-				title="dcrdata on GitHub"
-				target="_blank"
-				rel="noopener noreferrer"
+					class="text-nowrap d-none d-md-inline-block pr-3"
+					href="{{.Links.Github}}"
+					title="dcrdata on GitHub"
+					target="_blank"
+					rel="noopener noreferrer"
 			>dcrdata v{{.Version}}</a>
 			{{- if ne .Links.OnionURL "" }}
-			<a
-				class="text-nowrap d-none d-md-inline-block pr-3"
-				href="{{.Links.OnionURL}}"
-				title="Access dcrdata over Tor"
-				target="_blank"
-				rel="noopener noreferrer"
-			>Tor site</a>
+				<a
+						class="text-nowrap d-none d-md-inline-block pr-3"
+						href="{{.Links.OnionURL}}"
+						title="Access dcrdata over Tor"
+						target="_blank"
+						rel="noopener noreferrer"
+				>Tor site</a>
 			{{ end }}
 			<a
-				class="text-nowrap"
-				href="{{.Links.License}}"
-				target="_blank"
-				rel="noopener noreferrer"
+					class="text-nowrap"
+					href="{{.Links.License}}"
+					target="_blank"
+					rel="noopener noreferrer"
 			>© 2020 The Decred developers (ISC)</a>
 		</span>
-		<span
-			id="connection"
-			class="text-nowrap align-items-center clickable d-inline-block"
-			data-turbolinks-permanent
-			data-controller="connection"
-			data-target="connection.indicator"
-			data-action="click->connection#requestNotifyPermission"
-			title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
+			<span
+					id="connection"
+					class="text-nowrap align-items-center clickable d-inline-block"
+					data-turbolinks-permanent
+					data-controller="connection"
+					data-target="connection.indicator"
+					data-action="click->connection#requestNotifyPermission"
+					title="While connected, you will receive live page updates and, if enabled, desktop notifications (click to enable)."
 			><span class="d-none d-sm-inline" data-target="connection.status">Connecting <span class="d-none d-md-inline-block">to WebSocket...</span></span><div></div>
 		</span>
-	</div>
-	<script
-		src="/dist/js/vendors~app.bundle.js"
-		data-turbolinks-eval="false"
-		data-turbolinks-suppress-warning
-	></script>
-	<script
-		src="/dist/js/app.bundle.js"
-		data-turbolinks-eval="false"
-		data-turbolinks-suppress-warning
-	></script>
-</footer>
+		</div>
+		<script
+				src="/dist/js/vendors~app.bundle.js?x=55tv3"
+				data-turbolinks-eval="false"
+				data-turbolinks-suppress-warning
+		></script>
+		<script
+				src="/dist/js/app.bundle.js?x=55tv3"
+				data-turbolinks-eval="false"
+				data-turbolinks-suppress-warning
+		></script>
+	</footer>
 {{end}}
 
 {{define "decimalParts" -}}
-<div class="decimal-parts d-inline-block">
-	{{- if eq (len .) 4 -}}
-		<span class="int">{{ index . 0 }}.{{ index . 1 }}</span>
-		{{- if gt (len (index . 2)) 0 -}}
-		<span class="decimal">{{ index . 2 }}</span>
-		{{- /* trailing zeros  */ -}}
-		<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
-		{{- end}}
-	{{- else -}}
-		<span class="int">{{index . 0}}</span>
-		{{- if gt (len (index . 1)) 0 -}}
-		<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
-		{{- /* trailing zeros  */ -}}
-		<span class="decimal trailing-zeroes">{{index . 2}}</span>
-		{{- end}}
-	{{- end -}}
+	<div class="decimal-parts d-inline-block">
+		{{- if eq (len .) 4 -}}
+			<span class="int">{{ index . 0 }}.{{ index . 1 }}</span>
+			{{- if gt (len (index . 2)) 0 -}}
+				<span class="decimal">{{ index . 2 }}</span>
+				{{- /* trailing zeros  */ -}}
+				<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
+			{{- end}}
+		{{- else -}}
+			<span class="int">{{index . 0}}</span>
+			{{- if gt (len (index . 1)) 0 -}}
+				<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
+				{{- /* trailing zeros  */ -}}
+				<span class="decimal trailing-zeroes">{{index . 2}}</span>
+			{{- end}}
+		{{- end -}}
 	</div>
 {{- end}}
 
 {{define "fmtPercentage"}}
-  {{- if gt . 0.0 -}}
-    <span class="text-green">+{{printf "%.2f" .}} %</span>
-  {{- else -}}
-    <span class="text-danger">{{printf "%.2f" .}} %</span>
-  {{- end -}}
-{{end}}
-
-{{define "listViewRouting"}}
-	<div class="fs12 nowrap text-left" style="margin:auto auto auto 0px;">
-		<select
-		  class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
-		  data-target="pagenavigation.listview"
-		  data-action="change->pagenavigation#setListView"
-		  >
-			<option {{if eq . "years"}}selected {{end}}value="years">Years</option>
-			<option {{if eq . "months"}}selected {{end}}value="months">Months</option>
-			<option {{if eq . "weeks"}}selected {{end}}value="weeks">Weeks</option>
-			<option {{if eq . "days"}}selected {{end}}value="days">Days</option>
-			<option {{if eq . "windows"}}selected {{end}}value="ticketpricewindows">Windows</option>
-			<option {{if eq . "blocks"}}selected {{end}}value="blocks">Blocks</option>
-		</select>
-	</div>
+	{{- if gt . 0.0 -}}
+		<span class="text-green">+{{printf "%.2f" .}} %</span>
+	{{- else -}}
+		<span class="text-danger">{{printf "%.2f" .}} %</span>
+	{{- end -}}
 {{end}}
 
 {{define "hashElide"}}
-  {{- $hash := (index . 0) -}}
-  {{- $link := (index . 1) -}}
-  {{- if eq $link "" -}}
-	<div
-  {{- else -}}
-	<a href="{{$link}}"
-  {{- end}} data-keynav-priority class="elidedhash mono" data-head="{{hashStart $hash}}" data-tail="{{hashEnd $hash}}">
-  {{- $hash}}
-  {{- if eq $link ""}}</div>{{else}}</a>{{template "copyTextIcon"}}{{end -}}
+	{{- $hash := (index . 0) -}}
+	{{- $link := (index . 1) -}}
+	{{- if eq $link "" -}}
+		<div
+	{{- else -}}
+		<a href="{{$link}}"
+	{{- end}} data-keynav-priority class="elidedhash mono" data-head="{{hashStart $hash}}" data-tail="{{hashEnd $hash}}">
+	{{- $hash}}
+	{{- if eq $link ""}}</div>{{else}}</a>{{template "copyTextIcon"}}{{end -}}
 {{end}}
 
 {{define "addressTable"}}
-{{- $txType := .TxnType}}
-{{- if .Transactions}}
-<table class="table table-mono-cells table-responsive-sm">
-	<thead>
-		<tr>
-		<th class="d-none d-sm-table-cell">Tx Type</th>
-		<th class="text-left">Input/&#8203;Output ID</th>
-	{{- if eq $txType "merged_debit"}}
-		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
-			><span class="d-none d-sm-inline">Inputs</span>
-		</th>
-		<th class="text-right">Debit DCR</th>
-	{{- else if eq $txType "merged_credit" }}
-		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
-			><span class="d-none d-sm-inline">Outputs</span>
-		</th>
-		<th class="text-right">Credit DCR</th>
-	{{- else if eq $txType "merged" }}
-		<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
-		<th class="text-right">Credit DCR</th>
-		<th class="text-right">Debit DCR</th>
+	{{- $txType := .TxnType}}
+	{{- if .Transactions}}
+		<table class="table table-mono-cells table-responsive-sm">
+			<thead>
+			<tr>
+				<th class="d-none d-sm-table-cell">Tx Type</th>
+				<th class="text-left">Input/&#8203;Output ID</th>
+				{{- if eq $txType "merged_debit"}}
+					<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged input count">Cnt</span
+						><span class="d-none d-sm-inline">Inputs</span>
+					</th>
+					<th class="text-right">Debit DCR</th>
+				{{- else if eq $txType "merged_credit" }}
+					<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="merged output count">Cnt</span
+						><span class="d-none d-sm-inline">Outputs</span>
+					</th>
+					<th class="text-right">Credit DCR</th>
+				{{- else if eq $txType "merged" }}
+					<th title="Count of address's inputs and outputs in the transaction." class="text-right"><span class="d-none d-sm-inline-block">I/O Count</span><span class="d-sm-none position-relative" data-tooltip="# of inputs and outputs">#</span></th>
+					<th class="text-right">Credit DCR</th>
+					<th class="text-right">Debit DCR</th>
+				{{- else}}
+					<th class="text-right">Credit DCR</th>
+					<th class="text-right">Debit DCR</th>
+				{{- end}}
+				<th class="d-none d-sm-table-cell text-right">Time (UTC)</th>
+				<th class="text-right">Age</th>
+				<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
+				<th class="d-none d-sm-table-cell text-right">Size</th>
+			</tr>
+			</thead>
+			<tbody>
+			{{- range .Transactions}}
+				<tr{{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
+					<td class="d-none d-sm-table-cell">{{.TxType}}</td>
+					<td class="clipboard">{{template "hashElide" (hashlink .TxID .Link)}}</td>
+					{{- if eq $txType "merged_debit"}}
+						<td class="text-right">{{.MergedTxnCount}}</td>
+						<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+					{{- else if eq $txType "merged_credit"}}
+						<td class="text-right">{{.MergedTxnCount}}</td>
+						<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+					{{- else if eq $txType "merged"}}
+						<td class="text-right">{{.MergedTxnCount}}</td>
+						{{- if .IsFunding}}
+							<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+							<td class="text-right">&mdash;</td>
+						{{- else}}
+							<td class="text-right">&mdash;</td>
+							<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+						{{- end}}
+					{{- else if or (eq $txType "credit") .IsFunding}}{{/* .IsFunding = true && txType = "all" is a credit */}}
+					<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
+					{{- if ne .MatchedTx ""}}
+						<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
+												  data-txid="{{.MatchedTx}}"
+												  data-action="mouseover->address#hashOver mouseout->address#hashOut"
+							>spent</a></td>
+					{{- else}}
+						<td class="text-right">unspent</td>
+					{{- end}}
+					{{- else}}{{/* either "debit", or "all" with .IsFunding = false */ -}}
+					{{- if eq .SentTotal 0.0}}
+						<td class="text-right">sstxcommitment</td>
+					{{- else if ne .MatchedTx ""}}
+						<td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" data-action="mouseover->address#hashOver mouseout->address#hashOut">source</a></td>
+					{{- else}}
+						<td class="text-right">N/A</td>
+					{{- end}}
+					<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
+					{{- end}}
+					<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time.DatetimeWithoutTZ}}{{end}}</td>
+					<td class="addr-tx-age text-right">
+						{{- if eq (.Time.T.Unix) 0}}
+							N/A
+						{{- else}}
+							<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
+						{{- end}}
+					</td>
+					<td class="addr-tx-confirms text-right"	{{/*Update confirmations with Stimulus*/ -}}
+						data-target="newblock.confirmations" {{/*trim*/ -}}
+						data-confirmations="{{.Confirmations}}" {{/*trim*/ -}}
+						data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}" {{/*trim*/ -}}
+						data-yes="#" {{/*trim*/ -}}
+						data-no="(unconfirmed)" {{/*trim*/ -}}
+					>{{.Confirmations}}</td>
+					<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
+				</tr>
+			{{- end}}
+			</tbody>
+		</table>
 	{{- else}}
-		<th class="text-right">Credit DCR</th>
-		<th class="text-right">Debit DCR</th>
+		<table class="table table-mono-cells">
+			<tr>
+				<td>
+					No transactions found for this address.
+				</td>
+			</tr>
+		</table>
 	{{- end}}
-		<th class="d-none d-sm-table-cell text-right">Time (UTC)</th>
-		<th class="text-right">Age</th>
-		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
-		<th class="d-none d-sm-table-cell text-right">Size</th>
-		</tr>
-	</thead>
-	<tbody>
-	{{- range .Transactions}}
-		<tr{{if eq .Confirmations 0}} data-target="address.pending" data-txid="{{.TxID}}"{{end}}>
-			<td class="d-none d-sm-table-cell">{{.TxType}}</td>
-			<td class="clipboard">{{template "hashElide" (hashlink .TxID .Link)}}</td>
-		{{- if eq $txType "merged_debit"}}
-			<td class="text-right">{{.MergedTxnCount}}</td>
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-		{{- else if eq $txType "merged_credit"}}
-			<td class="text-right">{{.MergedTxnCount}}</td>
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-		{{- else if eq $txType "merged"}}
-			<td class="text-right">{{.MergedTxnCount}}</td>
-			{{- if .IsFunding}}
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-			<td class="text-right">&mdash;</td>
-			{{- else}}
-			<td class="text-right">&mdash;</td>
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-			{{- end}}
-		{{- else if or (eq $txType "credit") .IsFunding}}{{/* .IsFunding = true && txType = "all" is a credit */}}
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}</td>
-			{{- if ne .MatchedTx ""}}
-			<td class="text-right"><a href="/tx/{{.MatchedTx}}/in/{{.MatchedTxIndex}}"
-				data-txid="{{.MatchedTx}}"
-				data-action="mouseover->address#hashOver mouseout->address#hashOut"
-				>spent</a></td>
-			{{- else}}
-			<td class="text-right">unspent</td>
-			{{- end}}
-		{{- else}}{{/* either "debit", or "all" with .IsFunding = false */ -}}
-			{{- if eq .SentTotal 0.0}}
-			<td class="text-right">sstxcommitment</td>
-			{{- else if ne .MatchedTx ""}}
-			<td class="text-right"><a href="/tx/{{.MatchedTx}}/out/{{.MatchedTxIndex}}" data-action="mouseover->address#hashOver mouseout->address#hashOut">source</a></td>
-			{{- else}}
-			<td class="text-right">N/A</td>
-			{{- end}}
-			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
-		{{- end}}
-			<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time.DatetimeWithoutTZ}}{{end}}</td>
-			<td class="addr-tx-age text-right">
-			{{- if eq (.Time.T.Unix) 0}}
-				N/A
-			{{- else}}
-				<span data-controller="time" data-target="time.age" data-age="{{.Time.UNIX}}"></span>
-			{{- end}}
-			</td>
-			<td class="addr-tx-confirms text-right"	{{/*Update confirmations with Stimulus*/ -}}
-				data-target="newblock.confirmations" {{/*trim*/ -}}
-				data-confirmations="{{.Confirmations}}" {{/*trim*/ -}}
-				data-confirmation-block-height="{{if eq .Confirmations 0}}-1{{else}}{{.BlockHeight}}{{end}}" {{/*trim*/ -}}
-				data-yes="#" {{/*trim*/ -}}
-				data-no="(unconfirmed)" {{/*trim*/ -}}
-			>{{.Confirmations}}</td>
-			<td class="text-right d-none d-sm-table-cell text-right">{{.FormattedSize}}</td>
-		</tr>
-	{{- end}}
-	</tbody>
-</table>
-{{- else}}
-<table class="table table-mono-cells">
-	<tr>
-		<td>
-			No transactions found for this address.
-		</td>
-	</tr>
-</table>
-{{- end}}
 {{- end}}
 
 {{define "mempoolDump"}}
-  {{$likely := .LikelyMineable}}
-  data-id="{{.Ident}}"
-  data-total="{{$likely.Total}}"
-  data-size="{{$likely.Size}}"
-  data-count="{{$likely.Count}}"
-  data-reg-total="{{$likely.RegularTotal}}"
-  data-reg-count="{{.NumRegular}}"
-  data-vote-total="{{$likely.VoteTotal}}"
-  data-vote-count="{{.VotingInfo.TicketsVoted}}"
-  data-ticket-total="{{$likely.TicketTotal}}"
-  data-ticket-count="{{.NumTickets}}"
-  data-rev-total="{{$likely.RevokeTotal}}"
-  data-rev-count="{{.NumRevokes}}"
+	{{$likely := .LikelyMineable}}
+	data-id="{{.Ident}}"
+	data-total="{{$likely.Total}}"
+	data-size="{{$likely.Size}}"
+	data-count="{{$likely.Count}}"
+	data-reg-total="{{$likely.RegularTotal}}"
+	data-reg-count="{{.NumRegular}}"
+	data-vote-total="{{$likely.VoteTotal}}"
+	data-vote-count="{{.VotingInfo.TicketsVoted}}"
+	data-ticket-total="{{$likely.TicketTotal}}"
+	data-ticket-count="{{.NumTickets}}"
+	data-rev-total="{{$likely.RevokeTotal}}"
+	data-rev-count="{{.NumRevokes}}"
 {{end}}
 
 {{define "blocksBanner"}}
-<div class="bg-white block-banner">
-	<div class="container px-0">
-		<div>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/blocks">
-				<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Blocks"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/ticketpricewindows">
-				<span class="px-2{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
-				<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/weeks">
-				<span class="px-2{{if eq .TimeGrouping "Weeks"}} unstyled-link{{else}} text-secondary{{end}}">Weeks</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Weeks"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
-				<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
-			</a>
-			<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
-				<span class="px-2{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
-				<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
-			</a>
+	<div class="bg-white block-banner">
+		<div class="container px-0">
+			<div>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/blocks">
+					<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>
+					<div class="blocks-selector{{if eq .TimeGrouping "Blocks"}} active{{end}}"></div>
+				</a>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/ticketpricewindows">
+					<span class="separator pl-2 pr-5{{if eq .TimeGrouping "Windows"}} unstyled-link{{else}} text-secondary{{end}}">Windows</span>
+					<div class="separator blocks-selector{{if eq .TimeGrouping "Windows"}} active{{end}}"></div>
+				</a>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/years">
+					<span class="pr-2 pl-3{{if eq .TimeGrouping "Years"}} unstyled-link{{else}} text-secondary{{end}}">Years</span>
+					<div class="blocks-selector{{if eq .TimeGrouping "Years"}} active{{end}}"></div>
+				</a>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/months">
+					<span class="px-2{{if eq .TimeGrouping "Months"}} unstyled-link{{else}} text-secondary{{end}}">Months</span>
+					<div class="blocks-selector{{if eq .TimeGrouping "Months"}} active{{end}}"></div>
+				</a>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/weeks">
+					<span class="px-2{{if eq .TimeGrouping "Weeks"}} unstyled-link{{else}} text-secondary{{end}}">Weeks</span>
+					<div class="blocks-selector{{if eq .TimeGrouping "Weeks"}} active{{end}}"></div>
+				</a>
+				<a class="d-inline-block position-relative mr-4 py-2 unstyled-link" href="/days">
+					<span class="px-2{{if eq .TimeGrouping "Days"}} unstyled-link{{else}} text-secondary{{end}}">Days</span>
+					<div class="blocks-selector{{if eq .TimeGrouping "Days"}} active{{end}}"></div>
+				</a>
+			</div>
 		</div>
 	</div>
-</div>
 {{end}}
 
 {{define "copyTextIcon"}}
-  <span class="dcricon-copy clickable"
-  data-controller="clipboard"
-  data-action="click->clipboard#copyTextToClipboard"
-  ></span>
-  <span class="alert alert-success alert-copy">
+	<span class="dcricon-copy clickable"
+		  data-controller="clipboard"
+		  data-action="click->clipboard#copyTextToClipboard"
+	></span>
+	<span class="alert alert-success alert-copy">
   </span>
 {{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -49,7 +49,7 @@
 	<link rel="preload" href="/images/disconnected.svg?x=55tv3" as="image" type="image/svg+xml" />
 	<link href="/dist/css/style.css?x=9nfyu4m" rel="stylesheet">
 
-	<script src="/js/vendor/turbolinks.min.js"></script>
+	<script src="/js/vendor/turbolinks.min.js?x=55tv3"></script>
 </head>
 {{end}}
 


### PR DESCRIPTION
Fix #1022 
This is a replacement for #1617 
It is a continuation of work done by other developers on the 51% attack cost.
This PR adds a page for majority attack cost calculation for both internal and external attack type using network hashrate, ticket price and ticket pool size. 
The user has the ability to adjust parameters like attack time, electricity cost, exchange rate and mining device, and see the attack cost in US dollar for every selected set of options.

![image](https://user-images.githubusercontent.com/11990092/71747824-ff243800-2e70-11ea-956f-033df07f0a6a.png)
