### PR TITLE
Address page pagination rows fix and comma formatting

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1270,6 +1270,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		Data         *dbtypes.AddressInfo
 		CRLFDownload bool
 		FiatBalance  *exchanges.Conversion
+		Pages        []pageNumber
 	}
 
 	// Grab the URL query parameters
@@ -1351,12 +1352,19 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	// endings.
 	UseCRLF := strings.Contains(r.UserAgent(), "Windows")
 
+	linkTemplate := "/address/" + addrData.Address + "?start=%d&n=" + strconv.FormatInt(limitN, 10) + "&txntype=" + fmt.Sprintf("%v", txnType)
+
+	if limitN == 0 {
+		limitN = 20
+	}
+
 	// Execute the HTML template.
 	pageData := AddressPageData{
 		CommonPageData: exp.commonData(r),
 		Data:           addrData,
 		CRLFDownload:   UseCRLF,
 		FiatBalance:    conversion,
+		Pages:          calcPages(int(addrData.TxnCount), int(limitN), int(offsetAddrOuts), linkTemplate),
 	}
 	str, err := exp.templates.exec("address", pageData)
 	if err != nil {
@@ -1392,11 +1400,15 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	linkTemplate := "/address/" + addrData.Address + "?start=%d&n=" + strconv.FormatInt(limitN, 10) + "&txntype=" + fmt.Sprintf("%v", txnType)
+
 	response := struct {
-		TxnCount int64  `json:"tx_count"`
-		HTML     string `json:"html"`
+		TxnCount int64        `json:"tx_count"`
+		HTML     string       `json:"html"`
+		Pages    []pageNumber `json:"pages"`
 	}{
 		TxnCount: addrData.TxnCount + addrData.NumUnconfirmed,
+		Pages:    calcPages(int(addrData.TxnCount), int(limitN), int(offsetAddrOuts), linkTemplate),
 	}
 
 	response.HTML, err = exp.templates.exec("addresstable", struct {
@@ -2206,9 +2218,9 @@ func (exp *explorerUI) commonData(r *http.Request) *CommonPageData {
 // A page number has the information necessary to create numbered pagination
 // links.
 type pageNumber struct {
-	Active bool
-	Link   string
-	Str    string
+	Active bool   `json:"active"`
+	Link   string `json:"link"`
+	Str    string `json:"str"`
 }
 
 func makePageNumber(active bool, link, str string) pageNumber {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1352,11 +1352,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 	// endings.
 	UseCRLF := strings.Contains(r.UserAgent(), "Windows")
 
-	linkTemplate := "/address/" + addrData.Address + "?start=%d&n=" + strconv.FormatInt(limitN, 10) + "&txntype=" + fmt.Sprintf("%v", txnType)
-
 	if limitN == 0 {
 		limitN = 20
 	}
+
+	linkTemplate := fmt.Sprintf("/address/%s?start=%%d&n=%d&txntype=%v", addrData.Address, limitN, txnType)
 
 	// Execute the HTML template.
 	pageData := AddressPageData{

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1437,7 +1437,9 @@ func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTx
 	// Number of outputs for the address to query the database for. The URL
 	// query parameter "n" is used to specify the limit (e.g. "?n=20").
 	limitN = defaultAddressRows
+
 	if nParam := r.URL.Query().Get("n"); nParam != "" {
+
 		var val uint64
 		val, err = strconv.ParseUint(nParam, 10, 64)
 		if err != nil {
@@ -1448,6 +1450,8 @@ func parseAddressParams(r *http.Request) (address string, txnType dbtypes.AddrTx
 			log.Warnf("addressPage: requested up to %d address rows, "+
 				"limiting to %d", limitN, MaxAddressRows)
 			limitN = MaxAddressRows
+		} else {
+			limitN = int64(val)
 		}
 	}
 

--- a/public/js/controllers/address_controller.js
+++ b/public/js/controllers/address_controller.js
@@ -417,7 +417,7 @@ export default class extends Controller {
       `class="d-inline-block dcricon-arrow-right m-1 fs20" data-action="click->address#pageNumberLink"></a>`
     }
 
-    ctrl.tablePaginationTarget.innerHTML = links
+    ctrl.tablePaginationTarget.innerHTML = dompurify.sanitize(links)
   }
 
   drawGraph () {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -228,6 +228,23 @@
         <span class="fs13 py-1 d-block{{if not .IsMerged}} d-hide{{end}}" data-target="address.mergedMsg">
             *No unconfirmed transactions shown in merged views.
         </span>
+        <div class="text-right pr-3" data-target="address.tablePagination">
+          {{if ne .Offset 0}}
+            <a href="/address/{{.Address}}?start={{subtract .Offset .Limit}}&n={{.Limit}}"
+            class="d-inline-block dcricon-arrow-left m-1 fs20"></a>
+          {{end}}
+          {{range $.Pages}}
+            {{if eq .Link ""}}
+              <span>{{.Str}}</span>
+            {{else}}
+              <a href="{{.Link}}" class="fs18 pager px-1{{if .Active}} active{{end}}">{{.Str}}</a>
+            {{end}}
+          {{end}}
+          {{if gt (subtract $TxnCount .Offset) .Limit}}
+            <a href="/address/{{.Address}}?start={{add .Offset .Limit}}&n={{.Limit}}"
+            class="d-inline-block dcricon-arrow-right m-1 fs20"></a>
+          {{end}}
+        </div>
         <div class="d-flex align-items-center justify-content-between">
           {{- if gt $TxnCount 0}}
           <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -228,51 +228,50 @@
         <span class="fs13 py-1 d-block{{if not .IsMerged}} d-hide{{end}}" data-target="address.mergedMsg">
             *No unconfirmed transactions shown in merged views.
         </span>
-        <div
-            class="d-flex align-items-center justify-content-between"
-        >
+        <div class="d-flex align-items-center justify-content-between">
           {{- if gt $TxnCount 0}}
           <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
           {{- end}}
           <span></span>{{/*This dummy span ensures left/right alignment of the buttons, even if one is hidden.*/}}
-          <div class="d-inline-block text-right">
-            <label class="mb-0 mr-1" for="txntype">Type</label>
-            <select
-                name="txntype"
-                data-target="address.txntype"
-                data-action="change->address#changeTxType"
-                class="form-control-sm mb-2 mr-sm-2 mb-sm-0"
-            >
-                <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
-                <option {{if eq $txType "credit"}}selected{{end}} value="credit">Credits</option>
-                <option {{if eq $txType "debit"}}selected{{end}} value="debit">Debits</option>
-                <option {{if eq $txType "merged"}}selected{{end}} value="merged">Merged View</option>
-                <option {{if eq $txType "merged_credit"}}selected{{end}} value="merged_credit">Merged Credits</option>
-                <option {{if eq $txType "merged_debit"}}selected{{end}} value="merged_debit">Merged Debits</option>
-            </select>
+          <div class="d-flex flex-row">
+            <div class="d-inline-block text-right">
+              <label class="mb-0 mr-1" for="txntype">Type</label>
+              <select
+                  name="txntype"
+                  data-target="address.txntype"
+                  data-action="change->address#changeTxType"
+                  class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                  <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
+                  <option {{if eq $txType "credit"}}selected{{end}} value="credit">Credits</option>
+                  <option {{if eq $txType "debit"}}selected{{end}} value="debit">Debits</option>
+                  <option {{if eq $txType "merged"}}selected{{end}} value="merged">Merged View</option>
+                  <option {{if eq $txType "merged_credit"}}selected{{end}} value="merged_credit">Merged Credits</option>
+                  <option {{if eq $txType "merged_debit"}}selected{{end}} value="merged_debit">Merged Debits</option>
+              </select>
+            </div>
+            <div class="d-inline-block text-right">
+              <label class="mb-0 mr-1" for="pagesize">Page size</label>
+              <select
+                  name="pagesize"
+                  id="pagesize"
+                  data-target="address.pagesize"
+                  data-action="change->address#changePageSize"
+                  class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}}"
+                  {{- if lt $TxnCount 20}} disabled{{end}}
+              >
+              {{- $Txlen := len .Transactions}}
+                <option {{if eq $Txlen 20}}selected {{end}}value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
+                <option {{if eq $Txlen 40}}selected {{end}}value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
+                <option {{if eq $Txlen 80}}selected {{end}}value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
+              {{- if lt $TxnCount 160}}
+                <option {{if eq $Txlen $TxnCount}}selected {{end}}value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
+              {{- else}}
+                <option {{if ge $Txlen 160}}selected {{end}}value="160">160</option>
+              {{- end}}
+              </select>
+              </select>
+            </div>
           </div>
-        </div>
-        <div class="hidden d-flex align-items-center justify-content-end">
-            <label class="my-2 mr-1" for="pagesize">Page size</label>
-            <select
-                name="pagesize"
-                id="pagesize"
-                data-target="address.pagesize"
-                data-action="change->address#changePageSize"
-                class="form-control-sm mb-2 mr-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}}"
-                {{- if lt $TxnCount 20}} disabled{{end}}
-            >
-            {{- $Txlen := len .Transactions}}
-              <option {{if eq $Txlen 20}}selected {{end}}value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
-              <option {{if eq $Txlen 40}}selected {{end}}value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
-              <option {{if eq $Txlen 80}}selected {{end}}value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
-            {{- if lt $TxnCount 160}}
-              <option {{if eq $Txlen $TxnCount}}selected {{end}}value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
-            {{- else}}
-              <option {{if ge $Txlen 160}}selected {{end}}value="160">160</option>
-            {{- end}}
-            </select>
-            </select>
         </div>
     </div>
     {{- end}}{{/* if not .IsDummyAddress */}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -230,19 +230,23 @@
         </span>
         <div class="text-right pr-3" data-target="address.tablePagination">
           {{if ne .Offset 0}}
-            <a href="/address/{{.Address}}?start={{subtract .Offset .Limit}}&n={{.Limit}}"
-            class="d-inline-block dcricon-arrow-left m-1 fs20"></a>
+            <a  class="d-inline-block dcricon-arrow-left m-1 fz20"
+                data-action="click->address#pageNumberLink"
+                href="/address/{{.Address}}?start={{subtract .Offset .Limit}}&n={{.Limit}}&txntype={{$txType}}"></a>
           {{end}}
           {{range $.Pages}}
             {{if eq .Link ""}}
               <span>{{.Str}}</span>
             {{else}}
-              <a href="{{.Link}}" class="fs18 pager px-1{{if .Active}} active{{end}}">{{.Str}}</a>
+              <a  class="fs18 pager px-1{{if .Active}} active{{end}}"
+                  data-action="click->address#pageNumberLink"
+                  href="{{.Link}}">{{.Str}}</a>
             {{end}}
           {{end}}
           {{if gt (subtract $TxnCount .Offset) .Limit}}
-            <a href="/address/{{.Address}}?start={{add .Offset .Limit}}&n={{.Limit}}"
-            class="d-inline-block dcricon-arrow-right m-1 fs20"></a>
+            <a  class="d-inline-block dcricon-arrow-right m-1 fs20"
+                data-action="click->address#pageNumberLink"
+                href="/address/{{.Address}}?start={{add .Offset .Limit}}&n={{.Limit}}&txntype={{$txType}}"></a>
           {{end}}
         </div>
         <div class="d-flex align-items-center justify-content-between">


### PR DESCRIPTION
Pagination selector on address page was not changing the number of rows displayed. The param being passed in was not properly being used. The function was hard coded to 20 rows. This has been resolved.

Additionally, changing the transaction type selector caused the total transaction count to lose comma formatting. This has also been fixed.

Also added pagination page number links.

Resolves https://github.com/decred/dcrdata/pull/1719