### PR TITLE
api: add a simpler exchange rate API endpoint

### DIFF
--- a/cmd/dcrdata/api/apirouter.go
+++ b/cmd/dcrdata/api/apirouter.go
@@ -248,6 +248,10 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 		r.With(m.ProposalTokenCtx).Get("/{token}", app.getProposalChartData)
 	})
 
+	mux.Route("/exchangerate", func(r chi.Router) {
+		r.Get("/", app.getExchangeRates)
+	})
+
 	mux.Route("/exchanges", func(r chi.Router) {
 		r.Get("/", app.getExchanges)
 		r.Get("/codes", app.getCurrencyCodes)

--- a/cmd/dcrdata/api/insight/apirouter.go
+++ b/cmd/dcrdata/api/insight/apirouter.go
@@ -48,6 +48,7 @@ func NewInsightAPIRouter(app *InsightApi, useRealIP, compression bool, maxAddrs 
 	// may now access the configured indentation string if indent was specified
 	// and parsed as a boolean, otherwise the empty string, from
 	// m.GetIndentCtx(*http.Request).
+
 	mux.Use(m.Indent(app.JSONIndent))
 
 	mux.Use(middleware.Logger)

--- a/exchanges/exchanges_test.go
+++ b/exchanges/exchanges_test.go
@@ -172,7 +172,7 @@ func newTestPoloniexExchange() *PoloniexExchange {
 		CommonExchange: &CommonExchange{
 			token: Poloniex,
 			currentState: &ExchangeState{
-				Price: 1,
+				BaseState: BaseState{Price: 1},
 			},
 			channels: &BotChannels{
 				exchange: make(chan *ExchangeUpdate, 2),
@@ -211,7 +211,7 @@ func TestPoloniexWebsocket(t *testing.T) {
 	poloniex.wsProcessor = poloniex.processWsMessage
 	poloniex.buys = make(wsOrders)
 	poloniex.asks = make(wsOrders)
-	poloniex.currentState = &ExchangeState{Price: 1}
+	poloniex.currentState = &ExchangeState{BaseState: BaseState{Price: 1}}
 	poloniex.startWebsocket()
 	time.Sleep(300 * time.Millisecond)
 	poloniex.ws.Close()
@@ -253,7 +253,7 @@ func newTestBittrexExchange() *BittrexExchange {
 		CommonExchange: &CommonExchange{
 			token: Bittrex,
 			currentState: &ExchangeState{
-				Price: 1,
+				BaseState: BaseState{Price: 1},
 			},
 			channels: &BotChannels{
 				exchange: make(chan *ExchangeUpdate, 2),
@@ -415,7 +415,7 @@ func newTestDex() *DecredDEX {
 		CommonExchange: &CommonExchange{
 			token: DexDotDecred,
 			currentState: &ExchangeState{
-				Price: 1,
+				BaseState: BaseState{Price: 1},
 			},
 			channels: &BotChannels{
 				exchange: make(chan *ExchangeUpdate, 2),
@@ -518,7 +518,7 @@ func TestDecredDEX(t *testing.T) {
 	dcr.wsProcessor = dcr.processWsMessage
 	dcr.buys = make(wsOrders)
 	dcr.asks = make(wsOrders)
-	dcr.currentState = &ExchangeState{Price: 1}
+	dcr.currentState = &ExchangeState{BaseState: BaseState{Price: 1}}
 	dcr.startWebsocket()
 
 	ws.r <- mustEncode(t, initialOrderBook)


### PR DESCRIPTION
`api/exchanges` is a lot of data. `api/exchangereate` is the same thing without the huge binned order data sets.