### PR TITLE
8-decimals notation on fee rate in mempool tickets and transactions

### DIFF
--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -184,7 +184,7 @@
                                     {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
                                   </td>
                                   <td class="mono fs15 text-right">{{.Size}} B</td>
-                                  <td class="mono fs15 text-right">{{.FeeRate}} DCR/kB</td>
+                                  <td class="mono fs15 text-right">{{printf "%.8f" (.FeeRate)}} DCR/kB</td>
                                   <td class="mono fs15 text-right" data-target="time.age" data-age="{{.Time}}"></td>
                               </tr>
                               {{end}}
@@ -260,7 +260,7 @@
                                     {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
                                   </td>
                                   <td class="mono fs15 text-right">{{.Size}} B</td>
-                                  <td class="mono fs15 text-right">{{.FeeRate}} DCR/kB</td>
+                                  <td class="mono fs15 text-right">{{printf "%.8f" (.FeeRate)}} DCR/kB</td>
                                   <td class="mono fs15 text-right" data-target="time.age" data-age="{{.Time}}"></td>
                               </tr>
                               {{end}}


### PR DESCRIPTION
Fix for [#1680](https://github.com/decred/dcrdata/issues/1680)
mempool: small fee rate are displayed in scientific notation instead of the standard 8-decimal notation

_Steps to reproduce_
Go to [mempool](https://explorer.planetdecred.org/mempool) page
_Expected results_
Standard 8-decimal notations for fee rate
_Actual results_
Scientific notations for small fee rates.
_Cause_
The fee rates not being rounded up to 8-decimal notations
_Solution_
Rounded the fee rates to 8-decimal notations