### PR TITLE
Mix chart tweaks

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -420,7 +420,6 @@ type ChartData struct {
 	Blocks       *zoomSet
 	Windows      *windowSet
 	Days         *zoomSet
-	chainParams  *chaincfg.Params
 	cacheMtx     sync.RWMutex
 	cache        map[string]*cachedChart
 	updaters     []ChartUpdater
@@ -892,7 +891,6 @@ func NewChartData(ctx context.Context, height uint32, chainParams *chaincfg.Para
 		Blocks:       newBlockSet(size),
 		Windows:      newWindowSet(windows),
 		Days:         newDaySet(days),
-		chainParams:  chainParams,
 		cache:        make(map[string]*cachedChart),
 		updaters:     make([]ChartUpdater, 0),
 	}

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -551,11 +551,11 @@ export default class extends Controller {
 
       case 'coin-supply': // supply graph
         d = circulationFunc(data)
-        assign(gOptions, mapDygraphOptions(d.data, [xlabel, 'Coin Supply', 'Inflation Limit', 'Coinjoins'],
+        assign(gOptions, mapDygraphOptions(d.data, [xlabel, 'Coin Supply', 'Inflation Limit', 'Mix Rate'],
           true, 'Coin Supply (DCR)', true, false))
         gOptions.y2label = 'Inflation Limit'
-        gOptions.y3label = 'Coinjoins'
-        gOptions.series = { 'Inflation Limit': { axis: 'y2' }, 'Coinjoins': { axis: 'y3' } }
+        gOptions.y3label = 'Mix Rate'
+        gOptions.series = { 'Inflation Limit': { axis: 'y2' }, 'Mix Rate': { axis: 'y3' } }
         this.visibility = [true, true, this.anonymitySetTarget.checked]
         gOptions.visibility = this.visibility
         gOptions.series = {
@@ -564,7 +564,7 @@ export default class extends Controller {
             color: '#888',
             strokeWidth: 1.5
           },
-          'Coinjoins': {
+          'Mix Rate': {
             color: '#2dd8a3'
           }
         }
@@ -574,15 +574,15 @@ export default class extends Controller {
           var change = 0
           if (i < d.inflation.length) {
             const supply = data.series[0].y
-            let predicted = d.inflation[i]
-            let unminted = predicted - data.series[0].y
-            change = ((unminted / predicted) * 100).toFixed(2)
-            div.appendChild(legendEntry(`${legendMarker()} Unminted: ${intComma(unminted)} DCR (${change}%)`))
             if (this.anonymitySetTarget.checked) {
               const mixed = data.series[2].y
               const mixedPercentage = ((mixed / supply) * 100).toFixed(2)
               div.appendChild(legendEntry(`${legendMarker()} Mixed: ${intComma(mixed)} DCR (${mixedPercentage}%)`))
             }
+            let predicted = d.inflation[i]
+            let unminted = predicted - data.series[0].y
+            change = ((unminted / predicted) * 100).toFixed(2)
+            div.appendChild(legendEntry(`${legendMarker()} Unminted: ${intComma(unminted)} DCR (${change}%)`))
           }
         }
         break
@@ -595,7 +595,7 @@ export default class extends Controller {
       case 'privacy-participation': // anonymity set graph
         d = anonymitySetFunc(data)
         this.customLimits = d.limits
-        const label = 'Coinjoins'
+        const label = 'Mix Rate'
         assign(gOptions, mapDygraphOptions(d.data, [xlabel, label], false, `${label} (DCR)`, true, false))
 
         yFormatter = (div, data, i) => {

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -188,7 +188,7 @@
                             </li>
                             <li class="nav-item">
                                 <label class="customcheck mx-2 d-inline-flex"
-                                    data-target="charts.vSelectorItem" data-charts="coin-supply">Anonymity Set
+                                    data-target="charts.vSelectorItem" data-charts="coin-supply">Mixed Coins
                                     <input
                                         type="checkbox"
                                         data-action="click->charts#setVisibility"


### PR DESCRIPTION
This removes the unused chainparams field that, and tweaks some chart wording:
- Anonymity Set -> Mixed Coins (as per matrix discussion)
- Coinjoins y axis label -> Mix Rate