### PR TITLE
rigorous html escaping

### DIFF
--- a/cmd/dcrdata/api/insight/apimiddleware.go
+++ b/cmd/dcrdata/api/insight/apimiddleware.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -160,7 +161,8 @@ func PostAddrsTxsCtxN(n int) func(next http.Handler) http.Handler {
 			body, err := ioutil.ReadAll(r.Body)
 			r.Body.Close()
 			if err != nil {
-				writeInsightError(w, fmt.Sprintf("error reading JSON message: %v", err))
+				errStr := html.EscapeString(err.Error())
+				writeInsightError(w, fmt.Sprintf("error reading JSON message: %q", errStr))
 				return
 			}
 
@@ -168,7 +170,8 @@ func PostAddrsTxsCtxN(n int) func(next http.Handler) http.Handler {
 			var req apitypes.InsightMultiAddrsTx
 			err = json.Unmarshal(body, &req)
 			if err != nil {
-				writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
+				errStr := html.EscapeString(err.Error())
+				writeInsightError(w, fmt.Sprintf("Failed to parse request: %q", errStr))
 				return
 			}
 
@@ -265,13 +268,15 @@ func PostAddrsUtxoCtxN(n int) func(next http.Handler) http.Handler {
 			body, err := ioutil.ReadAll(r.Body)
 			r.Body.Close()
 			if err != nil {
-				writeInsightError(w, fmt.Sprintf("error reading JSON message: %v", err))
+				errStr := html.EscapeString(err.Error())
+				writeInsightError(w, fmt.Sprintf("error reading JSON message: %q", errStr))
 				return
 			}
 
 			err = json.Unmarshal(body, &req)
 			if err != nil {
-				writeInsightError(w, fmt.Sprintf("Failed to parse request: %v", err))
+				errStr := html.EscapeString(err.Error())
+				writeInsightError(w, fmt.Sprintf("Failed to parse request: %q", errStr))
 				return
 			}
 

--- a/cmd/dcrdata/middleware/apimiddleware_test.go
+++ b/cmd/dcrdata/middleware/apimiddleware_test.go
@@ -84,14 +84,13 @@ func TestGetAddressCtx(t *testing.T) {
 			args:     args{2, []string{"DcxxxxcGjmENx4DhNqDctW5wJCVyT3Qeqkx"}},
 			want:     nil,
 			wantErr:  true,
-			errMsg:   "invalid address 'DcxxxxcGjmENx4DhNqDctW5wJCVyT3Qeqkx' for this network: checksum mismatch",
-		},
+			errMsg:   `invalid address "DcxxxxcGjmENx4DhNqDctW5wJCVyT3Qeqkx" for this network: checksum mismatch`},
 		{
 			testName: "wrong_net",
 			args:     args{2, []string{"TsWmwignm9Q6iBQMSHw9WhBeR5wgUPpD14Q"}},
 			want:     nil,
 			wantErr:  true,
-			errMsg:   `invalid address 'TsWmwignm9Q6iBQMSHw9WhBeR5wgUPpD14Q' for this network: unknown address type`,
+			errMsg:   `invalid address "TsWmwignm9Q6iBQMSHw9WhBeR5wgUPpD14Q" for this network: unknown address type`,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/dcrdata/sample-nginx.conf
+++ b/cmd/dcrdata/sample-nginx.conf
@@ -77,7 +77,7 @@ http {
                 font/otf font/ttf image/bmp image/svg+xml image/x-icon application/octet-stream;
 
         add_header Referrer-Policy "same-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.dcrdata.org; manifest-src 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; font-src 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' wss://*.dcrdata.org; manifest-src 'self'" always;
         add_header X-Content-Type-Options nosniff always;
         add_header X-Frame-Options SAMEORIGIN always;
         add_header X-XSS-Protection "1; mode=block" always;

--- a/exchanges/exchanges_test.go
+++ b/exchanges/exchanges_test.go
@@ -269,7 +269,7 @@ func (conn testBittrexConnection) On() bool {
 	return false
 }
 
-func (conn testBittrexConnection) Send(subscription hubs.ClientMsg) error {
+func (conn testBittrexConnection) Send(hubs.ClientMsg) error {
 	return nil
 }
 


### PR DESCRIPTION
Both the insight and dcrdata http APIs need to be more cautious with their responses that might include html.
For the most part this involves using `html.EscapeString` with any string that might contain user input, such as an error message.