### PR TITLE
Fixed vote status for proposals showing in discussion instead of abandoned

### DIFF
--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -145,9 +145,15 @@
                         <td class="text-left">
                             {{if .VoteStatus}}
                                 {{if eq .VoteStatus.ShortDesc "Not Authorized"}}
-                                    <span class="text-abandoned position-relative" data-tooltip="Proposal in discussion">
-                                        In Discussion
-                                    </span>
+                                    {{if .AbandonedDate}}
+                                        <span class="text-abandoned position-relative" data-tooltip="Proposal abandoned">
+                                            Abandoned
+                                        </span>
+                                    {{else}}
+                                        <span class="text-abandoned position-relative" data-tooltip="Proposal in discussion">
+                                            In Discussion
+                                        </span>
+                                    {{end}}
                                 {{else if eq (len .VoteResults) 0 }}
                                     <span class="text-progress position-relative" data-tooltip="Waiting for administrator approval to start voting">
                                         Vote pending


### PR DESCRIPTION
Fixes [#1583](https://github.com/decred/dcrdata/issues/1583)

Added a fix for proposals showing `In discussion` instead of `Abandoned`.