### PR TITLE
docs: Removed an old sketchy URL that appeared to be pwnd

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,11 +57,11 @@ Only submit a PR once the intended edits are either done or nearing completion. 
 
 ### Suggested Toolkit
 
-- Go language distribution - latest release or latest-1 (e.g. 1.8.3 and 1.9). [download](https://golang.org/doc/install)
+- Go - the [latest release](https://golang.org/doc/install) or the one immediately prior (e.g. 1.21 or 1.20).
 - git client with command line support. [download](https://git-scm.com/downloads)
 - [GitHub](https://github.com/) account
 - Visual Studio Code with Go extension plus `gometalinter`
-- coffee, preferably black. [some good stuff](http://haiticoffeeacademy.com/)
+- Coffee, preferably black.
 
 ### Git Workflow
 


### PR DESCRIPTION
I was reading `contributing.md`, and I noticed there was a link to coffee. I clicked it and was immediately warned by Google that it was dangerous due to some security breach and phishing attacks. I didn't investigate much further, but I figured I should remove the link.

While there, I just did a quick update to the suggested Go line. Figured 1.8.3 was a bit old.