### PR TITLE
ui: show tx & script version on tx details

### DIFF
--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -228,25 +228,23 @@
                   {{end}}
               {{end}}
               <tr>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2"
-                  >Raw Tx:
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Tx Raw: </td>
+                <td class="text-left py-1 text-secondary">
+                  <a href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">decoded</a> &middot;
+                  <a href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">hex</a>
                 </td>
-                <td class="text-left py-1 text-secondary"><a
-                  href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">decoded</a> &middot; <a
-                  href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">hex</a>
-                </td>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2"
-                  >Time:
-                </td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Time: </td>
                 <td class="text-left py-1 text-secondary" data-target="tx.formattedAge">{{.Time.String}}</td>
               </tr>
               <tr>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2"
-                  >Size:
-                </td>
-                <td class="text-left py-1 text-secondary">{{.FormattedSize}}</td>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Rate:</td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Tx Version: </td>
+                <td class="text-left py-1 text-secondary">{{.TxVersion}}</td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Rate: </td>
                 <td class="text-left py-1 text-secondary">{{.FeeRate}}/kB</td>
+              </tr>
+              <tr>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Size: </td>
+                <td class="text-left py-1 text-secondary">{{.FormattedSize}}</td>
               </tr>
               {{if $.SwapsFound}}
                 <tr>
@@ -362,6 +360,7 @@
                     <th class="shrink-to-fit">#</th>
                     <th class="addr-hash-column"><div class="pl-1">Address</div></th>
                     <th class="text-left shrink-to-fit">Type</th>
+                    <th class="text-left shrink-to-fit">Version</th>
                     <th class="text-left shrink-to-fit">Spent</th>
                     <th class="text-right shrink-to-fit">DCR</th>
                   </tr>
@@ -395,6 +394,9 @@
                         </td>
                         <td class="fs13 break-word shrink-to-fit">
                             {{.Type}}
+                        </td>
+                        <td class="fs13 break-word shrink-to-fit">
+                            {{$v.Version}}
                         </td>
                         <td class="text-left fs13 shrink-to-fit">{{with $spending := (index $.Data.SpendingTxns $i) }}
                             {{if $spending.Hash}}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5712,6 +5712,7 @@ func (pgb *ChainDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 	txBasic, txType := makeExplorerTxBasic(txraw, ticketPrice, msgTx, pgb.chainParams)
 	tx := &exptypes.TxInfo{
 		TxBasic:       txBasic,
+		TxVersion:     txraw.Version,
 		BlockHeight:   txraw.BlockHeight,
 		BlockIndex:    txraw.BlockIndex,
 		BlockHash:     txraw.BlockHash,
@@ -5845,6 +5846,7 @@ func (pgb *ChainDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 			Type:            vout.ScriptPubKey.Type,
 			Spent:           txout == nil,
 			Index:           vout.N,
+			Version:         vout.Version,
 		})
 	}
 	tx.Vout = outputs

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -173,6 +173,7 @@ type TrimmedTxInfo struct {
 // TxInfo models data needed for display on the tx page
 type TxInfo struct {
 	*TxBasic
+	TxVersion        int32
 	SpendingTxns     []TxInID
 	Vin              []Vin
 	Vout             []Vout
@@ -427,6 +428,7 @@ type Vout struct {
 	OP_RETURN       string
 	OP_TADD         bool
 	Index           uint32
+	Version         uint16
 }
 
 // TrimmedBlockInfo models data needed to display block info on the new home page


### PR DESCRIPTION
This diff adds the tx and script versions to the tx details areabox.

Edit:

Before:

![image](https://user-images.githubusercontent.com/2729122/133791053-f53793cd-26f1-438b-8fc3-6e1c3587c4ab.png)

After: 

![image](https://user-images.githubusercontent.com/2729122/133790957-59156c7b-98d5-457f-a83c-884470f05487.png)

Let me know if any UI changes are needed for a better UX 👍 

closes #1851 