### PR TITLE
{cmd/dcrdata/views}: Fix orphan block `api` link on the block view

### DIFF
--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -46,7 +46,11 @@
 						{{- else }}
 						<a class="fs13" href="/mempool">mempool </a>|
 						{{- end}}
+						{{if .MainChain}}
 						<a class="fs13" href="/api/block/{{.Height}}/verbose?indent=true" data-turbolinks="false">api</a>
+						{{- else}}
+						<a class="fs13" href="/api/block/hash/{{.Hash}}/verbose?indent=true" data-turbolinks="false">api</a>
+						{{- end}}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #1745

Issue: Visit the https://dcrdata.decred.org/side and click on any block, then click on the `api` link on the displayed block view. It'll display data for the mainchain block.