### PR TITLE
ui: Fix customcheck width on treasury page

### DIFF
--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -418,6 +418,7 @@ body.darkBG .chartview .dygraph-y2label {
   margin: 0.3rem auto;
   border: black;
   cursor: pointer;
+  width: unset;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -61,7 +61,7 @@
 	<link rel="preload" href="/images/connected.svg?x=65tv3" as="image" type="image/svg+xml" />
 	<link rel="preload" href="/images/disconnected.svg?x=65tv3" as="image" type="image/svg+xml" />
 
-	<link href="/dist/css/style.css?v=PdgRb7S" rel="stylesheet">
+	<link href="/dist/css/style.css?v=PdgRb7t" rel="stylesheet">
 
 	<script src="/js/vendor/turbolinks.min.js?v=65tv3"></script>
 </head>
@@ -186,7 +186,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.bundle.js?v=PdgRb7u"
+		src="/dist/js/app.bundle.js?v=PdgRb7v"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>


### PR DESCRIPTION
Bootstrap 5 updated the `row` class to apply a `width: 100%` to its childrens. Apparently this was done to prevent the columns from becoming too narrow when dealing with smaller grids. This made the custom input checks from the treasury page to be overflown from its parent div. Since we do want the columns to be narrow in this specific case,
this diff applies a `width: unset` to the column children's class `.customcheck`.

Before:

![image](https://user-images.githubusercontent.com/2729122/151627871-c2683845-bf62-4b05-86fa-2c94fbdfd66b.png)

After:
![image](https://user-images.githubusercontent.com/2729122/151629585-77b1010f-b756-4acd-bfe4-e0ed2af97ada.png)
