### PR TITLE
markets: partially resolve Dygraphs spikes issue on agg depth chart

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -171,7 +171,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.bundle.js?x=65tv3"
+		src="/dist/js/app.bundle.js?x=65tv4"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>


### PR DESCRIPTION
This PR removes the dark line of the spikes seen on the aggregated depth chart. Have not yet figured out how to remove the colored part, but that is much more subtle. 

It should be noted that the Dygraphs issue also has the consequence that the sell value at duplicated price points in the overlapping region are not accumulated correctly, so there is still a display bug. At this point, I don't plan to try to work around Dygraphs anymore. I'll spin up the chart on my own if we really want these kinks worked out.