### PR TITLE
script Version for MempoolTx

### DIFF
--- a/cmd/dcrdata/explorer/explorerroutes.go
+++ b/cmd/dcrdata/explorer/explorerroutes.go
@@ -859,6 +859,7 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 			TxBasic: &types.TxBasic{
 				TxID:          hash,
 				Type:          txTypeStr,
+				Version:       int32(dbTx0.Version),
 				FormattedSize: humanize.Bytes(uint64(dbTx0.Size)),
 				Total:         dcrutil.Amount(dbTx0.Sent).ToCoin(),
 				Fee:           fees,
@@ -922,11 +923,12 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				Addresses:       vouts[iv].ScriptPubKeyData.Addresses,
 				Amount:          amount,
 				FormattedAmount: humanize.Commaf(amount),
-				Type:            txTypeStr, // wrong, needs to be output script type
+				Type:            vouts[iv].ScriptPubKeyData.Type,
 				Spent:           spendingTx != "",
 				OP_RETURN:       opReturn,
 				OP_TADD:         opTAdd,
 				Index:           vouts[iv].TxIndex,
+				Version:         vouts[iv].Version,
 			})
 		}
 

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -228,22 +228,22 @@
                   {{end}}
               {{end}}
               <tr>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Tx Raw: </td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Raw Tx:</td>
                 <td class="text-left py-1 text-secondary">
                   <a href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">decoded</a> &middot;
                   <a href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">hex</a>
                 </td>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Time: </td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Time:</td>
                 <td class="text-left py-1 text-secondary" data-target="tx.formattedAge">{{.Time.String}}</td>
               </tr>
               <tr>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Tx Version: </td>
-                <td class="text-left py-1 text-secondary">{{.TxVersion}}</td>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Rate: </td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Version:</td>
+                <td class="text-left py-1 text-secondary">{{.Version}}</td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Rate:</td>
                 <td class="text-left py-1 text-secondary">{{.FeeRate}}/kB</td>
               </tr>
               <tr>
-                <td class="text-right medium-sans text-nowrap pr-2 py-2">Size: </td>
+                <td class="text-right medium-sans text-nowrap pr-2 py-2">Size:</td>
                 <td class="text-left py-1 text-secondary">{{.FormattedSize}}</td>
               </tr>
               {{if $.SwapsFound}}
@@ -360,7 +360,7 @@
                     <th class="shrink-to-fit">#</th>
                     <th class="addr-hash-column"><div class="pl-1">Address</div></th>
                     <th class="text-left shrink-to-fit">Type</th>
-                    <th class="text-left shrink-to-fit">Version</th>
+                    <th class="text-left shrink-to-fit"><span class="d-none d-sm-inline">Version</span><span class="d-sm-none">Ver</span></th>
                     <th class="text-left shrink-to-fit">Spent</th>
                     <th class="text-right shrink-to-fit">DCR</th>
                   </tr>

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -837,7 +837,6 @@ func (a UInt64Array) Value() (driver.Value, error) {
 
 // Vout defines a transaction output
 type Vout struct {
-	// txDbID           int64
 	TxHash           string           `json:"tx_hash"`
 	TxIndex          uint32           `json:"tx_index"`
 	TxTree           int8             `json:"tx_tree"`
@@ -1685,7 +1684,7 @@ type ScriptPubKeyData struct {
 	ReqSigs   uint32   `json:"reqSigs"`
 	Type      string   `json:"type"`
 	Addresses []string `json:"addresses"`
-	// TODO: script version here instead?
+	// NOTE: Script version is in Vout struct.
 }
 
 // VinTxProperty models a transaction input with previous outpoint information.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5382,6 +5382,7 @@ func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *
 	tx := &exptypes.TxBasic{
 		TxID:          data.Txid,
 		Type:          txhelpers.TxTypeToString(int(txType)),
+		Version:       data.Version,
 		FormattedSize: humanize.Bytes(uint64(len(data.Hex) / 2)),
 		Total:         txhelpers.TotalVout(data.Vout).ToCoin(),
 	}
@@ -5712,7 +5713,6 @@ func (pgb *ChainDB) GetExplorerTx(txid string) *exptypes.TxInfo {
 	txBasic, txType := makeExplorerTxBasic(txraw, ticketPrice, msgTx, pgb.chainParams)
 	tx := &exptypes.TxInfo{
 		TxBasic:       txBasic,
-		TxVersion:     txraw.Version,
 		BlockHeight:   txraw.BlockHeight,
 		BlockIndex:    txraw.BlockIndex,
 		BlockHash:     txraw.BlockHash,
@@ -6216,6 +6216,7 @@ func (pgb *ChainDB) GetMempool() []exptypes.MempoolTx {
 
 		txs = append(txs, exptypes.MempoolTx{
 			TxID:     hashStr,
+			Version:  rawtx.Version, // or int32(msgTx.Version)
 			Fees:     fee.ToCoin(),
 			FeeRate:  feeRate.ToCoin(),
 			Hash:     hashStr, // dup of TxID!

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -150,6 +150,7 @@ type WebBasicBlock struct {
 type TxBasic struct {
 	TxID          string
 	Type          string
+	Version       int32
 	FormattedSize string
 	Total         float64
 	Fee           dcrutil.Amount
@@ -173,7 +174,6 @@ type TrimmedTxInfo struct {
 // TxInfo models data needed for display on the tx page
 type TxInfo struct {
 	*TxBasic
-	TxVersion        int32
 	SpendingTxns     []TxInID
 	Vin              []Vin
 	Vout             []Vout
@@ -696,13 +696,14 @@ func TrimMempoolTx(tx *MempoolTx) (trimmedTx *TrimmedTxInfo) {
 	}
 	txBasic := &TxBasic{
 		TxID:          tx.TxID,
+		Type:          tx.Type,
+		Version:       tx.Version,
 		FormattedSize: BytesString(uint64(tx.Size)),
 		Total:         tx.TotalOut,
 		Fee:           fee,
 		FeeRate:       feeRate,
 		VoteInfo:      tx.VoteInfo,
-		Coinbase:      tx.Coinbase, // eh, in mempool???
-		// TreasuryBase not in mempool (either)
+		// TreasuryBase and Coinbase are not in mempool
 	}
 
 	var voteValid bool
@@ -986,6 +987,7 @@ type TicketPoolInfo struct {
 // MempoolTx models the tx basic data for the mempool page
 type MempoolTx struct {
 	TxID    string  `json:"txid"`
+	Version int32   `json:"version"`
 	Fees    float64 `json:"fees"`
 	FeeRate float64 `json:"fee_rate"`
 	// Consider atom representation:
@@ -993,7 +995,7 @@ type MempoolTx struct {
 	VinCount  int            `json:"vin_count"`
 	VoutCount int            `json:"vout_count"`
 	Vin       []MempoolInput `json:"vin,omitempty"`
-	Coinbase  bool           `json:"coinbase"` // why?
+	Coinbase  bool           `json:"coinbase"` // to signal the coinbase tx on new block despite not being in mempool
 	Hash      string         `json:"hash"`     // dup of TxID?
 	Time      int64          `json:"time"`
 	Size      int32          `json:"size"`

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -42,6 +42,7 @@ func TestDeepCopys(t *testing.T) {
 	tickets := []MempoolTx{
 		{
 			TxID:      "96e10d7ce108b1a357168b0a923d86d2744ba9777a2d81cbff71ffb982381c95",
+			Version:   1,
 			Fees:      0.0001,
 			VinCount:  2,
 			VoutCount: 5,
@@ -64,6 +65,7 @@ func TestDeepCopys(t *testing.T) {
 		},
 		{
 			TxID:      "8eb2f6c8f3a9cdc8d6de2ef3bfca9efcffed4484dd4fde2d01dc0fc0e415c75a",
+			Version:   2,
 			Fees:      0.0001,
 			VinCount:  2,
 			VoutCount: 5,

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -149,6 +149,7 @@ func (t *DataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAd
 
 		txs = append(txs, exptypes.MempoolTx{
 			TxID:      hashStr,
+			Version:   rawtx.Version,
 			Fees:      tx.Fee,
 			FeeRate:   feeRate.ToCoin(),
 			VinCount:  len(msgTx.TxIn),

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -245,6 +245,7 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 
 	tx := exptypes.MempoolTx{
 		TxID:      hash,
+		Version:   rawTx.Version,
 		Fees:      fee.ToCoin(),
 		FeeRate:   feeRate.ToCoin(),
 		VinCount:  len(msgTx.TxIn),

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -745,7 +745,8 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	// The coinbase transaction is also sent in a new transaction signal to
 	// pubsub clients. It's not really mempool.
 	newTxCoinbase := exptypes.MempoolTx{
-		TxID: coinbaseHash,
+		TxID:    coinbaseHash,
+		Version: int32(coinbaseTx.Version),
 		// Fees are 0
 		VinCount:  len(coinbaseTx.TxIn),
 		VoutCount: len(coinbaseTx.TxOut),


### PR DESCRIPTION
This updates the `explorer/types.MempoolTx` type with a `Version` field (transaction version).

It also moves the script version from `explorer/types.TxInfo` to `explorer/types.TxBasic`, which is embedded by other types including `TxInfo` and `TrimmedTxInfo`.

The first commit changes the "Version" column of the Transaction Outputs table on the /tx page to change between "Version" and "Ver" at the `sm` responsive break point.