### PR TITLE
api: add address/{address}/exists endpoint

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -167,6 +167,7 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 		r.Route("/{address}", func(rd chi.Router) {
 			rd.Use(m.AddressPathCtx)
 			rd.Get("/totals", app.addressTotals)
+			rd.Get("/exists", app.addressExists)
 			rd.Get("/", app.getAddressTransactions)
 			rd.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
 			rd.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)

--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -163,25 +163,32 @@ func NewAPIRouter(app *appContext, useRealIP, compressLarge bool) apiMux {
 		r.Post("/trimmed", app.getDecodedTransactions)
 	})
 
+	// DO NOT CHANGE maxExistAddrs.
+	// maxExistsAddrs must be <= 64 so that the bit mask can fit into a uint64.
+	const maxExistAddrs = 64
+
 	mux.Route("/address", func(r chi.Router) {
 		r.Route("/{address}", func(rd chi.Router) {
-			rd.Use(m.AddressPathCtx)
-			rd.Get("/totals", app.addressTotals)
-			rd.Get("/exists", app.addressExists)
-			rd.Get("/", app.getAddressTransactions)
-			rd.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
-			rd.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)
-			rd.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
-			rd.Route("/count/{N}", func(ri chi.Router) {
-				ri.Use(m.NPathCtx)
-				ri.Get("/", app.getAddressTransactions)
-				ri.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
-				ri.Route("/skip/{M}", func(rj chi.Router) {
-					rj.Use(m.MPathCtx)
-					rj.Get("/", app.getAddressTransactions)
-					rj.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
+			rd.With(m.AddressPathCtxN(maxExistAddrs)).Get("/exists", app.addressExists)
+			rd.Group(func(re chi.Router) {
+				re.Use(m.AddressPathCtxN(1))
+				re.Get("/totals", app.addressTotals)
+				re.Get("/", app.getAddressTransactions)
+				re.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
+				re.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)
+				re.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
+				re.Route("/count/{N}", func(ri chi.Router) {
+					ri.Use(m.NPathCtx)
+					ri.Get("/", app.getAddressTransactions)
+					ri.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
+					ri.Route("/skip/{M}", func(rj chi.Router) {
+						rj.Use(m.MPathCtx)
+						rj.Get("/", app.getAddressTransactions)
+						rj.With(compMiddleware).Get("/raw", app.getAddressTransactionsRaw)
+					})
 				})
 			})
+
 		})
 	})
 
@@ -279,7 +286,7 @@ func NewFileRouter(app *appContext, useRealIP bool) fileMux {
 	mux.Route("/address", func(rd chi.Router) {
 		// Allow browser cache for 3 minutes.
 		rd.Use(m.CacheControl(180))
-		rd.With(m.AddressPathCtx).Get("/io/{address}", app.addressIoCsv)
+		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}", app.addressIoCsv)
 	})
 
 	return fileMux{mux}

--- a/api/apiroutes.go
+++ b/api/apiroutes.go
@@ -37,15 +37,9 @@ import (
 	appver "github.com/decred/dcrdata/v5/version"
 )
 
-const (
-	// maxBlockRangeCount is the maximum number of blocks that can be requested at
-	// once.
-	maxBlockRangeCount = 1000
-
-	// maxExistsAddrs is the highest number of addresses accepted to the
-	// address/{address}/exists request.
-	maxExistAddrs = 64
-)
+// maxBlockRangeCount is the maximum number of blocks that can be requested at
+// once.
+const maxBlockRangeCount = 1000
 
 // DataSource specifies an interface for advanced data collection using the
 // auxiliary DB (e.g. PostgreSQL).
@@ -1719,7 +1713,7 @@ func (c *appContext) addressTotals(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -1751,7 +1745,7 @@ func (c *appContext) addressExists(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	addresses, err := m.GetAddressRawCtx(r, c.Params, maxExistAddrs)
+	addresses, err := m.GetAddressRawCtx(r, c.Params)
 	if err != nil {
 		apiLog.Errorf("addressExists rejecting request: %v", err)
 		http.Error(w, "address parsing error", http.StatusBadRequest)
@@ -1791,7 +1785,7 @@ func (c *appContext) addressIoCsv(w http.ResponseWriter, r *http.Request) {
 		useCRLF = b
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
@@ -1825,7 +1819,7 @@ func (c *appContext) getAddressTxTypesData(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -1861,7 +1855,7 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -1957,7 +1951,7 @@ func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return
@@ -1996,7 +1990,7 @@ func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	addresses, err := m.GetAddressCtx(r, c.Params, 1)
+	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
 		http.Error(w, http.StatusText(422), 422)
 		return

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -24,7 +24,7 @@ const APIVersion = 0
 
 // NewInsightApiRouter returns a new HTTP path router, ApiMux, for the Insight
 // API, app.
-func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
+func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool, maxAddrs int) ApiMux {
 	// chi router
 	mux := chi.NewRouter()
 
@@ -74,10 +74,13 @@ func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
 	mux.With(NbBlocksCtx).Get("/utils/estimatefee", app.getEstimateFee)
 	mux.Get("/peer", app.GetPeerStatus)
 
+	addrs1Ctx := m.AddressPathCtxN(1)
+	addrsMaxCtx := m.AddressPathCtxN(maxAddrs)
+
 	// Addresses endpoints
 	mux.Route("/addrs", func(rd chi.Router) {
 		rd.Route("/{address}", func(ra chi.Router) {
-			ra.Use(m.AddressPathCtx, FromToPaginationCtx)
+			ra.Use(addrsMaxCtx, FromToPaginationCtx)
 			ra.Get("/txs", app.getAddressesTxn)
 			ra.Get("/utxo", app.getAddressesTxnOutput)
 		})
@@ -90,11 +93,10 @@ func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool) ApiMux {
 
 	// Address endpoints
 	mux.Route("/addr/{address}", func(rd chi.Router) {
-		rd.Use(m.AddressPathCtx)
-		rd.With(FromToPaginationCtx, NoTxListCtx).Get("/", app.getAddressInfo)
-		rd.Get("/utxo", app.getAddressesTxnOutput)
+		rd.With(addrs1Ctx, FromToPaginationCtx, NoTxListCtx).Get("/", app.getAddressInfo)
+		rd.With(addrsMaxCtx).Get("/utxo", app.getAddressesTxnOutput)
 		rd.Route("/{command}", func(ra chi.Router) {
-			ra.With(AddressCommandCtx).Get("/", app.getAddressInfo)
+			ra.With(addrs1Ctx, AddressCommandCtx).Get("/", app.getAddressInfo)
 		})
 	})
 

--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -78,14 +78,13 @@ type InsightApi struct {
 	status          *apitypes.Status
 	JSONIndent      string
 	ReqPerSecLimit  float64
-	maxCSVAddrs     int
 	inflightUTXOs   int64
 	inflightLimiter sync.Mutex
 }
 
 // NewInsightApi is the constructor for InsightApi.
 func NewInsightApi(client *rpcclient.Client, blockData BlockDataSource, params *chaincfg.Params,
-	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, maxAddrs int, status *apitypes.Status) *InsightApi {
+	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, status *apitypes.Status) *InsightApi {
 
 	newContext := InsightApi{
 		nodeClient:     client,
@@ -94,7 +93,6 @@ func NewInsightApi(client *rpcclient.Client, blockData BlockDataSource, params *
 		mp:             memPoolData,
 		status:         status,
 		ReqPerSecLimit: defaultReqPerSecLimit,
-		maxCSVAddrs:    maxAddrs,
 	}
 	return &newContext
 }
@@ -343,7 +341,7 @@ func (iapi *InsightApi) broadcastTransactionRaw(w http.ResponseWriter, r *http.R
 }
 
 func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, iapi.params, iapi.maxCSVAddrs) // Required
+	addresses, err := m.GetAddressCtx(r, iapi.params) // Required
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
@@ -560,7 +558,7 @@ func removeSliceElements(txOuts []*apitypes.AddressTxnOutput, inds []int) []*api
 func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) {
 	pageNum := m.GetPageNumCtx(r)
 	hash, blockerr := m.GetBlockHashCtx(r)
-	addresses, addrerr := m.GetAddressCtx(r, iapi.params, 1)
+	addresses, addrerr := m.GetAddressCtx(r, iapi.params)
 
 	if blockerr != nil && addrerr != nil {
 		msg := fmt.Sprintf(`Required query parameters (address or block) not present. `+
@@ -768,7 +766,7 @@ func (iapi *InsightApi) getTransactions(w http.ResponseWriter, r *http.Request) 
 }
 
 func (iapi *InsightApi) getAddressesTxn(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, iapi.params, iapi.maxCSVAddrs) // Required
+	addresses, err := m.GetAddressCtx(r, iapi.params) // Required
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return
@@ -1154,7 +1152,7 @@ func (iapi *InsightApi) getBlockSummaryByTime(w http.ResponseWriter, r *http.Req
 }
 
 func (iapi *InsightApi) getAddressInfo(w http.ResponseWriter, r *http.Request) {
-	addresses, err := m.GetAddressCtx(r, iapi.params, 1)
+	addresses, err := m.GetAddressCtx(r, iapi.params)
 	if err != nil {
 		writeInsightError(w, err.Error())
 		return

--- a/main.go
+++ b/main.go
@@ -725,9 +725,10 @@ func _main(ctx context.Context) error {
 		r.Mount("/api", apiMux.Mux)
 		// Setup and mount the Insight API.
 		insightApp := insight.NewInsightApi(dcrdClient, chainDB,
-			activeChain, mpm, cfg.IndentJSON, cfg.MaxCSVAddrs, app.Status)
+			activeChain, mpm, cfg.IndentJSON, app.Status)
 		insightApp.SetReqRateLimit(cfg.InsightReqRateLimit)
-		insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP, cfg.CompressAPI)
+		insightMux := insight.NewInsightApiRouter(insightApp, cfg.UseRealIP,
+			cfg.CompressAPI, cfg.MaxCSVAddrs)
 		r.Mount("/insight/api", insightMux.Mux)
 
 		if insightSocketServer != nil {


### PR DESCRIPTION
Provides access to the `existsaddresses` RPC call and parses the result to a `[]bool`. Allows multiple comma-separated addresses to be specified in the same way as the `addrs` insight endpoints. Limited to 64 addresses, mostly because it simplifies parsing and use of the RPC result.

The dcrd address existence index is enabled by default and seems to be quite fast. I did a little DB testing with the query

```
SELECT exists(select 1 from addresses where address = a) FROM unnest(ARRAY[...]) AS a;
```

and it seems to be roughly the same speed on my system and network.