### PR TITLE
Legend element appears over the mobile menu on mobile view.

### DIFF
--- a/public/scss/navigation.scss
+++ b/public/scss/navigation.scss
@@ -3,7 +3,7 @@
 .top-nav,
 .navbar-fixed-bottom {
   position: fixed;
-  z-index: 1000;
+  z-index: 20000;
 }
 
 .top-nav {


### PR DESCRIPTION
A PR that fix the issue of a legend on majority attack cost chart that appears over the mobile menu on mobile view. This fix sets the z-index of the menu above the z-index of the legend element and ensures the menu stays above other elements on the page.

![attack cost2](https://user-images.githubusercontent.com/17119508/83217097-b4c68f00-a162-11ea-8438-8ea5ff255d9d.PNG)
