### PR TITLE
dcrpg: query for only valid mainchain data in address chart queries

### DIFF
--- a/cmd/dcrdata/sample-dcrdata.conf
+++ b/cmd/dcrdata/sample-dcrdata.conf
@@ -49,6 +49,7 @@
 ; with no value for Host. Multiple values may be specified. (no default)
 ; For example:
 ;allowedhost=127.0.0.1
+;allowedhost=127.0.0.1:7777
 ;allowedhost=explorer.dcrdata.org
 ;allowedhost=dcrdata.decred.org
 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -298,7 +298,7 @@ const (
 		COUNT(CASE WHEN tx_type = 2 THEN 1 ELSE NULL END) as SSGen,
 		COUNT(CASE WHEN tx_type = 3 THEN 1 ELSE NULL END) as SSRtx
 		FROM addresses
-		WHERE address=$1
+		WHERE address=$1 AND valid_mainchain
 		GROUP BY timestamp
 		ORDER BY timestamp;`
 
@@ -306,7 +306,7 @@ const (
 		SUM(CASE WHEN is_funding = TRUE THEN value ELSE 0 END) as received,
 		SUM(CASE WHEN is_funding = FALSE THEN value ELSE 0 END) as sent
 		FROM addresses
-		WHERE address=$1
+		WHERE address=$1 AND valid_mainchain
 		GROUP BY timestamp
 		ORDER BY timestamp;`
 


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdata/issues/1961

```
$  curl -ks http://127.0.0.1:7777/api/address/DshMNsvETDWpVoCe1re9NTAChiJagzsFV7J/amountflow/day | jq '.net | add'
-3.637978807091713e-12
$  curl -ks http://127.0.0.1:7777/api/address/DshMNsvETDWpVoCe1re9NTAChiJagzsFV7J/amountflow/day | jq '.received | add'
950200.8645353797
```

jq is doing lossy floating point addition there and I didn't feel like multiplying by 1e8 and rounding before adding.