### PR TITLE
Force UTC timezone and fix day links in time-based block list.

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -138,7 +138,7 @@ const (
 		GROUP BY window_start
 		ORDER BY window_start DESC;`
 
-	SelectBlocksTimeListingByLimit = `SELECT date_trunc($1, time) as index_value,
+	SelectBlocksTimeListingByLimit = `SELECT date_trunc($1, time at time zone 'utc') as index_value,
 		MAX(height),
 		SUM(num_rtx) AS txs,
 		SUM(fresh_stake) AS tickets,

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -476,7 +476,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			}
 			return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(path, "/")
 		},
-		"fetchRowLinkURL": func(groupingStr string, start, end time.Time) string {
+		"fetchRowLinkURL": func(groupingStr string, endBlock int64, start, end time.Time) string {
 			// fetchRowLinkURL creates links url to be used in the blocks list
 			// views in hierarchical order i.e. /years -> /months -> weeks ->
 			// /days -> /blocks (/years -> /months) simply means that on
@@ -506,7 +506,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			intervalVal, err := dbtypes.TimeBasedGroupingToInterval(matchingVal)
 			if err != nil {
 				log.Debugf("Resolving the new group interval failed: error : %v", err)
-				return "/blocks?offset=0&rows=20"
+				return fmt.Sprintf("/blocks?height=%d&rows=20", endBlock)
 			}
 
 			rowsCount := int64(end.Sub(start).Seconds()/intervalVal) + 1

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -89,7 +89,7 @@
           <table class="table v3">
               <thead>
                   <tr>
-                      <th class="text-left pl-0">Start Date</th>
+                      <th class="text-left pl-0">Start Date (UTC)</th>
                       <th class="text-center d-none d-sm-table-cell">
                           <span class="d-none d-md-inline">Regular</span>
                           <span class="d-md-none position-relative" data-tooltip="regular transactions">R</span>
@@ -116,7 +116,7 @@
               {{range .Data}}
                   <tr>
                       <td class="text-left pl-0"
-                        ><a class="fs16 height" data-keynav-priority href="{{fetchRowLinkURL $lowerCaseVal .StartTime.T .EndTime.T}}">{{.FormattedStartTime}}</a>
+                        ><a class="fs16 height" data-keynav-priority href="{{fetchRowLinkURL $lowerCaseVal .EndBlock .StartTime.T .EndTime.T}}">{{.FormattedStartTime}}</a>
                       </td>
                       <td class="text-center d-none d-sm-table-cell">{{intComma .Transactions}}</td>
                       <td class="text-center d-none d-sm-table-cell">{{intComma .Voters}}</td>


### PR DESCRIPTION
Group blocks by UTC datetime regardless of server timezone;
Link day rows to the last block of each day instead of the tip.