### PR TITLE
Bug Fix: fix unsigned underflow in per-block net calculation

### DIFF
--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -4027,7 +4027,7 @@ func parseRowsSentReceived(rows *sql.Rows) (*dbtypes.ChartsData, error) {
 		// given block. If the difference is positive then the value is unspent amount
 		// otherwise if the value is zero then all amount is spent and if the net amount
 		// is negative then for the given block more amount was sent than received.
-		items.Net = append(items.Net, toCoin(received-sent))
+		items.Net = append(items.Net, toCoin(int64(received)-int64(sent)))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
The per-block net value was previously computed using uint64, which caused underflow when sent > received within a block.

This resulted in incorrect large positive values due to unsigned wraparound.

Net flow per-block can legitimately be negative, the calculation now uses int64 which correctly represents block level balance changes and prevents overflow.

Closes #2031

Checkout the balances on the Treasury page to confirm issue and also address balances like this one: https://dcrdata.decred.org/address/DsSCPWJX871jTQ8CmN1ZaCQw4pW27YW2wDa?chart=amountflow&zoom=mm6vmelc-mm6x0uy8&bin=all&flow=7

Before:
<img width="1399" height="498" alt="before" src="https://github.com/user-attachments/assets/2c92af21-d52e-4847-9363-edf39860bf55" />

After
<img width="1335" height="632" alt="after" src="https://github.com/user-attachments/assets/52de458c-a4b2-4a69-a654-27ce055c3c09" />
