### PR TITLE
views: restore missing spaces on ticket/vote/rev counts

### DIFF
--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -91,9 +91,9 @@
 			</div>
 			<div class="d-flex justify-content-around fs15 text-center text-secondary my-2">
 				<div class="d-inline-block">Regular: {{.Transactions}}</div>
-				<div class="d-inline-block">Votes: {{- .Voters -}}</div>
-				<div class="d-inline-block">Tickets: {{- .FreshStake -}}</div>
-				<div class="d-inline-block"><span class="d-sm-none d-inline-block position-relative" data-tooltip="Revocations">Revs</span><span class="d-none d-sm-inline">Revocations</span>: {{- .Revocations -}}</div>
+				<div class="d-inline-block">Votes: {{.Voters}}</div>
+				<div class="d-inline-block">Tickets: {{.FreshStake}}</div>
+				<div class="d-inline-block"><span class="d-sm-none d-inline-block position-relative" data-tooltip="Revocations">Revs</span><span class="d-none d-sm-inline">Revocations</span>: {{.Revocations}}</div>
 			</div>
 		</div>
 		<div class="col-24 col-xl-12 secondary-card py-3 px-3 px-xl-4">


### PR DESCRIPTION
This puts spaces that were incorrectly being eaten by the template generator on the block page:

Before:

![image](https://user-images.githubusercontent.com/9373513/80817065-55428700-8b96-11ea-928a-74c5857c3f1e.png)

After:

![image](https://user-images.githubusercontent.com/9373513/80817161-83c06200-8b96-11ea-83f4-041aeb581489.png)
