### PR TITLE
blocks page: (dis)approved vs. (in)valid wording

### DIFF
--- a/cmd/dcrdata/explorer/templates.go
+++ b/cmd/dcrdata/explorer/templates.go
@@ -330,6 +330,12 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 	netTheme := "theme-" + strings.ToLower(netName(params))
 
 	return template.FuncMap{
+		"blockVoteBitsStr": func(voteBits uint16) string {
+			if voteBits&1 == 0 {
+				return "disapprove"
+			}
+			return "approve"
+		},
 		"txtypeStr": func(txtype int) string {
 			return txhelpers.TxTypeToString(txtype)
 		},

--- a/cmd/dcrdata/explorer/templates_test.go
+++ b/cmd/dcrdata/explorer/templates_test.go
@@ -4,6 +4,38 @@ import (
 	"testing"
 )
 
+func TestBlockVoteBitsStr(t *testing.T) {
+	funcs := makeTemplateFuncMap(nil)
+
+	blockVoteBitsStr, ok := funcs["blockVoteBitsStr"]
+	if !ok {
+		t.Fatalf(`Template function map does not contain "blockVoteBitsStr".`)
+	}
+
+	blockVoteBitsStrFn, ok := blockVoteBitsStr.(func(voteBits uint16) string)
+	if !ok {
+		t.Fatalf(`Template function "blockVoteBitsStr" is not of type "func(voteBits uint16) string".`)
+	}
+
+	testData := []struct {
+		bits uint16
+		want string
+	}{
+		{0, "disapprove"},
+		{1, "approve"},
+		{2, "disapprove"},
+		{3, "approve"},
+		{10, "disapprove"},
+		{11, "approve"},
+	}
+
+	for i := range testData {
+		if got := blockVoteBitsStrFn(testData[i].bits); got != testData[i].want {
+			t.Errorf("wanted %q, got %q", testData[i].want, got)
+		}
+	}
+}
+
 func TestPrefixPath(t *testing.T) {
 	funcs := makeTemplateFuncMap(nil)
 

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -142,13 +142,13 @@
 							><span class="d-sm-none">Stk Ver</span>: </td>
 						<td class="text-left text-secondary">{{.StakeVersion}}</td>
 						<td class="d-none d-sm-table-cell text-right font-weight-bold text-nowrap pr-2">Vote Bits: </td>
-						<td class="d-none d-sm-table-cell text-left text-secondary">{{.VoteBits}}</td>
+						<td class="d-none d-sm-table-cell text-left text-secondary">{{.VoteBits}} ({{blockVoteBitsStr .VoteBits}})</td>
 					</tr>
 					<tr class="d-sm-none">
 						<td class="text-right font-weight-bold text-nowrap pr-2">Pool Size: </td>
 						<td class="text-left text-secondary">{{.PoolSize}}</td>
 						<td class="text-right font-weight-bold text-nowrap pr-2">Vote Bits: </td>
-						<td class="text-left text-secondary">{{.VoteBits}}</td>
+						<td class="text-left text-secondary">{{.VoteBits}} ({{blockVoteBitsStr .VoteBits}})</td>
 					</tr>
 					<tr class="d-sm-none">
 						<td class="text-right font-weight-bold text-nowrap pr-2">Nonce: </td>
@@ -259,7 +259,7 @@
 						<span><a class="hash lh1rem" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
 					</td>
 					<td class="mono fs15 text-right">{{.VoteInfo.Version}}</td>
-					<td class="text-right">{{if .VoteInfo.Validation.Validity}}Valid{{else}}Invalid{{end}}</td>
+					<td class="text-right">{{if .VoteInfo.Validation.Validity}}Approve{{else}}Disapprove{{end}}</td>
 					<td class="mono fs15 text-right">
 						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
 					</td>


### PR DESCRIPTION
This changes the wording around stakeholder (dis)approval to what it really means.
Saying (in)valid is misleading as the blocks are still valid, just that the stakeholders
have disapproved the regular tree transactions.

This change is visible on the /block page in two places:

![image](https://user-images.githubusercontent.com/9373513/126362565-fb70525b-1c72-43c1-9ae0-a99f235828a0.png)

Instead of just the integer vote bits above, it shows "approve" or "disapprove".

And in the votes table:

![image](https://user-images.githubusercontent.com/9373513/126362743-98d88c99-ffe1-4de6-aa4b-621a25caf23e.png)
