### PR TITLE
update chi to 4.1.0

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -44,7 +44,7 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 	compMiddleware := m.Next
 	if compressLarge {
 		log.Debug("Enabling compressed responses for large JSON payload endpoints.")
-		compMiddleware = middleware.NewCompressor(3).Handler()
+		compMiddleware = middleware.Compress(3)
 	}
 
 	mux.Route("/block", func(r chi.Router) {

--- a/api/insight/apirouter.go
+++ b/api/insight/apirouter.go
@@ -54,7 +54,7 @@ func NewInsightApiRouter(app *InsightApi, useRealIP, compression bool, maxAddrs 
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.StripSlashes)
 	if compression {
-		mux.Use(middleware.NewCompressor(3).Handler())
+		mux.Use(middleware.Compress(3))
 	}
 
 	mux.With(m.OriginalRequestURI).Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/decred/slog v1.0.0
 	github.com/dmigwi/go-piparser/proposals v0.0.0-20191219171828-ae8cbf4067e1
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-chi/chi v4.0.3-0.20191031103402-221acf29d02b+incompatible
+	github.com/go-chi/chi v4.1.0+incompatible
 	github.com/google/gops v0.3.7-0.20190802051910-59c8be2eaddf
 	github.com/googollee/go-engine.io v1.4.3-0.20190924125625-798118fc0dd2
 	github.com/googollee/go-socket.io v1.4.3-0.20191016204530-42fe90fa9ed0

--- a/go.sum
+++ b/go.sum
@@ -328,10 +328,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-chi/chi v4.0.3-0.20191003102842-906b567ebae8+incompatible h1:cL14NsYQCls8iA0JCGeDKdXMGfdkusxmNe8+Yi65oew=
-github.com/go-chi/chi v4.0.3-0.20191003102842-906b567ebae8+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-chi/chi v4.0.3-0.20191031103402-221acf29d02b+incompatible h1:Ji9JjCT5HUDnyuUN+28h360rAAWKGnhecvjg/HbLruo=
-github.com/go-chi/chi v4.0.3-0.20191031103402-221acf29d02b+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.1.0+incompatible h1:ETj3cggsVIY2Xao5ExCu6YhEh5MD6JTfcBzS37R260w=
+github.com/go-chi/chi v4.1.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/docgen v1.0.5 h1:TiGvJAuVPZJ9zFSwoF52eORe0SztOYqf9C79LVw/xbY=
 github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJelhWM=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=

--- a/middleware/go.mod
+++ b/middleware/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrdata/api/types/v5 v5.0.1
 	github.com/decred/slog v1.0.0
 	github.com/didip/tollbooth/v5 v5.1.1-0.20190817151620-2c720dff9427
-	github.com/go-chi/chi v4.0.3-0.20191003102842-906b567ebae8+incompatible
+	github.com/go-chi/chi v4.1.0+incompatible
 	github.com/go-chi/docgen v1.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect

--- a/middleware/go.sum
+++ b/middleware/go.sum
@@ -67,8 +67,8 @@ github.com/didip/tollbooth/v5 v5.1.1-0.20190817151620-2c720dff9427/go.mod h1:d9r
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-chi/chi v4.0.3-0.20191003102842-906b567ebae8+incompatible h1:cL14NsYQCls8iA0JCGeDKdXMGfdkusxmNe8+Yi65oew=
-github.com/go-chi/chi v4.0.3-0.20191003102842-906b567ebae8+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.1.0+incompatible h1:ETj3cggsVIY2Xao5ExCu6YhEh5MD6JTfcBzS37R260w=
+github.com/go-chi/chi v4.1.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/docgen v1.0.5 h1:TiGvJAuVPZJ9zFSwoF52eORe0SztOYqf9C79LVw/xbY=
 github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJelhWM=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=


### PR DESCRIPTION
chi 4.0.3-pre to 4.1.0 release has a number of fixes and improvements to
the Compress, Recover, and Throttle middlewares.

middleware too