### PR TITLE
{cmd/dcrdata}: Use template func for footer year

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, The Decred developers
+// Copyright (c) 2018-2024, The Decred developers
 // Copyright (c) 2017, The dcrdata developers
 // See LICENSE for details.
 
@@ -368,6 +368,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		},
 		"intMultiply": func(a, b int) int {
 			return a * b
+		},
+		"currentYear": func() string {
+			return strconv.Itoa(time.Now().Year())
 		},
 		"timezone": func() string {
 			t, _ := time.Now().Zone()

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -174,7 +174,7 @@
 				href="{{.Links.License}}"
 				target="_blank"
 				rel="noopener noreferrer"
-			>© 2024 The Decred developers (ISC)</a>
+			>© {{currentYear}} The Decred developers (ISC)</a>
 		</span>
 		<span
 			id="connection"


### PR DESCRIPTION
This PR adds a `currentYear` template function to display the correct current year so we don't need to update this every year. 