### PR TITLE
Allow searching for a transaction outpoint

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1641,10 +1641,10 @@ func (exp *explorerUI) Search(w http.ResponseWriter, r *http.Request) {
 			"", ExpStatusNotFound)
 		return
 	case len(searchStrSplit) > 1:
-		if _, err := strconv.ParseInt(searchStrSplit[1], 10, 0); err == nil {
+		if _, err := strconv.ParseUint(searchStrSplit[1], 10, 32); err == nil {
 			searchStrRewritten = searchStrRewritten + "/out/" + searchStrSplit[1]
 		} else {
-			exp.StatusPage(w, "search failed", "Transaction output index is not a valid integer: "+searchStrSplit[1],
+			exp.StatusPage(w, "search failed", "Transaction output index is not a valid non-negative integer: "+searchStrSplit[1],
 				"", ExpStatusNotFound)
 			return
 		}


### PR DESCRIPTION
Closes #1672

This pull request enables searching for a transaction outpoint formatted as `txid:out` where `txid` is a transaction hash and `out` is a transaction output index. Function `Search` redirects to path `/tx/{txid}/out/{out}` after seeing such search pattern. The transaction page then highlights the corresponding output.