### PR TITLE
CI: use latest Go with check-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
       with:
         go-version: ${{ matrix.go }}
+        check-latest: true
 
     - name: Go Build dcrdata
       run: go build -v ./...


### PR DESCRIPTION
TEST: let's see if this makes it fetch Go 1.20.6

https://github.com/actions/setup-go#check-latest-version

> If check-latest is set to true, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a Go version will then be downloaded. Set check-latest to true if you want the most up-to-date Go version to always be used.