### PR TITLE
charts: add raw data URL to charts page

### DIFF
--- a/public/js/controllers/charts_controller.js
+++ b/public/js/controllers/charts_controller.js
@@ -359,7 +359,8 @@ export default class extends Controller {
       'legendEntry',
       'legendMarker',
       'modeSelector',
-      'modeOption'
+      'modeOption',
+      'rawDataURL'
     ]
   }
 
@@ -639,6 +640,9 @@ export default class extends Controller {
           'Missed Votes per Window', true, false))
         break
     }
+
+    const baseURL = `${this.query.url.protocol}//${this.query.url.host}`
+    this.rawDataURLTarget.textContent = `${baseURL}/api/chart/${chartName}?axis=${this.settings.axis}&bin=${this.settings.bin}`
 
     this.chartsView.plotter_.clear()
     this.chartsView.updateOptions(gOptions, false)

--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -263,6 +263,15 @@
                     </ul>
                 </div>
             </div>
+            <div class="d-flex justify-content-center">
+              <div class="d-flex flex-column align-items-center p-2 px-3 my-2 bg-white">
+                <span class="fs18">JSON-formatted raw data for this chart @</span>
+                <div class="d-inline-block text-center fs15 clipboard py-1">
+                  <span class="text-center" data-target="charts.rawDataURL"></span>
+                  {{template "copyTextIcon"}}
+                </div>
+              </div>
+            </div>
             <div class="spinner-wrapper">
                 <div class="spinner-centerer d-flex align-items-center justify-content-center">
                     <div class="spinner">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -52,5 +52,10 @@ module.exports = {
     filename: 'js/[name].bundle.js',
     path: path.resolve(__dirname, 'public/dist'),
     publicPath: '/dist/'
+  },
+  // Fixes weird issue with watch script. See
+  // https://github.com/webpack/webpack/issues/2297#issuecomment-289291324
+  watchOptions: {
+    poll: true
   }
 }


### PR DESCRIPTION
Also work around bug in npm watch script.

![image](https://user-images.githubusercontent.com/6109680/77694682-781ac380-6f78-11ea-882d-b95e1b60b2a2.png)
