### PR TITLE
prevent double Close'ing of the signalr and websocket connections

### DIFF
--- a/exchanges/exchanges.go
+++ b/exchanges/exchanges.go
@@ -426,6 +426,11 @@ type Exchange interface {
 	UpdateIndices(FiatIndices)
 }
 
+// Doer is an interface for a *http.Client to allow testing of Refresh paths.
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
 // CommonExchange is embedded in all of the exchange types and handles some
 // state tracking and token handling for ExchangeBot communications. The
 // http.Request must be created individually for each exchange.
@@ -434,7 +439,7 @@ type CommonExchange struct {
 	token        string
 	URL          string
 	currentState *ExchangeState
-	client       *http.Client
+	client       Doer
 	lastUpdate   time.Time
 	lastFail     time.Time
 	lastRequest  time.Time
@@ -650,15 +655,20 @@ func (xc *CommonExchange) wsListening() bool {
 
 // Log the error and time, and increment the error counter.
 func (xc *CommonExchange) setWsFail(err error) {
+	log.Errorf("%s websocket error: %v", xc.token, err)
 	xc.wsMtx.Lock()
 	defer xc.wsMtx.Unlock()
 	if xc.ws != nil {
 		xc.ws.Close()
+		// Clear the field to prevent double Close'ing.
+		xc.ws = nil
 	}
 	if xc.sr != nil {
 		xc.sr.Close()
+		// Clear the field to prevent double Close'ing. signalr will hang on
+		// second call.
+		xc.sr = nil
 	}
-	log.Errorf("%s websocket error: %v", xc.token, err)
 	xc.wsSync.err = err
 	xc.wsSync.errCount++
 	xc.wsSync.fail = time.Now()
@@ -1704,7 +1714,7 @@ func (bittrex *BittrexExchange) Refresh() {
 	// Check for a depth chart from the websocket orderbook.
 	tryHttp, wsStarting, depth := bittrex.wsDepthStatus(bittrex.connectWs)
 
-	// // If not expecting depth data from the websocket, grab it from HTTP
+	// If not expecting depth data from the websocket, grab it from HTTP
 	if tryHttp {
 		depthResponse, err := bittrex.orderbook()
 		if err != nil {

--- a/exchanges/exchanges_live_test.go
+++ b/exchanges/exchanges_live_test.go
@@ -256,7 +256,6 @@ func TestBittrexLiveWebsocket(t *testing.T) {
 		}
 	}()
 
-	// bittrex := newTestBittrexExchange()
 	chans := &BotChannels{
 		index:    make(chan *IndexUpdate),
 		exchange: make(chan *ExchangeUpdate, 1),

--- a/exchanges/exchanges_test.go
+++ b/exchanges/exchanges_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -251,15 +252,14 @@ func (d *tDoer) queue(body interface{}) *http.Response {
 		panic("tDoer.queue error:" + err.Error())
 	}
 	resp := &http.Response{
-		Body: io.NopCloser(bytes.NewReader(b)),
+		Body: ioutil.NopCloser(bytes.NewReader(b)),
 	}
 	d.responses = append(d.responses, resp)
 	return resp
 }
 
 type testBittrexConnection struct {
-	xc           *BittrexExchange
-	subscription hubs.ClientMsg
+	xc *BittrexExchange
 }
 
 func (conn testBittrexConnection) Close() {}
@@ -270,7 +270,6 @@ func (conn testBittrexConnection) On() bool {
 }
 
 func (conn testBittrexConnection) Send(subscription hubs.ClientMsg) error {
-	conn.subscription = subscription
 	return nil
 }
 
@@ -422,7 +421,7 @@ func TestBittrexWebsocket(t *testing.T) {
 	bittrex.Refresh()
 	select {
 	case <-bittrex.channels.exchange:
-		t.Fatalf("emmited an update when we shouldn't have")
+		t.Fatalf("emitted an update when we shouldn't have")
 	default:
 	}
 


### PR DESCRIPTION
Also some basic Refresh tests, but they didn't catch the bug.