### PR TITLE
Fix ticket window end block and block count.

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -134,6 +134,7 @@ const (
 		COUNT(*) AS blocks_count
 		FROM blocks
 		WHERE height BETWEEN $2 AND $3
+			AND is_mainchain
 		GROUP BY window_start
 		ORDER BY window_start DESC;`
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1057,7 +1057,7 @@ func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHe
 			return nil, err
 		}
 
-		endBlock := startBlock + windowSize
+		endBlock := startBlock + windowSize - 1
 		index := dbtypes.CalculateWindowIndex(endBlock, windowSize)
 
 		data = append(data, &dbtypes.BlocksGroupedInfo{

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -23,7 +23,7 @@
 ;dcrdcert=/home/me/.dcrd/rpc.cert
 ;nodaemontls=0
 
-; The interface and protocol used by the web interface an HTTP API.
+; The interface and protocol used by the web interface and HTTP API.
 ;apilisten=127.0.0.1:7777
 ;apiproto=http
 

--- a/views/windows.tmpl
+++ b/views/windows.tmpl
@@ -109,15 +109,14 @@
                       <th class="text-center d-none d-sm-table-cell">Difficulty</th>
                       <th class="text-center"><span class="d-none d-sm-inline">Ticket </span>Price<span class="d-none d-sm-inline"> (DCR)</span></th>
                       <th class="text-right pr-0 jsonly">Age</th>
-                      <th class="text-right pr-0 d-none d-sm-table-cell">Start Time</th>
+                      <th class="text-right pr-0 d-none d-sm-table-cell">Start Time (UTC)</th>
                   </tr>
               </thead>
               <tbody>
               {{range .Data}}
                   <tr>
                       <td class="text-left pl-0">
-                          {{$blocksCount := (.BlocksCount)}}
-                          {{if lt .BlocksCount $.WindowSize}}{{$blocksCount = (subtract .BlocksCount 1)}} <span>({{$blocksCount}}/{{$.WindowSize}}) </span>{{end}}
+                          {{if lt .BlocksCount $.WindowSize}} <span>({{.BlocksCount}}/{{$.WindowSize}}) </span>{{end}}
                           <span>{{.IndexVal}}</span>
                       </td>
                       <td class="text-center">
@@ -132,7 +131,7 @@
                       <td class="text-center d-none d-sm-table-cell">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</td>
                       <td class="text-center">{{printf "%.2f" (toFloat64Amount .TicketPrice)}}</td>
                       <td class="text-right pr-0 jsonly" data-controller="time" data-target="time.age" data-age="{{.StartTime.UNIX}}"></td>
-                      <td class="text-right pr-0 d-none d-sm-table-cell">{{.StartTime}}</td>
+                      <td class="text-right pr-0 d-none d-sm-table-cell">{{.StartTime.DatetimeWithoutTZ}}</td>
                   </tr>
               {{end}}
               </tbody>


### PR DESCRIPTION
A ticket window ends when `(height + 1) % window_size == 0`;
Orphaned blocks should be excluded from ticket window block count in `/ticketpricewindows`.

![window](https://user-images.githubusercontent.com/11244180/75975027-bfcaa400-5f12-11ea-9cb9-48b164e654b5.png)