### PR TITLE
cmd/dcrdata: allowed hosts

### DIFF
--- a/cmd/dcrdata/config.go
+++ b/cmd/dcrdata/config.go
@@ -109,16 +109,17 @@ type config struct {
 	ReloadHTML   bool   `long:"reload-html" description:"Reload HTML templates on every request" env:"DCRDATA_RELOAD_HTML"`
 
 	// API/server
-	APIProto            string  `long:"apiproto" description:"Protocol for API (http or https)" env:"DCRDATA_ENABLE_HTTPS"`
-	APIListen           string  `long:"apilisten" description:"Listen address for API. default localhost:7777, :17778 testnet, :17779 simnet" env:"DCRDATA_LISTEN_URL"`
-	IndentJSON          string  `long:"indentjson" description:"String for JSON indentation (default is \"   \"), when indentation is requested via URL query." env:"DCRDATA_INDENT_JSON"`
-	UseRealIP           bool    `long:"userealip" description:"Use the RealIP middleware from the pressly/chi/middleware package to get the client's real IP from the X-Forwarded-For or X-Real-IP headers, in that order. You must have a trusted proxy!" env:"DCRDATA_USE_REAL_IP"`
-	TrustProxy          bool    `long:"trustproxy" description:"There is a trusted proxy between us and the actual client. If this is true, determine the original request scheme and host from X-Forwarded-{Proto,Host}. The regular Host header is likely to be set already."`
-	CacheControlMaxAge  int     `long:"cachecontrol-maxage" description:"Set CacheControl in the HTTP response header to a value in seconds for clients to cache the response. This applies only to FileServer routes." env:"DCRDATA_MAX_CACHE_AGE"`
-	InsightReqRateLimit float64 `long:"insight-limit-rps" description:"Requests/second per client IP for the Insight API's rate limiter." env:"DCRDATA_INSIGHT_RATE_LIMIT"`
-	MaxCSVAddrs         int     `long:"max-api-addrs" description:"Maximum allowed comma-separated addresses for endpoints that accept multiple addresses." env:"DCRDATA_MAX_CSV_ADDRS"`
-	CompressAPI         bool    `long:"compress-api" description:"Use compression for a number of endpoints with commonly large responses." env:"DCRDATA_COMPRESS_API"`
-	ServerHeader        string  `long:"server-http-header" description:"Set the HTTP response header Server key value. Valid values are \"off\", \"version\", or a custom string." env:"DCRDATA_SERVER_HEADER"`
+	APIProto            string   `long:"apiproto" description:"Protocol for API (http or https)" env:"DCRDATA_ENABLE_HTTPS"`
+	APIListen           string   `long:"apilisten" description:"Listen address for API. default localhost:7777, :17778 testnet, :17779 simnet" env:"DCRDATA_LISTEN_URL"`
+	IndentJSON          string   `long:"indentjson" description:"String for JSON indentation (default is \"   \"), when indentation is requested via URL query." env:"DCRDATA_INDENT_JSON"`
+	UseRealIP           bool     `long:"userealip" description:"Use the RealIP middleware from the pressly/chi/middleware package to get the client's real IP from the X-Forwarded-For or X-Real-IP headers, in that order. You must have a trusted proxy!" env:"DCRDATA_USE_REAL_IP"`
+	TrustProxy          bool     `long:"trustproxy" description:"There is a trusted proxy between us and the actual client. If this is true, determine the original request scheme and host from X-Forwarded-{Proto,Host}. The regular Host header is likely to be set already."`
+	AllowedHosts        []string `long:"allowedhost" description:"Permitted Host values in the request header. Unrecognized hosts are cleared."`
+	CacheControlMaxAge  int      `long:"cachecontrol-maxage" description:"Set CacheControl in the HTTP response header to a value in seconds for clients to cache the response. This applies only to FileServer routes." env:"DCRDATA_MAX_CACHE_AGE"`
+	InsightReqRateLimit float64  `long:"insight-limit-rps" description:"Requests/second per client IP for the Insight API's rate limiter." env:"DCRDATA_INSIGHT_RATE_LIMIT"`
+	MaxCSVAddrs         int      `long:"max-api-addrs" description:"Maximum allowed comma-separated addresses for endpoints that accept multiple addresses." env:"DCRDATA_MAX_CSV_ADDRS"`
+	CompressAPI         bool     `long:"compress-api" description:"Use compression for a number of endpoints with commonly large responses." env:"DCRDATA_COMPRESS_API"`
+	ServerHeader        string   `long:"server-http-header" description:"Set the HTTP response header Server key value. Valid values are \"off\", \"version\", or a custom string." env:"DCRDATA_SERVER_HEADER"`
 
 	// Mempool
 	MempoolMinInterval int `long:"mp-min-interval" description:"The minimum time in seconds between mempool reports, regardless of number of new tickets seen." env:"DCRDATA_MEMPOOL_MIN_INTERVAL"`

--- a/cmd/dcrdata/main.go
+++ b/cmd/dcrdata/main.go
@@ -684,6 +684,10 @@ func _main(ctx context.Context) error {
 	if cfg.TrustProxy {                        // try to determine actual request scheme and host from x-forwarded-{proto,host} headers
 		webMux.Use(explorer.ProxyHeaders)
 	}
+	if len(cfg.AllowedHosts) > 0 {
+		webMux.Use(explorer.AllowedHosts(cfg.AllowedHosts))
+	}
+
 	webMux.With(explore.SyncStatusPageIntercept).Group(func(r chi.Router) {
 		r.Get("/", explore.Home)
 		r.Get("/visualblocks", explore.VisualBlocks)

--- a/cmd/dcrdata/sample-dcrdata.conf
+++ b/cmd/dcrdata/sample-dcrdata.conf
@@ -44,6 +44,14 @@
 ; reverse proxy not to pass these headers unmodified from the client.
 ;trustproxy=true
 
+; Specify acceptable values for the Host request header. Any values that do not
+; match one of these hosts will be cleared and the requests will be processed
+; with no value for Host. Multiple values may be specified. (no default)
+; For example:
+;allowedhost=127.0.0.1
+;allowedhost=explorer.dcrdata.org
+;allowedhost=dcrdata.decred.org
+
 ; Sets the max number of blocks behind the best block past which only the syncing
 ; status page can be served on the running web server when blockchain sync is
 ; running after dcrdata startup. The maximum value that can be set is 5000. If set

--- a/cmd/dcrdata/sample-nginx.conf
+++ b/cmd/dcrdata/sample-nginx.conf
@@ -71,6 +71,9 @@ http {
     #}
 
     server {
+        # default_server is convenient, but consider creating a separate server
+        # section as a black hole or a redirect for requests with Host names
+        # that are not explictly listed by the server_name directive.
         listen       443 http2 ssl default_server;
         server_name  _;
 
@@ -120,6 +123,9 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
+            # WARNING: See comments about default_server above as it pertains to
+            # validation of acceptable Hosts in the request. When promiscuous,
+            # the backend must whitelist acceptable request host names.
 
             # Use the Server header set by the backend.
             # https://stackoverflow.com/questions/246227/how-do-you-change-the-server-header-returned-by-nginx
@@ -165,7 +171,7 @@ http {
             # setup proxy cache to use "dcrcache" cache
             proxy_cache dcrcache;
             proxy_connect_timeout 20s;
-            proxy_cache_valid 200 400 404 422 20s;
+            proxy_cache_valid 200 404 422 20s;
             proxy_cache_use_stale updating;
             # proxy_cache_lock prevents multiple identical requests from hitting
             # the backend at the same time.

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -3,6 +3,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	{{/* The above meta tags *must* come first in the head */ -}}
+	{{- if .Data.Host -}}
 	<meta name="description" content="dcrdata, an original Decred block explorer powered by Go">
 	<meta name="author" content="The Decred developers">
 	<meta name="application-name"           content="dcrdata - The Decred Block Explorer">
@@ -19,6 +20,7 @@
 	<meta property="og:type"        content="website" />
 	<meta property="og:url"         content="{{ .Data.CanonicalURL }}" />
 	<meta property="og:image"       content="{{ .Data.BaseURL }}/images/dcrdata400x348.png" />
+	{{- end}}
 
 	<!--  Custom favicon  -->
 		<!-- Apple PWA -->


### PR DESCRIPTION
Since reverse proxy config is often not adequate or correct, this adds an allowed hosts middleware to dcrdata to ensure that any `Host` header value set in the request header is on a whitelist of hosts.

However, the reverse proxy should be configured with:
- a `default_server` black hole or redirect-only `server`, as a catch-all, preventing one of the other `server`s from becoming the default
- all other `server`s should specify `server_name` values including fqns, IPs, and `""` for when the `Host` header is not set.  These configuration changes prevent invalid or unexpected `Host` values.

However, to use without the above settings (or no reverse proxy at all), this change adds the `AllowedHosts` middleware, which ensures the `http.Request.Host` matches one of a number of hosts specified in dcrdata.conf.  If it does not, the value is simply cleared and the request continues to process.  In particular, this causes the social media tags to be omitted from the rendered html.

As a side note, the default `proxy_cache_valid` nginx setting does NOT include 400 (bad request) responses, for good reason.  The caching of bad requests is not a dcrdata bug, but the operators responsibility to avoid when using a caching proxy.