### PR TITLE
config: remove pg option and other tweaks

### DIFF
--- a/api/insight/apiroutes.go
+++ b/api/insight/apiroutes.go
@@ -352,7 +352,7 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 			apiLog.Info("Relinquishing prioritized goroutine status.")
 		}
 		final := atomic.AddInt64(&iapi.inflightUTXOs, -inflightUTXOs)
-		apiLog.Debugf("Removing %d inflight UTXOs. New total = %d.", inflightUTXOs, final)
+		apiLog.Tracef("Removing %d inflight UTXOs. New total = %d.", inflightUTXOs, final)
 
 		apiLog.Debugf("getAddressesTxnOutput completed for %d addresses with %d UTXOs in %v.",
 			len(addresses), inflightUTXOs, time.Since(t0))
@@ -473,8 +473,8 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 		}
 
 		totalInflight = atomic.AddInt64(&iapi.inflightUTXOs, newInflightUTXOs)
-		apiLog.Tracef("Adding %d inflight (unconfirmed) UTXOs to the total.", newInflightUTXOs)
-		apiLog.Debugf("Total in-flight UTXOs: %v", totalInflight)
+		apiLog.Tracef("Adding %d inflight (unconfirmed) UTXOs for a total of %d.",
+			newInflightUTXOs, totalInflight)
 		inflightUTXOs += newInflightUTXOs
 
 		// On the first address, start with a slice of the correct size.
@@ -506,7 +506,7 @@ func (iapi *InsightApi) getAddressesTxnOutput(w http.ResponseWriter, r *http.Req
 			var garbage []int
 			for g, utxo := range txnOutputs {
 				if utxo.Vout == f.PreviousOutpoint.Index && utxo.TxnID == f.PreviousOutpoint.Hash.String() {
-					apiLog.Debug("Removing an unconfirmed spent UTXO.")
+					apiLog.Trace("Removing an unconfirmed spent UTXO.")
 					garbage = append(garbage, g)
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -83,8 +83,8 @@ var (
 	defaultDisabledExchanges = "dragonex,poloniex"
 	defaultRateCertFile      = filepath.Join(defaultHomeDir, "rpc.cert")
 
-	defaultMainnetLink  = "https://mainnet.decred.org/"
-	defaultTestnetLink  = "https://testnet.decred.org/"
+	defaultMainnetLink  = "https://explorer.dcrdata.org/"
+	defaultTestnetLink  = "https://testnet.dcrdata.org/"
 	defaultOnionAddress = ""
 
 	maxSyncStatusLimit = 5000

--- a/config.go
+++ b/config.go
@@ -125,7 +125,7 @@ type config struct {
 	MempoolMaxInterval int `long:"mp-max-interval" description:"The maximum time in seconds between mempool reports (within a couple seconds), regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MAX_INTERVAL"`
 	MPTriggerTickets   int `long:"mp-ticket-trigger" description:"The minimum number of new tickets that must be seen to trigger a new mempool report." env:"DCRDATA_MP_TRIGGER_TICKETS"`
 
-	// Politeia/proposals and concensus agendas
+	// Politeia/proposals and consensus agendas
 	AgendasDBFileName string `long:"agendadbfile" description:"Agendas DB file name (default is agendas.db)." env:"DCRDATA_AGENDAS_DB_FILE_NAME"`
 	ProposalsFileName string `long:"proposalsdbfile" description:"Proposals DB file name (default is proposals.db)." env:"DCRDATA_PROPOSALS_DB_FILE_NAME"`
 	PoliteiaAPIURL    string `long:"politeiaurl" description:"Defines the root API politeia URL (defaults to https://proposals.decred.org)."`

--- a/config.go
+++ b/config.go
@@ -83,8 +83,8 @@ var (
 	defaultDisabledExchanges = "dragonex,poloniex"
 	defaultRateCertFile      = filepath.Join(defaultHomeDir, "rpc.cert")
 
-	defaultMainnetLink  = "https://explorer.dcrdata.org/"
-	defaultTestnetLink  = "https://testnet.dcrdata.org/"
+	defaultMainnetLink  = "https://mainnet.decred.org/"
+	defaultTestnetLink  = "https://testnet.decred.org/"
 	defaultOnionAddress = ""
 
 	maxSyncStatusLimit = 5000

--- a/config.go
+++ b/config.go
@@ -109,7 +109,7 @@ type config struct {
 	UseGops      bool   `short:"g" long:"gops" description:"Run with gops diagnostics agent listening. See github.com/google/gops for more information." env:"DCRDATA_USE_GOPS"`
 	ReloadHTML   bool   `long:"reload-html" description:"Reload HTML templates on every request" env:"DCRDATA_RELOAD_HTML"`
 
-	// API
+	// API/server
 	APIProto            string  `long:"apiproto" description:"Protocol for API (http or https)" env:"DCRDATA_ENABLE_HTTPS"`
 	APIListen           string  `long:"apilisten" description:"Listen address for API. default localhost:7777, :17778 testnet, :17779 simnet" env:"DCRDATA_LISTEN_URL"`
 	IndentJSON          string  `long:"indentjson" description:"String for JSON indentation (default is \"   \"), when indentation is requested via URL query."`
@@ -120,44 +120,38 @@ type config struct {
 	CompressAPI         bool    `long:"compress-api" description:"Use compression for a number of endpoints with commonly large responses."`
 	ServerHeader        string  `long:"server-http-header" description:"Set the HTTP response header Server key value. Valid values are \"off\", \"version\", or a custom string."`
 
-	// Data I/O
-	MempoolMinInterval int    `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`
-	MempoolMaxInterval int    `long:"mp-max-interval" description:"The maximum time in seconds between mempool reports (within a couple seconds), regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MAX_INTERVAL"`
-	MPTriggerTickets   int    `long:"mp-ticket-trigger" description:"The number minimum number of new tickets that must be seen to trigger a new mempool report." env:"DCRDATA_MP_TRIGGER_TICKETS"`
-	AgendasDBFileName  string `long:"agendadbfile" description:"Agendas DB file name (default is agendas.db)." env:"DCRDATA_AGENDAS_DB_FILE_NAME"`
-	ProposalsFileName  string `long:"proposalsdbfile" description:"Proposals DB file name (default is proposals.db)." env:"DCRDATA_PROPOSALS_DB_FILE_NAME"`
-	PoliteiaAPIURL     string `long:"politeiaurl" description:"Defines the root API politeia URL (defaults to https://proposals.decred.org)."`
-	ChartsCacheDump    string `long:"chartscache" description:"Defines the file name that holds the charts cache data on system exit."`
-	PiPropRepoOwner    string `long:"piproposalsowner" description:"Defines the owner to the github repo where Politeia's proposals are pushed."`
-	PiPropRepoName     string `long:"piproposalsrepo" description:"Defines the name of the github repo where Politeia's proposals are pushed."`
-	DisablePiParser    bool   `long:"disable-piparser" description:"Disables the piparser tool from running."`
+	// Mempool
+	MempoolMinInterval int `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`
+	MempoolMaxInterval int `long:"mp-max-interval" description:"The maximum time in seconds between mempool reports (within a couple seconds), regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MAX_INTERVAL"`
+	MPTriggerTickets   int `long:"mp-ticket-trigger" description:"The minimum number of new tickets that must be seen to trigger a new mempool report." env:"DCRDATA_MP_TRIGGER_TICKETS"`
 
-	PurgeNBestBlocks int `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
+	// Politeia/proposals and concensus agendas
+	AgendasDBFileName string `long:"agendadbfile" description:"Agendas DB file name (default is agendas.db)." env:"DCRDATA_AGENDAS_DB_FILE_NAME"`
+	ProposalsFileName string `long:"proposalsdbfile" description:"Proposals DB file name (default is proposals.db)." env:"DCRDATA_PROPOSALS_DB_FILE_NAME"`
+	PoliteiaAPIURL    string `long:"politeiaurl" description:"Defines the root API politeia URL (defaults to https://proposals.decred.org)."`
+	PiPropRepoOwner   string `long:"piproposalsowner" description:"Defines the owner to the github repo where Politeia's proposals are pushed."`
+	PiPropRepoName    string `long:"piproposalsrepo" description:"Defines the name of the github repo where Politeia's proposals are pushed."`
+	DisablePiParser   bool   `long:"disable-piparser" description:"Disables the piparser tool from running."`
 
-	FullMode         bool          `long:"pg" description:"Run in \"Full Mode\" mode,  enables postgresql support" env:"DCRDATA_ENABLE_FULL_MODE"`
+	// Caching and optimization.
+	AddrCacheCap     int    `long:"addr-cache-cap" description:"Address cache capacity in bytes."`
+	AddrCacheLimit   int    `long:"addr-cache-address-limit" description:"Maximum number of addresses allowed in the address cache."`
+	AddrCacheUXTOCap int    `long:"addr-cache-utxo-cap" description:"UTXO cache capacity in bytes."`
+	NoDevPrefetch    bool   `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
+	ChartsCacheDump  string `long:"chartscache" description:"Defines the file name that holds the charts cache data on system exit."`
+
+	// DB backend
 	PGDBName         string        `long:"pgdbname" description:"PostgreSQL DB name." env:"DCRDATA_PG_DB_NAME"`
 	PGUser           string        `long:"pguser" description:"PostgreSQL DB user." env:"DCRDATA_POSTGRES_USER"`
 	PGPass           string        `long:"pgpass" description:"PostgreSQL DB password." env:"DCRDATA_POSTGRES_PASS"`
 	PGHost           string        `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)." env:"DCRDATA_POSTGRES_HOST_URL"`
 	PGQueryTimeout   time.Duration `short:"T" long:"pgtimeout" description:"Timeout (a time.Duration string) for most PostgreSQL queries used for user initiated queries."`
 	HidePGConfig     bool          `long:"hidepgconfig" description:"Blocks logging of the PostgreSQL db configuration on system start up."`
-	AddrCacheCap     int           `long:"addr-cache-cap" description:"Address cache capacity in bytes."`
-	AddrCacheLimit   int           `long:"addr-cache-address-limit" description:"Maximum number of addresses allowed in the address cache."`
-	AddrCacheUXTOCap int           `long:"addr-cache-utxo-cap" description:"UTXO cache capacity in bytes."`
 	DropIndexes      bool          `long:"drop-inds" short:"D" description:"Drop all table indexes and exit."`
-
-	NoDevPrefetch    bool `long:"no-dev-prefetch" description:"Disable automatic dev fund balance query on new blocks. When true, the query will still be run on demand, but not automatically after new blocks are connected." env:"DCRDATA_DISABLE_DEV_PREFETCH"`
-	SyncAndQuit      bool `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`
-	ImportSideChains bool `long:"import-side-chains" description:"(experimental) Enable startup import of side chains retrieved from dcrd via getchaintips." env:"DCRDATA_IMPORT_SIDE_CHAINS"`
-
-	SyncStatusLimit int `long:"sync-status-limit" description:"Sets the number of blocks behind the current best height past which only the syncing status page can be served on the running web server. Value should be greater than 2 but less than 5000."`
-
-	// WatchAddresses []string `short:"w" long:"watchaddress" description:"Watched address (receiving). One per line."`
-	// SMTPUser     string `long:"smtpuser" description:"SMTP user name"`
-	// SMTPPass     string `long:"smtppass" description:"SMTP password"`
-	// SMTPServer   string `long:"smtpserver" description:"SMTP host name"`
-	// EmailAddr    string `long:"emailaddr" description:"Destination email address for alerts"`
-	// EmailSubject string `long:"emailsubj" description:"Email subject. (default \"dcrdataapi transaction notification\")"`
+	PurgeNBestBlocks int           `long:"purge-n-blocks" description:"Purge all data for the N best blocks, using the best block across all DBs if they are out of sync."`
+	SyncAndQuit      bool          `long:"sync-and-quit" description:"Sync to the best block and exit. Do not start the explorer or API." env:"DCRDATA_ENABLE_SYNC_N_QUIT"`
+	ImportSideChains bool          `long:"import-side-chains" description:"(experimental) Enable startup import of side chains retrieved from dcrd via getchaintips." env:"DCRDATA_IMPORT_SIDE_CHAINS"`
+	SyncStatusLimit  int           `long:"sync-status-limit" description:"Sets the number of blocks behind the current best height past which only the syncing status page can be served on the running web server. Value should be greater than 2 but less than 5000."`
 
 	// RPC client options
 	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name" env:"DCRDATA_DCRD_USER"`
@@ -578,10 +572,6 @@ func loadConfig() (*config, error) {
 
 	log.Infof("Log folder:  %s", cfg.LogDir)
 	log.Infof("Config file: %s", configFile)
-
-	if cfg.FullMode {
-		log.Warn("The --pg switch is deprecated since full-mode is now required.")
-	}
 
 	// Disable dev balance prefetch if network has invalid script.
 	_, err = dbtypes.DevSubsidyAddress(activeChain)

--- a/config.go
+++ b/config.go
@@ -80,7 +80,7 @@ var (
 	defaultAddrCacheUXTOCap = 1 << 28
 
 	defaultExchangeIndex     = "USD"
-	defaultDisabledExchanges = "huobi,dragonex"
+	defaultDisabledExchanges = "dragonex,poloniex"
 	defaultRateCertFile      = filepath.Join(defaultHomeDir, "rpc.cert")
 
 	defaultMainnetLink  = "https://explorer.dcrdata.org/"

--- a/config.go
+++ b/config.go
@@ -74,10 +74,10 @@ var (
 	defaultPGUser           = "dcrdata"
 	defaultPGPass           = ""
 	defaultPGDBName         = "dcrdata"
-	defaultPGQueryTimeout   = time.Hour
-	defaultAddrCacheCap     = 1 << 28 // 256 MiB
-	defaultAddrCacheLimit   = 2048
-	defaultAddrCacheUXTOCap = 1 << 28
+	defaultPGQueryTimeout   = 20 * time.Minute
+	defaultAddrCacheCap     = 1 << 29 // 512 MiB
+	defaultAddrCacheLimit   = 4096
+	defaultAddrCacheUXTOCap = 1 << 29
 
 	defaultExchangeIndex     = "USD"
 	defaultDisabledExchanges = "dragonex,poloniex"

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -725,8 +725,8 @@ func (ac *AddressCache) Reporter() {
 		utxoHits, utxoMisses := ac.UtxoStats()
 		histHits, histMisses := ac.HistoryStats()
 		// Only report if a hit/miss count has changed.
-		if balHits != lastBH || balMisses != lastBM ||
-			rowHits != lastRH || rowMisses != lastRM ||
+		if rowHits != lastRH || rowMisses != lastRM ||
+			balHits != lastBH || balMisses != lastBM ||
 			utxoHits != lastUH || utxoMisses != lastUM ||
 			histHits != lastHH || histMisses != lastHM {
 			lastBH, lastBM = balHits, balMisses
@@ -737,11 +737,11 @@ func (ac *AddressCache) Reporter() {
 			log.Debugf("ADDRESS CACHE: addresses = %d, rows = %d, utxos = %d",
 				numAddrs, numRows, numUTXOs)
 			log.Debugf("ADDRESS CACHE:"+
-				"\n\t\t\t\t\t            HITS | MISSES"+
-				"\n\t\t\t\t\trows    %8d | %6d"+
-				"\n\t\t\t\t\tbalance %8d | %6d"+
-				"\n\t\t\t\t\tutxos   %8d | %6d"+
-				"\n\t\t\t\t\thist    %8d | %6d",
+				"\n\t\t\t\t              HITS |    MISSES"+
+				"\n\t\t\t\trows    %10d | %9d"+
+				"\n\t\t\t\tbalance %10d | %9d"+
+				"\n\t\t\t\tutxos   %10d | %9d"+
+				"\n\t\t\t\thist    %10d | %9d",
 				rowHits, rowMisses, balHits, balMisses,
 				utxoHits, utxoMisses, histHits, histMisses)
 		}

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1373,7 +1373,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf(`"address" template HTML size: %.2f kiB (%s, %v, %d)`,
+	log.Tracef(`"address" template HTML size: %.2f kiB (%s, %v, %d)`,
 		float64(len(str))/1024.0, address, txnType, addrData.NumTransactions)
 
 	w.Header().Set("Content-Type", "text/html")
@@ -1423,7 +1423,7 @@ func (exp *explorerUI) AddressTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf(`"addresstable" template HTML size: %.2f kiB (%s, %v, %d)`,
+	log.Tracef(`"addresstable" template HTML size: %.2f kiB (%s, %v, %d)`,
 		float64(len(response.HTML))/1024.0, address, txnType, addrData.NumTransactions)
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Multiple config tweaks and clean-up:

* remove deprecated --pg option

Full mode is the only option, and --pg was deprecated in a previous
release, so remove it now.  Also clean up config options.

* change default disabled exchanges
  - huobi is now enabled by default
  - polo disabled by default

* <s>change link urls to decred.org tlds (e.g. https://explorer.dcrdata.org/ => https://mainnet.decred.org)</s> The {mainnet,testnet}.decred.org domains are still special cases that rewrite /api => /insight/api for compatibility with older insight consumers that used these domains when they were actually running Insight.

* increase default address cache sizes