### PR TITLE
multi: add verify message feature

### DIFF
--- a/cmd/dcrdata/internal/api/apirouter.go
+++ b/cmd/dcrdata/internal/api/apirouter.go
@@ -333,5 +333,6 @@ func stackedMux(useRealIP bool) *chi.Mux {
 	corsMW := cors.Default()
 	corsMW.Log = loggerFunc(apiLog.Tracef)
 	mux.Use(corsMW.Handler)
+	mux.Use(m.RequestBodyLimiter(1 << 21)) // 2 MiB, down from 10 MiB default
 	return mux
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -366,7 +366,7 @@ func New(cfg *ExplorerConfig) *explorerUI {
 		"rawtx", "status", "parameters", "agenda", "agendas", "charts",
 		"sidechains", "disapproved", "ticketpool", "visualblocks", "statistics",
 		"windows", "timelisting", "addresstable", "proposals", "proposal",
-		"market", "insight_root", "attackcost", "treasury", "treasurytable"}
+		"market", "insight_root", "attackcost", "treasury", "treasurytable", "verify_message"}
 
 	for _, name := range tmpls {
 		if err := exp.templates.addTemplate(name); err != nil {

--- a/cmd/dcrdata/internal/explorer/explorermiddleware.go
+++ b/cmd/dcrdata/internal/explorer/explorermiddleware.go
@@ -39,7 +39,7 @@ var (
 
 // ProxyHeaders should only be used when behind a trusted proxy, not with direct
 // client connections. This sets Request.URL.Scheme from X-Forwarded-Proto, then
-// X-Forwarded-Scheme, and falls back to the scheme impled by the Request.TLS
+// X-Forwarded-Scheme, and falls back to the scheme implied by the Request.TLS
 // field. This also sets Request.Host if X-Forwarded-Host was set, but
 // Request.Host is usually already preserved by well-configured reverse proxies.
 func ProxyHeaders(next http.Handler) http.Handler {

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2844,7 +2844,13 @@ func (exp *explorerUI) VerifyMessageHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := dcrutil.VerifyMessage(address, signature, message, exp.ChainParams); err != nil {
-		displayPage("", false)
+		if strings.Contains(err.Error(), "message not signed by address") {
+			displayPage("", false)
+		} else if strings.Contains(err.Error(), "malformed base64 encoding") {
+			displayPage("invalid signature encoding", false)
+		} else {
+			displayPage(err.Error(), false)
+		}
 		return
 	}
 	displayPage("", true)

--- a/cmd/dcrdata/internal/middleware/apimiddleware.go
+++ b/cmd/dcrdata/internal/middleware/apimiddleware.go
@@ -114,6 +114,17 @@ func Tollbooth(l *Limiter) func(http.Handler) http.Handler {
 	}
 }
 
+// RequestBodyLimiter creates a middleware that wraps the request body using
+// MaxBytesReader for a certain number of bytes.
+func RequestBodyLimiter(lim int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, lim)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // GetBlockStepCtx retrieves the ctxBlockStep data from the request context. If
 // not set, the return value is -1.
 func GetBlockStepCtx(r *http.Request) int {

--- a/cmd/dcrdata/main.go
+++ b/cmd/dcrdata/main.go
@@ -680,7 +680,8 @@ func _main(ctx context.Context) error {
 	}
 
 	webMux.Use(middleware.Recoverer)
-	if cfg.TrustProxy { // try to determine actual request scheme and host from x-forwarded-{proto,host} headers
+	webMux.Use(mw.RequestBodyLimiter(1 << 21)) // 2 MiB, down from 10 MiB default
+	if cfg.TrustProxy {                        // try to determine actual request scheme and host from x-forwarded-{proto,host} headers
 		webMux.Use(explorer.ProxyHeaders)
 	}
 	webMux.With(explore.SyncStatusPageIntercept).Group(func(r chi.Router) {

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -111,6 +111,7 @@
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
 					<a class="menu-item" data-keynav-skip href="/treasury" title="Decred Treasury">Treasury</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
+					<a class="menu-item" data-keynav-skip href="/verify-message" title="Verify Message">Verify Message</a>
 				{{- if eq .NetName "Mainnet"}}
 					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
 				{{- else}}

--- a/cmd/dcrdata/views/verify_message.tmpl
+++ b/cmd/dcrdata/views/verify_message.tmpl
@@ -1,0 +1,62 @@
+{{define "verify_message"}}
+<!DOCTYPE html>
+<html lang="en">
+{{template "html-head" headData .CommonPageData "Verify Message"}}
+{{template "navbar" . }}
+<div class="container main">
+        <h4 class="mb-2">
+                Verify Message
+        </h4>
+        <div class="mb-1 fs15">
+                <p>After you or your counterparty has generated a signature, you can use this form to verify the
+                        validity of the signature. Once you have entered the address, the message and the corresponding
+                        signature, you will see VALID if the signature appropriately matches the address and message,
+                        otherwise INVALID.</p>
+        </div>
+        <form action="/verify-message" method="post">
+                <div class="mb-3 row">
+                        <label for="addressInput" class=" col-auto col-form-label">Address:</label>
+                        <div class="w-50 ms-2 border-1 border-bottom">
+                                <input type="text" name="address"
+                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
+                                        id="addressInput" required placeholder="Enter your address" autocomplete="off"
+                                        value="{{with .VerifyMessageResult}}{{.Address}}{{end}}">
+
+                        </div>
+                </div>
+                <div class="mb-3 row">
+                        <label for="signatureInput" class="col-auto col-form-label">Signature:</label>
+                        <div class="w-50 ms-2 border-1 border-bottom">
+                                <input type="text" name="signature"
+                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
+                                        id="signatureInput" required placeholder="Enter your signature"
+                                        autocomplete="off" value="{{with .VerifyMessageResult}}{{.Signature}}{{end}}">
+                        </div>
+                </div>
+                <div class="mb-3 row">
+                        <label for="messageInput" class="col-auto col-form-label">Message:</label>
+                        <div class="w-75 ms-2 border-1 border-bottom">
+                                <input type="text" name="message"
+                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
+                                        id="messageInput" required placeholder="Enter your message" autocomplete="off"
+                                        value="{{with .VerifyMessageResult}}{{.Message}}{{end}}">
+                        </div>
+                </div>
+                <button class="btn btn-primary mt-3 color-inherit" type="submit">Verify Message</button>
+        </form>
+
+        {{with .VerifyMessageResult}}
+        {{if .Error}}
+        <span class="border row border-danger m-3 p-4 fs-15 fw-bold rounded text-danger"> Something went
+                wrong... {{.Error}}</span>
+        {{else if .Valid}}
+        <span class="border row m-3 border-success m-3 p-4 fs-15 fw-bold rounded text-green"> Valid Signature! </span>
+        {{else}}
+        <span class="border row border-danger m-3 p-4 fs-15 fw-bold rounded text-danger"> Invalid Signature! </span>
+        {{end}}
+        {{end}}
+</div>
+{{ template "footer" . }}
+</body>
+</html>
+{{end}}

--- a/cmd/dcrdata/views/verify_message.tmpl
+++ b/cmd/dcrdata/views/verify_message.tmpl
@@ -1,62 +1,55 @@
-{{define "verify_message"}}
+{{define "verify_message" -}}
 <!DOCTYPE html>
 <html lang="en">
 {{template "html-head" headData .CommonPageData "Verify Message"}}
 {{template "navbar" . }}
 <div class="container main">
-        <h4 class="mb-2">
-                Verify Message
-        </h4>
-        <div class="mb-1 fs15">
-                <p>After you or your counterparty has generated a signature, you can use this form to verify the
-                        validity of the signature. Once you have entered the address, the message and the corresponding
-                        signature, you will see VALID if the signature appropriately matches the address and message,
-                        otherwise INVALID.</p>
+    <h4 class="mb-2">Verify Message</h4>
+    <div class="mb-1 fs15">
+        <p>Use this form to verify that the private key for a certain address was used to sign a message.</p>
+    </div>
+    <form action="/verify-message" method="post">
+        <div class="mb-3 row">
+            <label for="addressInput" class="col-auto col-form-label">Address:</label>
+            <div class="w-50 ms-2 border-1 border-bottom">
+                <input type="text" name="address"
+                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                    id="addressInput" required placeholder="Enter the address" autocomplete="off"
+                    value="{{with .VerifyMessageResult}}{{.Address}}{{end}}">
+            </div>
         </div>
-        <form action="/verify-message" method="post">
-                <div class="mb-3 row">
-                        <label for="addressInput" class=" col-auto col-form-label">Address:</label>
-                        <div class="w-50 ms-2 border-1 border-bottom">
-                                <input type="text" name="address"
-                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
-                                        id="addressInput" required placeholder="Enter your address" autocomplete="off"
-                                        value="{{with .VerifyMessageResult}}{{.Address}}{{end}}">
+        <div class="mb-3 row">
+            <label for="messageInput" class="col-auto col-form-label">Message:</label>
+            <div class="w-75 ms-2 border-1 border-bottom">
+                <input type="text" name="message"
+                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                    id="messageInput" required placeholder="Enter the message" autocomplete="off"
+                    value="{{with .VerifyMessageResult}}{{.Message}}{{end}}">
+            </div>
+        </div>
+        <div class="mb-3 row">
+            <label for="signatureInput" class="col-auto col-form-label">Signature:</label>
+            <div class="w-75 ms-2 border-1 border-bottom">
+                <input type="text" name="signature"
+                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                    id="signatureInput" required placeholder="Enter the corresponding signature"
+                    autocomplete="off" value="{{with .VerifyMessageResult}}{{.Signature}}{{end}}">
+            </div>
+        </div>
+        <button class="btn btn-primary mt-3 color-inherit" type="submit">Verify Message</button>
+    </form>
 
-                        </div>
-                </div>
-                <div class="mb-3 row">
-                        <label for="signatureInput" class="col-auto col-form-label">Signature:</label>
-                        <div class="w-50 ms-2 border-1 border-bottom">
-                                <input type="text" name="signature"
-                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
-                                        id="signatureInput" required placeholder="Enter your signature"
-                                        autocomplete="off" value="{{with .VerifyMessageResult}}{{.Signature}}{{end}}">
-                        </div>
-                </div>
-                <div class="mb-3 row">
-                        <label for="messageInput" class="col-auto col-form-label">Message:</label>
-                        <div class="w-75 ms-2 border-1 border-bottom">
-                                <input type="text" name="message"
-                                        class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none"
-                                        id="messageInput" required placeholder="Enter your message" autocomplete="off"
-                                        value="{{with .VerifyMessageResult}}{{.Message}}{{end}}">
-                        </div>
-                </div>
-                <button class="btn btn-primary mt-3 color-inherit" type="submit">Verify Message</button>
-        </form>
-
-        {{with .VerifyMessageResult}}
-        {{if .Error}}
-        <span class="border row border-danger m-3 p-4 fs-15 fw-bold rounded text-danger"> Something went
-                wrong... {{.Error}}</span>
-        {{else if .Valid}}
-        <span class="border row m-3 border-success m-3 p-4 fs-15 fw-bold rounded text-green"> Valid Signature! </span>
-        {{else}}
-        <span class="border row border-danger m-3 p-4 fs-15 fw-bold rounded text-danger"> Invalid Signature! </span>
-        {{end}}
-        {{end}}
+    {{with .VerifyMessageResult -}}
+    {{- if .Error -}}
+    <span class="border row border-danger m-3 p-3 fs-15 fw-bold rounded text-danger">Verification error: {{.Error}}</span>
+    {{- else if .Valid -}}
+    <span class="border row border-success m-3 p-3 fs-15 fw-bold rounded text-green">Matching signature</span>
+    {{- else -}}
+    <span class="border row border-danger m-3 p-3 fs-15 fw-bold rounded text-danger">Message not signed by address</span>
+    {{- end -}}
+    {{- end -}}
 </div>
 {{ template "footer" . }}
 </body>
 </html>
-{{end}}
+{{- end}}


### PR DESCRIPTION
This adds the verify message feature to dcrdata:
- New endpoints `GET /verify-message` and `POST /verify-message`
- Endpoint handlers `VerifyMessagePage` and `VerifyMessageHandler` for `GET` and `POST` respectively.
- A responsive page for the verify message form.
Closes #1771

UI:
![invalidres](https://user-images.githubusercontent.com/57448127/162834190-434876e5-3a70-4328-81f1-7ed79eaff283.png)
![validres](https://user-images.githubusercontent.com/57448127/162834365-8e97fc5d-72de-4fae-9e60-d6f76de27731.png)

