### PR TITLE
cmd/dcrdata/views: display treasury adds and treasury bases as not spendable

### DIFF
--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -559,15 +559,15 @@
                             {{$v.Version}}
                         </td>
                         <td class="text-start fs13 shrink-to-fit">{{with $spending := (index $.Data.SpendingTxns $i) }}
-                            {{if $spending.Hash}}
-                                <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
-                            {{else}}
-                                {{if gt $v.Amount 0.0}}
-                                {{$v.Spent}}
-                                {{else}}
-                                n/a
+                              {{if $spending.Hash}}
+                                 <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
+                              {{else}}
+                                {{if or $v.OP_TADD (le $v.Amount 0.0)}}
+                                  n/a
+                                {{else if gt $v.Amount 0.0}}
+                                  {{$v.Spent}}
                                 {{end}}
-                            {{end}}
+                              {{end}}
                             {{end}}
                         </td>
 			                  <td class="text-end mono fs13">


### PR DESCRIPTION
<img width="641" alt="Screenshot 2022-12-10 at 12 16 46 AM" src="https://user-images.githubusercontent.com/57448127/206810741-c7527e46-b754-4905-ac70-528a667b7413.png">

Closes #1932