### PR TITLE
[5.3] api: streaming CSV encodes

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -296,7 +296,10 @@ func NewFileRouter(app *appContext, useRealIP bool) fileMux {
 	mux.Route("/address", func(rd chi.Router) {
 		// Allow browser cache for 3 minutes.
 		rd.Use(m.CacheControl(180))
-		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}", app.addressIoCsv)
+		// The carriage return option is handled on the path to facilitate more
+		// effective caching in downstream delivery.
+		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}", app.addressIoCsvNoCR)
+		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}/win", app.addressIoCsvCR)
 	})
 
 	return fileMux{mux}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1859,7 +1858,8 @@ func RetrieveAllAddressTxns(ctx context.Context, db *sql.DB, address string) ([]
 }
 
 // RetrieveAllMainchainAddressTxns retrieves all non-merged and valid_mainchain
-// rows of the address table pertaining to the given address.
+// rows of the address table pertaining to the given address. For a limited
+// query, use RetrieveAddressTxns.
 func RetrieveAllMainchainAddressTxns(ctx context.Context, db *sql.DB, address string) ([]*dbtypes.AddressRow, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectAddressAllMainchainByAddress, address)
 	if err != nil {
@@ -1872,7 +1872,8 @@ func RetrieveAllMainchainAddressTxns(ctx context.Context, db *sql.DB, address st
 
 // RetrieveAllAddressMergedTxns retrieves all merged rows of the address table
 // pertaining to the given address. Specify only valid_mainchain=true rows via
-// the onlyValidMainchain argument.
+// the onlyValidMainchain argument. For a limited query, use
+// RetrieveAddressMergedTxns.
 func RetrieveAllAddressMergedTxns(ctx context.Context, db *sql.DB, address string, onlyValidMainchain bool) ([]uint64, []*dbtypes.AddressRow, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectAddressMergedViewAll, address)
 	if err != nil {
@@ -1937,57 +1938,6 @@ func retrieveAddressTxns(ctx context.Context, db *sql.DB, address string, N, off
 	default:
 		return scanAddressQueryRows(rows, queryType)
 	}
-}
-
-// retrieveAddressIoCsv grabs rows for an address and formats them as a 2-D
-// array of strings for CSV-formatting.
-func retrieveAddressIoCsv(ctx context.Context, db *sql.DB, address string) (csvRows [][]string, err error) {
-	dbRows, err := db.QueryContext(ctx, internal.SelectAddressCsvView, address)
-	if err != nil {
-		return nil, err
-	}
-	defer closeRows(dbRows)
-
-	var txHash, matchingTxHash, strValidMainchain, strDirection string
-	var validMainchain, isFunding bool
-	var value uint64
-	var ioIndex, txType int
-	var blockTime dbtypes.TimeDef
-
-	// header row
-	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index", "valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
-
-	for dbRows.Next() {
-		err = dbRows.Scan(&txHash, &validMainchain, &matchingTxHash,
-			&value, &blockTime, &isFunding, &ioIndex, &txType)
-		if err != nil {
-			return nil, fmt.Errorf("retrieveAddressIoCsv Scan error: %v", err)
-		}
-
-		if validMainchain {
-			strValidMainchain = "1"
-		} else {
-			strValidMainchain = "0"
-		}
-
-		if isFunding {
-			strDirection = "1"
-		} else {
-			strDirection = "-1"
-		}
-
-		csvRows = append(csvRows, []string{
-			txHash,
-			strDirection,
-			strconv.Itoa(ioIndex),
-			strValidMainchain,
-			strconv.FormatFloat(dcrutil.Amount(value).ToCoin(), 'f', -1, 64),
-			strconv.FormatInt(blockTime.UNIX(), 10),
-			txhelpers.TxTypeToString(txType),
-			matchingTxHash,
-		})
-	}
-	return
 }
 
 func scanAddressMergedRows(rows *sql.Rows, addr string, queryType int, onlyValidMainchain bool) (addressRows []*dbtypes.AddressRow, err error) {

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -140,8 +140,11 @@ http {
 
             # When using X-Original-Request-URI along with proxy_cache, the
             # cache key should use $request_uri instead of the dynamic $uri.
+            # However, note that in this configuration care should be taken to
+            # avoid the $args component from creating a multiplicity of cache
+            # keys for the same resource.
             proxy_cache_key $scheme$proxy_host$request_uri;
-            # Alternatively, use $host:
+            # Alternatively, use $host and $args:
             # proxy_cache_key $scheme$host$uri$is_args$args;
 
             # setup proxy cache to use "dcrcache" cache

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -251,7 +251,7 @@
         </div>
         <div class="d-flex align-items-center justify-content-between">
           {{- if gt $TxnCount 0}}
-          <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
+          <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}/win{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
           {{- end}}
           <span></span>{{/*This dummy span ensures left/right alignment of the buttons, even if one is hidden.*/}}
           <div class="d-flex flex-row">


### PR DESCRIPTION
The encoding of CSV should not have been entirely in memory, instead
encoding to the http.ResponseWriter one line at a time.

Previously this had a very specific requirement from a public facing
reverse proxy to avoid multiple simultaneous requests to the same
address but it was easy to mess up, so this is the best fix.

For the csv download path, eliminate the cr query and add an optional
"/win" suffix instead to use carriage returns at the end of each line.
This change also reduces the likelihood of server misconfiguration
causing a cache miss. And this change makes implementing said
server configuration all the simpler.

Thank you to the reporter of this issue, but note that the proxy config
required for safe deployment without this code change is both subtle
and error prone in practice.  This is the reason for acknowledging the
need to make this change from the start, and why it was implemented.