### PR TITLE
Added supply and predicted checkboxs. Corrected broken predicted chart on /charts page

### DIFF
--- a/views/charts.tmpl
+++ b/views/charts.tmpl
@@ -188,6 +188,17 @@
                             </li>
                             <li class="nav-item">
                                 <label class="customcheck mx-2 d-inline-flex"
+                                    data-target="charts.vSelectorItem" data-charts="coin-supply">Supply
+                                    <input
+                                        type="checkbox"
+                                        data-action="click->charts#setVisibility"
+                                        data-target="charts.supplySet"
+                                    >
+                                    <span class="checkmark tickets-price"></span>
+                                </label>
+                            </li>
+                            <li class="nav-item">
+                                <label class="customcheck mx-2 d-inline-flex"
                                     data-target="charts.vSelectorItem" data-charts="coin-supply">Mixed Coins
                                     <input
                                         type="checkbox"
@@ -195,6 +206,17 @@
                                         data-target="charts.anonymitySet"
                                     >
                                     <span class="checkmark total-mixed"></span>
+                                </label>
+                            </li>
+                            <li class="nav-item">
+                                <label class="customcheck mx-2 d-inline-flex"
+                                    data-target="charts.vSelectorItem" data-charts="coin-supply">Predicted
+                                    <input
+                                        type="checkbox"
+                                        data-action="click->charts#setVisibility"
+                                        data-target="charts.predictedSet"
+                                    >
+                                    <span class="checkmark tickets-price"></span>
                                 </label>
                             </li>
                         </ul>


### PR DESCRIPTION
This PR adds supply and predicted checkbox settings to /charts?chart=coin-supply page and corrects the broken predicted chart which was wrongly taken from the actual supply chart and creates a separate predicted chart that can be turned on/off by a user. URL params were also made persistent. 

![coinSupply2](https://user-images.githubusercontent.com/17119508/86990034-a02edb00-c193-11ea-96b0-c99a2a5e416c.PNG)

