### PR TITLE
views,explorer: Fix treasury pagination

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -1704,7 +1704,7 @@ func (exp *explorerUI) TreasuryTable(w http.ResponseWriter, r *http.Request) {
 		HTML     string       `json:"html"`
 		Pages    []pageNumber `json:"pages"`
 	}{
-		TxnCount: bal.TxCount, // + addrData.ImmatureCount,
+		TxnCount: treasuryTypeCount(bal, txType),
 		Pages:    calcPages(int(treasuryTypeCount(bal, txType)), int(limitN), int(offset), linkTemplate),
 	}
 

--- a/cmd/dcrdata/public/js/controllers/address_controller.js
+++ b/cmd/dcrdata/public/js/controllers/address_controller.js
@@ -158,7 +158,7 @@ export default class extends Controller {
       'range', 'chartbox', 'noconfirms', 'chart', 'pagebuttons',
       'pending', 'hash', 'matchhash', 'view', 'mergedMsg',
       'chartLoader', 'listLoader', 'expando', 'littlechart', 'bigchart',
-      'fullscreen', 'tablePagination']
+      'fullscreen', 'tablePagination', 'paginationheader']
   }
 
   async connect () {
@@ -353,6 +353,11 @@ export default class extends Controller {
     const params = ctrl.paginationParams
     const rowMax = params.count
     const count = ctrl.pageSize
+    if (ctrl.paginationParams.count === 0) {
+      ctrl.paginationheaderTarget.classList.add('d-hide')
+    } else {
+      ctrl.paginationheaderTarget.classList.remove('d-hide')
+    }
     if (rowMax > count) {
       ctrl.pagebuttonsTarget.classList.remove('d-hide')
     } else {

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -196,7 +196,7 @@
     <div class="position-relative" data-address-target="listbox">
         <div class="row align-items-center">
           <div class="me-auto mb-0 h4 col-24 col-sm-6">Transactions</div>
-          <div class="d-flex flex-wrap-reverse align-items-center justify-content-end py-1 col-24 col-sm-18">
+          <div data-address-target="paginationheader" class="d-flex flex-wrap-reverse align-items-center justify-content-end py-1 col-24 col-sm-18">
               <span class="fs12 nowrap text-end" data-address-target="range">
                   showing {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of
                       <span data-address-target="txnCount" data-txn-count="{{$TxnCount}}">{{intComma $TxnCount}}</span> transactions

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -187,7 +187,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.a072062c5c57ca58.bundle.js"
+		src="/dist/js/app.eb0b13eccb1813f6.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/views/treasury.tmpl
+++ b/cmd/dcrdata/views/treasury.tmpl
@@ -148,7 +148,7 @@
     <div class="position-relative" data-address-target="listbox">
       <div class="row align-items-center">
         <div class="me-auto mb-0 h4 col-24 col-sm-6">Transactions</div>
-        <div class="d-flex flex-wrap-reverse align-items-center justify-content-end py-1 col-24 col-sm-18">
+        <div data-address-target="paginationheader" class="d-flex flex-wrap-reverse align-items-center justify-content-end py-1 col-24 col-sm-18">
           <span class="fs12 nowrap text-end" data-address-target="range">
             showing {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of
             <span data-address-target="txnCount" data-txn-count="{{$bal.TxCount}}">{{intComma .TypeCount}}</span> transactions


### PR DESCRIPTION
The treasury page was returning all of the transactions for the tx count regardless of the selected tx type. Also, the pagination section is now hidden if there are no transactions returned.

Closes #1925