### PR TITLE
UI: add message to unused info icons

### DIFF
--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -18,7 +18,6 @@
             <div class="d-flex justify-content-between align-items-end">
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     Blocks
-                    <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Blocks"></span>
                 </span>
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -18,7 +18,7 @@
             <div class="d-flex justify-content-between align-items-end">
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     Blocks
-                    <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Blocks"></span>
+                    <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Blocks"></span>
                 </span>
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -18,7 +18,7 @@
             <div class="d-flex justify-content-between align-items-end">
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     Blocks
-                    <span class="dcricon-info fs24 ms-3 mt-2"></span>
+                    <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Blocks"></span>
                 </span>
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">
                   <span class="fs12 nowrap text-secondary px-2 my-2">

--- a/cmd/dcrdata/views/timelisting.tmpl
+++ b/cmd/dcrdata/views/timelisting.tmpl
@@ -19,7 +19,7 @@
                 {{if gt $lastGrouping 200}}{{$dropVal = 200}}{{end}}
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     {{.TimeGrouping}}
-                    <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Blocks arranged by {{.TimeGrouping}}"></span>
+                    <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Blocks grouped by {{.TimeGrouping}}"></span>
                 </span>
 
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">

--- a/cmd/dcrdata/views/timelisting.tmpl
+++ b/cmd/dcrdata/views/timelisting.tmpl
@@ -19,7 +19,7 @@
                 {{if gt $lastGrouping 200}}{{$dropVal = 200}}{{end}}
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     {{.TimeGrouping}}
-                    <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Blocks grouped by {{.TimeGrouping}}"></span>
+                    <span class="dcricon-info fs14 ms-2 mt-2" title="Decred Blocks Grouped By {{.TimeGrouping}}"></span>
                 </span>
 
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">

--- a/cmd/dcrdata/views/timelisting.tmpl
+++ b/cmd/dcrdata/views/timelisting.tmpl
@@ -19,7 +19,7 @@
                 {{if gt $lastGrouping 200}}{{$dropVal = 200}}{{end}}
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     {{.TimeGrouping}}
-                    <span class="dcricon-info fs24 ms-3 mt-2"></span>
+                    <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Blocks arranged by {{.TimeGrouping}}"></span>
                 </span>
 
                 <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -19,7 +19,7 @@
             <div class="d-flex justify-content-between align-items-end">
               <span class="h2 d-flex pt-4 pb-1 pe-2">
                 Windows
-                <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Windows"></span>
+                <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Ticket Price Windows"></span>
               </span>
 
               <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -19,7 +19,7 @@
             <div class="d-flex justify-content-between align-items-end">
               <span class="h2 d-flex pt-4 pb-1 pe-2">
                 Windows
-                <span class="dcricon-info fs24 ms-3 mt-2" title="Decred Ticket Price Windows"></span>
+                <span class="dcricon-info fs14 ms-2 mt-2" title="Decred Blocks Grouped By Ticket Price Windows"></span>
               </span>
 
               <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -19,7 +19,7 @@
             <div class="d-flex justify-content-between align-items-end">
               <span class="h2 d-flex pt-4 pb-1 pe-2">
                 Windows
-                <span class="dcricon-info fs24 ms-3 mt-2"></span>
+                <span class="dcricon-info fs24 ms-3 mt-2" title="List of Decred Windows"></span>
               </span>
 
               <div class="pb-1 d-flex justify-content-end align-items-end flex-wrap">


### PR DESCRIPTION
This diff adds a message to a hand full of unused info icons. Closes #1939 