### PR TITLE
api: streaming CSV encodes

### DIFF
--- a/api/apirouter.go
+++ b/api/apirouter.go
@@ -296,7 +296,10 @@ func NewFileRouter(app *appContext, useRealIP bool) fileMux {
 	mux.Route("/address", func(rd chi.Router) {
 		// Allow browser cache for 3 minutes.
 		rd.Use(m.CacheControl(180))
-		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}", app.addressIoCsv)
+		// The carriage return option is handled on the path to facilitate more
+		// effective caching in downstream delivery.
+		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}", app.addressIoCsvNoCR)
+		rd.With(m.AddressPathCtxN(1)).Get("/io/{address}/win", app.addressIoCsvCR)
 	})
 
 	return fileMux{mux}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1639,25 +1638,33 @@ func (pgb *ChainDB) AddressTransactions(address string, N, offset int64,
 }
 
 // AddressTransactionsAll retrieves all non-merged main chain addresses table
-// rows for the given address.
+// rows for the given address. There is presently a hard limit of 3 million rows
+// that may be returned, which is more than 4x the count for the treasury
+// adddress as of mainnet block 521900.
 func (pgb *ChainDB) AddressTransactionsAll(address string) (addressRows []*dbtypes.AddressRow, err error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 
-	addressRows, err = RetrieveAllMainchainAddressTxns(ctx, pgb.db, address)
+	const limit = 3000000
+	addressRows, err = RetrieveAddressTxns(ctx, pgb.db, address, limit, 0)
+	// addressRows, err = RetrieveAllMainchainAddressTxns(ctx, pgb.db, address)
 	err = pgb.replaceCancelError(err)
 	return
 }
 
 // AddressTransactionsAllMerged retrieves all merged (stakeholder-approved and
-// mainchain only) addresses table rows for the given address.
+// mainchain only) addresses table rows for the given address. There is
+// presently a hard limit of 3 million rows that may be returned, which is more
+// than 4x the count for the treasury adddress as of mainnet block 521900.
 func (pgb *ChainDB) AddressTransactionsAllMerged(address string) (addressRows []*dbtypes.AddressRow, err error) {
 	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
 	defer cancel()
 
-	onlyValidMainchain := true
-	_, addressRows, err = RetrieveAllAddressMergedTxns(ctx, pgb.db, address,
-		onlyValidMainchain)
+	const limit = 3000000
+	addressRows, err = RetrieveAddressMergedTxns(ctx, pgb.db, address, limit, 0)
+	// const onlyValidMainchain = true
+	// _, addressRows, err = RetrieveAllAddressMergedTxns(ctx, pgb.db, address,
+	// 	onlyValidMainchain)
 	err = pgb.replaceCancelError(err)
 	return
 }
@@ -2609,141 +2616,6 @@ func (pgb *ChainDB) AddressTotals(address string) (*apitypes.AddressTotals, erro
 		CoinsSpent:   dcrutil.Amount(ab.TotalSpent).ToCoin(),
 		CoinsUnspent: dcrutil.Amount(ab.TotalUnspent).ToCoin(),
 	}, nil
-}
-
-// MakeCsvAddressRows converts an AddressRow slice into a [][]string, including
-// column headers, suitable for saving to CSV.
-func MakeCsvAddressRows(rows []*dbtypes.AddressRow) [][]string {
-	csvRows := make([][]string, 0, len(rows)+1)
-	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index",
-		"valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
-
-	for _, r := range rows {
-		var strValidMainchain string
-		if r.ValidMainChain {
-			strValidMainchain = "1"
-		} else {
-			strValidMainchain = "0"
-		}
-
-		var strDirection string
-		if r.IsFunding {
-			strDirection = "1"
-		} else {
-			strDirection = "-1"
-		}
-
-		csvRows = append(csvRows, []string{
-			r.TxHash,
-			strDirection,
-			strconv.Itoa(int(r.TxVinVoutIndex)),
-			strValidMainchain,
-			strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64),
-			strconv.FormatInt(r.TxBlockTime.UNIX(), 10),
-			txhelpers.TxTypeToString(int(r.TxType)),
-			r.MatchingTxHash,
-		})
-	}
-	return csvRows
-}
-
-func MakeCsvAddressRowsCompact(rows []*dbtypes.AddressRowCompact) [][]string {
-	csvRows := make([][]string, 0, len(rows)+1)
-	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index",
-		"valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
-
-	for _, r := range rows {
-		var strValidMainchain string
-		if r.ValidMainChain {
-			strValidMainchain = "1"
-		} else {
-			strValidMainchain = "0"
-		}
-
-		var strDirection string
-		if r.IsFunding {
-			strDirection = "1"
-		} else {
-			strDirection = "-1"
-		}
-
-		csvRows = append(csvRows, []string{
-			r.TxHash.String(),
-			strDirection,
-			strconv.Itoa(int(r.TxVinVoutIndex)),
-			strValidMainchain,
-			strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64),
-			strconv.FormatInt(r.TxBlockTime, 10),
-			txhelpers.TxTypeToString(int(r.TxType)),
-			r.MatchingTxHash.String(),
-		})
-	}
-	return csvRows
-}
-
-// AddressTxIoCsv grabs rows of an address' transaction input/output data as a
-// 2-D array of strings to be CSV-formatted.
-func (pgb *ChainDB) AddressTxIoCsv(address string) ([][]string, error) {
-	rows, err := pgb.AddressRowsCompact(address)
-	if err != nil {
-		return nil, err
-	}
-
-	return MakeCsvAddressRowsCompact(rows), nil
-
-	// ALT implementation, without cache update:
-
-	// Try the address rows cache.
-	// hash := pgb.BestBlockHash()
-	// rows, validBlock := pgb.AddressCache.Rows(address)
-	// cacheCurrent := validBlock != nil && validBlock.Hash == *hash
-	// if cacheCurrent && rows != nil {
-	// 	log.Debugf("AddressTxIoCsv: Merged address rows cache HIT for %s.", address)
-
-	// 	csvRows := make([][]string, 0, len(rows)+1)
-	// 	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index",
-	// 		"valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
-
-	// 	for _, r := range rows {
-	// 		var strValidMainchain string
-	// 		if r.ValidMainChain {
-	// 			strValidMainchain = "1"
-	// 		} else {
-	// 			strValidMainchain = "0"
-	// 		}
-
-	// 		var strDirection string
-	// 		if r.IsFunding {
-	// 			strDirection = "1"
-	// 		} else {
-	// 			strDirection = "-1"
-	// 		}
-
-	// 		csvRows = append(csvRows, []string{
-	// 			r.TxHash,
-	// 			strDirection,
-	// 			strconv.Itoa(int(r.TxVinVoutIndex)),
-	// 			strValidMainchain,
-	// 			strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64),
-	// 			strconv.FormatInt(r.TxBlockTime.UNIX(), 10),
-	// 			txhelpers.TxTypeToString(int(r.TxType)),
-	// 			r.MatchingTxHash,
-	// 		})
-	// 	}
-
-	// 	return csvRows, nil
-	// }
-
-	// log.Debugf("AddressTxIoCsv: Merged address rows cache MISS for %s.", address)
-
-	// ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
-	// defer cancel()
-
-	// csvRows, err := retrieveAddressIoCsv(ctx, pgb.db, address)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("retrieveAddressIoCsv: %v", err)
-	// }
-	// return csvRows, nil
 }
 
 func (pgb *ChainDB) addressInfo(addr string, count, skip int64, txnType dbtypes.AddrTxnViewType) (*dbtypes.AddressInfo, *dbtypes.AddressBalance, error) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1859,7 +1858,8 @@ func RetrieveAllAddressTxns(ctx context.Context, db *sql.DB, address string) ([]
 }
 
 // RetrieveAllMainchainAddressTxns retrieves all non-merged and valid_mainchain
-// rows of the address table pertaining to the given address.
+// rows of the address table pertaining to the given address. For a limited
+// query, use RetrieveAddressTxns.
 func RetrieveAllMainchainAddressTxns(ctx context.Context, db *sql.DB, address string) ([]*dbtypes.AddressRow, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectAddressAllMainchainByAddress, address)
 	if err != nil {
@@ -1872,7 +1872,8 @@ func RetrieveAllMainchainAddressTxns(ctx context.Context, db *sql.DB, address st
 
 // RetrieveAllAddressMergedTxns retrieves all merged rows of the address table
 // pertaining to the given address. Specify only valid_mainchain=true rows via
-// the onlyValidMainchain argument.
+// the onlyValidMainchain argument. For a limited query, use
+// RetrieveAddressMergedTxns.
 func RetrieveAllAddressMergedTxns(ctx context.Context, db *sql.DB, address string, onlyValidMainchain bool) ([]uint64, []*dbtypes.AddressRow, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectAddressMergedViewAll, address)
 	if err != nil {
@@ -1937,57 +1938,6 @@ func retrieveAddressTxns(ctx context.Context, db *sql.DB, address string, N, off
 	default:
 		return scanAddressQueryRows(rows, queryType)
 	}
-}
-
-// retrieveAddressIoCsv grabs rows for an address and formats them as a 2-D
-// array of strings for CSV-formatting.
-func retrieveAddressIoCsv(ctx context.Context, db *sql.DB, address string) (csvRows [][]string, err error) {
-	dbRows, err := db.QueryContext(ctx, internal.SelectAddressCsvView, address)
-	if err != nil {
-		return nil, err
-	}
-	defer closeRows(dbRows)
-
-	var txHash, matchingTxHash, strValidMainchain, strDirection string
-	var validMainchain, isFunding bool
-	var value uint64
-	var ioIndex, txType int
-	var blockTime dbtypes.TimeDef
-
-	// header row
-	csvRows = append(csvRows, []string{"tx_hash", "direction", "io_index", "valid_mainchain", "value", "time_stamp", "tx_type", "matching_tx_hash"})
-
-	for dbRows.Next() {
-		err = dbRows.Scan(&txHash, &validMainchain, &matchingTxHash,
-			&value, &blockTime, &isFunding, &ioIndex, &txType)
-		if err != nil {
-			return nil, fmt.Errorf("retrieveAddressIoCsv Scan error: %v", err)
-		}
-
-		if validMainchain {
-			strValidMainchain = "1"
-		} else {
-			strValidMainchain = "0"
-		}
-
-		if isFunding {
-			strDirection = "1"
-		} else {
-			strDirection = "-1"
-		}
-
-		csvRows = append(csvRows, []string{
-			txHash,
-			strDirection,
-			strconv.Itoa(ioIndex),
-			strValidMainchain,
-			strconv.FormatFloat(dcrutil.Amount(value).ToCoin(), 'f', -1, 64),
-			strconv.FormatInt(blockTime.UNIX(), 10),
-			txhelpers.TxTypeToString(txType),
-			matchingTxHash,
-		})
-	}
-	return
 }
 
 func scanAddressMergedRows(rows *sql.Rows, addr string, queryType int, onlyValidMainchain bool) (addressRows []*dbtypes.AddressRow, err error) {

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -140,8 +140,11 @@ http {
 
             # When using X-Original-Request-URI along with proxy_cache, the
             # cache key should use $request_uri instead of the dynamic $uri.
+            # However, note that in this configuration care should be taken to
+            # avoid the $args component from creating a multiplicity of cache
+            # keys for the same resource.
             proxy_cache_key $scheme$proxy_host$request_uri;
-            # Alternatively, use $host:
+            # Alternatively, use $host and $args:
             # proxy_cache_key $scheme$host$uri$is_args$args;
 
             # setup proxy cache to use "dcrcache" cache

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -251,7 +251,7 @@
         </div>
         <div class="d-flex align-items-center justify-content-between">
           {{- if gt $TxnCount 0}}
-          <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}?cr=true{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
+          <a class="d-inline-block p-2 rounded download text-nowrap" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}/win{{end}}" type="text/csv" download><span class="dcricon-download mx-1"></span> Download CSV</a>
           {{- end}}
           <span></span>{{/*This dummy span ensures left/right alignment of the buttons, even if one is hidden.*/}}
           <div class="d-flex flex-row">


### PR DESCRIPTION
The encoding of CSV should not have been entirely in memory, instead
encoding to the http.ResponseWriter one line at a time.

Previously this had a very specific requirement from a public facing
reverse proxy to avoid multiple simultaneous requests to the same
address but it was easy to mess up, so this is the best fix.

For the csv download path, eliminate the cr query and add an optional
"/win" suffix instead to use carriage returns at the end of each line.
This change also reduces the likelihood of server misconfiguration
causing a cache miss.