### PR TITLE
interfacing and less rpcutils and rpcclient reliance

### DIFF
--- a/cmd/dcrdata/api/insight/apiroutes.go
+++ b/cmd/dcrdata/api/insight/apiroutes.go
@@ -27,7 +27,7 @@ import (
 	m "github.com/decred/dcrdata/cmd/dcrdata/middleware"
 	apitypes "github.com/decred/dcrdata/v6/api/types"
 	"github.com/decred/dcrdata/v6/db/dbtypes"
-	"github.com/decred/dcrdata/v6/rpcutils"
+	"github.com/decred/dcrdata/v6/txhelpers"
 )
 
 type BlockDataSource interface {
@@ -70,13 +70,18 @@ const (
 	inflightUTXOLimit = maxInsightAddrsUTXOs * 5 / 4
 )
 
+// MempoolAddressChecker is an interface implementing UnconfirmedTxnsForAddress
+type MempoolAddressChecker interface {
+	UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
+}
+
 // InsightApi contains the resources for the Insight HTTP API. InsightApi's
 // methods include the http.Handlers for the URL path routes.
 type InsightApi struct {
 	nodeClient      *rpcclient.Client
 	BlockData       BlockDataSource
 	params          *chaincfg.Params
-	mp              rpcutils.MempoolAddressChecker
+	mp              MempoolAddressChecker
 	status          *apitypes.Status
 	JSONIndent      string
 	ReqPerSecLimit  float64
@@ -86,7 +91,7 @@ type InsightApi struct {
 
 // NewInsightAPI is the constructor for InsightApi.
 func NewInsightAPI(client *rpcclient.Client, blockData BlockDataSource, params *chaincfg.Params,
-	memPoolData rpcutils.MempoolAddressChecker, JSONIndent string, status *apitypes.Status) *InsightApi {
+	memPoolData MempoolAddressChecker, JSONIndent string, status *apitypes.Status) *InsightApi {
 
 	return &InsightApi{
 		nodeClient:     client,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -4568,13 +4568,13 @@ func (pgb *ChainDB) GetStakeInfoExtendedByHash(hashStr string) *apitypes.StakeIn
 		log.Errorf("GetStakeInfoExtendedByHash -> NewHashFromStr: %v", err)
 		return nil
 	}
-	block, err := rpcutils.GetBlockByHash(hash, pgb.Client)
+	msgBlock, err := pgb.Client.GetBlock(pgb.ctx, hash)
 	if err != nil {
-		log.Errorf("GetStakeInfoExtendedByHash -> GetBlockByHash: %v", err)
+		log.Errorf("GetStakeInfoExtendedByHash -> GetBlock: %v", err)
 		return nil
 	}
+	block := dcrutil.NewBlock(msgBlock)
 
-	msgBlock := block.MsgBlock()
 	height := msgBlock.Header.Height
 
 	var size, val int64

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -53,7 +53,6 @@ type MempoolMonitor struct {
 	params     *chaincfg.Params
 	collector  *MempoolDataCollector
 	dataSavers []MempoolDataSaver
-	client     txhelpers.VerboseTransactionGetter
 
 	// Outgoing message
 	signalOuts []chan<- pstypes.HubMessage
@@ -65,7 +64,7 @@ type MempoolMonitor struct {
 // MempoolMonitor will process incoming transactions, and forward new ones on
 // via the newTxOutChan following an appropriate signal on hubRelay.
 func NewMempoolMonitor(ctx context.Context, collector *MempoolDataCollector,
-	savers []MempoolDataSaver, params *chaincfg.Params, client txhelpers.VerboseTransactionGetter,
+	savers []MempoolDataSaver, params *chaincfg.Params,
 	signalOuts []chan<- pstypes.HubMessage, initialStore bool) (*MempoolMonitor, error) {
 
 	// Make the skeleton MempoolMonitor.
@@ -74,7 +73,6 @@ func NewMempoolMonitor(ctx context.Context, collector *MempoolDataCollector,
 		params:     params,
 		collector:  collector,
 		dataSavers: savers,
-		client:     client,
 		signalOuts: signalOuts,
 	}
 
@@ -182,7 +180,7 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		p.txnsStore = make(txhelpers.TxnsStore)
 	}
 	newPrevOuts, addressesIn, valsIn := txhelpers.TxPrevOutsByAddr(
-		p.addrMap.store, p.txnsStore, msgTx, p.client, p.params, treasuryActive)
+		p.addrMap.store, p.txnsStore, msgTx, p.collector.dcrdChainSvr, p.params, treasuryActive)
 	var newInAddrs int
 	for addr, isNew := range addressesIn {
 		txAddresses[addr] = struct{}{}

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -41,13 +41,12 @@ const (
 	wsReadTimeout  = 7 * time.Second
 )
 
-// wsDataSource defines the interface for collecting required data.
-type wsDataSource interface {
+// DataSource defines the interface for collecting required data.
+type DataSource interface {
 	GetExplorerBlock(hash string) *exptypes.BlockInfo
 	DecodeRawTransaction(txhex string) (*chainjson.TxRawResult, error)
 	SendRawTransaction(txhex string) (string, error)
 	GetChainParams() *chaincfg.Params
-	// UnconfirmedTxnsForAddress(address string) (*txhelpers.AddressOutpoints, int64, error)
 	GetMempool() []exptypes.MempoolTx
 	BlockSubsidy(height int64, voters uint16) *chainjson.GetBlockSubsidyResult
 	Difficulty(timestamp int64) float64
@@ -82,7 +81,7 @@ type connection struct {
 // PubSubHub manages the collection and distribution of block chain and mempool
 // data to WebSocket clients.
 type PubSubHub struct {
-	sourceBase wsDataSource
+	sourceBase DataSource
 	wsHub      *WebsocketHub
 	state      *State
 	params     *chaincfg.Params
@@ -93,7 +92,7 @@ type PubSubHub struct {
 
 // NewPubSubHub constructs a PubSubHub given a data source. The WebSocketHub is
 // automatically started.
-func NewPubSubHub(dataSource wsDataSource) (*PubSubHub, error) {
+func NewPubSubHub(dataSource DataSource) (*PubSubHub, error) {
 	psh := new(PubSubHub)
 	psh.sourceBase = dataSource
 

--- a/txhelpers/staketree.go
+++ b/txhelpers/staketree.go
@@ -11,7 +11,6 @@ import (
 	"github.com/decred/dcrd/database/v2"
 	_ "github.com/decred/dcrd/database/v2/ffldb" // init the ffldb driver
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/rpcclient/v6"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -27,7 +26,7 @@ const (
 
 // BuildStakeTree returns a database with a stake tree
 func BuildStakeTree(blocks map[int64]*dcrutil.Block, netParams *chaincfg.Params,
-	nodeClient *rpcclient.Client, poolRequiredHeight int64, DBName ...string) (database.DB, []int64, error) {
+	nodeClient RawTransactionGetter, poolRequiredHeight int64, DBName ...string) (database.DB, []int64, error) {
 
 	if blocks[0] == nil || blocks[0].Height() != 0 {
 		return nil, nil, fmt.Errorf("Must start at height 0")

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -1,12 +1,10 @@
 package txhelpers
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -16,9 +14,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v3"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
-	"github.com/decred/dcrd/rpcclient/v6"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrdata/v6/semver"
 )
 
 type TxGetter struct {
@@ -144,6 +140,7 @@ func TxToWriter(tx *dcrutil.Tx, w io.Writer) error {
 	return nil
 }
 
+/*
 // ConnectNodeRPC attempts to create a new websocket connection to a dcrd node,
 // with the given credentials and optional notification handlers.
 func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool) (*rpcclient.Client, semver.Semver, error) {
@@ -182,6 +179,7 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool) (*rpcclient.
 
 	return dcrdClient, nodeVer, nil
 }
+*/
 
 func TestFilterHashSlice(t *testing.T) {
 	var hashList, blackList []chainhash.Hash


### PR DESCRIPTION
This reduced a lot of reliance on the rpcutils and rpcclient packages.

In a future version we might make rpcutils it's own module again since I'd like the main module not to require either github.com/decred/dcrd/rpcclient or rpcutils.