### PR TITLE
views: fix ticketpool's arg to html-head template

### DIFF
--- a/cmd/dcrdata/views/ticketpool.tmpl
+++ b/cmd/dcrdata/views/ticketpool.tmpl
@@ -1,7 +1,7 @@
 {{define "ticketpool"}}
 <!DOCTYPE html>
 <html lang="en">
-{{template "html-head" headData .CommonPageData "Decred Ticket Pool"}}
+{{template "html-head" headData . "Decred Ticket Pool"}}
     {{template "navbar" . }}
 
     <div class="container main" data-controller="ticketpool">


### PR DESCRIPTION
The /ticketpool page's handler is unique in that it does not embed
`CommonPageData` in a parent struct, instead passing it directly as the
only page data.  This broke the execution of `"html-head"` from that
page since it tried to use `.CommonPageData`.
This changes it to use just `.` so the template execution succeeds.