### PR TITLE
mempool: fix NaN in json without tickets in mempool

### DIFF
--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -197,7 +197,9 @@ func (c *DataCache) GetTicketPriceCountTime(feeAvgLength int) *apitypes.PriceCou
 	for i := 0; i < feeAvgLength; i++ {
 		feeAvg += c.allFees[numFees-i-1]
 	}
-	feeAvg /= float64(feeAvgLength)
+	if feeAvgLength > 0 {
+		feeAvg /= float64(feeAvgLength)
+	}
 
 	return &apitypes.PriceCountTime{
 		Price: dcrutil.Amount(c.stakeDiff).ToCoin() + feeAvg,


### PR DESCRIPTION
This resolves an issue with the /ticketpool page not loading when there are no tickets in mempool, which caused a NaN value for ticket price to break JSON parsing in the browser.