### PR TITLE
db/dcrpg: deleted oldest dups, not newest

### DIFF
--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -372,8 +372,8 @@ const (
 	// index uix_agendas_name. This should be run prior to creating the index.
 	DeleteAgendasDuplicateRows = `DELETE FROM agendas
 		WHERE id IN (SELECT id FROM (
-				SELECT id, ROW_NUMBER()
-				OVER (partition BY name ORDER BY id) AS rnum
+				SELECT id,
+					row_number() OVER (PARTITION BY name ORDER BY id DESC) AS rnum
 				FROM agendas) t
 			WHERE t.rnum > 1);`
 
@@ -403,8 +403,8 @@ const (
 	// index uix_agenda_votes. This should be run prior to creating the index.
 	DeleteAgendaVotesDuplicateRows = `DELETE FROM agenda_votes
 		WHERE id IN (SELECT id FROM (
-				SELECT id, ROW_NUMBER()
-				OVER (partition BY votes_row_id, agendas_row_id ORDER BY id) AS rnum
+				SELECT id,
+					row_number() OVER (PARTITION BY votes_row_id, agendas_row_id ORDER BY id DESC) AS rnum
 				FROM agenda_votes) t
 			WHERE t.rnum > 1);`
 

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -85,8 +85,8 @@ const (
 	// uix_tx_hashes. This should be run prior to creating the index.
 	DeleteTxDuplicateRows = `DELETE FROM transactions
 		WHERE id IN (SELECT id FROM (
-			SELECT id, ROW_NUMBER()
-			OVER (partition BY tx_hash, block_hash ORDER BY id) AS rnum
+			SELECT id,
+				row_number() OVER (PARTITION BY tx_hash, block_hash ORDER BY id DESC) AS rnum
 			FROM transactions) t
 		WHERE t.rnum > 1);`
 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -59,8 +59,8 @@ const (
 	// uix_vin. This should be run prior to creating the index.
 	DeleteVinsDuplicateRows = `DELETE FROM vins
 		WHERE id IN (SELECT id FROM (
-				SELECT id, ROW_NUMBER()
-				OVER (partition BY tx_hash, tx_index, tx_tree ORDER BY id) AS rnum
+				SELECT id,
+					row_number() OVER (PARTITION BY tx_hash, tx_index, tx_tree ORDER BY id DESC) AS rnum
 				FROM vins) t
 			WHERE t.rnum > 1);`
 
@@ -224,11 +224,14 @@ const (
 	// DeleteVoutDuplicateRows removes rows that would violate the unique index
 	// uix_vout_txhash_ind. This should be run prior to creating the index.
 	DeleteVoutDuplicateRows = `DELETE FROM vouts
-		WHERE id IN (SELECT id FROM (
-				SELECT id, ROW_NUMBER()
-				OVER (partition BY tx_hash, tx_index, tx_tree ORDER BY id) AS rnum
-				FROM vouts) t
-			WHERE t.rnum > 1);`
+		WHERE id IN (
+			SELECT id FROM (
+				SELECT id,
+					row_number() OVER (PARTITION BY tx_hash, tx_index, tx_tree ORDER BY id DESC) AS rnum
+				FROM vouts
+			) t
+			WHERE t.rnum > 1
+		);`
 
 	ShowCreateVoutsTable     = `WITH a AS (SHOW CREATE vouts) SELECT create_statement FROM a;`
 	DistinctVoutsToTempTable = `INSERT INTO vouts_temp


### PR DESCRIPTION
Duplicate deletion queries were keeping the vouts/vins that were from the stake-invalided transactions instead of the newer/replaced ones.

Before

![image](https://user-images.githubusercontent.com/9373513/203687201-5739a850-b6c3-4a8a-9ce8-cc190ea7d5bd.png)

After (the "unspent" is now a link)

![image](https://user-images.githubusercontent.com/9373513/203687341-9c351df2-32c1-4d95-bf00-eb43caae0c57.png)

@dajohi 

Requires full resync/ibd to resolve