### PR TITLE
Use `-n` to test for bash script argument

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ set -ex
 GV=$(go version | sed "s/^.*go\([0-9.]*\).*/\1/")
 echo "Go version: $GV"
 
-if [[ -v TESTTAGS ]]; then
+if [[ -n "${TESTTAGS}" ]]; then
   TESTTAGS="-tags \"${TESTTAGS}\""
 else
   TESTTAGS=


### PR DESCRIPTION
`./run_tests.sh` fails on my Mac. 

Error message: `./run_tests.sh: line 16: conditional binary operator expected.` 

```
% bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin22)
Copyright (C) 2007 Free Software Foundation, Inc.
```

This PR uses a stable conditional expression `-n` to test for bash script argument in `./run_tests.sh`.