### PR TITLE
Bad request on proposals page

### DIFF
--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -530,6 +530,15 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		return
 	}
 
+	lastOffsetRows := uint64(maxOffset) % rows
+	var lastOffset uint64
+
+	if lastOffsetRows == 0 && uint64(maxOffset) > rows {
+		lastOffset = uint64(maxOffset) - rows
+	} else if lastOffsetRows > 0 && uint64(maxOffset) > rows {
+		lastOffset = uint64(maxOffset) - lastOffsetRows
+	}
+
 	// If the view is "years" and the top row is this year, modify the formatted
 	// time string to indicate its a partial result.
 	if val == "Years" && len(data) > 0 && data[0].EndTime.T.Year() == time.Now().Year() {
@@ -545,6 +554,7 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		Offset       int64
 		Limit        int64
 		BestGrouping int64
+		LastOffset   int64
 		Pages        pageNumbers
 	}{
 		CommonPageData: exp.commonData(r),
@@ -553,6 +563,7 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		Offset:         int64(offset),
 		Limit:          int64(rows),
 		BestGrouping:   maxOffset,
+		LastOffset:     int64(lastOffset),
 		Pages:          calcPages(int(maxOffset), int(rows), int(offset), linkTemplate),
 	})
 
@@ -2022,6 +2033,15 @@ func (exp *explorerUI) ProposalsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	lastOffsetRows := uint64(count) % rowsCount
+	var lastOffset uint64
+
+	if lastOffsetRows == 0 && uint64(count) > rowsCount {
+		lastOffset = uint64(count) - rowsCount
+	} else if lastOffsetRows > 0 && uint64(count) > rowsCount {
+		lastOffset = uint64(count) - lastOffsetRows
+	}
+
 	str, err := exp.templates.exec("proposals", struct {
 		*CommonPageData
 		Proposals     []*pitypes.ProposalInfo
@@ -2030,6 +2050,7 @@ func (exp *explorerUI) ProposalsPage(w http.ResponseWriter, r *http.Request) {
 		Offset        int64
 		Limit         int64
 		TotalCount    int64
+		LastOffset    int64
 		PoliteiaURL   string
 		LastVotesSync int64
 		LastPropSync  int64
@@ -2042,6 +2063,7 @@ func (exp *explorerUI) ProposalsPage(w http.ResponseWriter, r *http.Request) {
 		Limit:          int64(rowsCount),
 		VStatusFilter:  int(filterBy),
 		TotalCount:     int64(count),
+		LastOffset:     int64(lastOffset),
 		PoliteiaURL:    exp.politeiaAPIURL,
 		LastVotesSync:  exp.dataSource.LastPiParserSync().UTC().Unix(),
 		LastPropSync:   exp.proposalsSource.LastProposalsSync(),

--- a/views/proposals.tmpl
+++ b/views/proposals.tmpl
@@ -31,7 +31,7 @@
                                 data-target="pagenavigation.votestatus"
                                 data-action="change->pagenavigation#setFilterbyVoteStatus"
                             >
-                                <option value="all">All</option>
+                                <option value="0">All</option>
                                 {{range $k, $v := .VotesStatus}}
                                     <option {{if eq $k $.VStatusFilter}}selected{{end}} value="{{$k}}">{{$v}}</option>
                                 {{end}}
@@ -101,7 +101,7 @@
                                 <li class="page-item {{if ge $oldest $.TotalCount}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="?offset={{subtract $.TotalCount .Limit}}&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
+                                        href="?offset={{.LastOffset}}&rows={{.Limit}}&byvotestatus={{$.VStatusFilter}}"
                                         id="prev"
                                     >Oldest</a>
                                 </li>

--- a/views/timelisting.tmpl
+++ b/views/timelisting.tmpl
@@ -71,7 +71,7 @@
                           <li>
                               <a
                               class="text-secondary"
-                              href="/{{$lowerCaseVal}}?offset={{subtract $lastGrouping .Limit}}&rows={{.Limit}}"
+                              href="/{{$lowerCaseVal}}?offset={{.LastOffset}}&rows={{.Limit}}"
                               >Oldest</a>
                           </li>
                           {{end}}


### PR DESCRIPTION
Closes [#1784](https://github.com/decred/dcrdata/issues/1784)

Fixes the `Bad request` error that occur on the `/proposals` page when one changes the vote status on the drop down from `All` to any other option, then back to `All`.