### PR TITLE
Market url and param string improvements

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -2184,7 +2184,12 @@ func (exp *explorerUI) StatsPage(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, str)
 }
 
-// MarketPage is the page handler for the "/agendas" path.
+// MarketPageRedirect is the page handler that redirects "/market" url permanently to "/markets".
+func (exp *explorerUI) MarketPageRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/markets", http.StatusMovedPermanently)
+}
+
+// MarketPage is the page handler for the "/markets" path.
 func (exp *explorerUI) MarketPage(w http.ResponseWriter, r *http.Request) {
 	str, err := exp.templates.exec("market", struct {
 		*CommonPageData

--- a/main.go
+++ b/main.go
@@ -771,7 +771,8 @@ func _main(ctx context.Context) error {
 		r.Get("/charts", explore.Charts)
 		r.Get("/ticketpool", explore.Ticketpool)
 		r.Get("/stats", explore.StatsPage)
-		r.Get("/market", explore.MarketPage)
+		r.Get("/market", explore.MarketPageRedirect) // Moved to markets but still keeping for backward compatibility.
+		r.Get("/markets", explore.MarketPage)
 		r.Get("/statistics", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/stats", http.StatusPermanentRedirect)
 		})

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -91,7 +91,7 @@
 					<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Decred charts">Charts</a>
 					<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
 					<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
-					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
+					<a class="menu-item" data-keynav-skip href="/markets" title="Markets">Markets</a>
 					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Decred Attack Cost">Attack Cost</a>
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
 					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>

--- a/views/market.tmpl
+++ b/views/market.tmpl
@@ -180,8 +180,8 @@
                     data-action="click->market#setConversion"
                 >
                   <label>Index</label>
-                  <button class="btn-selected" name="BTC">BTC</button>
-                  <button name="fiat">{{$botState.BtcIndex}}</button>
+                  <button class="btn-selected" data-index="BTC">BTC</button>
+                  <button data-index="fiat">{{$botState.BtcIndex}}</button>
                 </div>
 
                 {{- /* AGGREGATE DEPTH STACKING */ -}}
@@ -190,8 +190,8 @@
                     data-target="market.aggStack"
                 >
                   <label>Stacking</label>
-                  <button class="btn-selected" data-action="click->market#setStacking" name="on">On</button>
-                  <button data-action="click->market#setStacking" name="off">Off</button>
+                  <button class="btn-selected" data-action="click->market#setStacking" data-stacking="on">On</button>
+                  <button data-action="click->market#setStacking" data-stacking="off">Off</button>
                 </div>
 
                 {{- /* ZOOM */ -}}
@@ -201,10 +201,10 @@
                     data-action="click->market#setZoom"
                 >
                   <label>Zoom +/-</label>
-                  <button class="btn-selected" name="10">10%</button>
-                  <button name="20">20%</button>
-                  <button name="40">40%</button>
-                  <button name="95">95%</button>
+                  <button class="btn-selected" data-percentage="10">10%</button>
+                  <button data-percentage="20">20%</button>
+                  <button data-percentage="40">40%</button>
+                  <button data-percentage="95">95%</button>
                 </div>
 
                 {{- /* OTHER CHART OPTIONS */ -}}


### PR DESCRIPTION
This PR fixed the url parameters of /market page so they are updated automatically when a setting is changed. That way a user who shared a url will be sharing the specific view they are looking at. Also to simplify the url, only params are shown that are set other than the default value. Also added support for the url to be /markets so that it matches the plurality of the rest of the dcrdata urls, while still maintaining backwards-compatible support for /market.