### PR TITLE
UI: fix dcrdata UI quirks

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -390,7 +390,8 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"intComma": func(v interface{}) string {
 			return humanize.Comma(toInt64(v))
 		},
-		"int64Comma": humanize.Comma,
+		"int64Comma":       humanize.Comma,
+		"commaWithDecimal": humanize.CommafWithDigits,
 		"ticketWindowProgress": func(i int) float64 {
 			p := (float64(i) / float64(params.StakeDiffWindowSize)) * 100
 			return p

--- a/cmd/dcrdata/public/js/controllers/market_controller.js
+++ b/cmd/dcrdata/public/js/controllers/market_controller.js
@@ -1218,7 +1218,7 @@ export default class extends Controller {
     if (update.fiat) { // btc-fiat exchange update
       this.xcIndexTargets.forEach(span => {
         if (span.dataset.token === xc.token) {
-          span.textContent = xc.price.toFixed(2)
+          span.textContent = humanize.commaWithDecimal(xc.price, 2)
         }
       })
     } else { // dcr-btc exchange update

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -18,6 +18,12 @@ function hashParts (hash) {
 }
 
 const humanize = {
+  commaWithDecimal: function (val, decimal) {
+    if (isNaN(val) || val === 0) return '0'
+    if (isNaN(decimal)) decimal = 2
+    else if (decimal > 8) decimal = 8
+    return val.toLocaleString(undefined, { minimumFractionDigits: decimal, maximumFractionDigits: decimal })
+  },
   fmtPercentage: function (val) {
     let sign = '+'
     let cssClass = 'text-green'

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -10,7 +10,7 @@
         {{if gt (len $.Data) 0}}{{$pendingBlocks = ((index .Data 0).Height)}}{{end}}
 
         {{$blocksCount := (len $.Data)}}
-        <div class="mb-1">
+        <div class="px-1 mb-1">
             {{if gt $blocksCount 0}}
             {{$topBlock = ((index .Data 0).Height)}}
             {{$Offset := (subtract .BestBlock $topBlock)}}
@@ -19,7 +19,7 @@
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     Blocks
                 </span>
-                <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
+                <div class="pb-1 d-flex justify-content-end align-items-center flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">
                       {{intComma (add $Offset 1)}} &ndash; {{intComma (add $Offset .RowsCount)}} of {{intComma (add .BestBlock 1) }} rows
                   </span>

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -187,7 +187,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.015cc1c4c02affd7.bundle.js"
+		src="/dist/js/app.31da152a7693a3d5.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -359,7 +359,7 @@
 
 {{define "blocksBanner"}}
 <div class="bg-white block-banner">
-	<div class="container px-0">
+	<div class="container px-1">
 		<div>
 			<a class="d-inline-block position-relative me-4 py-2 unstyled-link" href="/blocks">
 				<span class="px-2{{if eq .TimeGrouping "Blocks"}} unstyled-link{{else}} text-secondary{{end}}">Blocks</span>

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -187,7 +187,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.31da152a7693a3d5.bundle.js"
+		src="/dist/js/app.ba2620d5445760b1.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/views/market.tmpl
+++ b/cmd/dcrdata/views/market.tmpl
@@ -18,11 +18,11 @@
 
         {{- /* PRICE */ -}}
         <div class="ms-4 me-2 my-4 p-2 p-lg-4 bg-white text-center">
-            <div class="text-center fs18 text-secondary">1 DCR =</div>
+            <span class="text-center fs18 text-secondary">1 DCR =</span>
             {{if eq $botState.BtcIndex "USD"}}
-                <span class="fs18 fw-bold d-inline-block pt-1" style="vertical-align:top;">$</span>
+                <span class="fs22 fw-bold d-inline-block">$</span>
             {{end}}
-            <span class="fs28" data-market-target="price">{{printf "%.2f" $botState.Price}}</span> <span class="fs16 text-secondary">{{$botState.BtcIndex}}</span>
+            <span class="fs24" data-market-target="price">{{printf "%.2f" $botState.Price}}</span> <span class="fs16 text-secondary">{{$botState.BtcIndex}}</span>
         </div>
 
 
@@ -87,7 +87,7 @@
                   <div class="col-12 text-center">
                       <div class="fs18 fw-bold d-flex align-items-center justify-content-center"><div class="exchange-logo {{$token}} me-1"></div> <span class="d-inline-block">{{toTitleCase $token}}</span></div>
                       {{if eq $botState.BtcIndex "USD"}}
-                          <span class="fs16 fw-bold d-inline-block pt-1 valign-top">$</span>
+                          <span class="fs22 fw-bold d-inline-block">$</span>
                       {{end}}
                       <span class="fs24" data-price="{{$state.Price}}" data-token="{{$token}}" data-market-target="xcIndex">{{printf "%.2f" $state.Price}}</span> <span class="fs16 text-secondary">{{$botState.BtcIndex}}</span><br>
                       {{if eq $token "coindesk"}}

--- a/cmd/dcrdata/views/market.tmpl
+++ b/cmd/dcrdata/views/market.tmpl
@@ -18,7 +18,7 @@
 
         {{- /* PRICE */ -}}
         <div class="ms-4 me-2 my-4 p-2 p-lg-4 bg-white text-center">
-            <span class="text-center fs18 text-secondary">1 DCR =</span>
+            <div class="text-center fs18 text-secondary">1 DCR =</div>
             {{if eq $botState.BtcIndex "USD"}}
                 <span class="fs22 fw-bold d-inline-block">$</span>
             {{end}}

--- a/cmd/dcrdata/views/market.tmpl
+++ b/cmd/dcrdata/views/market.tmpl
@@ -89,7 +89,7 @@
                       {{if eq $botState.BtcIndex "USD"}}
                           <span class="fs22 fw-bold d-inline-block">$</span>
                       {{end}}
-                      <span class="fs24" data-price="{{$state.Price}}" data-token="{{$token}}" data-market-target="xcIndex">{{printf "%.2f" $state.Price}}</span> <span class="fs16 text-secondary">{{$botState.BtcIndex}}</span><br>
+                      <span class="fs24" data-price="{{$state.Price}}" data-token="{{$token}}" data-market-target="xcIndex">{{commaWithDecimal $state.Price 2}}</span> <span class="fs16 text-secondary">{{$botState.BtcIndex}}</span><br>
                       {{if eq $token "coindesk"}}
                         <a class="fs12" href="https://www.coindesk.com/price/bitcoin">Powered by CoinDesk</a>
                       {{end}}

--- a/cmd/dcrdata/views/proposals.tmpl
+++ b/cmd/dcrdata/views/proposals.tmpl
@@ -10,7 +10,8 @@
                         Politeia Proposals
                         <span class="mb-0 fs11 text-black-50 nowrap">
                             &nbsp;(<span class="me-2">Proposals Sync:&nbsp;
-                                <span data-controller="time" data-time-target="age" data-age="{{$.LastPropSync}}"></span>&nbsp;ago
+                                <span data-controller="time" data-time-target="age" data-age="{{$.LastPropSync}}"></span>
+                            &nbsp;ago)
                             </span>
                         </span>
                     </h4>
@@ -69,7 +70,7 @@
                             {{if eq $count 20 30 50}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
                             </select>
                         </span>
-                        <span class="fs12 nowrap text-end px-2">
+                        <span class="fs12 nowrap text-end form-control-sm mb-2 me-sm-2 mb-sm-0">
                             {{intComma (add .Offset 1)}} &ndash; {{intComma $oldest}} of {{ intComma $.TotalCount }} rows
                         </span>
                         <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="m-2">

--- a/cmd/dcrdata/views/timelisting.tmpl
+++ b/cmd/dcrdata/views/timelisting.tmpl
@@ -8,7 +8,7 @@
     {{template "blocksBanner" .}}
     <div class="container main" data-controller="time pagenavigation">
         {{$count := (int64 (len .Data))}}
-        <div class="mb-1">
+        <div class="px-1 mb-1">
             {{if gt $count 0}}
             <div class="d-flex justify-content-between align-items-end">
                 {{$oldest = (add .Offset $count)}}
@@ -22,7 +22,7 @@
                     <span class="dcricon-info fs14 ms-2 mt-2" title="Decred Blocks Grouped By {{.TimeGrouping}}"></span>
                 </span>
 
-                <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
+                <div class="pb-1 d-flex justify-content-end align-items-center flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">
                     {{intComma (add .Offset 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastGrouping }} rows
                   </span>

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -9,7 +9,7 @@
     {{template "blocksBanner" .}}
     <div data-controller="pagenavigation" class="container main">
         {{$windowsCount := (int64 (len .Data))}}
-        <div class="mb-1">
+        <div class="px-1 mb-1">
             {{if gt $windowsCount 0}}
             {{$pendingWindows := (int64 (index .Data 0).IndexVal)}}
             {{$oldest = (add .OffsetWindow $windowsCount)}}
@@ -22,7 +22,7 @@
                 <span class="dcricon-info fs14 ms-2 mt-2" title="Decred Blocks Grouped By Ticket Price Windows"></span>
               </span>
 
-              <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
+              <div class="pb-1 d-flex justify-content-end align-items-center flex-wrap">
               <span class="fs12 nowrap text-secondary px-2 my-2">
                     {{intComma (add .OffsetWindow 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastWindow }} rows
                 </span>


### PR DESCRIPTION
Before:
<img width="349" alt="p before" src="https://user-images.githubusercontent.com/57448127/205883684-8eba7208-9ae1-40a8-a7c1-7f6079f0ff7b.png">
After:
<img width="350" alt="p after" src="https://user-images.githubusercontent.com/57448127/205883695-c0d37d79-ea42-4211-8650-fa58c9f1ff8d.png">
Before:
<img width="262" alt="p header before" src="https://user-images.githubusercontent.com/57448127/205883731-ed41aaa4-60a2-42ba-b25d-118efca3f27f.png">
After:
<img width="264" alt="p header after" src="https://user-images.githubusercontent.com/57448127/205883743-905efb53-807f-4b0f-9bc2-6aa29e23e975.png">
Before:
<img width="438" alt="markets before" src="https://user-images.githubusercontent.com/57448127/205883789-b4cf1dda-98d3-4d03-94fe-05b94ec72011.png">
After:
<img width="419" alt="Screenshot 2022-12-06 at 10 46 12 PM" src="https://user-images.githubusercontent.com/57448127/206029994-e4c6cd2d-e6dd-4ace-a548-cfd8e196faf3.png">

Before:
<img width="1107" alt="blocks before" src="https://user-images.githubusercontent.com/57448127/205883846-3d022413-2617-441b-8c60-4e732c47adbd.png">
After:
<img width="932" alt="blocks after" src="https://user-images.githubusercontent.com/57448127/205883875-9d81d112-76da-453f-bad0-a8cbe5a7f67e.png">
