### PR TITLE
views/home: Use ThreeSigFigs to display difficulty on homepage

### DIFF
--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -167,7 +167,7 @@ export default class extends Controller {
 
   _processBlock (blockData) {
     const ex = blockData.extra
-    this.difficultyTarget.innerHTML = humanize.decimalParts(ex.difficulty / 1000000, true, 0)
+    this.difficultyTarget.innerHTML = humanize.decimalParts(ex.difficulty, true, 0)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(ex.subsidy.pow / 100000000, false, 8, 2)
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts((ex.subsidy.pos / 500000000), false, 8, 2) // 5 votes per block (usually)
     this.bsubsidyDevTarget.innerHTML = humanize.decimalParts(ex.subsidy.dev / 100000000, false, 8, 2)

--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -167,7 +167,7 @@ export default class extends Controller {
 
   _processBlock (blockData) {
     const ex = blockData.extra
-    this.difficultyTarget.innerHTML = humanize.decimalParts(ex.difficulty, true, 0)
+    this.difficultyTarget.innerHTML = humanize.threeSigFigs(ex.difficulty)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(ex.subsidy.pow / 100000000, false, 8, 2)
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts((ex.subsidy.pos / 500000000), false, 8, 2) // 5 votes per block (usually)
     this.bsubsidyDevTarget.innerHTML = humanize.decimalParts(ex.subsidy.dev / 100000000, false, 8, 2)

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -189,7 +189,7 @@
 		data-turbolinks-suppress-warning
 	></script>
 	<script
-		src="/dist/js/app.3f014a316578f397.bundle.js"
+		src="/dist/js/app.935cecaf5560c863.bundle.js"
 		data-turbolinks-eval="false"
 		data-turbolinks-suppress-warning
 	></script>

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -309,7 +309,7 @@
                                 <a class="no-underline" href="/charts?chart=pow-difficulty">Difficulty</a>
                             </div>
                             <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                                <span data-homepage-target="difficulty">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</span>
+                                <span data-homepage-target="difficulty">{{threeSigFigs .Difficulty}}</span>
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -309,8 +309,7 @@
                                 <a class="no-underline" href="/charts?chart=pow-difficulty">Difficulty</a>
                             </div>
                             <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                                <span data-homepage-target="difficulty">{{template "decimalParts" (float64AsDecimalParts (divideFloat .Difficulty 1000000.0) 0 true)}}</span>
-                                <span class="ps-1 unit lh15rem">Mil</span>
+                                <span data-homepage-target="difficulty">{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}</span>
                             </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">


### PR DESCRIPTION
This is a quick fix for displaying the difficulty on the homepage. I just changed it to show the raw value instead of being divided by 1e6 and showing a "Mil" value.

I thought about trying to do something complicated and make a scaling value that switched formats if it became longer than 1e6, but I don't think it's worth the time investment it would take me.