### PR TITLE
middleware,api/insight: fix setting middleware.CtxAddress

### DIFF
--- a/api/insight/apimiddleware.go
+++ b/api/insight/apimiddleware.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	apitypes "github.com/decred/dcrdata/api/types/v5"
 	m "github.com/decred/dcrdata/middleware/v3"
@@ -159,7 +160,8 @@ func PostAddrsTxsCtx(next http.Handler) http.Handler {
 		}
 
 		// addrs must come from POST body.
-		ctx := context.WithValue(r.Context(), m.CtxAddress, req.Addresses)
+		addrs := strings.Split(req.Addresses, ",")
+		ctx := context.WithValue(r.Context(), m.CtxAddress, addrs)
 
 		// Other parameters may come from the POST body or URL query values.
 
@@ -236,7 +238,8 @@ func PostAddrsUtxoCtx(next http.Handler) http.Handler {
 		}
 
 		// Successful extraction of Body JSON
-		ctx := context.WithValue(r.Context(), m.CtxAddress, req.Addrs)
+		addrs := strings.Split(req.Addrs, ",")
+		ctx := context.WithValue(r.Context(), m.CtxAddress, addrs)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/middleware/apimiddleware.go
+++ b/middleware/apimiddleware.go
@@ -832,7 +832,7 @@ func TransactionsCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		address := r.FormValue("address")
 		if address != "" {
-			ctx := context.WithValue(r.Context(), CtxAddress, address)
+			ctx := context.WithValue(r.Context(), CtxAddress, []string{address})
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}
 
@@ -899,7 +899,7 @@ func PageNumCtx(next http.Handler) http.Handler {
 func AddressPostCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		address := r.PostFormValue("addrs")
-		ctx := context.WithValue(r.Context(), CtxAddress, address)
+		ctx := context.WithValue(r.Context(), CtxAddress, []string{address})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
A few middlewares (insight.PostAddrsUtxoCtx, insight.PostAddrsTxsCtx,
and middleware.TransactionsCtx) were still storing a string in
middleware.CtxAddress instead of a []string.

PostAddrsUtxoCtx and PostAddrsTxsCtx now Split the string from the
part of the request body holding the address list.

TransactionsCtx now just wraps the address string from the "?address="
url query, i.e. []string{address}.  And handler using this middleware is
responsible for validating the address in the slice.

fixes:
- GET /insight/api/txs?address={address} via middleware.TransactionsCtx
- POST /insight/api/addrs/utxo via insight.PostAddrsUtxoCtx
- POST /insight/api/addrs/txs via insight.PostAddrsTxsCtx