### PR TITLE
Pagination selector and incorrect row count

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -606,6 +606,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		Data         []*types.BlockBasic
 		BestBlock    int64
 		Rows         int64
+		RowsCount    int64
 		WindowSize   int64
 		TimeGrouping string
 		Pages        pageNumbers
@@ -614,6 +615,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		Data:           summaries,
 		BestBlock:      bestBlockHeight,
 		Rows:           int64(rows),
+		RowsCount:      int64(len(summaries)),
 		WindowSize:     exp.ChainParams.StakeDiffWindowSize,
 		TimeGrouping:   "Blocks",
 		Pages:          calcPagesDesc(int(bestBlockHeight), rows, height, linkTemplate),

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -483,7 +483,8 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 	now := time.Now()
 
 	if (grouping == dbtypes.YearGrouping && now.Month() < oldestBlockMonth) ||
-		grouping == dbtypes.MonthGrouping && now.Day() < oldestBlockDay {
+		grouping == dbtypes.MonthGrouping && now.Day() < oldestBlockDay ||
+		grouping == dbtypes.YearGrouping && now.Month() == oldestBlockMonth && now.Day() < oldestBlockDay {
 		maxOffset = maxOffset + 1
 	}
 
@@ -601,10 +602,13 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 
 	linkTemplate := "/blocks?height=%d&rows=" + strconv.Itoa(rows)
 
+	oldestHeight := int(bestBlockHeight) % rows
+
 	str, err := exp.templates.exec("explorer", struct {
 		*CommonPageData
 		Data         []*types.BlockBasic
 		BestBlock    int64
+		OldestHeight int64
 		Rows         int64
 		RowsCount    int64
 		WindowSize   int64
@@ -614,6 +618,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		CommonPageData: exp.commonData(r),
 		Data:           summaries,
 		BestBlock:      bestBlockHeight,
+		OldestHeight:   int64(oldestHeight),
 		Rows:           int64(rows),
 		RowsCount:      int64(len(summaries)),
 		WindowSize:     exp.ChainParams.StakeDiffWindowSize,

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -470,10 +470,26 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 	}
 
 	oldestBlockTime := exp.ChainParams.GenesisBlock.Header.Timestamp.Unix()
-	maxOffset := (time.Now().Unix() - oldestBlockTime) / int64(i)
+	maxOffset := int64(math.Ceil((float64(time.Now().Unix()) - float64(oldestBlockTime)) / float64(i)))
 	m := uint64(maxOffset)
 	if offset > m {
 		offset = m
+	}
+
+	if grouping != dbtypes.WeekGrouping {
+
+		oldestBlockMonth := exp.ChainParams.GenesisBlock.Header.Timestamp.Month()
+		oldestBlockDay := exp.ChainParams.GenesisBlock.Header.Timestamp.Day()
+
+		switch now := time.Now(); {
+		case now.Month() < oldestBlockMonth:
+			maxOffset = maxOffset + 1
+			break
+		case (now.Month() == oldestBlockMonth) && (now.Day() < oldestBlockDay):
+			maxOffset = maxOffset + 1
+			break
+		default:
+		}
 	}
 
 	rows, err := strconv.ParseUint(r.URL.Query().Get("rows"), 10, 64)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -476,19 +476,15 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		offset = m
 	}
 
-	if grouping == dbtypes.YearGrouping || grouping == dbtypes.MonthGrouping {
+	oldestBlockTimestamp := exp.ChainParams.GenesisBlock.Header.Timestamp
+	oldestBlockMonth := oldestBlockTimestamp.Month()
+	oldestBlockDay := oldestBlockTimestamp.Day()
 
-		oldestBlockTimestamp := exp.ChainParams.GenesisBlock.Header.Timestamp
-		oldestBlockMonth := oldestBlockTimestamp.Month()
-		oldestBlockDay := oldestBlockTimestamp.Day()
+	now := time.Now()
 
-		switch now := time.Now(); {
-		case now.Month() < oldestBlockMonth:
-			maxOffset = maxOffset + 1
-		case (now.Month() == oldestBlockMonth) && (now.Day() < oldestBlockDay):
-			maxOffset = maxOffset + 1
-		default:
-		}
+	if (grouping == dbtypes.YearGrouping && now.Month() < oldestBlockMonth) ||
+		grouping == dbtypes.MonthGrouping && now.Day() < oldestBlockDay {
+		maxOffset = maxOffset + 1
 	}
 
 	rows, err := strconv.ParseUint(r.URL.Query().Get("rows"), 10, 64)

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -66,7 +66,7 @@
                             <li>
                                 <a
                                 class="text-secondary"
-                                href="/blocks?height={{subtract .Rows 1}}&rows={{.Rows}}"
+                                href="/blocks?height={{.OldestHeight}}&rows={{.Rows}}"
                                 >Oldest</a>
                             </li>
                           {{end}}

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -33,12 +33,11 @@
                           class="dropdown text-secondary my-2 {{if lt $blocksCount 10}}disabled{{end}}"
                           {{if lt $blocksCount 10}}disabled="disabled"{{end}}
                       >
+                        {{if eq $blocksCount 20 30 50 100 .WindowSize}}{{else}}<option selected value="{{$blocksCount}}">{{$blocksCount}} per page</option>{{end}}
                         {{if ge $pendingBlocks 20}}<option {{if eq $blocksCount 20}}selected{{end}} value="20">20 per page</option>{{end}}
                         {{if ge $pendingBlocks 30}}<option {{if eq $blocksCount 30}}selected{{end}} value="30">30 per page</option>{{end}}
                         {{if ge $pendingBlocks 50}}<option {{if eq $blocksCount 50}}selected{{end}} value="50">50 per page</option>{{end}}
                         {{if ge $pendingBlocks 100}}<option {{if eq $blocksCount 100}}selected{{end}} value="100">100 per page</option>{{end}}
-                        {{if ge $pendingBlocks .WindowSize}}<option {{if eq $blocksCount .WindowSize}}selected{{end}} value="{{.WindowSize}}">{{.WindowSize}} per page</option>{{end}}
-                        {{if eq $blocksCount 20 30 50 100 .WindowSize}}{{else}}<option selected value="{{$blocksCount}}">{{$blocksCount}} per page</option>{{end}}
                       </select>
                   </span>
                   <nav aria-label="blocks navigation" data-limit="{{.Rows}}" class="ml-2 my-2 d-inline-block text-right">

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -15,7 +15,6 @@
             {{$topBlock = ((index .Data 0).Height)}}
             {{$Offset := (subtract .BestBlock $topBlock)}}
             {{$pendingBlocks := ((index .Data 0).Height)}}
-            {{$rowsCount := (int64 $blocksCount)}}
             <div class="d-flex justify-content-between align-items-end">
                 <span class="h2 d-flex pt-4 pb-1 pr-2">
                     Blocks
@@ -23,8 +22,7 @@
                 </span>
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">
-                      <!-- {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .Rows)}} of {{intComma (add .BestBlock 1) }} rows -->
-                      {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset $rowsCount)}} of {{intComma (add .BestBlock 1) }} rows
+                      {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .RowsCount)}} of {{intComma (add .BestBlock 1) }} rows
                   </span>
                   <span class="fs12 nowrap text-right">
                       <select

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -15,6 +15,7 @@
             {{$topBlock = ((index .Data 0).Height)}}
             {{$Offset := (subtract .BestBlock $topBlock)}}
             {{$pendingBlocks := ((index .Data 0).Height)}}
+            {{$rowsCount := (int64 $blocksCount)}}
             <div class="d-flex justify-content-between align-items-end">
                 <span class="h2 d-flex pt-4 pb-1 pr-2">
                     Blocks
@@ -22,7 +23,8 @@
                 </span>
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">
-                      {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .Rows)}} of {{intComma (add .BestBlock 1) }} rows
+                      <!-- {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .Rows)}} of {{intComma (add .BestBlock 1) }} rows -->
+                      {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset $rowsCount)}} of {{intComma (add .BestBlock 1) }} rows
                   </span>
                   <span class="fs12 nowrap text-right">
                       <select

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -12,7 +12,7 @@
             {{if gt $count 0}}
             <div class="d-flex justify-content-between align-items-end">
                 {{$oldest = (add .Offset $count)}}
-                {{$lastGrouping = (.BestGrouping)}}
+                {{$lastGrouping = (add .BestGrouping 1)}}
                 {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
                 {{$pending := (subtract $lastGrouping .Offset)}}
                 {{$dropVal := $lastGrouping}}

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -12,7 +12,7 @@
             {{if gt $count 0}}
             <div class="d-flex justify-content-between align-items-end">
                 {{$oldest = (add .Offset $count)}}
-                {{$lastGrouping = (add .BestGrouping 1)}}
+                {{$lastGrouping = (.BestGrouping)}}
                 {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
                 {{$pending := (subtract $lastGrouping .Offset)}}
                 {{$dropVal := $lastGrouping}}
@@ -24,25 +24,27 @@
 
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">
-                      {{intComma (add .Offset 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastGrouping }} rows
+                    {{intComma (add .Offset 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastGrouping }} rows
                   </span>
-                  <span class="fs12 nowrap text-right">
-                      <select
-                          data-target="pagenavigation.pagesize"
-                          data-action="change->pagenavigation#setPageSize"
-                          data-offset="{{$.Offset}}"
-                          data-offsetkey="offset"
-                          class="dropdown text-secondary my-2 {{if lt $pending 10}}disabled{{end}}"
-                          {{if lt $pending 10}}disabled="disabled"{{end}}
-                      >
-                        {{if ge $pending 20}}<option {{if eq $count 20}}selected{{end}} value="20">20 per page</option>{{end}}
-                        {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30 per page</option>{{end}}
-                        {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50 per page</option>{{end}}
-                        {{if ge $pending 100}}<option {{if eq $count 100}}selected{{end}} value="100">100 per page</option>{{end}}
-                        {{if eq $dropVal $count 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}}
-                        {{if eq $count 20 30 50 100 200}}{{else}}<option selected value="{{$count}}">{{$count}} per page</option>{{end}}
-                      </select>
-                  </span>
+                  {{if ge $dropVal 10}}
+                    <span class="fs12 nowrap text-right">
+                        <select
+                            data-target="pagenavigation.pagesize"
+                            data-action="change->pagenavigation#setPageSize"
+                            data-offset="{{$.Offset}}"
+                            data-offsetkey="offset"
+                            class="dropdown text-secondary my-2 {{if lt $pending 10}}disabled{{end}}"
+                            {{if lt $pending 10}}disabled="disabled"{{end}}
+                        >
+                          {{if eq $count 20 30 50 100 200}}{{else}}<option selected value="{{$count}}">{{$count}} per page</option>{{end}}
+                          {{if ge $pending 20}}<option {{if eq $count 20}}selected{{end}} value="20">20 per page</option>{{end}}
+                          {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30 per page</option>{{end}}
+                          {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50 per page</option>{{end}}
+                          {{if ge $pending 100}}<option {{if eq $count 100}}selected{{end}} value="100">100 per page</option>{{end}}
+                          {{if eq $dropVal $count 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}}
+                        </select>
+                    </span>
+                  {{end}}
                   <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="ml-2 my-2 d-inline-block text-right">
                       <ul class="pages mb-0">
                           {{if ne .Offset 0}}

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -35,12 +35,12 @@
                         class="dropdown text-secondary my-2 {{if lt $pendingWindows 10}}disabled{{end}}"
                         {{if lt $pendingWindows 10}}disabled="disabled"{{end}}
                     >
+                      {{if eq $windowsCount 20 30 50 100 200}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}} per page</option>{{end}}
                       {{if ge $pendingWindows 20}}<option {{if eq $windowsCount 20}}selected{{end}} value="20">20 per page</option>{{end}}
                       {{if ge $pendingWindows 30}}<option {{if eq $windowsCount 30}}selected{{end}} value="30">30 per page</option>{{end}}
                       {{if ge $pendingWindows 50}}<option {{if eq $windowsCount 50}}selected{{end}} value="50">50 per page</option>{{end}}
                       {{if ge $pendingWindows 100}}<option {{if eq $windowsCount 100}}selected{{end}} value="100">100 per page</option>{{end}}
-                      {{if eq $dropVal $windowsCount 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}}
-                      {{if eq $windowsCount 20 30 50 100 200}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}} per page</option>{{end}}
+                      {# {{if eq $dropVal $windowsCount 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}} #}
                     </select>
                 </span>
                 <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="ml-2 my-2 d-inline-block text-right">


### PR DESCRIPTION
Here is the bug fix report for issue [1629](https://github.com/decred/dcrdata/issues/1629)
- Removed the pagination option for maximum number of rows per page with less than 10 rows, because it was greyed out and not selectable.
- Ordered the pagination options for maximum number of rows per page numerically.
- Removed the 144 rows per page on pagination options, to prevent overlapping of windows.

___OTHER BUGS ENCOUNTERED___

___Incorrect rows count on /years page___

_Steps to reproduce_:
Go to the table's top right on the [/years](https://explorer.planetdecred.org/years) page.
_Expected result_:
`1 – 5 of 5 rows` due to the 5 rows available.
_Actual result_:
`1 – 5 of 4 rows` despite having 5 rows.
_Cause_:
Data categorized per year which does not align with count of years since the first block was mined in Decred
_Solution_:
Increment row count by 1  on the period between `01-01` and `02-08` of every year.



___Table is broken on the last page of /blocks___

_Steps to reproduce_:
Click the last page of the table on [/blocks](https://explorer.planetdecred.org/blocks) page
_Expected result_:
To show the correct number of rows and highlight the last page as active
_Actual result_:
Shows incorrect number of rows and highlights the second last page as active
_Cause_:
Serverside logic getting faulty when getting records to be displayed in the last page of the table
_Solution_:
Rewrote part of the logic to get the correct number rows to be queried from database.