### PR TITLE
js: fix proposal contoller for props with no progress or votes

### DIFF
--- a/cmd/dcrdata/public/js/controllers/proposal_controller.js
+++ b/cmd/dcrdata/public/js/controllers/proposal_controller.js
@@ -118,20 +118,20 @@ export default class extends Controller {
   }
 
   async connect () {
-    if (this.hasApprovalMeterTarget) {
-      const d = this.approvalMeterTarget.dataset
-      const opts = {
-        darkMode: darkEnabled(),
-        segments: [
-          { end: d.threshold, color: '#ed6d47' },
-          { end: 1, color: '#2dd8a3' }
-        ]
-      }
-      this.approvalMeter = new MiniMeter(this.approvalMeterTarget, opts)
+    if (!this.hasApprovalMeterTarget) return // there will be no meter or charts
+
+    const d = this.approvalMeterTarget.dataset
+    const opts = {
+      darkMode: darkEnabled(),
+      segments: [
+        { end: d.threshold, color: '#ed6d47' },
+        { end: 1, color: '#2dd8a3' }
+      ]
     }
+    this.approvalMeter = new MiniMeter(this.approvalMeterTarget, opts)
 
     chartData = await requestJSON('/api/proposal/' + this.tokenTarget.dataset.hash)
-
+    if (!chartData) return
     Dygraph = await getDefault(
       import(/* webpackChunkName: "dygraphs" */ '../vendor/dygraphs.min.js')
     )


### PR DESCRIPTION
This resolves the JS error described in https://github.com/decred/dcrdata/pull/1829#issuecomment-893836773

![image](https://user-images.githubusercontent.com/9373513/128426751-3d124278-b034-43a7-b7a0-a9bb794736a0.png)

The above happens when a proposal has no votes yet and thus cannot have charts or a progress meter.