### PR TITLE
sync clarity and eliminate batch vouts.spend_tx_row_id update

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,12 +433,14 @@ the `dcrdata` executable.
 
 The time required to sync varies greatly with system hardware and software
 configuration. The most important factor is the storage medium on the database
-machine. An SSD (preferably NVMe, not SATA) is strongly recommended if you value
-your time and system performance.
+machine. An SSD (preferably NVMe, not SATA) is REQUIRED. The PostgreSQL
+operations are extremely disk intensive, especially during the initial
+synchronization process. Both high throughput and low latencies for fast
+random accesses are essential.
 
 ### dcrdata only (PostgreSQL on other host)
 
-Minimum:
+Without PostgreSQL, the dcrdata process can get by with:
 
 - 1 CPU core
 - 2 GB RAM
@@ -452,13 +454,13 @@ Minimum:
 
 - 2 CPU core
 - 6 GB RAM
-- HDD with 120GB free space
+- SSD with 120GB free space (no spinning hard drive for the DB!)
 
 Recommend:
 
-- 2+ CPU cores
-- 8+ GB RAM
-- SSD (NVMe preferred) with 120 GB free space
+- 3+ CPU cores
+- 12+ GB RAM
+- NVMe SSD with 120 GB free space
 
 ## dcrdata Daemon
 

--- a/cmd/dcrdata/explorer/explorer.go
+++ b/cmd/dcrdata/explorer/explorer.go
@@ -102,7 +102,6 @@ type explorerDataSource interface {
 	GetBlockHeight(hash string) (int64, error)
 	GetBlockHash(idx int64) (string, error)
 	GetExplorerTx(txid string) *types.TxInfo
-	GetExplorerAddress(address string, count, offset int64) (*dbtypes.AddressInfo, txhelpers.AddressType, txhelpers.AddressError)
 	GetTip() (*types.WebBasicBlock, error)
 	DecodeRawTransaction(txhex string) (*chainjson.TxRawResult, error)
 	SendRawTransaction(txhex string) (string, error)

--- a/cmd/dcrdata/sample-dcrdata.conf
+++ b/cmd/dcrdata/sample-dcrdata.conf
@@ -48,10 +48,6 @@
 ; Set "Cache-Control: max-age=X" in HTTP response header for FileServer routes.
 ;cachecontrol-maxage=86400
 
-; Enable postgresql support, providing more features such as linking outputs to
-; spending transactions, and full balance queries. (Default is false.)
-;pg=true
-
 ; politeiaurl set the root API URL need to query the politeia data via HTTP.
 ;politeiaurl="https://proposals.decred.org"
 

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1550,6 +1550,9 @@ func CompactRows(rows []*AddressRow) []*AddressRowCompact {
 // []*AddressRow. VinVoutDbID is unknown and set to zero. Do not use
 // VinVoutDbID, or insert the AddressRow.
 func UncompactRows(compact []*AddressRowCompact) []*AddressRow {
+	if compact == nil {
+		return nil
+	}
 	rows := make([]*AddressRow, 0, len(compact))
 	for _, r := range compact {
 		// An unset matching hash is represented by the zero-value array.
@@ -1577,6 +1580,9 @@ func UncompactRows(compact []*AddressRowCompact) []*AddressRow {
 // to a []*AddressRow. VinVoutDbID is unknown and set to zero. Do not use
 // VinVoutDbID, or insert the AddressRow.
 func UncompactMergedRows(merged []*AddressRowMerged) []*AddressRow {
+	if merged == nil {
+		return nil
+	}
 	rows := make([]*AddressRow, 0, len(merged))
 	for _, r := range merged {
 		rows = append(rows, &AddressRow{

--- a/db/dcrpg/chainmonitor.go
+++ b/db/dcrpg/chainmonitor.go
@@ -106,9 +106,10 @@ func (p *ChainMonitor) switchToSideChain(reorgData *txhelpers.ReorgData) (int32,
 		// New blocks stored this way are considered part of mainchain. They are
 		// also considered valid unless invalidated by the next block
 		// (invalidation of previous handled inside StoreBlock).
-		isValid, isMainChain, updateExisting := true, true, true
+		isValid, isMainChain := true, true
+		updateExistingRecords, updateAddressesSpendingInfo := true, true
 		_, _, _, err = p.db.StoreBlock(msgBlock, isValid, isMainChain,
-			updateExisting, true, true, chainWork)
+			updateExistingRecords, updateAddressesSpendingInfo, chainWork)
 		if err != nil {
 			return int32(p.db.bestBlock.Height()), p.db.bestBlock.Hash(),
 				fmt.Errorf("error connecting block %v", newChain[i])

--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -559,9 +559,8 @@ func (pgb *ChainDB) DeindexAll() error {
 }
 
 // IndexAll creates most indexes in the tables. Exceptions: (1) addresses on
-// matching_tx_hash (use IndexAddressTable or do it individually), (2) all
-// tickets table indexes (use IndexTicketsTable), and (3) vouts on
-// spend_tx_row_id (use IndexVoutTableOnSpendTxID).
+// matching_tx_hash (use IndexAddressTable or do it individually) and (2) all
+// tickets table indexes (use IndexTicketsTable).
 func (pgb *ChainDB) IndexAll(barLoad chan *dbtypes.ProgressBarLoad) error {
 	allIndexes := []indexingInfo{
 		// blocks table
@@ -580,7 +579,7 @@ func (pgb *ChainDB) IndexAll(barLoad chan *dbtypes.ProgressBarLoad) error {
 
 		// vouts table
 		{Msg: "vouts table on tx hash and index", IndexFunc: IndexVoutTableOnTxHashIdx},
-		// {Msg: "vouts table on spend tx row id", IndexFunc: IndexVoutTableOnSpendTxID},
+		{Msg: "vouts table on spend tx row id", IndexFunc: IndexVoutTableOnSpendTxID},
 
 		// votes table
 		{Msg: "votes table on candidate block", IndexFunc: IndexVotesTableOnCandidate},

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -42,18 +42,6 @@ func (pgb *ChainDB) GetRawTransaction(txid *chainhash.Hash) (*chainjson.TxRawRes
 	return txraw, nil
 }
 
-// GetBlockHeight returns the height of the block with the specified hash.
-func (pgb *ChainDB) GetBlockHeight(hash string) (int64, error) {
-	ctx, cancel := context.WithTimeout(pgb.ctx, pgb.queryTimeout)
-	defer cancel()
-	height, err := RetrieveBlockHeight(ctx, pgb.db, hash)
-	if err != nil {
-		log.Errorf("Unable to get block height for hash %s: %v", hash, err)
-		return -1, pgb.replaceCancelError(err)
-	}
-	return height, nil
-}
-
 // SendRawTransaction attempts to decode the input serialized transaction,
 // passed as hex encoded string, and broadcast it, returning the tx hash.
 func (pgb *ChainDB) SendRawTransaction(txhex string) (string, error) {

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -228,10 +228,15 @@ func (pgb *ChainDB) BlockSummaryTimeRange(min, max int64, limit int) ([]dbtypes.
 // AddressUTXO returns the unspent transaction outputs (UTXOs) paying to the
 // specified address in a []*dbtypes.AddressTxnOutput.
 func (pgb *ChainDB) AddressUTXO(address string) ([]*dbtypes.AddressTxnOutput, bool, error) {
+	_, err := dcrutil.DecodeAddress(address, pgb.chainParams)
+	if err != nil {
+		return nil, false, err
+	}
+
 	// Check the cache first.
 	bestHash, height := pgb.BestBlock()
 	utxos, validHeight := pgb.AddressCache.UTXOs(address)
-	if utxos != nil && *bestHash == validHeight.Hash {
+	if utxos != nil && validHeight != nil /* validHeight.Hash == *bestHash */ {
 		return utxos, false, nil
 	}
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -306,10 +306,12 @@ const (
 	AssignMatchingTxHashForOutpoint = SetAddressMatchingTxHashForOutpoint + ` AND matching_tx_hash='';`
 
 	SetAddressMainchainForVoutIDs = `UPDATE addresses SET valid_mainchain=$1
-		WHERE is_funding = TRUE AND tx_vin_vout_row_id=$2;`
+		WHERE is_funding = TRUE AND tx_vin_vout_row_id=$2
+		RETURNING address;`
 
 	SetAddressMainchainForVinIDs = `UPDATE addresses SET valid_mainchain=$1
-		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2;`
+		WHERE is_funding = FALSE AND tx_vin_vout_row_id=$2
+		RETURNING address;`
 
 	// Patches/upgrades
 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -256,7 +256,7 @@ const (
 		` ON vouts(spend_tx_row_id);`
 	DeindexVoutTableOnSpendTxID = `DROP INDEX IF EXISTS ` + IndexOfVoutsTableOnSpendTxID + ` CASCADE;`
 
-	SelectAddressByTxHash = `SELECT id, script_addresses, value, mixed FROM vouts
+	SelectVoutAddressesByTxOut = `SELECT id, script_addresses, value, mixed FROM vouts
 		WHERE tx_hash = $1 AND tx_index = $2 AND tx_tree = $3;`
 
 	SelectPkScriptByID       = `SELECT version, pkscript FROM vouts WHERE id=$1;`

--- a/gov/politeia/proposals.go
+++ b/gov/politeia/proposals.go
@@ -6,6 +6,7 @@
 package politeia
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -330,7 +331,9 @@ func (db *ProposalDB) proposal(searchBy, searchTerm string) (*pitypes.ProposalIn
 	var pInfo pitypes.ProposalInfo
 	err := db.dbP.Select(q.Eq(searchBy, searchTerm)).Limit(1).First(&pInfo)
 	if err != nil {
-		log.Errorf("Failed to fetch data from Proposals DB: %v", err)
+		if !errors.Is(err, storm.ErrNotFound) {
+			log.Errorf("Failed to fetch data from Proposals DB: %v", err)
+		}
 		return nil, err
 	}
 

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1275,20 +1275,20 @@ const (
 
 // AddressValidation performs several validation checks on the given address
 // string. Initially, decoding as a Decred address is attempted. If it fails to
-// decode, AddressErrorDecodeFailed is returned with AddressTypeUnknown.
-// If the address decoded successfully as a Decred address, it is checked
-// against the specified network. If it is the wrong network,
-// AddressErrorWrongNet is returned with AddressTypeUnknown. If the address is
-// the correct network, the address type is obtained. A final check is performed
-// to determine if the address is the zero pubkey hash address, in which case
-// AddressErrorZeroAddress is returned with the determined address type. If it
-// is another address, AddressErrorNoError is returned with the determined
-// address type.
+// decode, AddressErrorDecodeFailed is returned with AddressTypeUnknown. If the
+// address decoded successfully as a Decred address, it is checked against the
+// specified network. A final check is performed to determine if the address is
+// the zero pubkey hash address, in which case AddressErrorZeroAddress is
+// returned with the determined address type. If it is another address,
+// AddressErrorNoError (nil) is returned with the determined address type.
 func AddressValidation(address string, params *chaincfg.Params) (dcrutil.Address, AddressType, AddressError) {
 	// Decode and validate the address.
 	addr, err := dcrutil.DecodeAddress(address, params)
 	if err != nil {
-		return nil, AddressTypeUnknown, AddressErrorDecodeFailed // AddressErrorWrongNet?
+		// if errors.Is(err, dcrutil.ErrUnknownAddressType) {
+		// 	return nil, AddressTypeUnknown, AddressErrorWrongNet // possible? ErrUnknownAddressType means many things
+		// }
+		return nil, AddressTypeUnknown, AddressErrorDecodeFailed
 	}
 
 	// Determine address type for this valid Decred address. Ignore the error


### PR DESCRIPTION
This PR has been running on tip.dcrdata.org, the hidden service, testnet, and one mainnet backend.

This contains a few distinct improvements, all related to DB or sync and are thus stacked commits:

- Each step of the startup sync is described in terms of **stages**.  e.g. `Beginning SYNC STAGE 1 of 6 (block data import)...`
- The **batch update of `the vouts.spend_tx_row_id` column is eliminated** and is done on-the-fly always, just like normal during operation.  The mega query that did this update (see `updateSpendTxInfoInAllVouts`) during the initial sync step previously was surprisingly costly on slower drives.  On an SSD, it would be less than 30 minutes, but on a HDD it ran for 12+ hours (not acceptable).  Doing the update on the fly even for the initial block data import is acceptable since it updates with a condition on the primary key of the vouts table, and before the index on `spend_tx_row_id` is created.  On my machine this increased the stage 1 time from 155 to about 165 minutes.  This increase is likely to be higher on spinning disks, but it is more tolerable than an impractically large query at the end.
- The **address cache** now relies on proactive address eviction by `StoreBlock` via `FreshenAddressCaches`.  Previously, the DB layer would consider cached data as expired if the block returned by a cache query was less than the best block.  But this had the effect of invalidating the entire cache when a new block was recorded, even if there were no transactions that would actually invalidate a cache item for a certain address.  This is particularly important for keeping the legacy treasury entry valid since it is not always updated each block any more.  Reorg and block disapproval are also rigged to evict affected addresses.
- **Search page** handler optimizations:
  * Just check for addresses with `DecodeAddress` and redirect to the address page. Don't use the `searchrawtransactions` RPC or the `AddressHistory` DB method. 
  * Only try proposals _after_ tx, block, and address.
  * Only try block if not "utxo-like".
  * Only try tx if less than 5 bytes of leading/trailing zeros. NOTE: 10 hex zeros (`'0'`) has never gotten close to happening for a random txid. The most ever is 0000031b3776cfb6ea658198a89e96a83abfc72a401552dee6fdc4e26d30f3f1.  Would someone have any interest in hiding a tx from the search function by brute-forcing some element of the raw tx like an output amount?  It would still be viewable on the /tx page or the containing /block page.
  * Only check DB for a tx in an orphaned block after everything else.

This also updates the README to require an SSD for the postgres process.