### PR TITLE
{cmd/dcrdata}: Use `sync.RWMutex` to prevent concurrent template map writes

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -211,7 +211,7 @@ type explorerUI struct {
 	proposals        PoliteiaBackend
 	dbsSyncing       atomic.Value
 	devPrefetch      bool
-	templates        templates
+	templates        *templates
 	wsHub            *WebsocketHub
 	pageData         *pageData
 	ChainParams      *chaincfg.Params


### PR DESCRIPTION
Closes #1991 