### PR TITLE
ui: add margin between last element display and footer on `/charts` page

### DIFF
--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -189,7 +189,7 @@
         </div>
 
 
-        <div data-charts-target="chartWrapper" class="chart-wrapper ps-2 pe-2 mb-5">
+        <div data-charts-target="chartWrapper" class="chart-wrapper px-2 pb-5">
             <div
                 class="chartview"
                 data-charts-target="chartsView">


### PR DESCRIPTION
Before:
<img width="500" alt="Screenshot 2022-12-05 at 8 32 28 PM" src="https://user-images.githubusercontent.com/57448127/205726514-1e2bb652-135e-45f2-8681-44643384f282.png">
After:
<img width="576" alt="Screenshot 2022-12-05 at 8 32 14 PM" src="https://user-images.githubusercontent.com/57448127/205726622-d2f6423d-ec80-4782-8bfa-8f9e48e1ded2.png">
