### PR TITLE
explorer,views: fix charts page target ticket pool size

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -340,7 +340,7 @@ func New(cfg *ExplorerConfig) *explorerUI {
 				MeanVotingBlocks: exp.MeanVotingBlocks,
 			},
 			PoolInfo: types.TicketPoolInfo{
-				Target: exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock,
+				Target: uint32(exp.ChainParams.TicketPoolSize) * uint32(exp.ChainParams.TicketsPerBlock),
 			},
 		},
 	}
@@ -492,7 +492,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.HomeInfo.PoolInfo = types.TicketPoolInfo{}
 	if blockData.PoolInfo != nil {
-		tpTarget := exp.ChainParams.TicketPoolSize * exp.ChainParams.TicketsPerBlock
+		tpTarget := uint32(exp.ChainParams.TicketPoolSize) * uint32(exp.ChainParams.TicketsPerBlock)
 		p.HomeInfo.PoolInfo = types.TicketPoolInfo{
 			Size:          blockData.PoolInfo.Size,
 			Value:         blockData.PoolInfo.Value,

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1447,12 +1447,18 @@ func (exp *explorerUI) DecodeTxPage(w http.ResponseWriter, r *http.Request) {
 
 // Charts handles the charts displays showing the various charts plotted.
 func (exp *explorerUI) Charts(w http.ResponseWriter, r *http.Request) {
+	exp.pageData.RLock()
+	tpSize := exp.pageData.HomeInfo.PoolInfo.Target
+	exp.pageData.RUnlock()
+
 	str, err := exp.templates.exec("charts", struct {
 		*CommonPageData
-		Premine int64
+		Premine        int64
+		TargetPoolSize uint32
 	}{
 		CommonPageData: exp.commonData(r),
 		Premine:        exp.premine,
+		TargetPoolSize: tpSize,
 	})
 	if err != nil {
 		log.Errorf("Template execute failure: %v", err)

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -859,7 +859,7 @@ type TicketPoolInfo struct {
 	Value         float64 `json:"value"`
 	ValAvg        float64 `json:"valavg"`
 	Percentage    float64 `json:"percent"`
-	Target        uint16  `json:"target"`
+	Target        uint32  `json:"target"`
 	PercentTarget float64 `json:"percent_target"`
 }
 

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -123,7 +123,7 @@ func NewPubSubHub(dataSource wsDataSource) (*PubSubHub, error) {
 				MeanVotingBlocks: txhelpers.CalcMeanVotingBlocks(params),
 			},
 			PoolInfo: exptypes.TicketPoolInfo{
-				Target: params.TicketPoolSize * params.TicketsPerBlock,
+				Target: uint32(params.TicketPoolSize) * uint32(params.TicketsPerBlock),
 			},
 		},
 		// BlockInfo and BlockchainInfo are set by Store()
@@ -664,7 +664,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{}
 	if blockData.PoolInfo != nil {
-		tpTarget := psh.params.TicketPoolSize * psh.params.TicketsPerBlock
+		tpTarget := uint32(psh.params.TicketPoolSize) * uint32(psh.params.TicketsPerBlock)
 		p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{
 			Size:          blockData.PoolInfo.Size,
 			Value:         blockData.PoolInfo.Value,

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -5,7 +5,7 @@
     {{template "navbar" . }}
 
     <div data-controller="charts"
-         data-charts-tps="{{.ChainParams.TicketExpiry}}"
+         data-charts-tps="{{.TargetPoolSize}}"
          data-charts-svh="{{.ChainParams.StakeValidationHeight}}"
          data-charts-pos="{{.ChainParams.StakeRewardProportion}}"
          data-charts-premine="{{.Premine}}"


### PR DESCRIPTION
This fixes the charts page's target ticket pool size, which was showing ticket expiry in blocks. This must have slipped in because on mainnet these are equal values although their units are different and need not be the same value.

In `(*explorerUI).Charts` get target pool size from `exp.pageData.HomeInfo.PoolInfo.Target`, and pass to page template.

`explorer/types`: change `TicketPoolInfo.Target` from `uint16` to `uint32`.