### PR TITLE
supply only

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,12 +676,13 @@ Exchange monitoring is off by default. Server must be started with
 The server will set a default currency code. To use a different code, pass URL
 parameter `?code=[code]`. For example, `/exchanges?code=EUR`.
 
-| Other                           | Path            | Type               |
-| ------------------------------- | --------------- | ------------------ |
-| Status                          | `/status`       | `types.Status`     |
-| Health (HTTP 200 or 503)        | `/status/happy` | `types.Happy`     |
-| Coin Supply                     | `/supply`       | `types.CoinSupply` |
-| Endpoint list (always indented) | `/list`         | `[]string`         |
+| Other                           | Path                                          | Type                                    |
+| ------------------------------- | --------------------------------------------- | --------------------------------------- |
+| Status                          | `/status`                                     | `types.Status`                          |
+| Health (HTTP 200 or 503)        | `/status/happy`                               | `types.Happy`                           |
+| Coin Supply                     | `/supply`                                     | `types.CoinSupply`                      |
+| Coin Supply Circulating (Mined) | `/supply/circulating?dcr=[true\|false]`       | `int` (default) or `float` (`dcr=true`) |
+| Endpoint list (always indented) | `/list`                                       | `[]string`                              |
 
 All JSON endpoints accept the URL query `indent=[true|false]`. For example,
 `/stake/diff?indent=true`. By default, indentation is off. The characters to use

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -39,7 +39,7 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 	mux.Get("/status", app.status)
 	mux.Get("/status/happy", app.statusHappy)
 	mux.Get("/supply", app.coinSupply)
-	mux.Get("/supply/now", app.coinSupplyCirculating)
+	mux.Get("/supply/circulating", app.coinSupplyCirculating)
 
 	compMiddleware := m.Next
 	if compressLarge {

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -39,6 +39,7 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 	mux.Get("/status", app.status)
 	mux.Get("/status/happy", app.statusHappy)
 	mux.Get("/supply", app.coinSupply)
+	mux.Get("/supply/now", app.coinSupplyCirculating)
 
 	compMiddleware := m.Next
 	if compressLarge {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -371,6 +371,17 @@ func (c *appContext) coinSupply(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, supply, m.GetIndentCtx(r))
 }
 
+func (c *appContext) coinSupplyCirculating(w http.ResponseWriter, r *http.Request) {
+	supply := c.DataSource.CurrentCoinSupply()
+	if supply == nil {
+		apiLog.Error("Unable to get coin supply.")
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSONBytes(w, []byte(strconv.Itoa(int(supply.Mined))))
+}
+
 func (c *appContext) currentHeight(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	if _, err := io.WriteString(w, strconv.Itoa(int(c.Status.Height()))); err != nil {

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/dcrutil/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/rpcclient/v5"
 	"github.com/decred/dcrd/wire"
@@ -372,6 +373,16 @@ func (c *appContext) coinSupply(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *appContext) coinSupplyCirculating(w http.ResponseWriter, r *http.Request) {
+	var dcr bool
+	if dcrParam := r.URL.Query().Get("dcr"); dcrParam != "" {
+		var err error
+		dcr, err = strconv.ParseBool(dcrParam)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+	}
+
 	supply := c.DataSource.CurrentCoinSupply()
 	if supply == nil {
 		apiLog.Error("Unable to get coin supply.")
@@ -379,7 +390,13 @@ func (c *appContext) coinSupplyCirculating(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeJSONBytes(w, []byte(strconv.Itoa(int(supply.Mined))))
+	if dcr {
+		coinSupply := dcrutil.Amount(supply.Mined).ToCoin()
+		writeJSONBytes(w, []byte(strconv.FormatFloat(coinSupply, 'f', 8, 64)))
+		return
+	}
+
+	writeJSONBytes(w, []byte(strconv.FormatInt(supply.Mined, 10)))
 }
 
 func (c *appContext) currentHeight(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
This adds the `/api/supply/circulating` endpoint with the optional `dcr=[true|false]` URL query (default is false, meaning atoms).

Because CMC needs a number not some silly JSON thign.

```
$  curl http://127.0.0.1:7777/api/supply/circulating
1134639036687827
$  curl http://127.0.0.1:7777/api/supply/circulating?dcr=false
1134639036687827
$  curl http://127.0.0.1:7777/api/supply/circulating?dcr=true
11346390.36687827
```