### PR TITLE
Timestamp cleanup in table views

### DIFF
--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -50,8 +50,9 @@ type TimeDef struct {
 }
 
 const (
-	timeDefFmtHuman = "2006-01-02 15:04:05 (MST)"
-	timeDefFmtJS    = time.RFC3339
+	timeDefFmtHuman        = "2006-01-02 15:04:05 (MST)"
+	timeDefFmtDateTimeNoTZ = "2006-01-02 15:04:05"
+	timeDefFmtJS           = time.RFC3339
 )
 
 // String formats the time in a human-friendly layout. This may be used when
@@ -72,6 +73,12 @@ func (t TimeDef) UNIX() int64 {
 
 func (t TimeDef) Format(layout string) string {
 	return t.T.Format(layout)
+}
+
+// DatetimeWithoutTZ formats the time in a human-friendly layout, without
+// time zone.
+func (t *TimeDef) DatetimeWithoutTZ() string {
+	return t.T.Format(timeDefFmtDateTimeNoTZ)
 }
 
 // MarshalJSON is set as the default marshalling function for TimeDef struct.

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -455,12 +455,12 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			dateTime := time.Unix(int64(a), 0).UTC()
 			return dateTime.Format("2006-01-02 15:04:05 MST")
 		},
-		"timeWithoutDateAndTimeZone": func(a uint64) string {
+		"dateTimeWithoutTimeZone": func(a uint64) string {
 			if a == 0 {
 				return "N/A"
 			}
 			dateTime := time.Unix(int64(a), 0).UTC()
-			return dateTime.Format("2006-01-02")
+			return dateTime.Format("2006-01-02 15:04:05")
 		},
 		"toLowerCase": strings.ToLower,
 		"toTitleCase": strings.Title,

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -35,8 +35,9 @@ type TimeDef struct {
 }
 
 const (
-	timeDefFmtHuman = "2006-01-02 15:04:05 (MST)"
-	timeDefFmtJS    = time.RFC3339
+	timeDefFmtHuman        = "2006-01-02 15:04:05 (MST)"
+	timeDefFmtDateTimeNoTZ = "2006-01-02 15:04:05"
+	timeDefFmtJS           = time.RFC3339
 )
 
 // String formats the time in a human-friendly layout. This ends up on the
@@ -88,6 +89,12 @@ func (t *TimeDef) PrettyMDY() string {
 // HMSTZ is the hour:minute:second with 3-digit timezone code.
 func (t *TimeDef) HMSTZ() string {
 	return t.T.Format("15:04:05 MST")
+}
+
+// DatetimeWithoutTZ formats the time in a human-friendly layout, without
+// time zone.
+func (t *TimeDef) DatetimeWithoutTZ() string {
+	return t.T.Format(timeDefFmtDateTimeNoTZ)
 }
 
 // NewTimeDef constructs a TimeDef from the given time.Time. It presets the

--- a/public/js/controllers/blocklist_controller.js
+++ b/public/js/controllers/blocklist_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
           newTd.textContent = humanize.threeSigFigs(block.TotalSent)
           break
         case 'time':
-          newTd.textContent = humanize.date(block.time, true)
+          newTd.textContent = humanize.date(block.time, false)
           break
         default:
           newTd.textContent = block[dataType]

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -160,8 +160,10 @@ var humanize = {
   },
   date: function (stamp, withTimezone) {
     var d = new Date(stamp)
-    return `${String(d.getUTCFullYear())}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')} ` +
-          `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')} (UTC)`
+    var dateStr = `${String(d.getUTCFullYear())}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')} ` +
+          `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')}`
+    if (withTimezone) dateStr += ' (UTC)'
+    return dateStr
   },
   hashElide: function (hash, link, asNode) {
     var div = document.createElement(link ? 'a' : 'div')

--- a/views/agendas.tmpl
+++ b/views/agendas.tmpl
@@ -244,8 +244,8 @@
                     <th class="d-none d-md-table-cell">Description</th>
                     <th class="text-right">Status</th>
                     <th class="text-right">Vote Version</th>
-                    <th class="text-right d-none d-sm-table-cell">Start Time</th>
-                    <th class="text-right d-none d-sm-table-cell">Expire Time</th>
+                    <th class="text-right d-none d-sm-table-cell">Start Time (UTC)</th>
+                    <th class="text-right d-none d-sm-table-cell">Expire Time (UTC)</th>
                   </tr>
                 </thead>
                 {{range $i, $v := .Agendas}}
@@ -255,8 +255,8 @@
                     <td class="d-none d-md-table-cell truncate">{{.Description}}</td>
                     <td class="text-right">{{.Status}}</td>
                     <td class="text-right">{{.VoteVersion}}</td>
-                    <td class="text-right d-none d-sm-table-cell">{{TimeConversion .StartTime}}</td>
-                    <td class="text-right d-none d-sm-table-cell">{{TimeConversion .ExpireTime}}</td>
+                    <td class="text-right d-none d-sm-table-cell">{{dateTimeWithoutTimeZone .StartTime}}</td>
+                    <td class="text-right d-none d-sm-table-cell">{{dateTimeWithoutTimeZone .ExpireTime}}</td>
                 </tbody>
                 {{end}}
                 {{end}}

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -109,7 +109,7 @@
                             <span class="d-md-none position-relative" data-tooltip="block version">Ver</span>
                         </th>
                         <th class="text-right px-0" class="jsonly">Age</th>
-                        <th class="text-right px-0">Time</th>
+                        <th class="text-right px-0">Time (UTC)</th>
                     </tr>
                 </thead>
                 <tbody data-target="blocklist.table">
@@ -125,7 +125,7 @@
                         <td class="text-center" data-type="size">{{.FormattedBytes}}</td>
                         <td class="text-center d-none d-sm-table-cell" data-type="version">{{.Version}}</td>
                         <td class="text-right px-0" data-type="age" class="jsonly" data-target="time.age" data-age="{{.BlockTime.UNIX}}"></td>
-                        <td class="text-right px-0" data-type="time">{{.BlockTime}}</td>
+                        <td class="text-right px-0" data-type="time">{{.BlockTime.DatetimeWithoutTZ}}</td>
                     </tr>
                 {{end}}
                 </tbody>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -243,7 +243,7 @@
 		<th class="text-right">Credit DCR</th>
 		<th class="text-right">Debit DCR</th>
 	{{- end}}
-		<th class="d-none d-sm-table-cell text-right">Time</th>
+		<th class="d-none d-sm-table-cell text-right">Time (UTC)</th>
 		<th class="text-right">Age</th>
 		<th class="text-right"><span class="d-sm-none position-relative" data-tooltip="Confirmations">Cons</span><span class="d-none d-sm-inline">Confirms</span></th>
 		<th class="d-none d-sm-table-cell text-right">Size</th>
@@ -289,7 +289,7 @@
 			{{- end}}
 			<td class="text-right fs15">{{template "decimalParts" (float64AsDecimalParts .SentTotal 8 false)}}</td>
 		{{- end}}
-			<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time}}{{end}}</td>
+			<td class="addr-tx-time d-none d-sm-table-cell text-right">{{if eq .Confirmations 0}}Unconfirmed{{else}}{{.Time.DatetimeWithoutTZ}}{{end}}</td>
 			<td class="addr-tx-age text-right">
 			{{- if eq (.Time.T.Unix) 0}}
 				N/A


### PR DESCRIPTION
Moved timezone strings from timestamps to column headers in table views in order to clean them up.

Closes #1614 