### PR TITLE
Expired revocation labelled as vote on transaction details

### DIFF
--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -266,16 +266,13 @@
                   </td>
                   <td class="text-right medium-sans text-nowrap pr-2 py-2"><span class="d-none d-sm-inline">Spending</span><span class="d-sm-none">Sp.</span> Tx:</td>
                   <td class="text-left py-1 text-secondary" data-target="tx.spendingTx">
-                    {{$spendingTx := index .SpendingTxns 0}}
-                    {{if $spendingTx.Hash}}
-                      <a href="/tx/{{$spendingTx.Hash}}"
-                      >{{if eq .TicketInfo.PoolStatus "missed"}}revocation{{else}}vote{{end}}
+                    {{- $spendingTx := index .SpendingTxns 0 -}}
+                    {{- if $spendingTx.Hash -}}
+                      <a href="/tx/{{$spendingTx.Hash}}">
+                        {{- if or (eq .TicketInfo.PoolStatus "missed") (eq .TicketInfo.PoolStatus "expired") -}}revocation{{- else -}}vote{{- end -}}
                       </a>
-                    {{else if ne .TicketInfo.SpendStatus ""}}
-                      {{.TicketInfo.SpendStatus}}
-                    {{else}}
-                      unspent
-                    {{end}}
+                    {{- else if ne .TicketInfo.SpendStatus "" -}} {{- .TicketInfo.SpendStatus -}}
+                    {{- else -}}unspent{{- end -}}
                   </td>
                 </tr>
               {{end}}


### PR DESCRIPTION
Corrects the labeling of expired revocation transactions as vote. Both missed and expired transactions fall under revocation and should be labelled appropriately.
To reproduce this issue, visit: https://testnet.dcrdata.org/tx/11385737d5b5cd651e5e3d348874ff3ae12b26100845149bffa2db16fea91877

Resolves https://github.com/decred/dcrdata/issues/1756