### PR TITLE
webpack: Add plugin to replace bundle hashes

### DIFF
--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -61,7 +61,7 @@
 	<link rel="preload" href="/images/connected.svg?x=65tv3" as="image" type="image/svg+xml" />
 	<link rel="preload" href="/images/disconnected.svg?x=65tv3" as="image" type="image/svg+xml" />
 
-	<link href="/dist/css/style.css?v=PdgRb7t" rel="stylesheet">
+	<link href="/dist/css/style.ab1819205fd75f31.css" rel="stylesheet">
 
 	<script src="/js/vendor/turbolinks.min.js?v=65tv3"></script>
 </head>
@@ -181,12 +181,12 @@
 		</span>
 	</div>
 	<script
-		src="/dist/js/4.0155dc3b6238166a.bundle.js"
+		src="/dist/js/4.e9d3dc224da38d00.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.bundle.js?v=PdgRb7v"
+		src="/dist/js/app.59f68a8a6b633166.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -181,7 +181,7 @@
 		</span>
 	</div>
 	<script
-		src="/dist/js/4.bundle.js?v=PdgRb7u"
+		src="/dist/js/4.0155dc3b6238166a.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/webpack.common.js
+++ b/cmd/dcrdata/webpack.common.js
@@ -2,6 +2,8 @@ const path = require('path')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
+const Path = require("path");
+const FileSystem = require("fs");
 
 module.exports = {
   entry: {
@@ -47,16 +49,37 @@ module.exports = {
       // both options are optional
       // filename: '[name].css',
       // chunkFilename: '[id].css'
-      filename: 'css/style.css'
+      filename: 'css/style.[fullhash].css'
     }),
     new StyleLintPlugin({
       threads: true,
       allowEmptyInput: true, // avoid errors with .stylelintignore
-    })
+    }),
+    new class ReplaceBuildHash {
+      apply(compiler) {
+        compiler.hooks.done.tap('ReplaceBuildHash', (stats) => {
+          const s = stats.toJson()
+          if (s.errors.length) {
+            // Do nothing on error
+            return;
+          }
+          // Update js/css bundles with the generated cache hash on the
+          // extras.tmpl file
+          const jsRegexp = new RegExp('(\\w)\\w+\\.bundle\\.js', 'g')
+          const cssRegexp = new RegExp('(\\w)\\w+\\.css', 'g')
+          const tmplPath = Path.join(__dirname, './views/extras.tmpl')
+          const tmplIn = FileSystem.readFileSync(tmplPath, "utf8")
+          const tmplOut = tmplIn
+            .replace(jsRegexp, `${s.hash}.bundle.js`)
+            .replace(cssRegexp, `${s.hash}.css`)
+          FileSystem.writeFileSync(tmplPath, tmplOut)
+        });
+      }
+    }
   ],
   output: {
     hashFunction: "xxhash64",
-    filename: 'js/[name].bundle.js',
+    filename: 'js/[name].[fullhash].bundle.js',
     path: path.resolve(__dirname, 'public/dist'),
     publicPath: '/dist/'
   },


### PR DESCRIPTION
This diff adds automatic cache bust by adding an inline webpack
plugin, which parses the bundles hashed filenames through the app
entrypoints and replaces them on the `extras.tmpl` template.