### PR TITLE
Fix chart loading indicator spinning forever

### DIFF
--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -227,7 +227,7 @@ export default class extends Controller {
 
   bindElements () {
     this.flowBoxes = this.flowTarget.querySelectorAll('input')
-    // pagesizeTarget is not available for addresses without txns
+    // pagesizeTarget is not available for dummy addresses
     this.pageSizeOptions = this.data.get('isDummy') === 'false' ? this.pagesizeTarget.querySelectorAll('option') : []
     this.zoomButtons = this.zoomTarget.querySelectorAll('button')
     this.binputs = this.intervalTarget.querySelectorAll('button')

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -228,7 +228,7 @@ export default class extends Controller {
   bindElements () {
     this.flowBoxes = this.flowTarget.querySelectorAll('input')
     // pagesizeTarget is not available for dummy addresses
-    this.pageSizeOptions = this.data.get('isDummy') === 'false' ? this.pagesizeTarget.querySelectorAll('option') : []
+    this.pageSizeOptions = this.hasPagesizeTarget ? this.pagesizeTarget.querySelectorAll('option') : []
     this.zoomButtons = this.zoomTarget.querySelectorAll('button')
     this.binputs = this.intervalTarget.querySelectorAll('button')
   }

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -227,7 +227,8 @@ export default class extends Controller {
 
   bindElements () {
     this.flowBoxes = this.flowTarget.querySelectorAll('input')
-    this.pageSizeOptions = this.pagesizeTarget.querySelectorAll('option')
+    // pagesizeTarget is not available for addresses without txns
+    this.pageSizeOptions = this.data.get('isDummy') === 'false' ? this.pagesizeTarget.querySelectorAll('option') : []
     this.zoomButtons = this.zoomTarget.querySelectorAll('button')
     this.binputs = this.intervalTarget.querySelectorAll('button')
   }

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -13,7 +13,6 @@
       data-address-dcraddress="{{.Address}}"
       data-address-txn-count="{{$TxnCount}}"
       data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"
-      data-address-is-dummy="{{.IsDummyAddress}}"
     >
     <div class="fullscreen d-none" data-target="address.fullscreen" data-action="click->address#exitFullscreen">
       <div class="secondary-card d-inline-block w-100 h-100 p-4" data-target="address.bigchart"></div>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -13,6 +13,7 @@
       data-address-dcraddress="{{.Address}}"
       data-address-txn-count="{{$TxnCount}}"
       data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"
+      data-address-is-dummy="{{.IsDummyAddress}}"
     >
     <div class="fullscreen d-none" data-target="address.fullscreen" data-action="click->address#exitFullscreen">
       <div class="secondary-card d-inline-block w-100 h-100 p-4" data-target="address.bigchart"></div>


### PR DESCRIPTION
Closes #1684 
 
This PR resolved the issue of chart loading indicator spinning forever on dummy address pages.
![image](https://user-images.githubusercontent.com/11990092/74325693-57602b00-4d89-11ea-870c-4d3a5b44f61a.png)

