### PR TITLE
multi: implement stake reward calculator

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -366,7 +366,8 @@ func New(cfg *ExplorerConfig) *explorerUI {
 		"rawtx", "status", "parameters", "agenda", "agendas", "charts",
 		"sidechains", "disapproved", "ticketpool", "visualblocks", "statistics",
 		"windows", "timelisting", "addresstable", "proposals", "proposal",
-		"market", "insight_root", "attackcost", "treasury", "treasurytable", "verify_message"}
+		"market", "insight_root", "attackcost", "treasury", "treasurytable",
+		"verify_message", "stake_reward"}
 
 	for _, name := range tmpls {
 		if err := exp.templates.addTemplate(name); err != nil {
@@ -569,9 +570,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	// Simulate the annual staking rate.
 	go func(height int64, sdiff float64, supply int64) {
-		ASR, _ := exp.simulateASR(1000, false, stakePerc,
+		ASR, _ := exp.simulateStakeReturn(1000, false, stakePerc,
 			dcrutil.Amount(supply).ToCoin(),
-			float64(height), sdiff)
+			float64(height), sdiff, 365 /* for a year */)
 		p.Lock()
 		p.HomeInfo.ASR = ASR
 		p.Unlock()
@@ -673,13 +674,12 @@ func (exp *explorerUI) addRoutes() {
 	exp.Mux.Get("/stats", redirect("statistics"))
 }
 
-// Simulate ticket purchase and re-investment over a full year for a given
-// starting amount of DCR and calculation parameters.  Generate a TEXT table of
-// the simulation results that can optionally be used for future expansion of
-// dcrdata functionality.
-func (exp *explorerUI) simulateASR(StartingDCRBalance float64, IntegerTicketQty bool,
-	CurrentStakePercent float64, ActualCoinbase float64, CurrentBlockNum float64,
-	ActualTicketPrice float64) (ASR float64, ReturnTable string) {
+// simulateStakeReturn simulates ticket purchase and re-investment over the
+// specified durationInDays for a given starting amount of DCR and calculation
+// parameters.
+func (exp *explorerUI) simulateStakeReturn(startingDCRBalance float64, integerTicketQty bool,
+	currentStakePercent float64, actualCoinbase float64, currentBlockNum float64,
+	actualTicketPrice float64, durationInDays float64) (stakeReturn float64, returnTable string) {
 
 	// Calculations are only useful on mainnet.  Short circuit calculations if
 	// on any other version of chain params.
@@ -687,18 +687,18 @@ func (exp *explorerUI) simulateASR(StartingDCRBalance float64, IntegerTicketQty 
 		return 0, ""
 	}
 
-	BlocksPerDay := 86400 / exp.ChainParams.TargetTimePerBlock.Seconds()
-	BlocksPerYear := 365 * BlocksPerDay
-	TicketsPurchased := float64(0)
+	blocksPerDay := 86400 / exp.ChainParams.TargetTimePerBlock.Seconds()
+	totalBlocksInDuration := durationInDays * blocksPerDay
+	ticketsPurchased := float64(0)
 
 	votesPerBlock := exp.ChainParams.VotesPerBlock()
 
-	StakeRewardAtBlock := func(blocknum float64) float64 {
-		Subsidy := exp.dataSource.BlockSubsidy(int64(blocknum), votesPerBlock)
-		return dcrutil.Amount(Subsidy.PoS / int64(votesPerBlock)).ToCoin()
+	stakeRewardAtBlock := func(blocknum float64) float64 {
+		subsidy := exp.dataSource.BlockSubsidy(int64(blocknum), votesPerBlock)
+		return dcrutil.Amount(subsidy.PoS / int64(votesPerBlock)).ToCoin()
 	}
 
-	MaxCoinSupplyAtBlock := func(blocknum float64) float64 {
+	maxCoinSupplyAtBlock := func(blocknum float64) float64 {
 		// 4th order poly best fit curve to Decred mainnet emissions plot.
 		// Curve fit was done with 0 Y intercept and Pre-Mine added after.
 
@@ -709,72 +709,70 @@ func (exp *explorerUI) simulateASR(StartingDCRBalance float64, IntegerTicketQty 
 			1680000) // Premine 1.68M
 	}
 
-	CoinAdjustmentFactor := ActualCoinbase / MaxCoinSupplyAtBlock(CurrentBlockNum)
+	coinAdjustmentFactor := actualCoinbase / maxCoinSupplyAtBlock(currentBlockNum)
 
-	TheoreticalTicketPrice := func(blocknum float64) float64 {
-		ProjectedCoinsCirculating := MaxCoinSupplyAtBlock(blocknum) * CoinAdjustmentFactor * CurrentStakePercent
-		TicketPoolSize := (float64(exp.MeanVotingBlocks) + float64(exp.ChainParams.TicketMaturity) +
+	theoreticalTicketPrice := func(blocknum float64) float64 {
+		projectedCoinsCirculating := maxCoinSupplyAtBlock(blocknum) * coinAdjustmentFactor * currentStakePercent
+		ticketPoolSize := (float64(exp.MeanVotingBlocks) + float64(exp.ChainParams.TicketMaturity) +
 			float64(exp.ChainParams.CoinbaseMaturity)) * float64(exp.ChainParams.TicketsPerBlock)
-		return ProjectedCoinsCirculating / TicketPoolSize
+		return projectedCoinsCirculating / ticketPoolSize
 	}
-	TicketAdjustmentFactor := ActualTicketPrice / TheoreticalTicketPrice(CurrentBlockNum)
+	ticketAdjustmentFactor := actualTicketPrice / theoreticalTicketPrice(currentBlockNum)
 
 	// Prepare for simulation
-	simblock := CurrentBlockNum
-	TicketPrice := ActualTicketPrice
-	DCRBalance := StartingDCRBalance
+	simblock := currentBlockNum
+	ticketPrice := actualTicketPrice
+	dcrBalance := startingDCRBalance
 
-	ReturnTable += "\n\nBLOCKNUM        DCR  TICKETS TKT_PRICE TKT_REWRD  ACTION\n"
-	ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    INIT\n",
-		int64(simblock), DCRBalance, TicketsPurchased,
-		TicketPrice, StakeRewardAtBlock(simblock))
+	returnTable = "\n\nBLOCKNUM        DCR  TICKETS TKT_PRICE TKT_REWRD  ACTION\n"
+	returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    INIT\n",
+		int64(simblock), dcrBalance, ticketsPurchased,
+		ticketPrice, stakeRewardAtBlock(simblock))
 
-	for simblock < (BlocksPerYear + CurrentBlockNum) {
+	for simblock < (totalBlocksInDuration + currentBlockNum) {
 		// Simulate a Purchase on simblock
-		TicketPrice = TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor
+		ticketPrice = theoreticalTicketPrice(simblock) * ticketAdjustmentFactor
 
-		if IntegerTicketQty {
+		if integerTicketQty {
 			// Use this to simulate integer qtys of tickets up to max funds
-			TicketsPurchased = math.Floor(DCRBalance / TicketPrice)
+			ticketsPurchased = math.Floor(dcrBalance / ticketPrice)
 		} else {
 			// Use this to simulate ALL funds used to buy tickets - even fractional tickets
 			// which is actually not possible
-			TicketsPurchased = (DCRBalance / TicketPrice)
+			ticketsPurchased = (dcrBalance / ticketPrice)
 		}
 
-		DCRBalance -= (TicketPrice * TicketsPurchased)
-		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f     BUY\n",
-			int64(simblock), DCRBalance, TicketsPurchased,
-			TicketPrice, StakeRewardAtBlock(simblock))
+		dcrBalance -= (ticketPrice * ticketsPurchased)
+		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f     BUY\n",
+			int64(simblock), dcrBalance, ticketsPurchased,
+			ticketPrice, stakeRewardAtBlock(simblock))
 
 		// Move forward to average vote
 		simblock += (float64(exp.ChainParams.TicketMaturity) + float64(exp.MeanVotingBlocks))
-		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    VOTE\n",
-			int64(simblock), DCRBalance, TicketsPurchased,
-			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    VOTE\n",
+			int64(simblock), dcrBalance, ticketsPurchased,
+			(theoreticalTicketPrice(simblock) * ticketAdjustmentFactor), stakeRewardAtBlock(simblock))
 
 		// Simulate return of funds
-		DCRBalance += (TicketPrice * TicketsPurchased)
+		dcrBalance += (ticketPrice * ticketsPurchased)
 
 		// Simulate reward
-		DCRBalance += (StakeRewardAtBlock(simblock) * TicketsPurchased)
-		TicketsPurchased = 0
+		dcrBalance += (stakeRewardAtBlock(simblock) * ticketsPurchased)
+		ticketsPurchased = 0
 
 		// Move forward to coinbase maturity
 		simblock += float64(exp.ChainParams.CoinbaseMaturity)
 
-		ReturnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f  REWARD\n",
-			int64(simblock), DCRBalance, TicketsPurchased,
-			(TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor), StakeRewardAtBlock(simblock))
+		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f  REWARD\n",
+			int64(simblock), dcrBalance, ticketsPurchased,
+			(theoreticalTicketPrice(simblock) * ticketAdjustmentFactor), stakeRewardAtBlock(simblock))
 
 		// Need to receive funds before we can use them again so add 1 block
 		simblock++
 	}
 
-	// Scale down to exactly 365 days
-	SimulationReward := ((DCRBalance - StartingDCRBalance) / StartingDCRBalance) * 100
-	ASR = (BlocksPerYear / (simblock - CurrentBlockNum)) * SimulationReward
-	ReturnTable += fmt.Sprintf("ASR over 365 Days is %.2f.\n", ASR)
+	simulationReward := ((dcrBalance - startingDCRBalance) / startingDCRBalance) * 100
+	stakeReturn = (totalBlocksInDuration / (simblock - currentBlockNum)) * simulationReward
 	return
 }
 

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -570,7 +570,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	// Simulate the annual staking rate.
 	go func(height int64, sdiff float64, supply int64) {
-		ASR, _ := exp.simulateStakeReturn(1000, false, stakePerc,
+		ASR := exp.simulateStakeReturn(1000, false, stakePerc,
 			dcrutil.Amount(supply).ToCoin(),
 			float64(height), sdiff, 365 /* for a year */)
 		p.Lock()
@@ -679,17 +679,16 @@ func (exp *explorerUI) addRoutes() {
 // parameters.
 func (exp *explorerUI) simulateStakeReturn(startingDCRBalance float64, integerTicketQty bool,
 	currentStakePercent float64, actualCoinbase float64, currentBlockNum float64,
-	actualTicketPrice float64, durationInDays float64) (stakeReturn float64, returnTable string) {
+	actualTicketPrice float64, durationInDays float64) float64 {
 
 	// Calculations are only useful on mainnet.  Short circuit calculations if
 	// on any other version of chain params.
 	if exp.ChainParams.Name != "mainnet" {
-		return 0, ""
+		return 0
 	}
 
 	blocksPerDay := 86400 / exp.ChainParams.TargetTimePerBlock.Seconds()
 	totalBlocksInDuration := durationInDays * blocksPerDay
-	ticketsPurchased := float64(0)
 
 	votesPerBlock := exp.ChainParams.VotesPerBlock()
 
@@ -721,17 +720,12 @@ func (exp *explorerUI) simulateStakeReturn(startingDCRBalance float64, integerTi
 
 	// Prepare for simulation
 	simblock := currentBlockNum
-	ticketPrice := actualTicketPrice
 	dcrBalance := startingDCRBalance
-
-	returnTable = "\n\nBLOCKNUM        DCR  TICKETS TKT_PRICE TKT_REWRD  ACTION\n"
-	returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    INIT\n",
-		int64(simblock), dcrBalance, ticketsPurchased,
-		ticketPrice, stakeRewardAtBlock(simblock))
 
 	for simblock < (totalBlocksInDuration + currentBlockNum) {
 		// Simulate a Purchase on simblock
-		ticketPrice = theoreticalTicketPrice(simblock) * ticketAdjustmentFactor
+		var ticketsPurchased float64
+		ticketPrice := theoreticalTicketPrice(simblock) * ticketAdjustmentFactor
 
 		if integerTicketQty {
 			// Use this to simulate integer qtys of tickets up to max funds
@@ -743,37 +737,25 @@ func (exp *explorerUI) simulateStakeReturn(startingDCRBalance float64, integerTi
 		}
 
 		dcrBalance -= (ticketPrice * ticketsPurchased)
-		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f     BUY\n",
-			int64(simblock), dcrBalance, ticketsPurchased,
-			ticketPrice, stakeRewardAtBlock(simblock))
 
 		// Move forward to average vote
 		simblock += (float64(exp.ChainParams.TicketMaturity) + float64(exp.MeanVotingBlocks))
-		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f    VOTE\n",
-			int64(simblock), dcrBalance, ticketsPurchased,
-			(theoreticalTicketPrice(simblock) * ticketAdjustmentFactor), stakeRewardAtBlock(simblock))
 
 		// Simulate return of funds
 		dcrBalance += (ticketPrice * ticketsPurchased)
 
 		// Simulate reward
 		dcrBalance += (stakeRewardAtBlock(simblock) * ticketsPurchased)
-		ticketsPurchased = 0
 
 		// Move forward to coinbase maturity
 		simblock += float64(exp.ChainParams.CoinbaseMaturity)
-
-		returnTable += fmt.Sprintf("%8d  %9.2f %8.1f %9.2f %9.2f  REWARD\n",
-			int64(simblock), dcrBalance, ticketsPurchased,
-			(theoreticalTicketPrice(simblock) * ticketAdjustmentFactor), stakeRewardAtBlock(simblock))
 
 		// Need to receive funds before we can use them again so add 1 block
 		simblock++
 	}
 
 	simulationReward := ((dcrBalance - startingDCRBalance) / startingDCRBalance) * 100
-	stakeReturn = (totalBlocksInDuration / (simblock - currentBlockNum)) * simulationReward
-	return
+	return (totalBlocksInDuration / (simblock - currentBlockNum)) * simulationReward
 }
 
 func (exp *explorerUI) watchExchanges() {

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2985,12 +2985,6 @@ func (exp *explorerUI) CalculateStakeReward(w http.ResponseWriter, r *http.Reque
 	}
 
 	amountInDCR := float64(amount) / exchangeRate.Value
-	if amountInDCR < currentTicketPrice {
-		displayPage(fmt.Sprintf("%s (%s) cannot buy a single ticket, need at least %.2f (%s)",
-			amountStr, exchangeRate.Index, (currentTicketPrice * exchangeRate.Value), exchangeRate.Index))
-		return
-	}
-
 	durationInDays = endDate.Sub(startDate).Hours() / 24
 	minimumRewardDurationInDays := ((float64(exp.ChainParams.TicketMaturity) +
 		float64(exp.MeanVotingBlocks) +
@@ -3001,8 +2995,7 @@ func (exp *explorerUI) CalculateStakeReward(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	poolPercent := homeInfo.PoolInfo.Percentage / 100
-	reward = exp.simulateStakeReturn(amountInDCR, true, poolPercent,
+	reward = exp.simulateStakeReturn(amountInDCR, false, homeInfo.PoolInfo.Percentage/100,
 		dcrutil.Amount(homeInfo.CoinSupply).ToCoin(), float64(exp.pageData.BlockInfo.Height),
 		currentTicketPrice, durationInDays)
 

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -3002,7 +3002,7 @@ func (exp *explorerUI) CalculateStakeReward(w http.ResponseWriter, r *http.Reque
 	}
 
 	poolPercent := homeInfo.PoolInfo.Percentage / 100
-	reward, _ = exp.simulateStakeReturn(amountInDCR, true, poolPercent,
+	reward = exp.simulateStakeReturn(amountInDCR, true, poolPercent,
 		dcrutil.Amount(homeInfo.CoinSupply).ToCoin(), float64(exp.pageData.BlockInfo.Height),
 		currentTicketPrice, durationInDays)
 

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2854,3 +2854,160 @@ func (exp *explorerUI) VerifyMessageHandler(w http.ResponseWriter, r *http.Reque
 	}
 	displayPage("", true)
 }
+
+type stakeReward struct {
+	Reward               float64
+	RewardInDcr          float64
+	RewardDurationInDays float64
+	TotalTicketsCost     float64
+	Amount               string
+	StartDate            string
+	EndDate              string
+	Error                string
+}
+
+// StakeReward is the page handler for the "GET /stake-reward" path.
+func (exp *explorerUI) StakeReward(w http.ResponseWriter, r *http.Request) {
+	voteReward := exp.pageData.HomeInfo.NBlockSubsidy.PoS / int64(exp.ChainParams.VotesPerBlock())
+	str, err := exp.templates.exec("stake_reward", struct {
+		*CommonPageData
+		VoteReward          float64
+		CurrentTicketPrice  float64
+		TicketReward        float64
+		MinimumRewardPeriod string
+		ExchangeRate        *types.Conversion
+		StakeReward         *stakeReward
+	}{
+		VoteReward:          toFloat64Amount(voteReward),
+		CurrentTicketPrice:  exp.pageData.HomeInfo.StakeDiff,
+		TicketReward:        exp.pageData.HomeInfo.TicketReward,
+		MinimumRewardPeriod: exp.pageData.HomeInfo.RewardPeriod,
+		ExchangeRate:        exp.pageData.HomeInfo.ExchangeRate,
+		CommonPageData:      exp.commonData(r),
+	})
+	if err != nil {
+		log.Errorf("Template execute failure: %v", err)
+		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, str)
+}
+
+// CalculateStakeReward is the handler for "POST /stake-reward" path.
+func (exp *explorerUI) CalculateStakeReward(w http.ResponseWriter, r *http.Request) {
+	startDateStr := r.PostFormValue("startDate")
+	endDateStr := r.PostFormValue("endDate")
+	amountStr := r.PostFormValue("amount")
+
+	var reward, rewardInDcr, totalTicketCost float64
+	var durationInDays float64
+	var err error
+	exchangeRate := exp.pageData.HomeInfo.ExchangeRate
+	currentTicketPrice := exp.pageData.HomeInfo.StakeDiff
+	homeInfo := exp.pageData.HomeInfo
+	voteReward := exp.pageData.HomeInfo.NBlockSubsidy.PoS / int64(exp.ChainParams.VotesPerBlock())
+
+	displayPage := func(errMsg string) {
+		str, err := exp.templates.exec("stake_reward", struct {
+			*CommonPageData
+			VoteReward          float64
+			CurrentTicketPrice  float64
+			TicketReward        float64
+			MinimumRewardPeriod string
+			ExchangeRate        *types.Conversion
+			StakeReward         *stakeReward
+		}{
+			CommonPageData:      exp.commonData(r),
+			VoteReward:          toFloat64Amount(voteReward),
+			CurrentTicketPrice:  currentTicketPrice,
+			TicketReward:        homeInfo.TicketReward,
+			MinimumRewardPeriod: homeInfo.RewardPeriod,
+			ExchangeRate:        exchangeRate,
+			StakeReward: &stakeReward{
+				Reward:               reward,
+				Amount:               amountStr,
+				RewardDurationInDays: durationInDays,
+				TotalTicketsCost:     totalTicketCost,
+				StartDate:            startDateStr,
+				RewardInDcr:          rewardInDcr,
+				EndDate:              endDateStr,
+				Error:                errMsg,
+			},
+		})
+
+		if err != nil {
+			log.Errorf("Template execute failure: %v", err)
+			exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, str)
+	}
+
+	startDate, err := time.Parse("2006-01-02", startDateStr)
+	if err != nil {
+		displayPage("invalid start date")
+		return
+	}
+
+	now := time.Now()
+	if startDate.Before(now) {
+		displayPage("staking start date must be in the future")
+		return
+	}
+
+	endDate, err := time.Parse("2006-01-02", endDateStr)
+	if err != nil {
+		displayPage("invalid end date")
+		return
+	}
+
+	if endDate.Before(now) {
+		displayPage("staking end date must be in the future")
+		return
+	}
+
+	if startDate.After(endDate) {
+		displayPage("staking start date cannot be before specified end date")
+		return
+	}
+
+	// Parse and ensure amount provided for tickets is sane.
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil {
+		displayPage(err.Error())
+		return
+	}
+
+	amountInDCR := float64(amount) / exchangeRate.Value
+	if amountInDCR < currentTicketPrice {
+		displayPage(fmt.Sprintf("%s (%s) cannot buy a single ticket, need at least %.2f (%s)",
+			amountStr, exchangeRate.Index, (currentTicketPrice * exchangeRate.Value), exchangeRate.Index))
+		return
+	}
+
+	durationInDays = endDate.Sub(startDate).Hours() / 24
+	minimumRewardDurationInDays := ((float64(exp.ChainParams.TicketMaturity) +
+		float64(exp.MeanVotingBlocks) +
+		float64(exp.ChainParams.CoinbaseMaturity)) * exp.ChainParams.TargetTimePerBlock.Hours()) / 24
+
+	if durationInDays < minimumRewardDurationInDays {
+		displayPage(fmt.Sprintf("minimum stake reward duration is %.2f days", minimumRewardDurationInDays))
+		return
+	}
+
+	poolPercent := homeInfo.PoolInfo.Percentage / 100
+	reward, _ = exp.simulateStakeReturn(amountInDCR, true, poolPercent,
+		dcrutil.Amount(homeInfo.CoinSupply).ToCoin(), float64(exp.pageData.BlockInfo.Height),
+		currentTicketPrice, durationInDays)
+
+	rewardInDcr = amountInDCR * reward / 100
+	totalTicketCost = math.Floor(amountInDCR/currentTicketPrice) * currentTicketPrice
+
+	displayPage("")
+}

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -325,6 +325,10 @@ func formattedDuration(duration time.Duration, str *periodMap) string {
 	return i(durationsec) + pl(str.s, durationsec)
 }
 
+func toFloat64Amount(intAmount int64) float64 {
+	return dcrutil.Amount(intAmount).ToCoin()
+}
+
 func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 	netTheme := "theme-" + strings.ToLower(netName(params))
 
@@ -362,6 +366,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		},
 		"divideFloat": func(n, d float64) float64 {
 			return n / d
+		},
+		"float64Multiply": func(x, y float64) float64 {
+			return x * y
 		},
 		"multiply": func(a, b int64) int64 {
 			return a * b
@@ -404,9 +411,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"amountAsDecimalParts": func(v int64, useCommas bool) []string {
 			return float64Formatting(dcrutil.Amount(v).ToCoin(), 8, useCommas)
 		},
-		"toFloat64Amount": func(intAmount int64) float64 {
-			return dcrutil.Amount(intAmount).ToCoin()
-		},
+		"toFloat64Amount": toFloat64Amount,
 		"dcrPerKbToAtomsPerByte": func(amt dcrutil.Amount) int64 {
 			return int64(math.Round(float64(amt) / 1e3))
 		},

--- a/cmd/dcrdata/main.go
+++ b/cmd/dcrdata/main.go
@@ -786,6 +786,8 @@ func _main(ctx context.Context) error {
 		r.Get("/attack-cost", explore.AttackCost)
 		r.Get("/verify-message", explore.VerifyMessagePage)
 		r.With(mw.Tollbooth(limiter)).Post("/verify-message", explore.VerifyMessageHandler)
+		r.Get("/stake-reward", explore.StakeReward)
+		r.With(mw.Tollbooth(limiter)).Post("/stake-reward", explore.CalculateStakeReward)
 	})
 
 	// Configure a page for the bare "/insight" path. This mounts the static

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -112,6 +112,7 @@
 					<a class="menu-item" data-keynav-skip href="/treasury" title="Decred Treasury">Treasury</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
 					<a class="menu-item" data-keynav-skip href="/verify-message" title="Verify Message">Verify Message</a>
+					<a class="menu-item" data-keynav-skip href="/stake-reward" title="Calculate Stake Reward">Calculate Stake Reward</a>
 				{{- if eq .NetName "Mainnet"}}
 					<a class="menu-item" data-keynav-skip href="{{.Links.Testnet}}" title="Home">Switch To Testnet</a>
 				{{- else}}

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -120,8 +120,7 @@
                                     <span class="h4" data-homepage-target="mpRegTotal">{{threeSigFigs .Mempool.LikelyMineable.RegularTotal}}</span>
                                     <span class="h6">DCR</span>
                                 </div>
-                                {{- /* TODO: pe-SM, pe-MD, ETC CAN GO */ -}}
-                                <div class="text-end pe-3 pe-sm-3 pe-md-3 pe-lg-3 tx-bar tx-ticket d-inline-block">
+                                <div class="text-end pe-3 tx-bar tx-ticket d-inline-block">
                                     <span data-homepage-target="mpTicketCount" class="h4">{{.Mempool.NumTickets}}</span>
                                     <span class="h6"> tickets</span>
                                     <br>

--- a/cmd/dcrdata/views/stake_reward.tmpl
+++ b/cmd/dcrdata/views/stake_reward.tmpl
@@ -1,0 +1,150 @@
+{{define "stake_reward" -}}
+<!DOCTYPE html>
+<html lang="en">
+{{template "html-head" headData .CommonPageData "Decred Staking Reward Calculator"}}
+{{template "navbar" . }}
+<div class="container main">
+    <h4 class="mb-2">Calculate Decred Staking Reward</h4>
+    <div class="mb-1 fs15">
+        <p> Use this Decred Staking Calculator to estimate your potential stake reward to see how much you'll earn by staking Decred.
+            The rewards predicted by this calculator are only an estimate, It does not consider network fees or fees paid to a VSP. 
+            Staking Decred provides stake holders with rewards in addition to the potential market price gains.
+        </p>
+        <p> The mimimum duration required for a ticket to recieve a stake reward of {{printf "%.2f" .TicketReward}}% is {{ .MinimumRewardPeriod}}. The more Decred you stake, the more rewards you can earn.
+         <a href="https://docs.decred.org/proof-of-stake/how-to-stake/"> Learn how to stake Decred</a>.
+        </p>
+        <p> <b>Disclaimer</b>: This calculator only predicts an estimate of rewards. The actual amount of Decred earned may vary and will depend on several factors,
+            including actual stake reward or changes to network parameters.
+            Decred provides this calculator for guidance only and accepts no responsibility for any discrepancy between estimated and actual rewards.
+        </p>
+
+    </div>
+    <div class="row">
+      <form action="/stake-reward" method="post" class="py-1 px-lg-3 text-start col-24 col-lg-12 my-2">
+        <div class="mb-3 row">
+            <label for="amount" class="col-auto col-form-label">Amount ({{.ExchangeRate.Index}}):</label>
+            <div class="ms-2 border-1 border-bottom">
+                 <input 
+                   type="number" name="amount"
+                   class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                   id="amount" required min={{with .ExchangeRate}}{{printf "%.f" (float64Multiply $.CurrentTicketPrice .Value)}}{{end}}
+                   placeholder="Enter an amount you want to stake" autocomplete="off"
+                   value="{{with .StakeReward}}{{.Amount}}{{end}}">
+            </div>
+        </div>
+        <div class="mb-3 row">
+            <label for="startDate" class="col-auto col-form-label">Start Date:</label>
+            <div class="ms-2 border-1 border-bottom">
+                <input type="date" name="startDate"
+                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                    id="startDate" required placeholder="Specify a start date"
+                    autocomplete="off" value="{{with .StakeReward}}{{.StartDate}}{{end}}">
+            </div>
+        </div>
+        <div class="mb-3 row">
+            <label for="endDate" class="col-auto col-form-label">End Date:</label>
+            <div class="ms-2 border-1 border-bottom">
+                <input type="date" name="endDate"
+                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
+                    id="endDate" required placeholder="Specify an end date"
+                    autocomplete="off" value="{{with .StakeReward}}{{.EndDate}}{{end}}">
+            </div>
+        </div>
+        <button class="btn btn-primary mt-3 color-inherit" type="submit">Calculate Reward</button>
+        {{with .StakeReward}}
+          {{- if .Error -}}
+            <span class="border row border-danger m-3 p-3 fs-15 fw-bold rounded text-danger">Error calculating stake reward: {{.Error}}</span>
+          {{end}}
+        {{end}}
+    </form>
+
+    {{$conv := .ExchangeRate}}
+    <div class="py-1 px-lg-3 text-start col-24 col-lg-12 my-2">
+          <div class="row my-2">
+             <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+             <div class="fs16 text-secondary">
+                  <a class="no-underline" href="/charts?chart=ticket-price&zoom=month">Current Ticket Price</a>
+             </div>
+             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+               <span>{{template "decimalParts" (float64AsDecimalParts .CurrentTicketPrice 8 false 2)}}</span>
+               <span class="ps-1 unit lh15rem">DCR</span>
+             </div>
+             {{if $conv}}
+              <div class="fs12 lh1rem text-black-50">
+                  <span>{{printf "%.2f" (float64Multiply .CurrentTicketPrice $conv.Value)}} {{$conv.Index}}</span>
+              </div>
+             {{- end}}
+            </div>
+            <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+               <div class="fs16 text-secondary">Vote Reward</div>
+               <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                  <span>
+                     {{template "decimalParts" (float64AsDecimalParts .VoteReward 8 true 2)}}
+                  </span>
+                  <span class="ps-1 unit lh15rem" style="font-size:13px;">DCR/vote</span>
+               </div>
+               {{if $conv}}
+                <div class="fs12 lh1rem text-black-50">
+                  <span>{{printf "%.2f" (float64Multiply .VoteReward $conv.Value)}} {{$conv.Index}}</span>
+                </div>
+               {{- end}}
+             </div>
+          </div>
+          {{with .StakeReward -}}
+          {{- if not .Error -}}
+           <h6>Estimated Stake Rewards</h6>
+           <div class="row my-2">
+             <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                <div class="fs16 text-secondary">
+                    Reward
+                    <span 
+                     class="dcricon-info fs14 ms-2 mt-2" 
+                     title="This is an estimated reward for the duration specified, a ticket receives a reward of {{printf "%.2f" $.TicketReward}}% ususally after {{$.MinimumRewardPeriod}}."
+                    >
+                    </span>
+                </div>
+                <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                  <span>
+                     {{template "decimalParts" (float64AsDecimalParts .RewardInDcr 8 true 2)}}
+                  </span>
+                  <span class="ps-1 unit lh15rem" style="font-size:13px;">DCR</span>
+                </div>
+               {{if $conv}}
+                <div class="fs12 lh1rem text-black-50">
+                  <span>{{printf "%.2f" (float64Multiply .RewardInDcr $conv.Value)}} {{$conv.Index}}</span>
+                </div>
+               {{- end}}
+               <div class="fs12 lh1rem text-black-50">
+                  <span>~{{printf "%.2f" .Reward}}%</span> in ~{{.RewardDurationInDays}} days
+               </div>
+             </div>
+             <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                {{$nTickets := divideFloat .TotalTicketsCost $.CurrentTicketPrice}}
+                <div class="fs16 text-secondary">
+                  Total Cost
+                  <span class="dcricon-info fs14 ms-2 mt-2" title="Cost of purchasing {{$nTickets}} Ticket(s), excluding network and VSP fees."></span>
+                </div>
+                <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                  <span>
+                     {{template "decimalParts" (float64AsDecimalParts .TotalTicketsCost 8 true 2)}}
+                  </span>
+                  <span class="ps-1 unit lh15rem" style="font-size:13px;">DCR</span>
+                </div>
+               {{if $conv}}
+                <div class="fs12 lh1rem text-black-50">
+                  <span>{{printf "%.2f" (float64Multiply .TotalTicketsCost $conv.Value)}} {{$conv.Index}}</span>
+                </div>
+               {{- end}}
+                <div class="fs12 lh1rem text-black-50">
+                  <span>{{printf "%.f" $nTickets}} {{if gt $nTickets 1.0}}Tickets{{else}}Ticket{{end}}</span>
+                </div>
+             </div>
+          </div>
+         {{- end -}}
+         {{- end -}}
+    </div> 
+</div>
+{{ template "footer" . }}
+</body>
+</html>
+{{- end}}

--- a/cmd/dcrdata/views/stake_reward.tmpl
+++ b/cmd/dcrdata/views/stake_reward.tmpl
@@ -27,8 +27,8 @@
                  <input 
                    type="number" name="amount"
                    class="bg-transparent border-0 ps-0 color-inherit form-control shadow-none mono"
-                   id="amount" required min={{with .ExchangeRate}}{{printf "%.f" (float64Multiply $.CurrentTicketPrice .Value)}}{{end}}
-                   placeholder="Enter an amount you want to stake" autocomplete="off"
+                   id="amount" required min=1
+                   placeholder="Enter the amount you want to stake" autocomplete="off"
                    value="{{with .StakeReward}}{{.Amount}}{{end}}">
             </div>
         </div>
@@ -99,7 +99,7 @@
                     Reward
                     <span 
                      class="dcricon-info fs14 ms-2 mt-2" 
-                     title="This is an estimated reward for the duration specified, a ticket receives a reward of {{printf "%.2f" $.TicketReward}}% ususally after {{$.MinimumRewardPeriod}}."
+                     title="This is an estimated reward for the duration specified, even if your stake amount cannot purchase a single ticket. A ticket receives a reward of ~{{printf "%.2f" $.TicketReward}}% usually after ~{{$.MinimumRewardPeriod}}."
                     >
                     </span>
                 </div>
@@ -122,7 +122,7 @@
                 {{$nTickets := divideFloat .TotalTicketsCost $.CurrentTicketPrice}}
                 <div class="fs16 text-secondary">
                   Total Cost
-                  <span class="dcricon-info fs14 ms-2 mt-2" title="Cost of purchasing {{$nTickets}} Ticket(s), excluding network and VSP fees."></span>
+                  <span class="dcricon-info fs14 ms-2 mt-2" title="Cost of purchasing {{printf "%.f" $nTickets}} Ticket(s), excluding network and VSP fees."></span>
                 </div>
                 <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
                   <span>
@@ -136,7 +136,13 @@
                 </div>
                {{- end}}
                 <div class="fs12 lh1rem text-black-50">
-                  <span>{{printf "%.f" $nTickets}} {{if gt $nTickets 1.0}}Tickets{{else}}Ticket{{end}}</span>
+                  <span> 
+                  {{if lt $nTickets 1.0}}
+                  Note: Stake amount is not sufficient to buy a single ticket.
+                  {{else}}
+                  {{printf "%.f" $nTickets}} {{if gt $nTickets 1.0}}Tickets{{else}}Ticket{{end}}
+                  {{end}}
+                  </span>
                 </div>
              </div>
           </div>


### PR DESCRIPTION
This implements a stake reward calculator and reactors an existing method to work with the stake reward calculator. Closes #1772.

-- Add a new `GET /stake-reward` endpoint.
-- Add a new `POST /stake-reward` endpoint.
-- Add stake reward calculator page.

While I could shutdown anytime to test other stuffs you can see the calculator here:
http://134.209.25.156:7777/stake-reward 

UI view:
<img width="1346" alt="Screenshot 2022-12-21 at 8 40 01 PM" src="https://user-images.githubusercontent.com/57448127/209061524-86a49383-18be-45aa-aca2-7a2364b80c23.png">
<img width="1312" alt="Screenshot 2022-12-22 at 6 02 01 AM" src="https://user-images.githubusercontent.com/57448127/209061532-a04bff3b-f133-48c2-a560-6bec86c890a9.png">
<img width="1278" alt="Screenshot 2022-12-22 at 6 02 43 AM" src="https://user-images.githubusercontent.com/57448127/209061542-724b9d2a-56aa-4987-8b55-73757a92e271.png">
