### PR TITLE
update min tool versions: go 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
-        go: [1.15, 1.16]
+        node-version: [14.x, 16.x]
+        go: [1.16, 1.17]
     steps:
     - uses: actions/checkout@v2
 
@@ -34,7 +34,7 @@ jobs:
       working-directory: ./cmd/dcrdata
 
     - name: Install Linters
-      run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0"
+      run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
     - name: tests
       env:
         GO111MODULE: "on"

--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ modern javascript features, as well as SCSS for styling.
 
 Always run the Current release or on the Current stable branch. Do not use `master` in production.
 
-|             | Series  | Branch        | Latest release tag | `dcrd` RPC server version required |
-| ----------- | ------- | ------------- | ------------------ | ---------------------------------- |
-| Development | 6.0     | `master`      | N/A                | ^6.2.0 (dcrd v1.6 release)         |
-| Current     | 5.3     | `5.3-stable`  | `v5.3.0`           | same as dcrdata 5.2                |
-| Legacy      | 5.2     | `5.2-stable`  | `v5.2.2`           | ^6.1.1 (dcrd v1.6 release)         |
+|             | Series  | Branch         | Latest release tag | `dcrd` RPC server version required |
+| ----------- | ------- | -------------- | ------------------ | ---------------------------------- |
+| Development | 6.1     | `master`       | N/A                | ^7.0.0 (dcrd v1.7 release)         |
+| Current     | 6.0     | `release-v6.0` | `v6.0.0`           | ^6.2.0 (dcrd v1.6 release)         |
 
 ## Repository Overview
 
@@ -131,8 +130,8 @@ Always run the Current release or on the Current stable branch. Do not use `mast
 
 ## Requirements
 
-- [Go](https://golang.org) 1.15 or 1.16
-- [Node.js](https://nodejs.org/en/download/) 14.x or 15.x. Node.js is only used
+- [Go](https://golang.org) 1.16 or 1.17
+- [Node.js](https://nodejs.org/en/download/) 14.x or 16.x. Node.js is only used
   as a build tool, and is **not used at runtime**.
 - Running `dcrd` running with `--txindex --addrindex`, and synchronized to the
   current best block on the network. On startup, dcrdata will verify that the

--- a/cmd/dcrdata/explorer/reloadsig.go
+++ b/cmd/dcrdata/explorer/reloadsig.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
 
 package explorer

--- a/cmd/dcrdata/explorer/reloadsig_windows.go
+++ b/cmd/dcrdata/explorer/reloadsig_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package explorer

--- a/cmd/dcrdata/go.mod
+++ b/cmd/dcrdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/cmd/dcrdata
 
-go 1.15
+go 1.16
 
 replace (
 	github.com/decred/dcrdata/db/dcrpg/v6 => ../../db/dcrpg/

--- a/cmd/dcrdata/signal_unix.go
+++ b/cmd/dcrdata/signal_unix.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main

--- a/cmd/swapscan-btc/go.mod
+++ b/cmd/swapscan-btc/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/cmd/swapscan-btc
 
-go 1.15
+go 1.16
 
 require (
 	github.com/btcsuite/btcd v0.21.0-beta

--- a/db/dcrpg/go.mod
+++ b/db/dcrpg/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/db/dcrpg/v6
 
-go 1.15
+go 1.16
 
 replace github.com/decred/dcrdata/v6 => ../../
 

--- a/db/dcrpg/pgblockchain_charts_test.go
+++ b/db/dcrpg/pgblockchain_charts_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline || chartdata
 // +build pgonline chartdata
 
 package dcrpg

--- a/db/dcrpg/pgblockchain_common_test.go
+++ b/db/dcrpg/pgblockchain_common_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline || chartdata
 // +build pgonline chartdata
 
 package dcrpg

--- a/db/dcrpg/pgblockchain_fullpgdb_test.go
+++ b/db/dcrpg/pgblockchain_fullpgdb_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline && fullpgdb
 // +build pgonline,fullpgdb
 
 package dcrpg

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package dcrpg

--- a/db/dcrpg/system_online_test.go
+++ b/db/dcrpg/system_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package dcrpg

--- a/db/dcrpg/types_online_test.go
+++ b/db/dcrpg/types_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package dcrpg

--- a/exchanges/exchanges_live_test.go
+++ b/exchanges/exchanges_live_test.go
@@ -1,4 +1,6 @@
+//go:build livexc
 // +build livexc
+
 // run these tests with go test -race -tags-livexc -run FuncName
 
 package exchanges

--- a/exchanges/go.mod
+++ b/exchanges/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/exchanges/v3
 
-go 1.15
+go 1.16
 
 require (
 	decred.org/dcrdex v0.0.0-20210401142326-529cb0d17154

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/v6
 
-go 1.15
+go 1.16
 
 require (
 	decred.org/dcrwallet v1.7.0

--- a/gov/go.mod
+++ b/gov/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrdata/gov/v4
 
-go 1.15
+go 1.16
 
 replace github.com/decred/dcrdata/v6 => ../
 

--- a/rpcutils/rpcclient_online_test.go
+++ b/rpcutils/rpcclient_online_test.go
@@ -1,3 +1,4 @@
+//go:build testnetRPC
 // +build testnetRPC
 
 // TODO: All these test should run with regnet. They were originally made for

--- a/testutil/dbconfig/config_fullpgdb.go
+++ b/testutil/dbconfig/config_fullpgdb.go
@@ -1,3 +1,4 @@
+//go:build fullpgdb
 // +build fullpgdb
 
 package dbconfig

--- a/testutil/dbconfig/config_testdb.go
+++ b/testutil/dbconfig/config_testdb.go
@@ -1,3 +1,4 @@
+//go:build !fullpgdb
 // +build !fullpgdb
 
 package dbconfig


### PR DESCRIPTION
Update for Go [1.16, 1.17] req. Update max node to 16.x from 15.x.
Re-run `go fmt` on everything with the go 1.17 version that adds the go:build comments.