### PR TITLE
Show date in YYYY-MM-DD format on chart legends

### DIFF
--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -53,7 +53,11 @@ function amountFlowProcessor (d, binSize) {
 }
 
 function formatter (data) {
-  var html = this.getLabels()[0] + ': ' + ((data.xHTML === undefined) ? '' : data.xHTML)
+  var xHTML = ''
+  if (data.xHTML !== undefined) {
+    xHTML = humanize.date(data.x, false, true)
+  }
+  var html = this.getLabels()[0] + ': ' + xHTML
   data.series.map((series) => {
     if (series.color === undefined) return ''
     // Skip display of zeros
@@ -66,7 +70,11 @@ function formatter (data) {
 }
 
 function customizedFormatter (data) {
-  var html = this.getLabels()[0] + ': ' + ((data.xHTML === undefined) ? '' : data.xHTML)
+  var xHTML = ''
+  if (data.xHTML !== undefined) {
+    xHTML = humanize.date(data.x, false, true)
+  }
+  var html = this.getLabels()[0] + ': ' + xHTML
   data.series.map((series) => {
     if (series.color === undefined) return ''
     // Skip display of zeros

--- a/public/js/controllers/agenda_controller.js
+++ b/public/js/controllers/agenda_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from 'stimulus'
 import { barChartPlotter } from '../helpers/chart_helper'
 import { getDefault } from '../helpers/module_helper'
+import humanize from '../helpers/humanize_helper'
 import axios from 'axios'
 
 var chartLayout = {
@@ -17,7 +18,12 @@ var chartLayout = {
 
 function agendasLegendFormatter (data) {
   if (data.x == null) return ''
-  var html = this.getLabels()[0] + ': ' + data.xHTML
+  var html
+  if (this.getLabels()[0] === 'Date') {
+    html = this.getLabels()[0] + ':' + humanize.date(data.x)
+  } else {
+    html = this.getLabels()[0] + ': ' + data.xHTML
+  }
   var total = data.series.reduce((total, n) => {
     return total + n.y
   }, 0)

--- a/public/js/controllers/agenda_controller.js
+++ b/public/js/controllers/agenda_controller.js
@@ -20,7 +20,7 @@ function agendasLegendFormatter (data) {
   if (data.x == null) return ''
   var html
   if (this.getLabels()[0] === 'Date') {
-    html = this.getLabels()[0] + ':' + humanize.date(data.x)
+    html = this.getLabels()[0] + ': ' + humanize.date(data.x)
   } else {
     html = this.getLabels()[0] + ': ' + data.xHTML
   }

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -106,7 +106,7 @@ function legendFormatter (data) {
   var div = document.createElement('div')
   var xHTML = data.xHTML
   if (data.dygraph.getLabels()[0] === 'Date') {
-    xHTML = humanize.date(data.x)
+    xHTML = humanize.date(data.x, false, selectedChart !== 'ticket-price')
   }
   div.appendChild(legendEntry(`${data.dygraph.getLabels()[0]}: ${xHTML}`))
   yFormatter(div, data, data.dygraph.getOption('legendIndex'))

--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -9,6 +9,7 @@ import TurboQuery from '../helpers/turbolinks_helper'
 import globalEventBus from '../services/event_bus_service'
 import { isEqual } from '../helpers/chart_helper'
 import dompurify from 'dompurify'
+import humanize from '../helpers/humanize_helper'
 
 var selectedChart
 let Dygraph // lazy loaded on connect
@@ -103,7 +104,11 @@ function legendFormatter (data) {
   if (data.x == null) return legendElement.classList.add('d-hide')
   legendElement.classList.remove('d-hide')
   var div = document.createElement('div')
-  div.appendChild(legendEntry(`${data.dygraph.getLabels()[0]}: ${data.xHTML}`))
+  var xHTML = data.xHTML
+  if (data.dygraph.getLabels()[0] === 'Date') {
+    xHTML = humanize.date(data.x)
+  }
+  div.appendChild(legendEntry(`${data.dygraph.getLabels()[0]}: ${xHTML}`))
   yFormatter(div, data, data.dygraph.getOption('legendIndex'))
   dompurify.sanitize(div, { IN_PLACE: true, FORBID_TAGS: ['svg', 'math'] })
   return div.innerHTML

--- a/public/js/controllers/proposal_controller.js
+++ b/public/js/controllers/proposal_controller.js
@@ -6,6 +6,7 @@ import { getDefault } from '../helpers/module_helper'
 import { multiColumnBarPlotter, synchronize } from '../helpers/chart_helper'
 import dompurify from 'dompurify'
 import axios from 'axios'
+import humanize from '../helpers/humanize_helper'
 
 let common = {
   labelsKMB: true,
@@ -68,7 +69,7 @@ function legendFormatter (data) {
         series.color + ';">' + series.labelHTML + ' </span> '
     }).join('')
   } else {
-    html = this.getLabels()[0] + ': ' + data.xHTML + ' UTC &nbsp;&nbsp;'
+    html = this.getLabels()[0] + ': ' + humanize.date(data.x) + ' UTC &nbsp;&nbsp;'
     data.series.forEach(function (series, index) {
       if (!series.isVisible) return
 

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -158,10 +158,10 @@ var humanize = {
     }
     return Math.floor(seconds) + 's'
   },
-  date: function (stamp, withTimezone) {
+  date: function (stamp, withTimezone, hideHisForMidnight) {
     var d = new Date(stamp)
     var dateStr = `${String(d.getUTCFullYear())}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
-    if (d.getUTCHours() > 0 || d.getUTCMinutes() > 0 || d.getUTCSeconds() > 0) {
+    if (!hideHisForMidnight) {
       dateStr += ` ${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')}`
     }
     if (withTimezone) dateStr += ' (UTC)'

--- a/public/js/helpers/humanize_helper.js
+++ b/public/js/helpers/humanize_helper.js
@@ -160,8 +160,10 @@ var humanize = {
   },
   date: function (stamp, withTimezone) {
     var d = new Date(stamp)
-    var dateStr = `${String(d.getUTCFullYear())}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')} ` +
-          `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')}`
+    var dateStr = `${String(d.getUTCFullYear())}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
+    if (d.getUTCHours() > 0 || d.getUTCMinutes() > 0 || d.getUTCSeconds() > 0) {
+      dateStr += ` ${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')}`
+    }
     if (withTimezone) dateStr += ' (UTC)'
     return dateStr
   },


### PR DESCRIPTION
Closes #1681 
This PR updated the legend formatter of the chart on all the pages to show date in YYYY-MM-DD format. This include the charts on the main chart page, address, proposal and agenda page.
![image](https://user-images.githubusercontent.com/11990092/74338083-d2cdd680-4da1-11ea-88a4-2b636631561d.png)

huminzie.date function is updated to accept a third parameter for hiding the H:i:s part of the date string
