### PR TITLE
Treasury balance updates

### DIFF
--- a/cmd/dcrdata/api/apirouter.go
+++ b/cmd/dcrdata/api/apirouter.go
@@ -202,6 +202,7 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 
 	// Treasury
 	mux.Route("/treasury", func(r chi.Router) {
+		r.Get("/balance", app.getTreasuryBalance)
 		r.With(m.ChartGroupingCtx).Get("/io/{chartgrouping}", app.getTreasuryIO)
 	})
 

--- a/cmd/dcrdata/api/apiroutes.go
+++ b/cmd/dcrdata/api/apiroutes.go
@@ -63,6 +63,7 @@ type DataSource interface {
 	VotesInBlock(hash string) (int16, error)
 	TxHistoryData(address string, addrChart dbtypes.HistoryChart,
 		chartGroupings dbtypes.TimeBasedGrouping) (*dbtypes.ChartsData, error)
+	TreasuryBalance() (*dbtypes.TreasuryBalance, error)
 	BinnedTreasuryIO(chartGroupings dbtypes.TimeBasedGrouping) (*dbtypes.ChartsData, error)
 	TicketPoolVisualization(interval dbtypes.TimeBasedGrouping) (
 		*dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, *dbtypes.PoolTicketsData, int64, error)
@@ -1726,6 +1727,17 @@ func (c *appContext) getAddressTxAmountFlowData(w http.ResponseWriter, r *http.R
 	}
 
 	writeJSON(w, data, m.GetIndentCtx(r))
+}
+
+func (c *appContext) getTreasuryBalance(w http.ResponseWriter, r *http.Request) {
+	treasuryBalance, err := c.DataSource.TreasuryBalance()
+	if err != nil {
+		log.Errorf("TreasuryBalance failed: %v", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, treasuryBalance, m.GetIndentCtx(r))
 }
 
 func (c *appContext) getTreasuryIO(w http.ResponseWriter, r *http.Request) {

--- a/cmd/dcrdata/explorer/explorer.go
+++ b/cmd/dcrdata/explorer/explorer.go
@@ -478,6 +478,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	treasuryBalance, err := exp.dataSource.TreasuryBalance()
 	if err != nil {
 		log.Errorf("Store: TreasuryBalance failed: %v", err)
+		treasuryBalance = &dbtypes.TreasuryBalance{}
 	}
 
 	// Update pageData with block data and chain (home) info.

--- a/cmd/dcrdata/explorer/explorerroutes.go
+++ b/cmd/dcrdata/explorer/explorerroutes.go
@@ -1752,7 +1752,7 @@ func treasuryTypeCount(treasuryBalance *dbtypes.TreasuryBalance, txType stake.Tx
 	case stake.TxTypeTAdd:
 		typedCount = treasuryBalance.AddCount
 	case stake.TxTypeTreasuryBase:
-		typedCount = treasuryBalance.TGenCount
+		typedCount = treasuryBalance.TBaseCount
 	}
 	return typedCount
 }

--- a/cmd/dcrdata/views/treasury.tmpl
+++ b/cmd/dcrdata/views/treasury.tmpl
@@ -43,15 +43,15 @@
             <span class="text-secondary fs13">Received</span>
             <br>
             <span class="lh1rem d-inline-block pt-1 fs18 fs14-decimal fw-bold">
-            {{- if or $bal.Added $bal.TGen}}
-              {{- $received := add $bal.Added $bal.TGen}}
+            {{- if or $bal.Added $bal.TBase}}
+              {{- $received := add $bal.Added $bal.TBase}}
               {{- template "decimalParts" (amountAsDecimalParts $received true)}} <span class="text-secondary fs14">DCR</span>
             {{- else}}
               <span class="fs18">0</span> <span class="text-secondary fs14">DCR</span>
             {{- end}}
             </span>
             <br>
-            <span class="text-secondary fs14 lh1rem">{{intComma $bal.TGenCount}} gens, {{intComma $bal.AddCount}} adds</span>
+            <span class="text-secondary fs14 lh1rem">{{intComma $bal.TBaseCount}} gens, {{intComma $bal.AddCount}} adds</span>
           </div>
           <div class="d-inline-block text-start pe-2 pb-3">
             <span class="text-secondary fs13">Spent</span>

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -2045,17 +2045,18 @@ type TreasuryTx struct {
 // TreasuryBalance is the current balance, spent amount, and tx count for the
 // treasury.
 type TreasuryBalance struct {
-	Balance int64 `json:"balance"`
-	// TxCount should probably be called OutputCount.
-	TxCount       int64 `json:"tx_count"`
-	AddCount      int64 `json:"add_count"`
-	Added         int64 `json:"added"`
-	SpendCount    int64 `json:"spend_count"`
-	Spent         int64 `json:"spent"`
-	TGenCount     int64 `json:"tgen_count"`
-	TGen          int64 `json:"tbase"`
-	ImmatureCount int64 `json:"immature_count"`
-	Immature      int64 `json:"immature"`
+	Height         int64 `json:"height"`
+	MaturityHeight int64 `json:"maturity_height"`
+	Balance        int64 `json:"balance"`
+	TxCount        int64 `json:"output_count"`
+	AddCount       int64 `json:"add_count"`
+	Added          int64 `json:"added"`
+	SpendCount     int64 `json:"spend_count"`
+	Spent          int64 `json:"spent"`
+	TBaseCount     int64 `json:"tbase_count"`
+	TBase          int64 `json:"tbase"`
+	ImmatureCount  int64 `json:"immature_count"`
+	Immature       int64 `json:"immature"`
 }
 
 // AddressTransactions collects the transactions for an address as AddressTx


### PR DESCRIPTION
**db**: fix treasury spend tally amount

This fixes the treasury spend sum that uses a postgresql query.

This also renames the TGenCount and TGen fields of the
dbtypes.TreasuryBalance struct to TBaseCount and TBase.
The bins of the balance correspond to the treasury types: treasury
adds, spends, bases.  The "tgen" wording confuses this categorization
with output types, where TGEN is the opcode in the outputs of a
treasury spend, while the opcodes in the outputs of a both treasury add
and treasurybase txns are TADD.
Note that when rows are inserted into the treasury table, they are are
currently the change to the treasury and the txn type.

This adds Height and MaturityHeight to the TreasuryBalance struct.

**api:** add /api/treasury/balance