### PR TITLE
fix purge not resetting vouts.spend_tx_row_ids

### DIFF
--- a/db/dcrpg/internal/rewind.go
+++ b/db/dcrpg/internal/rewind.go
@@ -210,6 +210,9 @@ const (
 		USING blocks
 		WHERE purchase_tx_db_id = ANY(blocks.stxdbids)
 			AND blocks.hash=$1;`
+	// DeleteTicketsSimple is simple, but slower because block_hash is second in
+	// a multi-column index, whereas both tickets.purchase_tx_db_id and
+	// blocks.hash are their own unique indexes.
 	DeleteTicketsSimple = `DELETE FROM tickets
 		WHERE block_hash=$1;`
 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -198,7 +198,12 @@ const (
 
 	UpdateVoutSpendTxRowID  = `UPDATE vouts SET spend_tx_row_id = $1 WHERE id = $2;`
 	UpdateVoutsSpendTxRowID = `UPDATE vouts SET spend_tx_row_id = $1 WHERE id = ANY($2);`
-	ResetVoutSpendTxRowIDs  = `UPDATE vouts SET spend_tx_row_id = NULL WHERE id = ANY($1);`
+
+	// ResetVoutSpendTxRowIDs resets spend_tx_row_id for vouts given transaction
+	// row ids. e.g. For rolled-back/purged transactions that no longer spend
+	// the targeted vouts (previous outputs).
+	ResetVoutSpendTxRowIDs = `UPDATE vouts SET spend_tx_row_id = NULL
+		WHERE spend_tx_row_id = ANY($1);`
 
 	// InsertVoutRowOnConflictDoNothing allows an INSERT with a DO NOTHING on
 	// conflict with vouts' unique tx index, while returning the row id of

--- a/db/dcrpg/rewind.go
+++ b/db/dcrpg/rewind.go
@@ -56,7 +56,7 @@ func deleteVotesForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err 
 }
 
 func deleteTicketsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {
-	return sqlExec(dbTx, internal.DeleteTicketsSimple, "failed to delete tickets", hash)
+	return sqlExec(dbTx, internal.DeleteTickets, "failed to delete tickets", hash)
 }
 
 func deleteTreasuryTxnsForBlock(dbTx SqlExecutor, hash string) (rowsDeleted int64, err error) {


### PR DESCRIPTION
When using `--purge-n-blocks`, there was a bug that prevented the `vouts.spend_tx_row_id` column from being reset to `NULL` for purged transactions.  This fixes the buggy query (`ResetVoutSpendTxRowIDs`), adds purge timing to the `DeletionSummary` and it's `String` method, and cleans up some of the purge logic in `main` from when sqlite was removed.

```
2021-07-20 15:11:21.635 [INF] DATD: Purging PostgreSQL data for the 200 best blocks back to 573320...
2021-07-20 15:12:02.936 [INF] DATD: Successfully purged data for 200 blocks from PostgreSQL (new height = 573320):
      200 Blocks purged in 6.524621816s
    22774 Vins purged in 433.885111ms
    25705 Vouts purged in 387.882755ms
    42265 Addresses purged in 903.273033ms
     3899 Transactions purged in 97.149828ms
    21316 Vout spending tx row ids reset in 1.015206845s
     1115 Tickets purged in 30.141524961s
      976 Votes purged in 83.672047ms
       24 Misses purged in 535.631891ms
      200 Treasury transactions purged in 278.819753ms
       50 Swaps purged in 35.836891ms
```

And then no more warnings like `[WRN] PSQL: Unable to find cached UTXO data for ...:0` when sync resumes, which was the indication that the UTXO cache was lacking these tx outputs because they still had their `spend_tx_row_id` set.