### PR TITLE
use db instead of searchrawtransactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Always run the Current release or on the Current stable branch. Do not use `mast
 - [Go](https://golang.org) 1.18 or 1.19
 - [Node.js](https://nodejs.org/en/download/) 16.x or 18.x. Node.js is only used
   as a build tool, and is **not used at runtime**.
-- Running `dcrd` running with `--txindex --addrindex`, and synchronized to the
-  current best block on the network. On startup, dcrdata will verify that the
-  dcrd version is compatible.
+- Running `dcrd` running with `--txindex`, and synchronized to the current best
+  block on the network. On startup, dcrdata will verify that the dcrd version is
+  compatible.
 - PostgreSQL 11+
 
 ## Docker Support
@@ -367,7 +367,6 @@ dcrd.conf:
 
 ```ini
 txindex=1
-addrindex=1
 ```
 
 If these parameters are not set, dcrdata will be unable to retrieve transaction

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -624,6 +624,7 @@ func (c *appContext) setTrimmedTxSpends(tx *apitypes.TrimmedTx) error {
 	return c.setOutputSpends(tx.TxID, tx.Vout)
 }
 
+// getTransaction handles the /tx/{txid} API endpoint.
 func (c *appContext) getTransaction(w http.ResponseWriter, r *http.Request) {
 	// Look up any spending transactions for each output of this transaction
 	// when the client requests spends with the URL query ?spends=true.
@@ -811,6 +812,7 @@ func (c *appContext) getTxSwapsInfo(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, swapsInfo, m.GetIndentCtx(r))
 }
 
+// getTransactions handles the /txns POST API endpoint.
 func (c *appContext) getTransactions(w http.ResponseWriter, r *http.Request) {
 	// Look up any spending transactions for each output of this transaction
 	// when the client requests spends with the URL query ?spends=true.
@@ -1857,6 +1859,8 @@ func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, txs, m.GetIndentCtx(r))
 }
 
+// getAddressTransactionsRaw handles the various /address/{addr}/.../raw API
+// endpoints.
 func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Request) {
 	addresses, err := m.GetAddressCtx(r, c.Params)
 	if err != nil || len(addresses) > 1 {
@@ -1869,14 +1873,13 @@ func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Re
 	skip := int64(m.GetMCtx(r))
 	if count <= 0 {
 		count = 10
-	} else if count > 8000 {
-		count = 8000
+	} else if count > 1000 {
+		count = 1000
 	}
 	if skip <= 0 {
 		skip = 0
 	}
 
-	// TODO: add postgresql powered method
 	txs := c.DataSource.GetAddressTransactionsRawWithSkip(address, int(count), int(skip))
 	if txs == nil {
 		http.Error(w, http.StatusText(422), 422)

--- a/cmd/dcrdata/internal/middleware/apimiddleware.go
+++ b/cmd/dcrdata/internal/middleware/apimiddleware.go
@@ -766,6 +766,12 @@ func AddressPathCtxN(n int) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			addressStr := chi.URLParam(r, "address")
 			if len(addressStr) < minAddressLength {
+				apiLog.Warnf("AddressPathCtxN rejecting address parameter of length %d", len(addressStr))
+				http.Error(w, "invalid address", http.StatusUnprocessableEntity)
+				return
+			}
+			if n == 1 && len(addressStr) > maxAddressLength {
+				apiLog.Warnf("AddressPathCtxN rejecting address parameter of length %d", len(addressStr))
 				http.Error(w, "invalid address", http.StatusUnprocessableEntity)
 				return
 			}

--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -92,7 +92,7 @@ func processTransactions(msgBlock *wire.MsgBlock, tree int8, chainParams *chainc
 			BlockHash:        blockHash.String(),
 			BlockHeight:      int64(blockHeight),
 			BlockTime:        blockTime,
-			Time:             blockTime, // TODO, receive time?
+			Time:             blockTime, // TODO, receive time? no! REMOVE
 			TxType:           int16(txType),
 			Version:          tx.Version,
 			Tree:             tree,

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1923,7 +1923,7 @@ type Tx struct {
 	BlockHash   string  `json:"block_hash"`
 	BlockHeight int64   `json:"block_height"`
 	BlockTime   TimeDef `json:"block_time"`
-	Time        TimeDef `json:"time"`
+	Time        TimeDef `json:"time"` // REMOVE!
 	TxType      int16   `json:"tx_type"`
 	Version     uint16  `json:"version"`
 	Tree        int8    `json:"tree"`

--- a/db/dcrpg/insightapi.go
+++ b/db/dcrpg/insightapi.go
@@ -131,29 +131,6 @@ func (pgb *ChainDB) AddressIDsByOutpoint(txHash string, voutIndex uint32) ([]uin
 	return ids, addrs, val, pgb.replaceCancelError(err)
 }
 
-// InsightSearchRPCAddressTransactions performs a searchrawtransactions for the
-// specified address, max number of transactions, and offset into the transaction
-// list. The search results are in reverse temporal order.
-// TODO: Does this really need all the prev vout extra data?
-func (pgb *ChainDB) InsightSearchRPCAddressTransactions(addr string, count,
-	skip int) []*chainjson.SearchRawTransactionsResult {
-	address, err := stdaddr.DecodeAddress(addr, pgb.chainParams)
-	if err != nil {
-		log.Infof("Invalid address %s: %v", addr, err)
-		return nil
-	}
-	prevVoutExtraData := true
-	ctx, cancel := context.WithTimeout(pgb.ctx, 10*time.Second)
-	defer cancel()
-	txs, err := pgb.Client.SearchRawTransactionsVerbose(ctx,
-		address, skip, count, prevVoutExtraData, true, nil)
-	if err != nil {
-		log.Warnf("GetAddressTransactions failed for address %s: %v", addr, err)
-		return nil
-	}
-	return txs
-}
-
 // GetTransactionHex returns the full serialized transaction for the specified
 // transaction hash as a hex encode string.
 func (pgb *ChainDB) GetTransactionHex(txid *chainhash.Hash) string {

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -17,7 +17,7 @@ const (
 		block_hash TEXT,
 		block_height INT8,
 		block_time TIMESTAMPTZ,
-		time TIMESTAMPTZ,
+		time TIMESTAMPTZ,  -- TODO: REMOVE!
 		tx_type INT4,
 		version INT4,
 		tree INT2,

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -7,6 +7,7 @@ package internal
 // These queries relate primarily to the "vins" and "vouts" tables.
 const (
 	// vins
+	// TODO: add sequence num?
 
 	CreateVinTable = `CREATE TABLE IF NOT EXISTS vins (
 		id SERIAL8 PRIMARY KEY,
@@ -23,7 +24,7 @@ const (
 		tx_type INT4
 	);`
 
-	// insertVinRow is the basis for several vinvs insert/upsert statements.
+	// insertVinRow is the basis for several vins insert/upsert statements.
 	insertVinRow = `INSERT INTO vins (tx_hash, tx_index, tx_tree, prev_tx_hash, prev_tx_index, prev_tx_tree,
 		value_in, is_valid, is_mainchain, block_time, tx_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) `
 

--- a/db/dcrpg/pgblockchain_fullpgdb_test.go
+++ b/db/dcrpg/pgblockchain_fullpgdb_test.go
@@ -4,14 +4,33 @@ package dcrpg
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrdata/db/dcrpg/v8/internal"
 )
+
+func TestGetAddressTransactionsRawWithSkip(t *testing.T) {
+	// a := "DsoFFRrsCvWLSgy9wnjWuqrRkUrAYoWSH3s" // split tx and ticket spending it
+	a := "Dsnm5MaPtic52uveAP6savT8hkSHttAFpvv" // stakesubmission (ticket) and vote
+	// a := "DsSWTHFrsXV77SwAcMe451kJTwWjwPYjWTM" // miner with coinbases
+	t0 := time.Now()
+	res := db.GetAddressTransactionsRawWithSkip(a, 1000, 0)
+	d := time.Since(t0)
+	// spew.Dump(res)
+
+	b, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(string(b), len(res))
+	t.Log(d)
+}
 
 func TestMixedUtxosByHeight(t *testing.T) {
 	heights, utxoCountReg, utxoValueReg, utxoCountStk, utxoValueStk, err := db.MixedUtxosByHeight()

--- a/dev/dcrdata-harness.tmux
+++ b/dev/dcrdata-harness.tmux
@@ -47,7 +47,6 @@ rpcpass=${RPC_PASS}
 simnet=1
 debuglevel=INFO
 txindex=1
-addrindex=1
 EOF
 
 cat > "${HARNESS_ROOT}/${ALPHA}/dcractl.conf" <<EOF

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -17,7 +17,6 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
-	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 
 	"github.com/decred/dcrdata/v8/semver"
@@ -74,6 +73,7 @@ func NewAsyncTxClient(c *rpcclient.Client) *AsyncTxClient {
 // dcrdata.
 var compatibleChainServerAPIs = []semver.Semver{
 	semver.NewSemver(7, 0, 0),
+	semver.NewSemver(8, 0, 0), // removed methods we no longer use i.e. searchrawtransactions
 }
 
 var (
@@ -361,23 +361,6 @@ func reverseStringSlice(s []string) {
 		j := N - 1 - i
 		s[i], s[j] = s[j], s[i]
 	}
-}
-
-// SearchRawTransaction fetch transactions pertaining to an address.
-func SearchRawTransaction(ctx context.Context, client *rpcclient.Client, params *chaincfg.Params, count int, address string) ([]*chainjson.SearchRawTransactionsResult, error) {
-	addr, err := stdaddr.DecodeAddress(address, params)
-	if err != nil {
-		log.Infof("Invalid address %s: %v", address, err)
-		return nil, err
-	}
-
-	//change the 1000 000 number demo for now
-	txs, err := client.SearchRawTransactionsVerbose(ctx, addr, 0, count,
-		true, true, nil)
-	if err != nil {
-		log.Warnf("SearchRawTransaction failed for address %s: %v", addr, err)
-	}
-	return txs, nil
 }
 
 // CommonAncestor attempts to determine the common ancestor block for two chains


### PR DESCRIPTION
Requires https://github.com/decred/dcrdata/pull/1922.  This PR starts with the `use db instead of searchrawtransactions` commit.

dcrd's `addrindex` is no longer required.  Previously it wasn't even really strictly necessary except for a single http endpoint and unused functions; sync always worked without it.

There are breaking changes as a type has change, but this is in dcrdata/v7 only, which is not yet tagged.

db/dcrpg:

Rewrite `GetAddressTransactionsRawWithSkip` to use the pg db instead of the `searchrawtransactions` RPC.

Remove `InsightSearchRPCAddressTransactions`, which was unused.

api/types:

Stop using `chainjson.VinPrevOut`.

Add `VinShort` type that is similar to `chainjson.Vin`, although lacking `Sequence` and `ScriptSig`, and the `Coinbase`, `StakeBase`, etc. fields are just booleans rather than strings.
The `VinPrevOut` type is not even emulated because it was almost useless: the amount was already in the `Vin` struct, and the address of the prev out is not of high importance when requesting address transactions.
ref https://github.com/btcsuite/btcd/pull/487
The prev out in that is no longer provided.

Redefine `AddressTxRaw` with new `VinShort` type.  This only changes responses from the various `/api/address/{addr}/.../raw` endpoints.
Turns out it wasn't Insight using this after all, which is good because the Insight consumers are less adaptable.