### PR TITLE
fix missing mixedPctTarget breaking home page updates

### DIFF
--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -45,7 +45,8 @@ export default class extends Controller {
       'mpRevTotal', 'mpRevCount', 'mpRegBar', 'mpVoteBar', 'mpTicketBar',
       'mpRevBar', 'voteTally', 'blockVotes', 'blockHeight', 'blockSize',
       'blockTotal', 'consensusMsg', 'powConverted', 'convertedDev',
-      'convertedSupply', 'convertedDevSub', 'exchangeRate', 'convertedStake'
+      'convertedSupply', 'convertedDevSub', 'exchangeRate', 'convertedStake',
+      'mixedPct'
     ]
   }
 

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -166,12 +166,12 @@
 		</span>
 	</div>
 	<script
-		src="/dist/js/4.bundle.js?v=BLYwcKB"
+		src="/dist/js/4.bundle.js?v=qbcVdBV"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.bundle.js?v=BLYwcKB"
+		src="/dist/js/app.bundle.js?v=qbcVdBV"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>


### PR DESCRIPTION
The following line in homepage_controller.js would error when a new block arrived:

```js
this.mixedPctTarget.innerHTML = ex.mixed_percent.toFixed(0)
```

`this.mixedPctTarget` was undefined because the `'this.mixedPct'` target was not listed in output of the homepage controller's `targets` method.