### PR TITLE
explorer: display alt. block hashes on /block page

### DIFF
--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -176,7 +176,7 @@ const (
 		JOIN block_chain ON this_hash=hash
 		WHERE hash = $1;`
 
-	SelectBlockStatuses = `SELECT is_valid, is_mainchain, height, hash
+	SelectBlockStatuses = `SELECT is_valid, is_mainchain, hash
 		FROM blocks
 		WHERE height = $1;`
 

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -176,6 +176,10 @@ const (
 		JOIN block_chain ON this_hash=hash
 		WHERE hash = $1;`
 
+	SelectBlockStatuses = `SELECT is_valid, is_mainchain, height, hash
+		FROM blocks
+		WHERE height = $1;`
+
 	SelectBlockFlags = `SELECT is_valid, is_mainchain
 		FROM blocks
 		WHERE hash = $1;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -980,6 +980,15 @@ func (pgb *ChainDB) BlockStatus(hash string) (dbtypes.BlockStatus, error) {
 	return bs, pgb.replaceCancelError(err)
 }
 
+// BlockStatuses retrieves the block chain statuses of all blocks at the given
+// height.
+func (pgb *ChainDB) BlockStatuses(height int64) ([]*dbtypes.BlockStatus, error) {
+	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
+	defer cancel()
+	blocks, err := RetrieveBlockStatuses(ctx, pgb.db, height)
+	return blocks, pgb.replaceCancelError(err)
+}
+
 // blockFlags retrieves the block's isValid and isMainchain flags.
 func (pgb *ChainDB) blockFlags(ctx context.Context, hash string) (bool, bool, error) {
 	iv, im, err := RetrieveBlockFlags(ctx, pgb.db, hash)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -4133,11 +4133,11 @@ func RetrieveBlockStatuses(ctx context.Context, db *sql.DB, idx int64) (blocks [
 
 	for rows.Next() {
 		var bs dbtypes.BlockStatus
-		err = rows.Scan(&bs.IsValid, &bs.IsMainchain, &bs.Height, &bs.Hash)
+		err = rows.Scan(&bs.IsValid, &bs.IsMainchain, &bs.Hash)
 		if err != nil {
 			return
 		}
-
+		bs.Height = uint32(idx)
 		blocks = append(blocks, &bs)
 	}
 	err = rows.Err()

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -4121,6 +4121,30 @@ func RetrieveBlockStatus(ctx context.Context, db *sql.DB, hash string) (bs dbtyp
 	return
 }
 
+// RetrieveBlockStatuses retrieves the block chain statuses of all blocks at
+// the given height.
+func RetrieveBlockStatuses(ctx context.Context, db *sql.DB, idx int64) (blocks []*dbtypes.BlockStatus, err error) {
+	var rows *sql.Rows
+	rows, err = db.QueryContext(ctx, internal.SelectBlockStatuses, idx)
+	if err != nil {
+		return
+	}
+	defer closeRows(rows)
+
+	for rows.Next() {
+		var bs dbtypes.BlockStatus
+		err = rows.Scan(&bs.IsValid, &bs.IsMainchain, &bs.Height, &bs.Hash)
+		if err != nil {
+			return
+		}
+
+		blocks = append(blocks, &bs)
+	}
+	err = rows.Err()
+
+	return
+}
+
 // RetrieveBlockFlags retrieves the block's is_valid and is_mainchain flags.
 func RetrieveBlockFlags(ctx context.Context, db *sql.DB, hash string) (isValid bool, isMainchain bool, err error) {
 	err = db.QueryRowContext(ctx, internal.SelectBlockFlags, hash).Scan(&isValid, &isMainchain)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -79,6 +79,7 @@ type explorerDataSource interface {
 	SideChainBlocks() ([]*dbtypes.BlockStatus, error)
 	DisapprovedBlocks() ([]*dbtypes.BlockStatus, error)
 	BlockStatus(hash string) (dbtypes.BlockStatus, error)
+	BlockStatuses(height int64) ([]*dbtypes.BlockStatus, error)
 	BlockFlags(hash string) (bool, bool, error)
 	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) (*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, int64, error)
 	TransactionBlocks(hash string) ([]*dbtypes.BlockStatus, []uint32, error)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -706,20 +706,19 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 		log.Warnf("Unable to retrieve missed votes for block %s: %v", hash, err)
 	}
 
-	var relatedBlocks []*dbtypes.BlockStatus
-	relatedBlocks, err = exp.dataSource.BlockStatuses(data.Height)
+	var altBlocks []*dbtypes.BlockStatus
+	altBlocks, err = exp.dataSource.BlockStatuses(data.Height)
 	if exp.timeoutErrorPage(w, err, "BlockStatuses") {
 		return
 	}
 	if err != nil && err != sql.ErrNoRows {
 		log.Warnf("Unable to retrieve chain status for block %s: %v", hash, err)
 	}
-
-	for i, block := range relatedBlocks {
+	for i, block := range altBlocks {
 		if block.Hash == hash {
 			data.Valid = block.IsValid
 			data.MainChain = block.IsMainchain
-			relatedBlocks = append(relatedBlocks[:i], relatedBlocks[i+1:]...)
+			altBlocks = append(altBlocks[:i], altBlocks[i+1:]...)
 			break
 		}
 	}
@@ -732,7 +731,7 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 	}{
 		CommonPageData: exp.commonData(r),
 		Data:           data,
-		AltBlocks:      relatedBlocks,
+		AltBlocks:      altBlocks,
 	}
 
 	if exp.xcBot != nil && time.Since(data.BlockTime.T) < time.Hour {

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -55,6 +55,18 @@
 				<div class="fs13 text-secondary pb-1">Block Hash</div>
 				<div class="d-inline-block fs14 break-word rounded font-weight-bold">{{.Hash}}</div>
 			</div>
+			{{range $.AltBlocks}}
+			<div class="text-left lh1rem pt-2 pb-1">
+				<div class="fs13 text-secondary pb-1">
+					Alt. Block (on {{if .IsMainchain}}main chain{{else}}side chain{{end}})
+				</div>
+				<div class="d-inline-block fs14 break-word rounded font-weight-bold">
+					<a href="/block/{{.Hash}}" title="Valid: {{.IsValid}}">
+						{{.Hash}}
+					</a>
+				</div>
+			</div>
+			{{end}}
 			<div class="row py-2">
 				<div class="col-10 col-sm-8 text-left">
 					<span class="text-secondary fs13">Total Sent</span>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -55,16 +55,17 @@
 				<div class="fs13 text-secondary pb-1">Block Hash</div>
 				<div class="d-inline-block fs14 break-word rounded font-weight-bold">{{.Hash}}</div>
 			</div>
-			{{range $.AltBlocks}}
-			<div class="text-left lh1rem pt-2 pb-1">
+			{{if gt (len $.AltBlocks) 0}}
+			<div class="text-left lh1rem py-1">
 				<div class="fs13 text-secondary pb-1">
-					Alt. Block (on {{if .IsMainchain}}main chain{{else}}side chain{{end}})
+					Alternative Block{{if gt (len $.AltBlocks) 1}}s{{end}}
 				</div>
+				{{range $.AltBlocks}}
 				<div class="d-inline-block fs14 break-word rounded font-weight-bold">
-					<a href="/block/{{.Hash}}" title="Valid: {{.IsValid}}">
-						{{.Hash}}
-					</a>
+					<a href="/block/{{.Hash}}" title="Valid: {{.IsValid}}">{{.Hash}}</a>
+					<span> ({{if .IsMainchain}}main{{else}}side{{end}})</span>
 				</div>
+				{{end}}
 			</div>
 			{{end}}
 			<div class="row py-2">


### PR DESCRIPTION
Display (link to) other block hashes if two or more blocks are found for a given height. Helps to provide visual feedback when there are multiple blocks for a given height.

<img width="1279" alt="Screenshot 2020-04-22 at 3 26 05 AM" src="https://user-images.githubusercontent.com/18400051/79934730-2cf6b200-844b-11ea-8a33-762fc2b88206.png">
<img width="1280" alt="Screenshot 2020-04-22 at 3 26 14 AM" src="https://user-images.githubusercontent.com/18400051/79934737-308a3900-844b-11ea-9a13-7ab9dc5f620c.png">
