### PR TITLE
dcrpg: add "tree" to apitypes.Tx type

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -101,6 +101,7 @@ type TxShort struct {
 	Vin      []Vin  `json:"vin"`
 	Vout     []Vout `json:"vout"`
 	Tree     int8   `json:"tree"`
+	Type     string `json:"type"`
 }
 
 // AgendasInfo holds the high level details about an agenda.

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -100,6 +100,7 @@ type TxShort struct {
 	Expiry   uint32 `json:"expiry"`
 	Vin      []Vin  `json:"vin"`
 	Vout     []Vout `json:"vout"`
+	Tree     int8   `json:"tree"`
 }
 
 // AgendasInfo holds the high level details about an agenda.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -4838,6 +4838,8 @@ func (pgb *ChainDB) GetAPITransaction(txid *chainhash.Hash) *apitypes.Tx {
 		treasuryActive = txhelpers.IsTreasuryActive(pgb.chainParams.Net, txraw.BlockHeight)
 	}
 
+	txTree := txhelpers.TxTree(msgTx, treasuryActive)
+
 	tx := &apitypes.Tx{
 		TxShort: apitypes.TxShort{
 			TxID:     txraw.Txid,
@@ -4847,7 +4849,8 @@ func (pgb *ChainDB) GetAPITransaction(txid *chainhash.Hash) *apitypes.Tx {
 			Expiry:   txraw.Expiry,
 			Vin:      make([]apitypes.Vin, len(txraw.Vin)),
 			Vout:     make([]apitypes.Vout, len(txraw.Vout)),
-			Tree:     txhelpers.TxTree(msgTx, treasuryActive),
+			Tree:     txTree,
+			Type:     strings.ToLower(txhelpers.TxTypeToString(int(txTree))),
 		},
 		Confirmations: txraw.Confirmations,
 		Block: &apitypes.BlockID{


### PR DESCRIPTION
This returns a tx's `tree` as part of the  `apitypes.Tx` type which is used as the return value for the `api/tx/{txid}` endpoint. Closes #1797 