### PR TITLE
Show double-digit numbers for non-leading time units

### DIFF
--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -140,7 +140,7 @@ var humanize = {
     }
     var pad = function (x) {
       if (x < 10) {
-        return `0${x}`
+        return `&nbsp${x}`
       }
       return x
     }

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -138,25 +138,31 @@ var humanize = {
       }
       return result
     }
+    var pad = function (x) {
+      if (x < 10) {
+        return `0${x}`
+      }
+      return x
+    }
     interval = Math.floor(seconds / 3600)
     if (interval >= 1) {
       let extra = Math.floor((seconds - interval * 3600) / 60)
       let result = interval + 'h'
       if (extra > 0) {
-        result = result + ' ' + extra + 'm'
+        result = result + ' ' + pad(extra) + 'm'
       }
       return result
     }
     interval = Math.floor(seconds / 60)
     if (interval >= 1) {
       let extra = seconds - interval * 60
-      let result = interval + 'm'
+      let result = pad(interval) + 'm'
       if (extra > 0) {
-        result = result + ' ' + extra + 's'
+        result = result + ' ' + pad(extra) + 's'
       }
       return result
     }
-    return Math.floor(seconds) + 's'
+    return pad(Math.floor(seconds)) + 's'
   },
   date: function (stamp, withTimezone) {
     var d = new Date(stamp)

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -139,10 +139,7 @@ var humanize = {
       return result
     }
     var pad = function (x) {
-      if (x < 10) {
-        return `&nbsp${x}`
-      }
-      return x
+      return x.toString().padStart(2, '\u00a0')
     }
     interval = Math.floor(seconds / 3600)
     if (interval >= 1) {


### PR DESCRIPTION
Closes #1682 

This PR adds 0 to the left of minute and second time units that are less than 10.
![image](https://user-images.githubusercontent.com/11990092/74327644-d30fa700-4d8c-11ea-8b25-528c878c5a35.png)
