### PR TITLE
UI: add margin to connection icon

### DIFF
--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -172,7 +172,7 @@
 		</span>
 		<span
 			id="connection"
-			class="text-nowrap align-items-center clickable d-inline-block"
+			class="text-nowrap me-3 align-items-center clickable d-inline-block"
 			data-turbolinks-permanent
 			data-controller="connection"
 			data-connection-target="indicator"


### PR DESCRIPTION
Before:
<img width="89" alt="Screenshot 2022-12-22 at 6 21 06 AM" src="https://user-images.githubusercontent.com/57448127/209063363-5ec0489f-d346-4f66-bb15-e454f1915a19.png">

After:
<img width="104" alt="Screenshot 2022-12-22 at 6 20 49 AM" src="https://user-images.githubusercontent.com/57448127/209063366-99158301-4411-44f8-9d2b-811842c036b3.png">
