### PR TITLE
dcrpg: remove redundant stats(height) index

### DIFF
--- a/db/dcrpg/indexing.go
+++ b/db/dcrpg/indexing.go
@@ -579,7 +579,7 @@ func (pgb *ChainDB) IndexAll(barLoad chan *dbtypes.ProgressBarLoad) error {
 		//{Msg: "addresses table on matching tx hash", IndexFunc: IndexAddressTableOnMatchingTxHash},
 
 		// stats table
-		{Msg: "stats table on height", IndexFunc: IndexStatsTableOnHeight},
+		// {Msg: "stats table on height", IndexFunc: IndexStatsTableOnHeight}, // redundant with UNIQUE constraint in table def
 
 		// treasury table
 		{Msg: "treasury on tx hash", IndexFunc: IndexTreasuryTableOnTxHash},
@@ -722,12 +722,6 @@ func (pgb *ChainDB) DeindexAddressTable() error {
 		}
 	}
 	return err
-}
-
-// IndexStatsTableOnHeight creates the index for the stats table over height.
-func IndexStatsTableOnHeight(db *sql.DB) (err error) {
-	_, err = db.Exec(internal.IndexStatsOnHeight)
-	return
 }
 
 // DeindexStatsTableOnHeight drops the index for the stats table over height.

--- a/db/dcrpg/internal/indexes.go
+++ b/db/dcrpg/internal/indexes.go
@@ -61,7 +61,7 @@ const (
 
 	// stats table
 
-	IndexOfHeightOnStatsTable = "uix_stats_height"
+	IndexOfHeightOnStatsTable = "uix_stats_height" // REMOVED
 
 	// treasury table
 
@@ -102,7 +102,6 @@ var IndexDescriptions = map[string]string{
 	IndexOfMissesTableOnHashes:            "misses on ticket hash and block hash",
 	IndexOfAgendasTableOnName:             "agendas on agenda name",
 	IndexOfAgendaVotesTableOnRowIDs:       "agenda_votes on votes table row ID and agendas table row ID",
-	IndexOfHeightOnStatsTable:             "stats table on height",
 	IndexOfTreasuryTableOnTxHash:          "treasury table on tx hash",
 	IndexOfTreasuryTableOnHeight:          "treasury table on block height",
 }

--- a/db/dcrpg/internal/stats.go
+++ b/db/dcrpg/internal/stats.go
@@ -15,8 +15,8 @@ const (
 		pool_val INT8
 	);`
 
-	IndexStatsOnHeight   = `CREATE UNIQUE INDEX ` + IndexOfHeightOnStatsTable + ` ON stats(height);`
-	DeindexStatsOnHeight = `DROP INDEX ` + IndexOfHeightOnStatsTable + ` CASCADE;`
+	IndexStatsOnHeight   = `CREATE UNIQUE INDEX ` + IndexOfHeightOnStatsTable + ` ON stats(height);` // DO NOT USE
+	DeindexStatsOnHeight = `DROP INDEX IF EXISTS ` + IndexOfHeightOnStatsTable + ` CASCADE;`
 
 	UpsertStats = `
 		INSERT INTO stats (blocks_id, height, pool_size, pool_val)

--- a/db/dcrpg/rewind.go
+++ b/db/dcrpg/rewind.go
@@ -128,6 +128,7 @@ func deleteBlockFromChain(dbTx *sql.Tx, hash string) (err error) {
 		// attempt to locate a row with next_hash set to the hash of this block,
 		// and set it to the empty string.
 		if err == sql.ErrNoRows {
+			log.Warnf("Block %v not found in block_chain.this_hash column.", hash)
 			err = UpdateBlockNextByNextHash(dbTx, hash, "")
 		}
 		return


### PR DESCRIPTION
CAREFUL: This will upgrade your DB schema version.

This removes a redundant index on `stats.height`.

`\d stats` was showing this:

```
                 Table "public.stats"
  Column   |  Type   | Collation | Nullable | Default 
-----------+---------+-----------+----------+---------
 blocks_id | integer |           |          | 
 height    | integer |           |          | 
 pool_size | bigint  |           |          | 
 pool_val  | bigint  |           |          | 
Indexes:
    "stats_height_key" UNIQUE CONSTRAINT, btree (height)
    "uix_stats_height" UNIQUE, btree (height)
Foreign-key constraints:
    "stats_blocks_id_fkey" FOREIGN KEY (blocks_id) REFERENCES blocks(id) ON DELETE CASCADE
```

The `"stats_height_key" UNIQUE CONSTRAINT, btree (height)` index is created automatically because of the table definition:

https://github.com/decred/dcrdata/blob/147d0eee565788f6d4b974ada25724c4dfe2a190/db/dcrpg/internal/stats.go#L10-L16
