### PR TITLE
Fixed Group By bug on address data chart

### DIFF
--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -577,6 +577,8 @@ func (d *AddressCacheItem) OldestAddressTransaction() (*dbtypes.AddressRowCompac
 	var oldestTxBlockTime int64
 	oldestTransaction := &dbtypes.AddressRowCompact{}
 
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
 	if d.rows == nil {
 		return nil, fmt.Errorf("Not transactions found")
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6325,7 +6325,7 @@ func (pgb *ChainDB) MixedUtxosByHeight() (heights, utxoCountReg, utxoValueReg, u
 
 }
 
-// OldestTransaction queries the database for the data of the oldest address transaction
+// OldestTransaction retrieves data of the oldest transaction of an address
 func (pgb *ChainDB) OldestTransaction(address string) (*dbtypes.AddressRowCompact, error) {
 	return pgb.AddressCache.OldestAddressTransaction(address)
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6324,3 +6324,8 @@ func (pgb *ChainDB) MixedUtxosByHeight() (heights, utxoCountReg, utxoValueReg, u
 	return
 
 }
+
+// OldestTransaction queries the database for the data of the oldest address transaction
+func (pgb *ChainDB) OldestTransaction(address string) (*dbtypes.AddressRowCompact, error) {
+	return pgb.AddressCache.OldestAddressTransaction(address)
+}

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -72,6 +72,7 @@ type explorerDataSource interface {
 	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
 	AddressHistory(address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
 	AddressData(address string, N, offset int64, txnType dbtypes.AddrTxnViewType) (*dbtypes.AddressInfo, error)
+	OldestTransaction(address string) (*dbtypes.AddressRowCompact, error)
 	DevBalance() (*dbtypes.AddressBalance, error)
 	FillAddressTransactions(addrInfo *dbtypes.AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -156,7 +156,7 @@
                   <button {{if eq $.GroupBy "month"}} class="btn-selected" {{end}} name="month">Month</button>
                   <button {{if eq $.GroupBy "week"}} class="btn-selected" {{end}} name="week">Week</button>
                   <button {{if eq $.GroupBy "day"}} class="btn-selected" {{end}} name="day" data-fixed="1">Day</button>
-				          <button{{if eq $.GroupBy "all"}} class="btn-selected" {{end}} name="all" data-fixed="1">Block</button>
+                  <button{{if eq $.GroupBy "all"}} class="btn-selected" {{end}} name="all" data-fixed="1">Block</button>
               </div>
               <div class="row flex-nowrap d-inline-flex d-hide mx-2 mb-2" data-target="address.flow"
                   data-action="change->address#updateFlow">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -152,11 +152,11 @@
                   data-action="click->address#changeBin"
               >
                   <label class="d-inline-flex pr-1">Group By </label>
-                  <button name="year">Year</button>
-                  <button class="btn-selected" name="month">Month</button>
-                  <button name="week">Week</button>
-                  <button name="day" data-fixed="1">Day</button>
-                  <button name="all" data-fixed="1">Block</button>
+                  <button {{if eq $.GroupBy "year"}} class="btn-selected" {{end}} name="year">Year</button>
+                  <button {{if eq $.GroupBy "month"}} class="btn-selected" {{end}} name="month">Month</button>
+                  <button {{if eq $.GroupBy "week"}} class="btn-selected" {{end}} name="week">Week</button>
+                  <button {{if eq $.GroupBy "day"}} class="btn-selected" {{end}} name="day" data-fixed="1">Day</button>
+				          <button{{if eq $.GroupBy "all"}} class="btn-selected" {{end}} name="all" data-fixed="1">Block</button>
               </div>
               <div class="row flex-nowrap d-inline-flex d-hide mx-2 mb-2" data-target="address.flow"
                   data-action="change->address#updateFlow">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -151,7 +151,7 @@
                   data-target="address.interval"
                   data-action="click->address#changeBin"
               >
-                  <label class="d-inline-flex pr-1">Group By </label>
+                  <label class="d-inline-flex pr-1">Bin</label>
                   <button {{if eq $.GroupBy "year"}} class="btn-selected" {{end}} name="year">Year</button>
                   <button {{if eq $.GroupBy "month"}} class="btn-selected" {{end}} name="month">Month</button>
                   <button {{if eq $.GroupBy "week"}} class="btn-selected" {{end}} name="week">Week</button>


### PR DESCRIPTION
Solves #1734

Added a grouping logic for the graph as per the oldest address transaction block time as follows:
- `< 10 days` ago to group by `All`
- `< 70 days` ago to group by `Day`
- `< 12 months` ago to group by `Week`
- `< 5 years` ago to group by `Month`
- `> 5 years` ago to group by `Year`