### PR TITLE
show /nextreduction

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -354,7 +354,7 @@ func New(cfg *ExplorerConfig) *explorerUI {
 		"rawtx", "status", "parameters", "agenda", "agendas", "charts",
 		"sidechains", "disapproved", "ticketpool", "visualblocks", "statistics",
 		"windows", "timelisting", "addresstable", "proposals", "proposal",
-		"market", "insight_root", "attackcost"}
+		"market", "insight_root", "attackcost", "nextreduction"}
 
 	for _, name := range tmpls {
 		if err := exp.templates.addTemplate(name); err != nil {

--- a/explorer/templates.go
+++ b/explorer/templates.go
@@ -600,5 +600,15 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			return intStr
 		},
 		"floor": math.Floor,
+		"getCurrentRewardWindowRemainingTime": func(idx int, max, t int64) int {
+			// getRewardWindowRemainingTime returns the total time
+			// remaining till next reduction window occurs.
+
+			// Gets the difference between the reward window and reward window size.
+			x := (max - int64(idx)) * t
+
+			// Calculate the duration in seconds.
+			return int(time.Duration(x).Seconds())
+		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -779,6 +779,7 @@ func _main(ctx context.Context) error {
 		// fallback.
 		r.With(explorer.MenuFormParser).Post("/set", explore.Home)
 		r.Get("/attack-cost", explore.AttackCost)
+		r.Get("/nextreduction", explore.NextReduction)
 	})
 
 	// Configure a page for the bare "/insight" path. This mounts the static

--- a/public/js/controllers/nextreduction_controller.js
+++ b/public/js/controllers/nextreduction_controller.js
@@ -1,0 +1,81 @@
+import { Controller } from 'stimulus'
+import globalEventBus from '../services/event_bus_service'
+import humanize from '../helpers/humanize_helper'
+var remainingSeconds, nextReductionBlockHeight
+
+export default class extends Controller {
+  static get targets () {
+    return [
+      'bsubsidyPos', 'nextReductionTimer', 'hashrate', 'hashrateDelta', 'bsubsidyPow', 'powConverted',
+      'poolValue', 'ticketReward', 'poolSizePct', 'blockHeight', 'bsubsidyDev', 'convertedDevSub',
+      'devFund', 'convertedDev', 'nextRewardReductionBlockHeight', 'remainingBlocksTillReduction'
+    ]
+  }
+
+  connect () {
+    remainingSeconds = parseInt(this.data.get('remainingSeconds'))
+    nextReductionBlockHeight = parseInt(this.nextRewardReductionBlockHeightTarget.dataset.nextReductionBlock)
+    setInterval(() => {
+      this.countDownTimer(remainingSeconds)
+    }, 1000)
+    this.processBlock = this._processBlock.bind(this)
+    globalEventBus.on('BLOCK_RECEIVED', this.processBlock)
+  }
+  disconnect () {
+    globalEventBus.off('BLOCK_RECEIVED', this.processBlock)
+  }
+  setAllValues (targets, data) {
+    targets.forEach((n) => { n.innerHTML = data })
+  }
+  _processBlock (blockData) {
+    var ex = blockData.extra
+    this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(ex.subsidy.pow / 100000000, false, 8, 2)
+    this.bsubsidyPosTarget.innerHTML = humanize.decimalParts((ex.subsidy.pos / 500000000), false, 8, 2) // 5 votes per block (usually)
+    this.bsubsidyDevTarget.innerHTML = humanize.decimalParts(ex.subsidy.dev / 100000000, false, 8, 2)
+    this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
+    this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
+    this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
+    this.setAllValues(this.devFundTargets, humanize.decimalParts(ex.dev_fund / 100000000, true, 0))
+    this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)
+    this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
+    let block = blockData.block
+    this.blockHeightTarget.textContent = block.height
+    this.blockHeightTarget.href = `/block/${block.hash}`
+    this.remainingBlocksTillReductionTarget.innerHTML = nextReductionBlockHeight - block.height
+    if (ex.exchange_rate) {
+      let xcRate = ex.exchange_rate.value
+      let btcIndex = ex.exchange_rate.index
+      this.powConvertedTarget.textContent = `${humanize.twoDecimals(ex.subsidy.pow / 1e8 * xcRate)} ${btcIndex}`
+      this.setAllValues(this.convertedDevTargets, `${humanize.threeSigFigs(ex.dev_fund / 1e8 * xcRate)} ${btcIndex}`)
+      this.convertedDevSubTarget.textContent = `${humanize.twoDecimals(ex.subsidy.dev / 1e8 * xcRate)} ${btcIndex}`
+    }
+  }
+  countDownTimer (allsecs) {
+    let str = ''
+    if (allsecs > 604799) {
+      let weeks = allsecs / 604800
+      allsecs %= 604800
+      str += Math.floor(weeks) + 'w '
+    }
+    if (allsecs > 86399) {
+      let days = allsecs / 86400
+      allsecs %= 86400
+      str += Math.floor(days) + 'd '
+    }
+    if (allsecs > 3599) {
+      let hours = allsecs / 3600
+      allsecs %= 3600
+      str += Math.floor(hours) + 'h '
+    }
+    if (allsecs > 59) {
+      let mins = allsecs / 60
+      allsecs %= 60
+      str += Math.floor(mins) + 'm '
+    }
+    if (allsecs >= 0) {
+      str += Math.floor(allsecs) + 's '
+    }
+    this.nextReductionTimerTarget.innerHTML = str
+    remainingSeconds--
+  }
+}

--- a/public/scss/application.scss
+++ b/public/scss/application.scss
@@ -63,3 +63,4 @@
 @import "./home.scss";
 @import "./cards.scss";
 @import "./attackcost.scss";
+@import "./nextreeduction.scss";

--- a/public/scss/nextreeduction.scss
+++ b/public/scss/nextreeduction.scss
@@ -1,0 +1,50 @@
+.reduction-block-warpper {
+  margin: 0 auto;
+  text-align: center;
+  max-width: 50rem;
+}
+
+.botom-links-warpper {
+  margin: 0 auto;
+  max-width: 50rem;
+}
+
+.reduction-block-warpper .reduction-block-inner {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.mtb-0-lr-auto {
+  margin: 0 auto;
+}
+
+.reward-reduction-block {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.reward-reduction-block-timer {
+  font-size: 5rem;
+  line-height: 4rem;
+}
+
+.vote-reward-wrapper .unit {
+  font-size: 13px;
+}
+
+.bottom-link-separation {
+  margin-right: 1rem;
+  font-size: 1rem;
+  color: #b3b0b0;
+}
+
+@media (max-width: 576px) {
+  .next-reduction-treasury-d-xm-none {
+    display: none;
+  }
+
+  .reward-reduction-block-timer {
+    font-size: 2rem;
+    line-height: 2rem;
+  }
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -46,6 +46,7 @@ for i in $(find . -name go.mod -type f -print); do
   (cd ${module} && \
     go test $TESTTAGS ./... && \
     golangci-lint run --deadline=10m \
+      --out-format=github-actions \
       --disable-all \
       --enable govet \
       --enable staticcheck \
@@ -56,6 +57,7 @@ for i in $(find . -name go.mod -type f -print); do
       --enable goimports \
       --enable misspell \
       --enable unparam \
+      --enable asciicheck \
   )
 done
 

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -96,6 +96,7 @@
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
 					<a class="menu-item" data-keynav-skip href="/address/{{.DevAddress}}?txntype=merged_debit" title="Decred Treasury">Treasury</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
+					<a class="menu-item" data-keynav-skip href="/nextreduction" title="Next Reduction">Next Reduction</a>
 				{{- if eq .NetName "Mainnet"}}
 					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
 				{{- else}}

--- a/views/nextreduction.tmpl
+++ b/views/nextreduction.tmpl
@@ -1,0 +1,188 @@
+{{define "nextreduction"}}
+{{$conv := .Conversions}}
+<!DOCTYPE html>
+<html lang="en">
+{{ template "html-head" "Decred Block Explorer by dcrdata.org"}}
+    {{ template "navbar" . }}
+    <div class="container main" 
+    data-controller="nextreduction" data-nextreduction-remaining-seconds="{{getRewardWindowRemainingTime .Info.IdxInRewardWindow .Info.Params.RewardWindowSize .Info.Params.BlockTime}}">
+        <div class="row">
+            <div class="d-flex flex-column col-md-24 p-0 custom-next-reduction">
+                <div class="py-1 px-2 mb-1 bg-white flex-grow-1">
+                    <div class="my-3 h4 mb-3 text-center">
+                        <span class="dcricon-pickaxe d-inline-block pr-2 h3 title"></span>
+                        <span>Next Block Reward Reduction</span>
+                    </div>
+                     <div class="row mt-1 reduction-block-warpper">
+                        <div class="col-8 col-lg-5 col-md-5 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3 reduction-block-inner">
+                            <div class="fs13 text-secondary">
+                                Current Block
+                            </div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <div class="mtb-0-lr-auto">
+                                 <a class="d-inline-block h3 position-relative" href="/block/{{.BestBlock.Hash}}" data-target="nextreduction.blockHeight">{{.BestBlock.Height}}</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="reward-reduction-block col-8 col-lg-6 col-md-6 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                           {{$idxInRewardWindowInt64Parse := int64 .Info.IdxInRewardWindow}}
+                           {{$remainingBlocksTillReduction := subtract .Info.Params.RewardWindowSize $idxInRewardWindowInt64Parse}}
+                           {{$nextRewardReductionBlockHeight := add .BestBlock.Height $remainingBlocksTillReduction}}
+                            <div class="fs13 text-secondary">
+                                Next Reward Reduction Block
+                            </div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <div class="mtb-0-lr-auto">
+                                <a href="javascript:void(0)" data-target="nextreduction.nextRewardReductionBlockHeight" data-next-reduction-block="{{$nextRewardReductionBlockHeight}}" class="h3">{{$nextRewardReductionBlockHeight}}</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="reward-reduction-block col-8 col-lg-8 col-md-8 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">
+                                Number of Blocks Remaining till Reduction
+                            </div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <div  class="mtb-0-lr-auto"><a href="javascript:void(0)" class="h3" data-target="nextreduction.remainingBlocksTillReduction">{{$remainingBlocksTillReduction}}</a></div>
+                            </div>
+                        </div>
+                        </div>
+                        <div class="row mt-1 reward-reduction-block">
+                        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3 reward-reduction-block">
+                            <div class="fs12 lh1rem mt-md-3 mt-lg-3 mt-sm-1 text-center mb-3">
+                                <span class="text-black-50 timer reward-reduction-block-timer" data-target="nextreduction.nextReductionTimer">
+                                    {{remaining .Info.IdxInRewardWindow .Info.Params.RewardWindowSize .Info.Params.BlockTime}}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>  
+            </div>
+  {{with .Info}}
+            <div class="d-flex flex-column col-md-24 p-0">
+                <div class="bg-white mb-1 py-2 px-3">
+                    <div class="row mt-1 botom-links-warpper">
+
+                        <div class="col-12 col-lg-8 col-md-8 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">PoW Reward</div>
+                            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="nextreduction.bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 true 2)}}</span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="nextreduction.powConverted">{{$conv.PowSplit.TwoDecimals}} {{$conv.PowSplit.Index}}</span>
+                            </div>
+                            {{end}}
+                            <div class="fs13 text-secondary mt-2"><a href="/charts?chart=hashrate">Hashrate</a></div>
+                            <div class="mono lh1rem pt-1 pb-1 fs14-decimal fs24 d-flex align-items-baseline">
+                                <span data-target="nextreduction.hashrate">{{template "decimalParts" (float64AsDecimalParts .HashRate 8 true 2)}}</span>
+                                <span class="pl-1 unit lh15rem">Ph/s</span>
+                            </div>
+                            <div class="fs12 text-black-50 lh1rem text-black-50">
+                                <span data-target="nextreduction.hashrateDelta">{{template "fmtPercentage" .HashRateChangeMonth}}</span> in past 30 days
+                            </div>
+                        </div> 
+                        <div class="col-12 col-lg-8 col-md-8 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                          <div class="fs13 text-secondary vote-reward-wrapper">Vote Reward</div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="nextreduction.bsubsidyPos">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR/vote</span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="nextreduction.ticketReward">{{printf "%.2f" .TicketReward}}%</span> per ~{{.RewardPeriod}}
+                            </div>
+                            <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}}% per year</div>
+                            <div class="fs13 text-secondary mt-2"><a href="/charts?chart=stake-participation">Total Staked DCR</a></div>
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span data-target="nextreduction.poolValue">
+                                    {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="nextreduction.poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of circulating supply
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-8 col-md-8 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">Treasury Block Reward</div>
+                            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span data-target="nextreduction.bsubsidyDev">
+                                    {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.Dev) 8 true 2)}}
+                                </span>
+                                <span class="pl-1 unit lh15rem">DCR</span>
+                            </div>
+                            {{if $conv}}
+                            <div class="fs12 lh1rem text-black-50">
+                                <span data-target="nextreduction.convertedDevSub">{{$conv.TreasurySplit.TwoDecimals}} {{$conv.TreasurySplit.Index}}</span>
+                            </div>
+                            {{end}}
+                            {{if .DevFund}}
+                                <div class="next-reduction-treasury-d-xm-none mb-3 mb-sm-2 mt-2 mb-md-3 mb-lg-3">
+                                    <div class="fs13 text-secondary"><a href="/address/{{.DevAddress}}?n=20&start=0&txntype=merged_debit">Treasury</a></div>
+                                    <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                        <span data-target="nextreduction.devFund">
+                                            {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .DevFund) 0 true)}}
+                                        </span>
+                                        <span class="pl-1 unit lh15rem">DCR</span>
+                                    </div>
+                                    {{if $conv}}
+                                    <div class="fs12 lh1rem text-black-50">
+                                        <span data-target="nextreduction.convertedDev">{{threeSigFigs $conv.TreasuryBalance.Value}} {{$conv.TreasuryBalance.Index}}</span>
+                                    </div>
+                                    {{end}}
+                                </div>
+                            {{end}}
+                        </div>
+                        <div class="d-md-none d-lg-none d-sm-none col-12 col-lg-8 col-md-8 col-sm-8 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                             {{if .DevFund}}
+                                <div class="mb-3 mb-sm-2 mt-2 mb-md-3 mb-lg-3">
+                                    <div class="fs13 text-secondary"><a href="/address/{{.DevAddress}}?n=20&start=0&txntype=merged_debit">Treasury</a></div>
+                                    <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                        <span data-target="nextreduction.devFund">
+                                            {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .DevFund) 0 true)}}
+                                        </span>
+                                        <span class="pl-1 unit lh15rem">DCR</span>
+                                    </div>
+                                    {{if $conv}}
+                                    <div class="fs12 lh1rem text-black-50">
+                                        <span data-target="nextreduction.convertedDev">{{threeSigFigs $conv.TreasuryBalance.Value}} {{$conv.TreasuryBalance.Index}}</span>
+                                    </div>
+                                    {{end}}
+                                </div>
+                            {{end}}               
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <div class="d-flex flex-column col-md-24 p-0">
+            <div class="bg-white mb-1 py-2 px-3">
+                <div class="row mt-1">
+                    <div  class="mtb-0-lr-auto">
+                       <span>Read more:</span> <a
+                        class="text-nowrap pr-1"
+                        href="https://docs.decred.org/glossary/#block-reward"
+                        title="Block Reward"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >Block Reward</a>
+                        <span class="pr-1 text-secondary">|</span>
+                        <a
+                        class="text-nowrap pr-1"
+                        href="https://docs.decred.org/advanced/issuance/"
+                        title="Issuance"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >Issuance</a>
+                    </div>
+                </div>
+            </div>
+        </dv>
+    {{end}}
+    </div>
+    </div>
+    {{  template "footer" . }}
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
This creates a page similar to the many bitcoin halving pages out there. This page shows a countdown till the next block reward reduction for decred. It also shows basic information about the block reward itself and links to related documentation. People from our community can link to this page to provide an entryway for new people to be curious about how decred works and learn more.