### PR TITLE
cmd/dcrdata: version dcrdata APIs

### DIFF
--- a/cmd/dcrdata/internal/api/apirouter.go
+++ b/cmd/dcrdata/internal/api/apirouter.go
@@ -18,6 +18,11 @@ type apiMux struct {
 	*chi.Mux
 }
 
+// Version returns the version of this API handler.
+func (am *apiMux) Version() int {
+	return APIVersion
+}
+
 type fileMux struct {
 	*chi.Mux
 }

--- a/cmd/dcrdata/internal/api/insight/apirouter.go
+++ b/cmd/dcrdata/internal/api/insight/apirouter.go
@@ -19,8 +19,10 @@ type ApiMux struct {
 	*chi.Mux
 }
 
-// APIVersion is an integer value, incremented for breaking changes
-const APIVersion = 0
+// Version returns the version of this API handler.
+func (am *ApiMux) Version() int {
+	return APIVersion
+}
 
 // NewInsightAPIRouter returns a new HTTP path router, ApiMux, for the Insight
 // API, app.

--- a/cmd/dcrdata/internal/api/insight/version.go
+++ b/cmd/dcrdata/internal/api/insight/version.go
@@ -1,0 +1,4 @@
+package insight
+
+// APIVersion is an integer value, incremented for breaking changes
+const APIVersion = 1


### PR DESCRIPTION
This adds versioning to dcrdata's REST APIs. Closes #48 

http://134.209.25.156:7777/api/v1

While this is just a fundamental approach to the whole versioning system, It is a footwork for future API versioning-related work ([Comment](https://github.com/decred/dcrdata/issues/48#issuecomment-1364567356)). 