### PR TITLE
Short URL for the treasury page

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -5,6 +5,7 @@
 package explorer
 
 import (
+	"context"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -1259,6 +1260,13 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Turbolinks-Location", r.URL.RequestURI())
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, str)
+}
+
+// TreasuryPage is the page handler for the "/treasury" path
+func (exp *explorerUI) TreasuryPage(w http.ResponseWriter, r *http.Request) {
+	ctx := context.WithValue(r.Context(), ctxAddress, exp.pageData.HomeInfo.DevAddress)
+	r.URL.Query().Set("txntype", "merged_debit")
+	exp.AddressPage(w, r.WithContext(ctx))
 }
 
 // AddressPage is the page handler for the "/address" path.

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1265,7 +1265,13 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 // TreasuryPage is the page handler for the "/treasury" path
 func (exp *explorerUI) TreasuryPage(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), ctxAddress, exp.pageData.HomeInfo.DevAddress)
-	r.URL.Query().Set("txntype", "merged_debit")
+	rawURL := r.URL.RawQuery
+	if strings.Contains(rawURL, "?") {
+		rawURL += fmt.Sprintf("&%s=%s", "txntype", "merged_debit")
+	} else {
+		rawURL += fmt.Sprintf("?%s=%s", "txntype", "merged_debit")
+	}
+	r.URL.RawQuery = rawURL
 	exp.AddressPage(w, r.WithContext(ctx))
 }
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1265,14 +1265,19 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 // TreasuryPage is the page handler for the "/treasury" path
 func (exp *explorerUI) TreasuryPage(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), ctxAddress, exp.pageData.HomeInfo.DevAddress)
+	r = r.WithContext(ctx)
 	rawURL := r.URL.RawQuery
-	if strings.Contains(rawURL, "?") {
-		rawURL += fmt.Sprintf("&%s=%s", "txntype", "merged_debit")
+	if strings.Contains(rawURL, "txntype") {
+		exp.AddressPage(w, r)
+		return
+	}
+	if rawURL == "" {
+		rawURL = fmt.Sprintf("%s=%s", "txntype", "merged_debit")
 	} else {
-		rawURL += fmt.Sprintf("?%s=%s", "txntype", "merged_debit")
+		rawURL += fmt.Sprintf("&%s=%s", "txntype", "merged_debit")
 	}
 	r.URL.RawQuery = rawURL
-	exp.AddressPage(w, r.WithContext(ctx))
+	exp.AddressPage(w, r)
 }
 
 // AddressPage is the page handler for the "/address" path.

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -1266,17 +1266,10 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 func (exp *explorerUI) TreasuryPage(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), ctxAddress, exp.pageData.HomeInfo.DevAddress)
 	r = r.WithContext(ctx)
-	rawURL := r.URL.RawQuery
-	if strings.Contains(rawURL, "txntype") {
-		exp.AddressPage(w, r)
-		return
+	if queryVals := r.URL.Query(); queryVals.Get("txntype") == "" {
+		queryVals.Set("txntype", "merged_debit")
+		r.URL.RawQuery = queryVals.Encode()
 	}
-	if rawURL == "" {
-		rawURL = fmt.Sprintf("%s=%s", "txntype", "merged_debit")
-	} else {
-		rawURL += fmt.Sprintf("&%s=%s", "txntype", "merged_debit")
-	}
-	r.URL.RawQuery = rawURL
 	exp.AddressPage(w, r)
 }
 

--- a/main.go
+++ b/main.go
@@ -760,6 +760,7 @@ func _main(ctx context.Context) error {
 		r.With(explore.BlockHashPathOrIndexCtx).Get("/block/{blockhash}", explore.Block)
 		r.With(explorer.TransactionHashCtx).Get("/tx/{txid}", explore.TxPage)
 		r.With(explorer.TransactionHashCtx, explorer.TransactionIoIndexCtx).Get("/tx/{txid}/{inout}/{inoutid}", explore.TxPage)
+		r.Get("/treasury", explore.TreasuryPage)
 		r.With(explorer.AddressPathCtx).Get("/address/{address}", explore.AddressPage)
 		r.With(explorer.AddressPathCtx).Get("/addresstable/{address}", explore.AddressTable)
 		r.Get("/agendas", explore.AgendasPage)

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -94,7 +94,7 @@
 					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
 					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
-					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
+					<a class="menu-item" data-keynav-skip href="/treasury" title="Decred Treasury">Treasury</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
 				{{- if eq .NetName "Mainnet"}}
 					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -373,7 +373,7 @@
                     <div class="row mt-1">
                         {{if .DevFund}}
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-                            <div class="fs13 text-secondary"><a href="/address/{{.DevAddress}}?n=20&start=0&txntype=merged_debit">Treasury</a></div>
+                            <div class="fs13 text-secondary"><a href="/treasury">Treasury</a></div>
                             <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
                                 <span data-target="homepage.devFund">
                                     {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .DevFund) 0 true)}}


### PR DESCRIPTION
Close #1742 
This PR adds a /treasury path that shows the Decred Treasury address page.

![image](https://user-images.githubusercontent.com/11990092/82203034-a377ba00-98fa-11ea-8c52-ca71bb585643.png)
