### PR TITLE
 Attack Calc - Display warning about max possible DCR

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -2366,6 +2366,7 @@ func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 	ticketPoolSize := exp.pageData.HomeInfo.PoolInfo.Size
 	ticketPrice := exp.pageData.HomeInfo.StakeDiff
 	HashRate := exp.pageData.HomeInfo.HashRate
+	coinSupply := exp.pageData.HomeInfo.CoinSupply
 
 	exp.pageData.RUnlock()
 
@@ -2377,6 +2378,7 @@ func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 		TicketPrice     float64
 		TicketPoolSize  int64
 		TicketPoolValue float64
+		CoinSupply      int64
 	}{
 		CommonPageData:  exp.commonData(r),
 		HashRate:        HashRate,
@@ -2385,6 +2387,7 @@ func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 		TicketPrice:     ticketPrice,
 		TicketPoolSize:  int64(ticketPoolSize),
 		TicketPoolValue: ticketPoolValue,
+		CoinSupply:      coinSupply,
 	})
 
 	if err != nil {

--- a/public/js/controllers/attackcost_controller.js
+++ b/public/js/controllers/attackcost_controller.js
@@ -39,7 +39,7 @@ function removeTrailingZeros (value) {
 }
 
 let Dygraph // lazy loaded on connect
-var height, dcrPrice, hashrate, tpSize, tpValue, tpPrice, graphData, currentPoint
+var height, dcrPrice, hashrate, tpSize, tpValue, tpPrice, graphData, currentPoint, coinSupply
 
 function rateCalculation (y) {
   y = y || 0.99 // 0.99 TODO confirm why 0.99 is used as default instead of 1
@@ -113,16 +113,14 @@ export default class extends Controller {
   static get targets () {
     return [
       'actualHashRate', 'attackPercent', 'attackPeriod', 'blockHeight', 'countDevice', 'device',
-      'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash',
-      'kwhRate', 'kwhRateLabel', 'otherCosts', 'otherCostsValue', 'priceDCR', 'internalAttackText', 'targetHashRate', 'externalAttackText',
-      'externalAttackPosText', 'additionalDcr', 'newTicketPoolValue', 'internalAttackPosText',
-      'additionalHashRate', 'newHashRate', 'targetPos', 'targetPow',
-      'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize', 'ticketPoolSizeLabel',
-      'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
-      'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh',
-      'totalPos', 'totalPow', 'graph', 'labels', 'projectedTicketPrice', 'projectedTicketPriceIncrease', 'attackType',
-      'attackPosPercentAmountLabel', 'dcrPriceLabel', 'totalDCRPosLabel',
-      'projectedPriceDiv'
+      'deviceCost', 'deviceDesc', 'deviceName', 'external', 'internal', 'internalHash', 'kwhRate',
+      'kwhRateLabel', 'otherCosts', 'otherCostsValue', 'priceDCR', 'internalAttackText', 'targetHashRate',
+      'externalAttackText', 'externalAttackPosText', 'additionalDcr', 'newTicketPoolValue', 'internalAttackPosText',
+      'additionalHashRate', 'newHashRate', 'targetPos', 'targetPow', 'ticketAttackSize', 'ticketPoolAttack', 'ticketPoolSize',
+      'ticketPoolSizeLabel', 'ticketPoolValue', 'ticketPrice', 'tickets', 'ticketSizeAttack', 'durationLongDesc',
+      'total', 'totalDCRPos', 'totalDeviceCost', 'totalElectricity', 'totalExtraCostRate', 'totalKwh', 'totalPos', 'totalPow',
+      'graph', 'labels', 'projectedTicketPrice', 'projectedTicketPriceIncrease', 'attackType', 'attackPosPercentAmountLabel',
+      'dcrPriceLabel', 'totalDCRPosLabel', 'projectedPriceDiv', 'attackNotPossibleWrapperDiv', 'coinSupply', 'totalAttackCostContainer'
     ]
   }
 
@@ -141,6 +139,7 @@ export default class extends Controller {
     tpPrice = parseFloat(this.data.get('ticketPrice'))
     tpValue = parseFloat(this.data.get('ticketPoolValue'))
     tpSize = parseInt(this.data.get('ticketPoolSize'))
+    coinSupply = parseInt(this.data.get('coinSupply'))
 
     if (this.settings.attack_time) this.attackPeriodTarget.value = parseInt(this.settings.attack_time)
     if (this.settings.target_pow) this.targetPowTarget.value = parseFloat(this.settings.target_pow)
@@ -425,7 +424,6 @@ export default class extends Controller {
     var timeStr = this.attackPeriodTarget.value
     timeStr = this.attackPeriodTarget.value > 1 ? timeStr + ' hours' : timeStr + ' hour'
     this.ticketPoolSizeLabelTarget.innerHTML = digitformat(tpSize, 2)
-
     this.setAllValues(this.actualHashRateTargets, digitformat(hashrate, 4))
     this.priceDCRTarget.value = digitformat(dcrPrice, 2)
     this.setAllInputs(this.targetPosTargets, digitformat(parseFloat(this.targetPosTarget.value), 2))
@@ -452,6 +450,7 @@ export default class extends Controller {
     this.attackPosPercentAmountLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
     this.setAllValues(this.totalDCRPosLabelTargets, digitformat(totalDCRPos, 2))
     this.setAllValues(this.dcrPriceLabelTargets, digitformat(dcrPrice, 2))
+    this.showPosCostWarning(DCRNeed)
   }
 
   setAllValues (targets, data) {
@@ -468,5 +467,17 @@ export default class extends Controller {
 
   showAll (targets) {
     targets.forEach(el => el.classList.remove('d-none'))
+  }
+
+  showPosCostWarning (DCRNeed) {
+    var totalDCRInCirculation = coinSupply / 100000000
+    if (DCRNeed > totalDCRInCirculation) {
+      this.coinSupplyTarget.textContent = digitformat(totalDCRInCirculation, 2)
+      this.totalAttackCostContainerTarget.style.cssText = 'color: #f12222 !important'
+      this.showAll(this.attackNotPossibleWrapperDivTargets)
+    } else {
+      this.totalAttackCostContainerTarget.style.cssText = 'color: #6c757d !important'
+      this.hideAll(this.attackNotPossibleWrapperDivTargets)
+    }
   }
 }

--- a/views/attackcost.tmpl
+++ b/views/attackcost.tmpl
@@ -13,6 +13,7 @@
       data-attackcost-ticket-price="{{.TicketPrice}}"
       data-attackcost-ticket-pool-value="{{.TicketPoolValue}}"
       data-attackcost-ticket-pool-size="{{.TicketPoolSize}}"
+     data-attackcost-coin-supply="{{.CoinSupply}}"
     >
     <div class="col-md-24 p-0">
       <div class="bg-white mb-1 py-2 px-3 my-0">
@@ -282,7 +283,6 @@
           <div class="pl-1">
             <span class="h6 d-inline-block pl-2 font-weight-bold">PoS Attack</span>
           </div>
-
           <div class="ml-4 d-none" data-target="attackcost.internalAttackPosText">
             <div class="mt-1 ml-2">
               A <input
@@ -329,7 +329,6 @@
               </span>)
             </div>
           </div>
-
           <div class="ml-4 d-none" data-target="attackcost.externalAttackPosText">
             <div class="mt-1 ml-2">
               Current total staked is <span  data-target="attackcost.ticketPoolValue" class="font-weight-bold">0</span> <span class="fs11">DCR</span>.
@@ -348,41 +347,39 @@
               <span class="font-weight-bold" data-target="attackcost.additionalDcr">0</span><span class="fs11"> DCR</span>
               to the total staked.
             </div>
-
             <div class="mt-1 ml-2">
               New total staked will be <span class="font-weight-bold" data-target="attackcost.newTicketPoolValue">0</span> <span class="fs11"> DCR</span>.
             </div>
-
-            <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
-              The projected ticket price is
-              <span class="position-relative font-weight-bold">
-              <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
-                <span class="fs11">DCR</span>
-              </span>
-              (A <span class="font-weight-bold" data-target="attackcost.projectedTicketPriceIncrease">0</span>% increase).
-            </div>
-
-            <div class="mt-1 ml-2">
-              <span class="position-relative font-weight-bold">
-                <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
-              </span>
-              total PoS attack cost
-              (<span class="position-relative font-weight-bold">
-                <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
-                <span> * </span>
-                <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
-              </span>)
-            </div>
-
-          </div>
-
+        {{- /* CALCULATED PoS WARNING DISPLAY */ -}}
+        <div data-target="attackcost.attackNotPossibleWrapperDiv" class="mt-1 ml-2 blink-container d-none" style="color: #f12222; margin-left: 8px; ">
+            Attack not possible. Total coin supply is <span data-target="attackcost.coinSupply" class="font-weight-bold">0</span> <span class="fs11">DCR</span>.
+        </div>
+        <div class="mt-1 ml-2" data-target="attackcost.projectedPriceDiv" style="{display: block}">
+            The projected ticket price is
+            <span class="position-relative font-weight-bold">
+            <span class="font-weight-bold" data-target="attackcost.projectedTicketPrice">0</span>
+              <span class="fs11">DCR</span>
+            </span>
+            (A <span class="font-weight-bold" data-target="attackcost.projectedTicketPriceIncrease">0</span>% increase).
+        </div>
+        <div class="mt-1 ml-2">
+            <span class="position-relative font-weight-bold">
+              <span>$</span><span class="font-weight-bold" data-target="attackcost.totalPos">0</span>
+            </span>
+            total PoS attack cost
+            (<span class="position-relative font-weight-bold">
+              <span data-target="attackcost.totalDCRPosLabel">0</span><span class="fs11"> DCR</span>
+              <span> * </span>
+              <span data-target="attackcost.dcrPriceLabel">0</span><span class="fs11"> USD/DCR</span>
+            </span>)
         </div>
       </div>
-
+      </div>
+      </div>
       {{- /* CALCULATION SUMMARY */ -}}
       <div class="text-center h4 mb-3 mt-3">
         Total attack cost:
-        <span class="position-relative text-secondary font-weight-bold">
+        <span class="position-relative text-secondary font-weight-bold" data-target="attackcost.totalAttackCostContainer">
           $<span class="font-weight-bold" data-target="attackcost.total">0</span>
           <span class="fs11">USD</span>
         </span>
@@ -394,4 +391,3 @@
 </body>
 </html>
 {{end}}
-


### PR DESCRIPTION
This PR checks the total amount of DCR needed for the calculated PoS attack and displays a warning indicator when the amount of DCR needed for the attack is greater than the total amount of DCR in circulation.
![attackcost1](https://user-images.githubusercontent.com/17119508/80272307-0c835d80-86c0-11ea-8efb-bfde7c31a914.PNG)
![attackcost2](https://user-images.githubusercontent.com/17119508/80272312-1311d500-86c0-11ea-9ecb-7ba7c0776204.PNG)
