### PR TITLE
db/dcrpg: enforce a min required postgres version

### DIFF
--- a/db/dcrpg/internal/system.go
+++ b/db/dcrpg/internal/system.go
@@ -52,5 +52,6 @@ const (
 
 	RetrieveSyncCommitSetting = `SELECT setting FROM pg_settings WHERE name='synchronous_commit';`
 
-	RetrievePGVersion = `SELECT version();`
+	RetrievePGVersion    = `SELECT version();`
+	RetrievePGVersionNum = `SELECT current_setting('server_version_num');` // e.g. 130004
 )

--- a/db/dcrpg/system.go
+++ b/db/dcrpg/system.go
@@ -142,8 +142,12 @@ func (pgs PGSettings) String() string {
 }
 
 // RetrievePGVersion retrieves the version of the connected PostgreSQL server.
-func RetrievePGVersion(db *sql.DB) (ver string, err error) {
+func RetrievePGVersion(db *sql.DB) (ver string, verNum uint32, err error) {
 	err = db.QueryRow(internal.RetrievePGVersion).Scan(&ver)
+	if err != nil {
+		return
+	}
+	err = db.QueryRow(internal.RetrievePGVersionNum).Scan(&verNum)
 	return
 }
 

--- a/db/dcrpg/system_online_test.go
+++ b/db/dcrpg/system_online_test.go
@@ -33,9 +33,9 @@ func TestRetrieveSysSettingsServer(t *testing.T) {
 }
 
 func TestRetrievePGVersion(t *testing.T) {
-	ver, err := RetrievePGVersion(db.db)
+	ver, verNum, err := RetrievePGVersion(db.db)
 	if err != nil {
 		t.Errorf("Failed to retrieve postgres version: %v", err)
 	}
-	t.Logf("\n%s", ver)
+	t.Logf("\n%d: %s", verNum, ver)
 }


### PR DESCRIPTION
This adds a PostgreSQL version check to `NewChainDB`, which will return an error if the postgres service in use indicates a version less than the required minimum version defined by the new `pgVerNumMin` `const`.

This enforces the requirement already documented in README.md.