### PR TITLE
README: Update chat link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ here's the gist of it:
 
 **DO NOT merge from master to your feature branch; rebase.**
 
-Also, [come chat with us on Matrix](https://www.decred.org/matrix/) in the
+Also, [come chat with us on Matrix](https://chat.decred.org/) in the
 dcrdata channel!
 
 ## License


### PR DESCRIPTION
https://decred.org/matrix is an overly verbose relic from before we hosted our own instance of Element at https://chat.decred.org